### PR TITLE
docs: correct CLAUDE.md Node version to match package.json (#1976)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,4 +242,4 @@ This repo uses [Greptile](https://greptile.com) for automated PR reviews. After 
 
 ## Node Version
 
-Requires Node >= 22.6.
+Requires Node >= 22.12.0.


### PR DESCRIPTION
## Summary
- CLAUDE.md's Node Version section said \`>=22.6\`, but \`engines.node\` in \`package.json\` was bumped to \`>=22.12.0\` in a later commit without updating CLAUDE.md to match.
- Also found the identical staleness in README.md's Node badge — filed separately as #2190 since #1976 only named CLAUDE.md.

## Verification
- Docs-only, single-line change. No code surface touched.

Closes #1976