### PR TITLE
fix(hooks): point post-git-ops.sh fallback at dist/cli.js, not src/cli.js (#1979)

### DIFF
--- a/.claude/hooks/post-git-ops.sh
+++ b/.claude/hooks/post-git-ops.sh
@@ -44,7 +44,7 @@ if [ -f "$DB_PATH" ]; then
   if command -v codegraph &>/dev/null; then
     codegraph build "$PROJECT_DIR" -d "$DB_PATH" --no-incremental 2>/dev/null && BUILD_OK=1 || true
   else
-    node "${CLAUDE_PROJECT_DIR:-$PROJECT_DIR}/src/cli.js" build "$PROJECT_DIR" -d "$DB_PATH" --no-incremental 2>/dev/null && BUILD_OK=1 || true
+    node "${CLAUDE_PROJECT_DIR:-$PROJECT_DIR}/dist/cli.js" build "$PROJECT_DIR" -d "$DB_PATH" --no-incremental 2>/dev/null && BUILD_OK=1 || true
   fi
   # Update staleness marker only if the full rebuild succeeded
   if [ "$BUILD_OK" -eq 1 ]; then


### PR DESCRIPTION
## Summary
- \`.claude/hooks/post-git-ops.sh\` had the same broken fallback build path already fixed for \`update-graph.sh\` in #1836: \`src/cli.js\` has never existed in this repo (CLI entry point is TypeScript at \`src/cli.ts\`, compiled to \`dist/cli.js\`).
- The \`else\` branch (hit when the \`codegraph\` binary isn't on PATH) silently failed (stderr to \`/dev/null\`), so \`BUILD_OK\` stayed \`0\` and the full rebuild after a rebase/merge/pull never happened for contributors without a global \`codegraph\` install.
- Confirmed no other active hook/script has this same bug pattern remaining (swept all \`src/cli.js\` references repo-wide — the rest are historical dogfood reports, example CLI/MCP transcripts, and ROADMAP/BACKLOG history, not functional fallback paths).

## Verification
- Hook-script-only, single-line fix mirroring #1836's exact change.

Closes #1979