### PR TITLE
fix(skills): recognize Greptile's reaction as convergence, not a stall

### DIFF
--- a/.claude/skills/fixer/SKILL.md
+++ b/.claude/skills/fixer/SKILL.md
@@ -521,15 +521,13 @@ For Greptile's response to a re-trigger to arrive, use the `Monitor` tool to pol
 - a **new** review or comment from `greptile-apps[bot]` posted after the trigger's timestamp (new findings — go address them and re-trigger again), or
 - a **positive reaction** (`+1`, `hooray`, `heart`, `rocket`) from `greptile-apps[bot]` **on the trigger comment itself**, with no follow-up review — this means Greptile examined the fix and has nothing further to flag. Treat it as convergence for this round, not a reason to keep waiting for a review object that isn't coming.
 
+Capture the trigger comment's ID **from the post response itself** when you send it, and reuse that exact ID for the reaction check below. Do not post the trigger separately and then search for "the last `@greptileai` comment" afterward — if another trigger gets posted on the same PR in the meantime (a resumed run, a concurrent session per the Parallel Sessions rules), that search silently drifts to the wrong comment:
+
 ```bash
 mkdir -p .codegraph/fixer
 REPO=$(cat .codegraph/fixer/repo)
 PR=$(cat .codegraph/fixer/current-pr)
-# --paginate with --jq applies the filter per-page, not to the merged result, so 'last'
-# across a multi-page comment list would return one candidate PER PAGE instead of the true
-# global last — fetch raw and slurp instead, matching the pattern used elsewhere in this file.
-TRIGGER_COMMENT_ID=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
-  | jq -s '[.[][] | select(.body | test("^@greptileai\\s*$"))] | last | .id')
+TRIGGER_COMMENT_ID=$(gh api "repos/$REPO/issues/$PR/comments" -f body="@greptileai" --jq '.id')
 gh api "repos/$REPO/issues/comments/$TRIGGER_COMMENT_ID/reactions" \
   --jq '[.[] | select(.user.login == "greptile-apps[bot]" and (.content == "+1" or .content == "hooray" or .content == "heart" or .content == "rocket"))] | length'
 # > 0 with no new review after this comment's timestamp: converged, proceed to the gate evaluation below.

--- a/.claude/skills/fixer/SKILL.md
+++ b/.claude/skills/fixer/SKILL.md
@@ -525,8 +525,11 @@ For Greptile's response to a re-trigger to arrive, use the `Monitor` tool to pol
 mkdir -p .codegraph/fixer
 REPO=$(cat .codegraph/fixer/repo)
 PR=$(cat .codegraph/fixer/current-pr)
-TRIGGER_COMMENT_ID=$(gh api "repos/$REPO/issues/$PR/comments" --paginate --jq \
-  '[.[] | select(.body | test("^@greptileai\\s*$"))] | last | .id')
+# --paginate with --jq applies the filter per-page, not to the merged result, so 'last'
+# across a multi-page comment list would return one candidate PER PAGE instead of the true
+# global last — fetch raw and slurp instead, matching the pattern used elsewhere in this file.
+TRIGGER_COMMENT_ID=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+  | jq -s '[.[][] | select(.body | test("^@greptileai\\s*$"))] | last | .id')
 gh api "repos/$REPO/issues/comments/$TRIGGER_COMMENT_ID/reactions" \
   --jq '[.[] | select(.user.login == "greptile-apps[bot]" and (.content == "+1" or .content == "hooray" or .content == "heart" or .content == "rocket"))] | length'
 # > 0 with no new review after this comment's timestamp: converged, proceed to the gate evaluation below.

--- a/.claude/skills/fixer/SKILL.md
+++ b/.claude/skills/fixer/SKILL.md
@@ -516,7 +516,21 @@ PR=$(cat .codegraph/fixer/current-pr)
 gh pr checks "$PR" --repo "$REPO" --watch --interval 30 || echo "fixer: checks not all green — G5 needs work"
 ```
 
-For Greptile's review to arrive, use the `Monitor` tool to poll the comments endpoint until a `Confidence Score` appears (load it with `ToolSearch` if its schema is not present). Do not use foreground `sleep`.
+For Greptile's response to a re-trigger to arrive, use the `Monitor` tool to poll (load it with `ToolSearch` if its schema is not present). Do not use foreground `sleep`. **Do not poll only for a `Confidence Score` to appear** — Greptile typically posts that score once, in its *initial* summary, and it does not necessarily reappear on later reviews, so that condition can already be trivially satisfied from round 1 while giving no signal about whether a re-trigger has converged. The actual terminal signals after posting `@greptileai` are:
+
+- a **new** review or comment from `greptile-apps[bot]` posted after the trigger's timestamp (new findings — go address them and re-trigger again), or
+- a **positive reaction** (`+1`, `hooray`, `heart`, `rocket`) from `greptile-apps[bot]` **on the trigger comment itself**, with no follow-up review — this means Greptile examined the fix and has nothing further to flag. Treat it as convergence for this round, not a reason to keep waiting for a review object that isn't coming.
+
+```bash
+mkdir -p .codegraph/fixer
+REPO=$(cat .codegraph/fixer/repo)
+PR=$(cat .codegraph/fixer/current-pr)
+TRIGGER_COMMENT_ID=$(gh api "repos/$REPO/issues/$PR/comments" --paginate --jq \
+  '[.[] | select(.body | test("^@greptileai\\s*$"))] | last | .id')
+gh api "repos/$REPO/issues/comments/$TRIGGER_COMMENT_ID/reactions" \
+  --jq '[.[] | select(.user.login == "greptile-apps[bot]" and (.content == "+1" or .content == "hooray" or .content == "heart" or .content == "rocket"))] | length'
+# > 0 with no new review after this comment's timestamp: converged, proceed to the gate evaluation below.
+```
 
 Evaluate the whole gate in one pass:
 

