### PR TITLE
fix: raise Greptile re-trigger cap from 3 to 50 per PR

### DIFF
--- a/.claude/skills/sweep/SKILL.md
+++ b/.claude/skills/sweep/SKILL.md
@@ -299,7 +299,7 @@ After re-triggering:
 1. Wait for the new reviews to come in (check after a reasonable interval).
 2. Fetch new comments again (repeat Step 2d).
 3. If there are **new** comments from Greptile or Claude, go back to Step 2e and address them.
-4. **Repeat this loop for a maximum of 3 rounds.** If after 3 rounds there are still actionable comments, mark the PR as "needs human review" in the result.
+4. **Repeat this loop for a maximum of 50 rounds.** If after 50 rounds there are still actionable comments, mark the PR as "needs human review" in the result.
 5. Verify CI is still green after all changes.
 
 ### 2i. Return result


### PR DESCRIPTION
## Summary

- The `/sweep` skill's re-trigger loop (`.claude/skills/sweep/SKILL.md`, Step 2h) previously capped Greptile/Claude re-review rounds at **3** before forcing a PR into `needs-human-review` status.
- That cap of 3 was set by a prior autonomous Claude Code session without real human sign-off — it only carried the repo owner's name in git history because commits/API calls run under their authenticated `gh` CLI identity, not because it reflects an actual reviewed decision.
- The repo owner has now explicitly requested a budget of **50** rounds instead, since Greptile findings can legitimately require several genuine fix-and-retrigger rounds, and a cap of 3 was flagging PRs as needing human review while real, actionable bugs were still being found and fixed.

## Change

Single-line change in `.claude/skills/sweep/SKILL.md`:

```
- 4. **Repeat this loop for a maximum of 3 rounds.** If after 3 rounds there are still actionable comments, mark the PR as "needs human review" in the result.
+ 4. **Repeat this loop for a maximum of 50 rounds.** If after 50 rounds there are still actionable comments, mark the PR as "needs human review" in the result.
```

No other content in the file was touched.

## Test plan

- [x] `npm run lint` passes clean on the changed file
- [x] Confirmed this is the only occurrence of the round/trigger cap in the file (grepped for "round"/"cap"/"trigger" near a literal "3")