### PR TITLE
fix(extractors): strip quotes from plain quoted method/property keys (#1944)

### DIFF
--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -1143,13 +1143,15 @@ fn resolve_computed_key_name(computed_node: &Node, source: &[u8]) -> Option<Stri
 /// For computed property names (`['methodName']`), strips brackets and quotes from
 /// string-literal keys so the stored name matches the plain identifier used at call
 /// sites (`obj.methodName()`). Non-string computed keys like `[Symbol.iterator]`
-/// cannot be resolved at dot-notation call sites — returns `None` for those.
+/// cannot be resolved at dot-notation call sites — returns `None` for those. Plain
+/// quoted keys (`'methodName'() {}`, kind `"string"`) also have their quotes
+/// stripped, mirroring `resolve_pair_key_name`'s handling of the same case.
 fn resolve_method_def_name(node: &Node, source: &[u8]) -> Option<String> {
     let name_node = node.child_by_field_name("name")?;
-    if name_node.kind() == "computed_property_name" {
-        resolve_computed_key_name(&name_node, source)
-    } else {
-        Some(node_text(&name_node, source).to_string())
+    match name_node.kind() {
+        "string" => extract_string_fragment(&name_node, source).map(|s| s.to_string()),
+        "computed_property_name" => resolve_computed_key_name(&name_node, source),
+        _ => Some(node_text(&name_node, source).to_string()),
     }
 }
 
@@ -6696,6 +6698,35 @@ mod tests {
             names
         );
         assert!(names.contains(&"obj.bar"), "expected 'obj.bar'; got: {:?}", names);
+    }
+
+    /// Issue #1944: a plain quoted (non-computed) method key (`'foo'() {}`, kind `"string"`,
+    /// distinct from `computed_property_name`) must have its quotes stripped, not stored as
+    /// the literal `'foo'` — mirrors the computed-key unwrapping `resolve_method_def_name`
+    /// already applies, extended to the plain-string branch.
+    #[test]
+    fn quoted_plain_method_key_resolves_to_plain_name() {
+        let s = parse_js("class A {\n  'foo'() { return 1; }\n}");
+        let names: Vec<_> = s.definitions.iter().map(|d| d.name.as_str()).collect();
+        assert!(names.contains(&"A.foo"), "expected 'A.foo'; got: {:?}", names);
+        assert!(
+            !names.iter().any(|n| n.contains('\'')),
+            "no definition name should retain the quoted form; got: {:?}",
+            names
+        );
+    }
+
+    /// Issue #1944: same quote-stripping for a plain quoted object-literal method shorthand key.
+    #[test]
+    fn quoted_plain_object_literal_method_key_resolves_to_plain_name() {
+        let s = parse_js("const obj = { 'quoted'() { return 1; } };");
+        let names: Vec<_> = s.definitions.iter().map(|d| d.name.as_str()).collect();
+        assert!(names.contains(&"obj.quoted"), "expected 'obj.quoted'; got: {:?}", names);
+        assert!(
+            !names.iter().any(|n| n.contains('\'')),
+            "no definition name should retain the quoted form; got: {:?}",
+            names
+        );
     }
 
     /// Issue #1764: the same computed-key unwrapping must apply to `let`/`var` object literals,

--- a/src/domain/parser.ts
+++ b/src/domain/parser.ts
@@ -170,6 +170,7 @@ const COMMON_QUERY_PATTERNS: string[] = [
   '(method_definition name: (property_identifier) @meth_name) @meth_node',
   '(method_definition name: (private_property_identifier) @meth_name) @meth_node',
   '(method_definition name: (computed_property_name) @meth_name) @meth_node',
+  '(method_definition name: (string) @meth_name) @meth_node',
   '(import_statement source: (string) @imp_source) @imp_node',
   '(export_statement) @exp_node',
   '(call_expression function: (identifier) @callfn_name) @callfn_node',

--- a/src/domain/wasm-worker-entry.ts
+++ b/src/domain/wasm-worker-entry.ts
@@ -118,6 +118,7 @@ const COMMON_QUERY_PATTERNS: string[] = [
   '(method_definition name: (property_identifier) @meth_name) @meth_node',
   '(method_definition name: (private_property_identifier) @meth_name) @meth_node',
   '(method_definition name: (computed_property_name) @meth_name) @meth_node',
+  '(method_definition name: (string) @meth_name) @meth_node',
   '(import_statement source: (string) @imp_source) @imp_node',
   '(export_statement) @exp_node',
   '(call_expression function: (identifier) @callfn_name) @callfn_node',

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -2421,10 +2421,12 @@ function resolveComputedKeyName(nameNode: TreeSitterNode): string {
 
 /**
  * Resolve the raw method name from a method_definition's name field, unwrapping
- * computed_property_name string literals (e.g. `['foo']() {}` -> 'foo'). Returns ''
- * for non-string computed keys (no resolvable name).
+ * computed_property_name string literals (e.g. `['foo']() {}` -> 'foo') and quoted
+ * plain string keys (e.g. `'foo'() {}` -> 'foo'). Returns '' for non-string computed
+ * keys (no resolvable name).
  */
 function resolveMethodDefinitionName(nameNode: TreeSitterNode): string {
+  if (nameNode.type === 'string') return nameNode.text.replace(/^['"]|['"]$/g, '');
   if (nameNode.type !== 'computed_property_name') return nameNode.text;
   return resolveComputedKeyName(nameNode);
 }

--- a/tests/engines/query-walk-parity.test.ts
+++ b/tests/engines/query-walk-parity.test.ts
@@ -313,6 +313,24 @@ class Derived extends Base {
 }
 `,
   },
+  {
+    // Regression guard for #1944: a plain quoted (non-computed) method key
+    // (`'foo'() {}`) has no query pattern for `method_definition name:
+    // (string)` — before the fix, the query path silently produced ZERO
+    // definitions for the class method (not merely a quote-unstripped name),
+    // since it never matched any of the property_identifier/
+    // private_property_identifier/computed_property_name capture patterns.
+    // The walk path (extractSymbolsWalk) always saw it via
+    // resolveMethodDefinitionName's generic node-type dispatch.
+    name: 'quoted (non-computed) class method key (#1944)',
+    file: 'test.js',
+    code: `
+class A {
+  'foo'() { return 1; }
+  bar() { return this.foo(); }
+}
+`,
+  },
   // TSX
   {
     name: 'TSX component with extends',

--- a/tests/parsers/javascript.test.ts
+++ b/tests/parsers/javascript.test.ts
@@ -2253,6 +2253,33 @@ function runDemo(reporter: Reporter, users: string[]): void {
     });
   });
 
+  describe('quoted (non-computed) method/property key extraction (#1944)', () => {
+    it('strips quotes from a plain quoted class method key', () => {
+      const symbols = parseJS(`class A { 'foo'() { return 1; } }`);
+      expect(symbols.definitions).toContainEqual(
+        expect.objectContaining({ name: 'A.foo', kind: 'method' }),
+      );
+      const def = symbols.definitions.find((d) => d.name.includes("'"));
+      expect(def).toBeUndefined();
+    });
+
+    it('strips quotes from a plain quoted object-literal method shorthand key', () => {
+      const symbols = parseJS(`const obj = { 'quoted'() { return 1; } };`);
+      expect(symbols.definitions).toContainEqual(
+        expect.objectContaining({ name: 'obj.quoted', kind: 'function' }),
+      );
+      const def = symbols.definitions.find((d) => d.name.includes("'"));
+      expect(def).toBeUndefined();
+    });
+
+    it('strips double quotes too', () => {
+      const symbols = parseJS(`class B { "bar"() { return 1; } }`);
+      expect(symbols.definitions).toContainEqual(
+        expect.objectContaining({ name: 'B.bar', kind: 'method' }),
+      );
+    });
+  });
+
   describe('computed pair key extraction (#1764)', () => {
     it('extracts a computed string-literal pair key as a plain qualified name', () => {
       // `{ ['foo']: () => {} }` — computed_property_name wrapping a string literal must be


### PR DESCRIPTION
## Summary
- `resolveMethodDefinitionName` (and the native `resolve_method_def_name` mirror) only stripped quotes on the `computed_property_name` branch (`['foo']() {}`), so a plain quoted key (`'foo'() {}`) fell through to raw source text including the quote characters — producing broken definition names like `A.'foo'` instead of `A.foo`.
- While verifying the fix, found a related, more severe gap: the WASM **query path** (used by the real `codegraph build` worker) has no tree-sitter query pattern for `method_definition name: (string)` at all — only `property_identifier`/`private_property_identifier`/`computed_property_name` are matched — so a quoted class method was completely invisible to a real build (not merely mis-named). The walk path (`extractSymbolsWalk`) was unaffected since it dispatches on any node type generically. Added the missing pattern to both `parser.ts` and its `wasm-worker-entry.ts` mirror.
- Object-literal quoted method shorthand was already reachable via `extractObjectLiteralFunctions`'s own tree walk (not the `meth_node` query capture, which explicitly skips object-literal methods to avoid a duplicate per #1818), so only the class-method quote-stripping + query pattern needed fixing for that path.

## Verification
- Added unit tests (`tests/parsers/javascript.test.ts`) covering class method + object-literal shorthand quoted keys (single and double quotes).
- Added a native Rust test mirror (`crates/codegraph-core/src/extractors/javascript.rs`) — `cargo test --lib`: 666 passed.
- Added a query-vs-walk parity regression test (`tests/engines/query-walk-parity.test.ts`) for the missing-pattern bug specifically.
- Verified end-to-end via a real `codegraph build` on both engines (WASM + native) against a minimal fixture — both now correctly produce `A.foo`/`obj.quoted` with quotes stripped.
- Full suite: `npm test` — 260 files, 4182 passed, 0 failed.
- `npm run lint` — clean.

Closes #1944