--- a/.claude/skills/sweep/SKILL.md
+++ b/.claude/skills/sweep/SKILL.md
@@ -336,7 +336,15 @@ If all changes were only in response to Greptile feedback, do NOT re-trigger Cla
 
 After re-triggering:
 
-1. Poll for new reviews on an interval — see "Before you start: how to wait." Do not end your turn to wait passively, and don't declare a round "done" from a single check taken right after triggering — Greptile can take 15–30 minutes to respond. **But also check the trigger comment's own reactions on each poll**, using the same reaction check as Step 2g's Step 1 (positive reaction from `greptile-apps[bot]` — `+1`/`hooray`/`heart`/`rocket` — on the `@greptileai` comment you just posted). A positive reaction there with no new review following it means Greptile examined the fix and has nothing further to add — that is a terminal "done" signal for this round on its own; don't keep polling the full 15–30 minutes waiting for a review object that isn't coming.
+1. Poll for new reviews on an interval — see "Before you start: how to wait." Do not end your turn to wait passively, and don't declare a round "done" from a single check taken right after triggering — Greptile can take 15–30 minutes to respond. **But also check the trigger comment's own reactions on each poll** — a positive reaction (`+1`/`hooray`/`heart`/`rocket`) from `greptile-apps[bot]` there, with no new review following it, means Greptile examined the fix and has nothing further to add: a terminal "done" signal for this round on its own, so don't keep polling the full 15–30 minutes waiting for a review object that isn't coming. Look up the trigger comment **by its content**, not "the most recent non-Greptile comment" — if anything else gets posted after your trigger (another user, another agent), that lookup would silently drift to the wrong comment:
+   ```bash
+   # --paginate with --jq applies the filter per-page, not to the merged result — fetch raw
+   # and slurp instead, or a multi-page comment list silently misses the true global last.
+   trigger_id=$(gh api repos/<repo>/issues/<number>/comments --paginate \
+     | jq -s '[.[][] | select(.body | test("^@greptileai\\s*$"))] | last | .id')
+   positive_count=$(gh api repos/<repo>/issues/comments/$trigger_id/reactions \
+     --jq '[.[] | select(.user.login == "greptile-apps[bot]" and (.content == "+1" or .content == "hooray" or .content == "heart" or .content == "rocket"))] | length')
+   ```
 2. Fetch new comments again (repeat Step 2d + 2d.1 — re-mine the summary body too, not just inline comments).
 3. If there are **new** comments from Greptile or Claude, go back to Step 2e and address them, then re-trigger per 2g **only if** the trigger-count cap in 2g hasn't already been hit.
 4. **The 50-trigger cap in Step 2g is the actual stop condition — not a mental "round" count.** If you hit the cap mid-loop, stop re-triggering immediately (you may still reply to outstanding comments), run the mandatory Step 2h.1 final live check, and only then go to 2i with `Status: needs-human-review`.

--- a/.claude/skills/sweep/SKILL.md
+++ b/.claude/skills/sweep/SKILL.md
@@ -336,7 +336,7 @@ If all changes were only in response to Greptile feedback, do NOT re-trigger Cla
 
 After re-triggering:
 
-1. Poll for new reviews on an interval — see "Before you start: how to wait." Do not end your turn to wait passively, and don't declare a round "done" from a single check taken right after triggering — Greptile can take 15–30 minutes to respond.
+1. Poll for new reviews on an interval — see "Before you start: how to wait." Do not end your turn to wait passively, and don't declare a round "done" from a single check taken right after triggering — Greptile can take 15–30 minutes to respond. **But also check the trigger comment's own reactions on each poll**, using the same reaction check as Step 2g's Step 1 (positive reaction from `greptile-apps[bot]` — `+1`/`hooray`/`heart`/`rocket` — on the `@greptileai` comment you just posted). A positive reaction there with no new review following it means Greptile examined the fix and has nothing further to add — that is a terminal "done" signal for this round on its own; don't keep polling the full 15–30 minutes waiting for a review object that isn't coming.
 2. Fetch new comments again (repeat Step 2d + 2d.1 — re-mine the summary body too, not just inline comments).
 3. If there are **new** comments from Greptile or Claude, go back to Step 2e and address them, then re-trigger per 2g **only if** the trigger-count cap in 2g hasn't already been hit.
 4. **The 50-trigger cap in Step 2g is the actual stop condition — not a mental "round" count.** If you hit the cap mid-loop, stop re-triggering immediately (you may still reply to outstanding comments), run the mandatory Step 2h.1 final live check, and only then go to 2i with `Status: needs-human-review`.

