### PR TITLE
fix(db): add missing index on dataflow.call_edge_id (#1948)

### DIFF
--- a/crates/codegraph-core/src/db/connection.rs
+++ b/crates/codegraph-core/src/db/connection.rs
@@ -362,6 +362,17 @@ const MIGRATIONS: &[Migration] = &[
       ALTER TABLE deleted_export_advisories ADD COLUMN consumer_kind TEXT;
     "#,
     },
+    Migration {
+        // dataflow.call_edge_id (added in v18, `REFERENCES edges(id)`) was never
+        // given its own index — every DELETE FROM edges pays an O(dataflow-rows)
+        // scan under better-sqlite3, which defaults `PRAGMA foreign_keys = ON`
+        // (this native/rusqlite connection never sets that pragma, so native
+        // never paid this cost — WASM-only exposure, see issue #1948).
+        version: 23,
+        up: r#"
+      CREATE INDEX IF NOT EXISTS idx_dataflow_call_edge ON dataflow(call_edge_id);
+    "#,
+    },
 ];
 
 // ── napi types ──────────────────────────────────────────────────────────

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -354,6 +354,23 @@ export const MIGRATIONS: Migration[] = [
       ALTER TABLE deleted_export_advisories ADD COLUMN consumer_kind TEXT;
     `,
   },
+  {
+    // dataflow.call_edge_id (added in v18, `REFERENCES edges(id)`) was never
+    // given its own index — every DELETE FROM edges pays an O(dataflow-rows)
+    // scan under better-sqlite3, which defaults `PRAGMA foreign_keys = ON`
+    // (rusqlite/native never sets this pragma, so native never paid this
+    // cost — this is WASM-only exposure, matching issue #1948's report).
+    // Confirmed via EXPLAIN QUERY PLAN: without this index, deleting a
+    // single file's edges triggers `SCAN dataflow` for both the explicit
+    // `dataflowByCallEdge` cleanup query (build-stmts.ts) and SQLite's own
+    // automatic FK-constraint check; with it, both become an indexed SEARCH.
+    // Measured on this repo's own ~19.8K-node/~41.8K-edge graph: a 1-file
+    // incremental purge dropped from 62ms to 1.47ms (97.6% reduction).
+    version: 23,
+    up: `
+      CREATE INDEX IF NOT EXISTS idx_dataflow_call_edge ON dataflow(call_edge_id);
+    `,
+  },
 ];
 
 interface PragmaColumnInfo {


### PR DESCRIPTION
## Summary

Root-causes and fixes the WASM engine's `detectMs` regression reported in #1948.

`dataflow.call_edge_id` (added in migration v18, `REFERENCES edges(id)`) was never given its own index. Every `DELETE FROM edges` forces SQLite to scan the entire `dataflow` table to enforce the foreign-key constraint, and the explicit `dataflowByCallEdge` cleanup query in `build-stmts.ts` scans it too. Confirmed via `EXPLAIN QUERY PLAN`: without the index both queries show `SCAN dataflow`; with it, both become an indexed `SEARCH`.

**Why WASM-only:** `better-sqlite3` defaults `PRAGMA foreign_keys = ON`. The native/rusqlite connection (`crates/codegraph-core/src/db/connection.rs`) never sets this pragma at all, so it stays at SQLite's true default of OFF — native never pays the FK-check-scan cost. This exactly matches #1948's own report that native's `detectMs` stayed flat (2-3ms) while WASM regressed.

## Investigation note

A previous `/fixer` pass's comment on #1948 hypothesized the cause was uncached `db.prepare()` calls inside `clearDeletedExportAdvisories`/`recordDeletedExportAdvisories`. I measured that path directly (microbenchmark against both an in-memory DB and a real WAL-mode file-backed DB) and found it costs ~0.02-0.3ms per call — nowhere near the ~57ms reported gap. That hypothesis doesn't hold up quantitatively. Instrumenting the real `detectChanges` pipeline end-to-end on this repo's own build pointed to `purgeStaleReverseDeps` → `purgeFilesFromGraph` → the FK-check scan as the actual dominant cost (~81ms of ~91ms total on one profiling run).

## Verification

- `EXPLAIN QUERY PLAN` before/after: `DELETE FROM edges ...` and the `dataflowByCallEdge` delete both flip from `SCAN dataflow` to `SEARCH dataflow USING COVERING INDEX idx_dataflow_call_edge`
- Direct before/after benchmark of `purgeFilesData` against this repo's own built graph (~19.8K nodes, ~41.8K edges): **62.01ms → 1.47ms (97.6% reduction)** for a 1-file purge
- End-to-end via the real CLI (`codegraph build --engine wasm`, 1-file touch + incremental rebuild): `purgeStaleReverseDeps` dropped from 62.02ms → 1.79ms, total `handle*Build` from 63.26ms → 2.93ms — combined with `getChangedFiles` (~9ms), overall `detectMs` for a 1-file rebuild now lands well under the pre-regression 3.15.0 baseline of 56ms
- `cargo test --release` (crates/codegraph-core): 669 passed
- `npm test`: 260 files, 4197 passed, 30 skipped, 2 todo, 0 failed
- `npm run lint`: clean
- Migration is mirrored in both engines (`src/db/migrations.ts` v23, `crates/codegraph-core/src/db/connection.rs` v23) and is a plain `CREATE INDEX IF NOT EXISTS`, safe on existing databases

Refs #1948