### PR TITLE
fix: update stale .js usage comments and husky cli.js fallback path (#1975)

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -2,7 +2,7 @@
 npx --no -- commitlint --edit $1
 
 # Append codegraph impact summary if available
-IMPACT=$(codegraph diff-impact --staged --json -T 2>/dev/null || node src/cli.js diff-impact --staged --json -T 2>/dev/null || true)
+IMPACT=$(codegraph diff-impact --staged --json -T 2>/dev/null || node dist/cli.js diff-impact --staged --json -T 2>/dev/null || true)
 if [ -n "$IMPACT" ]; then
   SUMMARY=$(echo "$IMPACT" | node -e "
     let d=''; process.stdin.on('data',c=>d+=c);

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,3 @@
 #!/bin/sh
 npm run lint
-codegraph build 2>/dev/null || node src/cli.js build . 2>/dev/null || true
+codegraph build 2>/dev/null || node dist/cli.js build . 2>/dev/null || true

--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -7,7 +7,7 @@
  * in the native addon only kills the child — the parent survives and collects
  * partial results from whichever engines succeeded.
  *
- * Usage: node scripts/benchmark.js
+ * Usage: node --experimental-strip-types --import ./scripts/ts-resolve-loader.js scripts/benchmark.ts
  */
 
 import fs from 'node:fs';

--- a/scripts/build-wasm.ts
+++ b/scripts/build-wasm.ts
@@ -3,7 +3,7 @@
 /**
  * Build WASM grammar files from tree-sitter grammar packages.
  *
- * Usage: node scripts/build-wasm.js
+ * Usage: node scripts/node-ts.js scripts/build-wasm.ts
  *
  * Requires devDependencies: tree-sitter-cli + grammar packages.
  * Outputs .wasm files into grammars/ (committed to repo).

--- a/scripts/embedding-benchmark.ts
+++ b/scripts/embedding-benchmark.ts
@@ -7,7 +7,7 @@
  * in the ONNX runtime) only kills the child — the parent survives and collects
  * partial results from whichever models succeeded.
  *
- * Usage: node scripts/embedding-benchmark.js > result.json
+ * Usage: node --experimental-strip-types --import ./scripts/ts-resolve-loader.js scripts/embedding-benchmark.ts > result.json
  */
 
 import fs from 'node:fs';

--- a/scripts/incremental-benchmark.ts
+++ b/scripts/incremental-benchmark.ts
@@ -7,7 +7,7 @@
  * in the native addon only kills the child — the parent survives and collects
  * partial results from whichever engines succeeded.
  *
- * Usage: node scripts/incremental-benchmark.js > result.json
+ * Usage: node --experimental-strip-types --import ./scripts/ts-resolve-loader.js scripts/incremental-benchmark.ts > result.json
  */
 
 import fs from 'node:fs';

--- a/scripts/query-benchmark.ts
+++ b/scripts/query-benchmark.ts
@@ -7,7 +7,7 @@
  * in the native addon only kills the child — the parent survives and collects
  * partial results from whichever engines succeeded.
  *
- * Usage: node scripts/query-benchmark.js > result.json
+ * Usage: node --experimental-strip-types --import ./scripts/ts-resolve-loader.js scripts/query-benchmark.ts > result.json
  */
 
 import { execFileSync } from 'node:child_process';


### PR DESCRIPTION
## Summary
- 5 \`scripts/*.ts\` files (benchmark, build-wasm, embedding-benchmark, query-benchmark, incremental-benchmark) still had \`Usage: node scripts/X.js\` header comments from before they were renamed to \`.ts\`. Updated each to the actual current invocation (\`node --experimental-strip-types --import ./scripts/ts-resolve-loader.js scripts/X.ts\`, or \`node scripts/node-ts.js scripts/build-wasm.ts\` for build-wasm specifically, matching its own npm script).
- \`.husky/pre-commit\` and \`.husky/commit-msg\` both fell back to \`node src/cli.js\` when the global \`codegraph\` binary isn't on PATH — \`src/cli.js\` hasn't existed since the source moved to \`src/cli.ts\` (compiled to \`dist/cli.js\`). The \`|| true\` swallowed the failure silently, so on any machine without a global \`codegraph\` install, the pre-commit graph rebuild and commit-msg impact summary silently never ran. Pointed both fallbacks at \`dist/cli.js\`.

## Verification
- Comment-only + shell-hook-only change; nothing in \`src/\`/\`tests/\` (biome's lint scope) touched.
- \`npm run lint\` — clean.
- Manually confirmed \`node dist/cli.js build <path>\` runs correctly (the exact fallback invocation).

Closes #1975