### PR TITLE
fix(bench): exempt 3.15.0 baseline drift for Full build / 1-file rebuild

### DIFF
--- a/tests/benchmarks/regression-guard.test.ts
+++ b/tests/benchmarks/regression-guard.test.ts
@@ -238,12 +238,22 @@ const SKIP_VERSIONS = new Set(['3.8.0']);
  * strict thresholds and is the canary for real algorithmic regressions.
  */
 const KNOWN_REGRESSIONS = new Set<string>([
-  // (empty) — all 3.12.0/3.13.0 entries pruned at the 3.15.0 release once the
-  // 3.15.0 benchmark baseline landed (PR #1702). The erlang 0% drop and the
-  // dataflow/no-op timing deltas are now baked into the 3.15.0 baseline, so
-  // dev-vs-3.15.0 comparisons no longer flag them. Add a new
-  // "version:metric-label" entry here (with root-cause analysis above) only
-  // when a fresh regression needs exempting against the current baseline.
+  // v3.15.0 was released 2026-06-21 and no stable release has landed since,
+  // while 150+ PRs merged into main — including many new per-language
+  // resolution-benchmark fixtures. The repo's own tracked source file count
+  // (this is a self-benchmark: `root` in scripts/benchmark.ts is the repo
+  // itself) grew from 629 files (3.15.0 baseline) to 1000+ files, a ~60%
+  // increase. Full-build and 1-file-rebuild time both scale with file count
+  // (the latter via the repo-wide change-detection scan), so every
+  // dev-vs-3.15.0 comparison now measures a real, but growth-driven — not
+  // algorithmic — increase that clears the 25%/50%/75% thresholds. This hit
+  // every open PR regardless of content (chore/deps-only PRs included),
+  // confirming it isn't PR-introduced. Tracked in #2081. Exemption clears
+  // itself: prune both entries once the next stable release folds current
+  // repo size into a fresh baseline (same pattern as the 3.12.0/3.13.0 prune
+  // at 3.15.0 documented above).
+  '3.15.0:Full build',
+  '3.15.0:1-file rebuild',
 ]);
 
 /**


### PR DESCRIPTION
## Summary
- Every open PR's `Pre-publish benchmark gate` fails on `Full build` and `1-file rebuild` against the v3.15.0 baseline, regardless of PR content (confirmed across 10 unrelated PRs, including pure dependency bumps).
- Root cause: `scripts/benchmark.ts` self-benchmarks this repo, and the repo's tracked source file count grew from 629 to 1013 (+61%) in the 24 days since v3.15.0 was released, with no release since to refresh the baseline (a manual release would hit the identical gate in `publish.yml`, creating a deadlock).
- Adds two `KNOWN_REGRESSIONS` entries (`3.15.0:Full build`, `3.15.0:1-file rebuild`) following this repo's established pattern for exactly this scenario (see the 3.12.0/3.13.0 entries pruned once the 3.15.0 baseline landed). These should be pruned again once the next release folds current repo size into a fresh baseline.
- Filed full diagnosis on #2081, which already tracked this class of flakiness but scoped to CI-runner noise on `1-file rebuild` alone rather than baseline staleness affecting both metrics.

## Test plan
- [x] `npx biome check` clean on the changed file
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run tests/benchmarks/regression-guard.test.ts` — 25/25 pass, including `KNOWN_REGRESSIONS entries are not stale` (confirms the new entries aren't flagged stale against the current 3.15.0 baseline)
- [ ] CI's `Pre-publish benchmark gate` passes on this PR (only way to exercise the actual `dev vs 3.15.0` comparison path)