### PR TITLE
fix(complexity): add cognitive/cyclomatic/Halstead support for CUDA (#1923)

### DIFF
--- a/crates/codegraph-core/src/ast_analysis/complexity.rs
+++ b/crates/codegraph-core/src/ast_analysis/complexity.rs
@@ -361,6 +361,12 @@ pub static C_RULES: LangRules = LangRules {
 
 // Mirrors C_RULES: tree-sitter-cpp's if_statement uses the same else_clause
 // wrapper (Pattern A), confirmed by parsing the same if/else-if/else shape.
+//
+// CUDA (see `lang_rules` below) reuses this struct as-is: tree-sitter-cuda is
+// a C++-superset grammar (only adding qualifier keywords and kernel-launch
+// syntax), and parsing sample CUDA control flow confirms identical
+// if_statement/else_clause/for_statement/while_statement/switch_statement/
+// binary_expression node kinds to plain C++.
 pub static CPP_RULES: LangRules = LangRules {
     branch_nodes: &["if_statement", "else_clause", "for_statement", "for_range_loop", "while_statement", "do_statement", "case_statement", "conditional_expression", "catch_clause"],
     case_nodes: &["case_statement"],
@@ -491,7 +497,7 @@ pub fn lang_rules(lang_id: &str) -> Option<&'static LangRules> {
         "ruby" => Some(&RUBY_RULES),
         "php" => Some(&PHP_RULES),
         "c" => Some(&C_RULES),
-        "cpp" => Some(&CPP_RULES),
+        "cpp" | "cuda" => Some(&CPP_RULES),
         "kotlin" => Some(&KOTLIN_RULES),
         "swift" => Some(&SWIFT_RULES),
         "scala" => Some(&SCALA_RULES),
@@ -1115,7 +1121,7 @@ pub fn halstead_rules(lang_id: &str) -> Option<&'static HalsteadRules> {
         "ruby" => Some(&RUBY_HALSTEAD),
         "php" => Some(&PHP_HALSTEAD),
         "c" => Some(&C_HALSTEAD),
-        "cpp" => Some(&CPP_HALSTEAD),
+        "cpp" | "cuda" => Some(&CPP_HALSTEAD),
         "kotlin" => Some(&KOTLIN_HALSTEAD),
         "swift" => Some(&SWIFT_HALSTEAD),
         "scala" => Some(&SCALA_HALSTEAD),
@@ -1133,7 +1139,7 @@ pub fn comment_prefixes(lang_id: &str) -> &'static [&'static str] {
         }
         "python" | "ruby" => &["#"],
         "php" => &["//", "#", "/*", "*", "*/"],
-        "c" | "cpp" => &["//", "/*"],
+        "c" | "cpp" | "cuda" => &["//", "/*"],
         "kotlin" => &["//", "/*"],
         "swift" => &["//", "/*"],
         "scala" => &["//", "/*"],
@@ -1875,6 +1881,46 @@ mod tests {
         assert_eq!(m.cognitive, 1);
         assert_eq!(m.cyclomatic, 2);
         assert_eq!(m.max_nesting, 1);
+    }
+
+    // ─── CUDA tests (issue #1923) ────────────────────────────────────────────
+    //
+    // tree-sitter-cuda is a C++-superset grammar (only adding qualifier
+    // keywords like __global__/__device__ and kernel-launch syntax) —
+    // confirmed by parsing sample CUDA control flow that its if_statement/
+    // else_clause/for_statement/while_statement/switch_statement/
+    // binary_expression node kinds are identical to plain C++, so CUDA
+    // reuses CPP_RULES/CPP_HALSTEAD as-is.
+
+    fn compute_cuda(code: &str) -> ComplexityMetrics {
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_cuda::LANGUAGE.into())
+            .unwrap();
+        let tree = parser.parse(code.as_bytes(), None).unwrap();
+        let root = tree.root_node();
+        let func = find_first_function(&root, &CPP_RULES).expect("no function found");
+        compute_function_complexity(&func, &CPP_RULES)
+    }
+
+    #[test]
+    fn cuda_global_kernel_if_elseif_else() {
+        // The __global__ qualifier is a leading anonymous token on
+        // function_definition and does not disrupt function-body detection.
+        let m = compute_cuda(
+            "__global__ void classify(int *a) {\n  if (a[0] > 0) {\n    a[0] = 1;\n  } else if (a[0] < 0) {\n    a[0] = -1;\n  } else {\n    a[0] = 0;\n  }\n}",
+        );
+        assert_eq!(m.cognitive, 3);
+        assert_eq!(m.cyclomatic, 3);
+        assert_eq!(m.max_nesting, 1);
+    }
+
+    #[test]
+    fn cuda_for_loop_with_logical_operator() {
+        let m = compute_cuda(
+            "__global__ void kernel(int *a, int n) {\n  for (int i = 0; i < n && a[i] > 0; i++) {\n    a[i]++;\n  }\n}",
+        );
+        assert_eq!(m.cyclomatic, 3);
     }
 
     // ─── Kotlin tests (issue #1923) ─────────────────────────────────────────

--- a/src/ast-analysis/metrics.ts
+++ b/src/ast-analysis/metrics.ts
@@ -60,7 +60,7 @@ export function computeHalsteadDerived(
 
 const C_STYLE_PREFIXES = ['//', '/*', '*', '*/'];
 
-// c/cpp/kotlin/swift/scala intentionally mirror the native `comment_prefixes()`
+// c/cpp/cuda/kotlin/swift/scala intentionally mirror the native `comment_prefixes()`
 // 2-entry list (`//`, `/*`) rather than the 4-entry C_STYLE_PREFIXES used by
 // javascript/go/rust/java/csharp — see native `comment_prefixes()` in
 // crates/codegraph-core/src/ast_analysis/complexity.rs for the source of truth
@@ -81,6 +81,7 @@ const COMMENT_PREFIXES = new Map<string, string[]>([
   ['php', ['//', '#', '/*', '*', '*/']],
   ['c', C_LIKE_PREFIXES],
   ['cpp', C_LIKE_PREFIXES],
+  ['cuda', C_LIKE_PREFIXES],
   ['kotlin', C_LIKE_PREFIXES],
   ['swift', C_LIKE_PREFIXES],
   ['scala', C_LIKE_PREFIXES],

--- a/src/ast-analysis/rules/index.ts
+++ b/src/ast-analysis/rules/index.ts
@@ -33,6 +33,10 @@ export const COMPLEXITY_RULES: Map<string, ComplexityRules> = new Map([
   ['php', php.complexity],
   ['c', c.complexity],
   ['cpp', c.complexityCpp],
+  // CUDA is a C++ superset (see AST_TYPE_MAPS/DATAFLOW_RULES above) — its
+  // if/else/for/while/switch/logical-operator node kinds are byte-identical
+  // to C++'s, confirmed by parsing sample CUDA source with tree-sitter-cuda.
+  ['cuda', c.complexityCpp],
   ['kotlin', b2.complexityKotlin],
   ['swift', b2.complexitySwift],
   ['scala', b2.complexityScala],
@@ -55,6 +59,7 @@ export const HALSTEAD_RULES: Map<string, HalsteadRules> = new Map([
   ['php', php.halstead],
   ['c', c.halstead],
   ['cpp', c.halsteadCpp],
+  ['cuda', c.halsteadCpp],
   ['kotlin', b2.halsteadKotlin],
   ['swift', b2.halsteadSwift],
   ['scala', b2.halsteadScala],

--- a/tests/unit/complexity.test.ts
+++ b/tests/unit/complexity.test.ts
@@ -1142,6 +1142,41 @@ describe('C++ complexity', () => {
   });
 });
 
+// ─── CUDA (#1923) ─────────────────────────────────────────────────────────
+//
+// tree-sitter-cuda is a C++-superset grammar (only adding qualifier keywords
+// like __global__/__device__ and kernel-launch syntax) — confirmed by
+// parsing sample CUDA control flow that its if_statement/else_clause/
+// for_statement/while_statement/switch_statement/binary_expression node
+// kinds are identical to plain C++, so CUDA reuses complexityCpp/halsteadCpp
+// as-is rather than a separate rule set.
+
+describe('CUDA complexity', () => {
+  const { analyze, halstead } = makeHelpers('cuda', sharedParsers());
+
+  it('__global__ kernel with if/else-if/else chain', () => {
+    // The __global__ qualifier is a leading anonymous token on
+    // function_definition and does not disrupt function-body detection.
+    const r = analyze(
+      '__global__ void classify(int *a) {\n  if (a[0] > 0) {\n    a[0] = 1;\n  } else if (a[0] < 0) {\n    a[0] = -1;\n  } else {\n    a[0] = 0;\n  }\n}\n',
+    );
+    expect(r).toEqual({ cognitive: 3, cyclomatic: 3, maxNesting: 1 });
+  });
+
+  it('for loop with logical operator condition', () => {
+    const r = analyze(
+      '__global__ void kernel(int *a, int n) {\n  for (int i = 0; i < n && a[i] > 0; i++) {\n    a[i]++;\n  }\n}\n',
+    );
+    expect(r.cyclomatic).toBe(3);
+  });
+
+  it('halstead: positive volume', () => {
+    const h = halstead('__device__ int add(int a, int b) {\n  return a + b;\n}\n');
+    expect(h).not.toBeNull();
+    expect(h.volume).toBeGreaterThan(0);
+  });
+});
+
 // ─── Kotlin (#1923) ───────────────────────────────────────────────────────
 
 describe('Kotlin complexity', () => {


### PR DESCRIPTION
## Summary

Adds native + WASM complexity/Halstead support for CUDA, the next mechanical slice of #1923's remaining-language tracking issue.

CUDA's tree-sitter grammar is a strict C++ superset — this is already how the codebase treats it everywhere else (`AST_TYPE_MAPS`, `DATAFLOW_RULES`, the extractor comments in both `src/extractors/cuda.ts` and `crates/codegraph-core/src/extractors/cuda.rs` explicitly say "CUDA is a C++ superset"). Rather than trust that by inference, I parsed sample CUDA control flow directly with `tree-sitter-cuda` (if/else-if/else, for, while, switch/case, `&&`/`||`) and confirmed the node kinds are byte-identical to plain C++: `if_statement`/`else_clause` (Pattern A), `for_statement`, `while_statement`, `switch_statement`/`case_statement`, and `binary_expression` for logical operators. The `__global__`/`__device__` qualifiers are leading anonymous tokens on `function_definition` and don't disrupt function-body detection.

Given that, CUDA reuses `complexityCpp`/`halsteadCpp` (TS) and `CPP_RULES`/`CPP_HALSTEAD` (native) as-is — no new rule set, no grammar-design work.

Changes:
- `src/ast-analysis/rules/index.ts` — wire `cuda` into `COMPLEXITY_RULES`/`HALSTEAD_RULES`
- `src/ast-analysis/metrics.ts` — add `cuda` to the LOC comment-prefix map (same 2-entry `//`/`/*` list as c/cpp/kotlin/swift/scala)
- `crates/codegraph-core/src/ast_analysis/complexity.rs` — add `"cuda"` to `lang_rules()`, `halstead_rules()`, and `comment_prefixes()`, all pointing at the existing `CPP_RULES`/`CPP_HALSTEAD`
- Tests: new `CUDA complexity` describe block in `tests/unit/complexity.test.ts` (TS) and `cuda_global_kernel_if_elseif_else`/`cuda_for_loop_with_logical_operator` in the native `complexity.rs` test module

## Verification

- Direct engine-parity check: `codegraph complexity --file kernel.cu --health -T --json --engine native` vs `--engine wasm` on a real `__global__`/`__device__` fixture — byte-identical JSON output for both functions (cognitive/cyclomatic/maxNesting/Halstead/MI all match)
- Before this change, CUDA had no `lang_rules`/`COMPLEXITY_RULES` entry on either engine, so `codegraph complexity` silently returned `functions: []` for `.cu`/`.cuh` files — same root-cause shape as the rest of #1923
- `cargo test --release` (crates/codegraph-core): 669 passed, including 2 new CUDA tests
- `npm test`: 260 files, 4197 passed, 30 skipped, 2 todo, 0 failed
- `npm run lint`: clean

## Scope note

#1923 tracks 18 remaining languages (after this PR: 17) and stays open per the same convention `#2059` established (that PR used `Refs #1923` rather than closing it, since it's an ongoing multi-PR epic, not a single fixable bug). This PR does the same — CUDA is one more language done, not the whole issue resolved. Several of the remaining languages (Haskell, OCaml, F#, Clojure, Erlang, Gleam) are functional/pattern-matching languages that need real design work for what counts as a "branch," not just a mechanical port like this one.

Also filed #2201 (unrelated `Cargo.lock`/`Cargo.toml` version drift noticed incidentally while building the native addon locally — not fixed here since it's out of scope for this issue).

Refs #1923