--- a/.claude/skills/sweep/SKILL.md
+++ b/.claude/skills/sweep/SKILL.md
@@ -315,11 +315,15 @@ last_reply_id=$(gh api repos/<repo>/issues/<number>/comments --paginate \
 positive_count=$(gh api repos/<repo>/issues/comments/$last_reply_id/reactions \
   --jq '[.[] | select(.user.login == "greptile-apps[bot]" and (.content == "+1" or .content == "hooray" or .content == "heart" or .content == "rocket"))] | length')
 
-# Step 2: If positive reaction exists → skip. Otherwise → re-trigger.
+# Step 2: If positive reaction exists → skip. Otherwise → re-trigger, capturing this
+# trigger's own comment ID directly from the post response — Step 2h's reaction check
+# reuses this exact value rather than searching for "the last @greptileai comment",
+# which would drift to a different trigger if this PR is also being worked by another
+# session or agent (Parallel Sessions) before this round's poll runs.
 if [ "$positive_count" -gt 0 ]; then
   echo "Greptile already reacted positively — skipping re-trigger."
 else
-  gh api repos/<repo>/issues/<number>/comments -f body="@greptileai"
+  trigger_id=$(gh api repos/<repo>/issues/<number>/comments -f body="@greptileai" --jq '.id')
 fi
 ```
 
@@ -336,12 +340,8 @@ If all changes were only in response to Greptile feedback, do NOT re-trigger Cla
 
 After re-triggering:
 
-1. Poll for new reviews on an interval — see "Before you start: how to wait." Do not end your turn to wait passively, and don't declare a round "done" from a single check taken right after triggering — Greptile can take 15–30 minutes to respond. **But also check the trigger comment's own reactions on each poll** — a positive reaction (`+1`/`hooray`/`heart`/`rocket`) from `greptile-apps[bot]` there, with no new review following it, means Greptile examined the fix and has nothing further to add: a terminal "done" signal for this round on its own, so don't keep polling the full 15–30 minutes waiting for a review object that isn't coming. Look up the trigger comment **by its content**, not "the most recent non-Greptile comment" — if anything else gets posted after your trigger (another user, another agent), that lookup would silently drift to the wrong comment:
+1. Poll for new reviews on an interval — see "Before you start: how to wait." Do not end your turn to wait passively, and don't declare a round "done" from a single check taken right after triggering — Greptile can take 15–30 minutes to respond. **But also check the trigger comment's own reactions on each poll**, reusing the `$trigger_id` you captured in Step 2g when you posted it — a positive reaction (`+1`/`hooray`/`heart`/`rocket`) from `greptile-apps[bot]` there, with no new review following it, means Greptile examined the fix and has nothing further to add: a terminal "done" signal for this round on its own, so don't keep polling the full 15–30 minutes waiting for a review object that isn't coming:
    ```bash
-   # --paginate with --jq applies the filter per-page, not to the merged result — fetch raw
-   # and slurp instead, or a multi-page comment list silently misses the true global last.
-   trigger_id=$(gh api repos/<repo>/issues/<number>/comments --paginate \
-     | jq -s '[.[][] | select(.body | test("^@greptileai\\s*$"))] | last | .id')
    positive_count=$(gh api repos/<repo>/issues/comments/$trigger_id/reactions \
      --jq '[.[] | select(.user.login == "greptile-apps[bot]" and (.content == "+1" or .content == "hooray" or .content == "heart" or .content == "rocket"))] | length')
    ```


### PR DESCRIPTION
## Summary
- Both `/fixer` (Phase 2f) and `/sweep` (Step 2h) told the agent to wait for Greptile's response after posting an `@greptileai` re-trigger, but neither had a way to recognize that a positive reaction (`+1`/`hooray`/`heart`/`rocket`) from `greptile-apps[bot]` on the trigger comment itself — with no follow-up review — means Greptile examined the fix and has nothing further to flag.
- `/fixer` Phase 2f's G1 instructions also told the agent to poll "until a `Confidence Score` appears," but Greptile typically posts that score once, in its initial summary — it doesn't necessarily reappear on later reviews, so that condition can already be trivially satisfied from round 1 while giving no signal about whether a *re-trigger* actually converged.
- Observed live on PR #2193 (issue #1984): after fixing Greptile's round-2 finding and re-triggering, the agent waited over 4 hours re-arming a Monitor tool and even re-triggering a second time, because it kept waiting for a brand-new review object that was never coming — Greptile had already responded within ~2 minutes both times via a 👍 reaction on the trigger comment.
- Added explicit reaction-checking guidance (mirroring the existing pre-trigger check already in `/sweep`) to both skills' post-trigger wait logic, plus a copy-pasteable `gh api` snippet in `/fixer` so future runs check reactions directly instead of inventing an ad hoc "wait for a new review" polling loop.

## Verification
- Both are markdown skill-instruction files with no associated test suite (confirmed no test references `SKILL.md`).
- `npm run lint` — clean.

Closes #2194