### PR TITLE
fix(ci): anchor native-change detection to package.json's version, not the latest tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           # matching publish, which made this job wrongly report "unchanged"
           # against a fallback binary that was actually several releases
           # stale (#2127).
-          CURRENT_VERSION=$(grep -m1 '"version"' package.json | sed -E 's/.*: *"([^"]*)".*/\1/')
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
           LAST_TAG="v$CURRENT_VERSION"
 
           if [ -z "$CURRENT_VERSION" ] || ! git cat-file -e "$LAST_TAG" 2>/dev/null; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,11 +72,21 @@ jobs:
           # nothing about whether the published binary this job's skip relies
           # on has already drifted from HEAD. The only baseline that actually
           # answers "is the published fallback binary still trustworthy" is
-          # the last release tag.
-          LAST_TAG=$(git tag --sort=-version:refname --list 'v[0-9]*.[0-9]*.[0-9]*' | grep -v dev | head -1)
+          # the tag for the version package.json currently declares.
+          #
+          # This deliberately does NOT use "the most recent vX.Y.Z tag" —
+          # a release tag is created by the GitHub Release that kicks off
+          # publish.yml, but publish itself (and the package.json version
+          # bump that comes with it) can still fail afterwards, e.g. the
+          # pre-publish benchmark gate. That leaves a tag on origin with no
+          # matching publish, which made this job wrongly report "unchanged"
+          # against a fallback binary that was actually several releases
+          # stale (#2127).
+          CURRENT_VERSION=$(grep -m1 '"version"' package.json | sed -E 's/.*: *"([^"]*)".*/\1/')
+          LAST_TAG="v$CURRENT_VERSION"
 
-          if [ -z "$LAST_TAG" ] || ! git cat-file -e "$LAST_TAG" 2>/dev/null; then
-            echo "No usable release tag to diff against — assuming native changed"
+          if [ -z "$CURRENT_VERSION" ] || ! git cat-file -e "$LAST_TAG" 2>/dev/null; then
+            echo "No usable release tag ($LAST_TAG) to diff against — assuming native changed"
             echo "native_changed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi


### PR DESCRIPTION
## Problem

All 8 currently-open dependabot PRs (#2119-#2126) are failing CI identically on **Engine parity** (all 3 OSes) and **Test Node 22** (all 3 OSes), regardless of what each PR actually bumps — including PRs that only touch GitHub Actions versions (`setup-go`, `setup-node`, `claude-code-action`) with zero npm/Rust changes.

## Root cause

- The `v3.16.0` release attempt (commit `2e0e94f`, 2026-07-17) tagged the release, but its **Pre-publish benchmark gate** failed on a genuine build-time regression (filed as #2127), so `publish`/`publish-dev` never ran. `package.json` on `main` is still `3.15.0`, and npm still serves `3.15.0` — nothing was actually published under the `v3.16.0` tag.
- `detect-changes` in `ci.yml` picks "the most recent `vX.Y.Z` git tag" as its proxy for "last published release." That's now the dangling `v3.16.0` tag, which **is** current `main` HEAD — diffing HEAD against itself trivially finds zero native-relevant changes, so `native-host-build` gets skipped.
- With native build skipped, `test`/`parity` jobs fall back to whatever `npm install` resolves for the platform packages — the **actually published `3.15.0`** binary, which is 56 native-relevant files (extractors, builder pipeline, db layer) behind HEAD.
- Native (stale 3.15.0) vs. WASM (fresh HEAD) now disagree on real extraction behavior — exactly the parity failures seen on every open PR (TS/PHP AST-count mismatches, JS/TS callback-gating mismatches, C# edge/role mismatches).

## Fix

Anchor `detect-changes`'s diff base to the version `package.json` currently declares, instead of "the most recent semver-shaped tag." A tag can exist without a successful publish (exactly what happened here); `package.json`'s version cannot drift from what's published without the release job itself changing it.

Verified against the current repo state: the fix now correctly resolves to `v3.15.0` and detects the 56 native-relevant files changed since, which would set `native_changed=true` and restore the fresh-native-build path.

## Not in scope here

The underlying build-perf regression that blocked the v3.16.0 release is tracked separately in #2127.