### PR TITLE
perf(builder): cache prepared statements in technique-backfill chunk loops (#1952)

### DIFF
--- a/src/domain/graph/builder/incremental.ts
+++ b/src/domain/graph/builder/incremental.ts
@@ -12,6 +12,7 @@ import path from 'node:path';
 import { bulkNodeIdsByFile, purgeFileData } from '../../../db/index.js';
 import { PROPAGATION_HOP_PENALTY } from '../../../extractors/javascript.js';
 import { debug, warn } from '../../../infrastructure/logger.js';
+import { getOrCreatePerDbChunkStmt } from '../../../shared/chunked-stmt-cache.js';
 import { normalizePath, TS_NATIVE_CONFIDENCE_FLOOR } from '../../../shared/constants.js';
 import { FLAG_ONLY_DYNAMIC_KINDS, isTypeErasedImportTarget } from '../../../shared/kinds.js';
 import type {
@@ -1184,6 +1185,19 @@ function buildCallEdges(
  * files), not a full-table scan. Chunked to stay within SQLite's
  * SQLITE_LIMIT_VARIABLE_NUMBER (999 on older builds).
  */
+// Chunk-size-keyed statement caches for backfillIncrementalEdgeTechniques'
+// technique/confidence-floor UPDATEs below, scoped per db like the
+// techniqueBackfillStmtCache/confidenceFloorStmtCache pair in
+// stages/build-edges.ts's applyEdgeTechniquesAfterNativeInsert (#1768, #1952).
+const incrementalTechniqueBackfillStmtCache = new WeakMap<
+  BetterSqlite3Database,
+  Map<number, SqliteStatement>
+>();
+const incrementalConfidenceFloorStmtCache = new WeakMap<
+  BetterSqlite3Database,
+  Map<number, SqliteStatement>
+>();
+
 function backfillIncrementalEdgeTechniques(
   db: BetterSqlite3Database,
   touchedFiles: readonly string[],
@@ -1193,20 +1207,30 @@ function backfillIncrementalEdgeTechniques(
   const tx = db.transaction(() => {
     for (let i = 0; i < touchedFiles.length; i += CHUNK_SIZE) {
       const chunk = touchedFiles.slice(i, i + CHUNK_SIZE);
-      const placeholders = chunk.map(() => '?').join(',');
-      db.prepare(
-        `UPDATE edges SET technique = 'ts-native'
-         WHERE kind = 'calls' AND technique IS NULL AND dynamic_kind IS NULL
-           AND source_id IN (SELECT id FROM nodes WHERE file IN (${placeholders}))`,
-      ).run(...chunk);
+      const chunkSize = chunk.length;
+      const techniqueStmt = getOrCreatePerDbChunkStmt(
+        incrementalTechniqueBackfillStmtCache,
+        db,
+        chunkSize,
+        (n) =>
+          `UPDATE edges SET technique = 'ts-native'
+           WHERE kind = 'calls' AND technique IS NULL AND dynamic_kind IS NULL
+             AND source_id IN (SELECT id FROM nodes WHERE file IN (${Array.from({ length: n }, () => '?').join(',')}))`,
+      );
+      techniqueStmt.run(...chunk);
       // Lift resolved ts-native edges below the confidence floor for this
       // chunk, matching the floor lift the full-build native paths apply.
-      db.prepare(
-        `UPDATE edges SET confidence = ?
-         WHERE kind = 'calls' AND technique = 'ts-native'
-           AND confidence > 0 AND confidence < ?
-           AND source_id IN (SELECT id FROM nodes WHERE file IN (${placeholders}))`,
-      ).run(TS_NATIVE_CONFIDENCE_FLOOR, TS_NATIVE_CONFIDENCE_FLOOR, ...chunk);
+      const confidenceStmt = getOrCreatePerDbChunkStmt(
+        incrementalConfidenceFloorStmtCache,
+        db,
+        chunkSize,
+        (n) =>
+          `UPDATE edges SET confidence = ?
+           WHERE kind = 'calls' AND technique = 'ts-native'
+             AND confidence > 0 AND confidence < ?
+             AND source_id IN (SELECT id FROM nodes WHERE file IN (${Array.from({ length: n }, () => '?').join(',')}))`,
+      );
+      confidenceStmt.run(TS_NATIVE_CONFIDENCE_FLOOR, TS_NATIVE_CONFIDENCE_FLOOR, ...chunk);
     }
   });
   tx();

--- a/src/domain/graph/builder/stages/native-orchestrator.ts
+++ b/src/domain/graph/builder/stages/native-orchestrator.ts
@@ -25,6 +25,7 @@ import {
 import { debug, info, warn } from '../../../../infrastructure/logger.js';
 import { loadNative } from '../../../../infrastructure/native.js';
 import { semverCompare } from '../../../../infrastructure/update-check.js';
+import { getOrCreatePerDbChunkStmt } from '../../../../shared/chunked-stmt-cache.js';
 import { normalizePath, TS_NATIVE_CONFIDENCE_FLOOR } from '../../../../shared/constants.js';
 import { toErrorMessage } from '../../../../shared/errors.js';
 import { CODEGRAPH_VERSION } from '../../../../shared/version.js';
@@ -34,6 +35,7 @@ import type {
   DataflowResult,
   Definition,
   ExtractorOutput,
+  SqliteStatement,
 } from '../../../../types.js';
 import {
   classifyNativeDrops,
@@ -2063,20 +2065,29 @@ async function backfillNativeDroppedFiles(
  * Chunked to stay within SQLite's SQLITE_LIMIT_VARIABLE_NUMBER (999 on older
  * builds).
  */
+// Chunk-size-keyed statement cache for findOneHopReverseDepFiles' SELECT below,
+// scoped per db like the technique/confidence-floor caches further down —
+// avoids recompiling the same query on every chunk of a large reverse-dep
+// scan (#1952).
+const oneHopReverseDepStmtCache = new WeakMap<
+  BetterSqlite3Database,
+  Map<number, SqliteStatement<{ file: string }>>
+>();
+
 function findOneHopReverseDepFiles(db: BetterSqlite3Database, files: readonly string[]): string[] {
   const found = new Set<string>();
   const CHUNK_SIZE = 500;
   for (let i = 0; i < files.length; i += CHUNK_SIZE) {
     const chunk = files.slice(i, i + CHUNK_SIZE);
-    const placeholders = chunk.map(() => '?').join(',');
-    const rows = db
-      .prepare(
-        `SELECT DISTINCT n_src.file AS file FROM edges e
+    const chunkSize = chunk.length;
+    const stmt = getOrCreatePerDbChunkStmt(oneHopReverseDepStmtCache, db, chunkSize, (n) => {
+      const placeholders = Array.from({ length: n }, () => '?').join(',');
+      return `SELECT DISTINCT n_src.file AS file FROM edges e
          JOIN nodes n_src ON e.source_id = n_src.id
          JOIN nodes n_tgt ON e.target_id = n_tgt.id
-         WHERE e.kind = 'calls' AND n_tgt.file IN (${placeholders}) AND n_src.kind != 'directory'`,
-      )
-      .all(...chunk) as Array<{ file: string }>;
+         WHERE e.kind = 'calls' AND n_tgt.file IN (${placeholders}) AND n_src.kind != 'directory'`;
+    });
+    const rows = stmt.all(...chunk);
     for (const r of rows) found.add(r.file);
   }
   return [...found];
@@ -2094,6 +2105,19 @@ function findOneHopReverseDepFiles(db: BetterSqlite3Database, files: readonly st
  * their one-hop reverse dependents (#1744) — are updated to avoid overwriting
  * previously-set technique values on unchanged edges.
  */
+// Chunk-size-keyed statement caches for backfillEdgeTechniquesAfterNativeOrchestrator's
+// incremental-path technique/confidence-floor UPDATEs below, scoped per db like the
+// techniqueBackfillStmtCache/confidenceFloorStmtCache pair in
+// stages/build-edges.ts's applyEdgeTechniquesAfterNativeInsert (#1768, #1952).
+const nativeOrchestratorTechniqueBackfillStmtCache = new WeakMap<
+  BetterSqlite3Database,
+  Map<number, SqliteStatement>
+>();
+const nativeOrchestratorConfidenceFloorStmtCache = new WeakMap<
+  BetterSqlite3Database,
+  Map<number, SqliteStatement>
+>();
+
 function backfillEdgeTechniquesAfterNativeOrchestrator(
   db: BetterSqlite3Database,
   isFullBuild: boolean,
@@ -2129,23 +2153,33 @@ function backfillEdgeTechniquesAfterNativeOrchestrator(
   const tx = db.transaction(() => {
     for (let i = 0; i < scopeFiles.length; i += CHUNK_SIZE) {
       const chunk = scopeFiles.slice(i, i + CHUNK_SIZE);
-      const placeholders = chunk.map(() => '?').join(',');
-      db.prepare(
-        `UPDATE edges SET technique = 'ts-native'
-         WHERE kind = 'calls' AND technique IS NULL
-         AND source_id IN (
-           SELECT id FROM nodes WHERE file IN (${placeholders})
-         )`,
-      ).run(...chunk);
-      // Lift resolved ts-native edges below the confidence floor for this chunk.
-      db.prepare(
-        `UPDATE edges SET confidence = ?
-         WHERE kind = 'calls' AND technique = 'ts-native'
-           AND confidence > 0 AND confidence < ?
+      const chunkSize = chunk.length;
+      const techniqueStmt = getOrCreatePerDbChunkStmt(
+        nativeOrchestratorTechniqueBackfillStmtCache,
+        db,
+        chunkSize,
+        (n) =>
+          `UPDATE edges SET technique = 'ts-native'
+           WHERE kind = 'calls' AND technique IS NULL
            AND source_id IN (
-             SELECT id FROM nodes WHERE file IN (${placeholders})
+             SELECT id FROM nodes WHERE file IN (${Array.from({ length: n }, () => '?').join(',')})
            )`,
-      ).run(TS_NATIVE_CONFIDENCE_FLOOR, TS_NATIVE_CONFIDENCE_FLOOR, ...chunk);
+      );
+      techniqueStmt.run(...chunk);
+      // Lift resolved ts-native edges below the confidence floor for this chunk.
+      const confidenceStmt = getOrCreatePerDbChunkStmt(
+        nativeOrchestratorConfidenceFloorStmtCache,
+        db,
+        chunkSize,
+        (n) =>
+          `UPDATE edges SET confidence = ?
+           WHERE kind = 'calls' AND technique = 'ts-native'
+             AND confidence > 0 AND confidence < ?
+             AND source_id IN (
+               SELECT id FROM nodes WHERE file IN (${Array.from({ length: n }, () => '?').join(',')})
+             )`,
+      );
+      confidenceStmt.run(TS_NATIVE_CONFIDENCE_FLOOR, TS_NATIVE_CONFIDENCE_FLOOR, ...chunk);
     }
   });
   tx();


### PR DESCRIPTION
## Summary

Issue #1768/#1767 fixed the re-prepare-per-chunk anti-pattern in `applyEdgeTechniquesAfterNativeInsert` (`stages/build-edges.ts`) using a chunk-size-keyed `WeakMap` statement cache (`getOrCreatePerDbChunkStmt` in `src/shared/chunked-stmt-cache.ts`). That PR explicitly named two sibling functions with the identical pattern as out of scope, filed here per the one-PR-per-concern rule:

- `backfillIncrementalEdgeTechniques` (`incremental.ts`) — same two-statement chunk-of-500 loop
- `backfillEdgeTechniquesAfterNativeOrchestrator` (`stages/native-orchestrator.ts`) — same two-statement chunk loop
- `findOneHopReverseDepFiles` (`stages/native-orchestrator.ts`) — a third chunked loop in the same file, a single re-prepared SELECT per chunk

This PR applies the same fix to all three, reusing the existing `getOrCreatePerDbChunkStmt` helper (not reinventing it) with a dedicated per-function `WeakMap` cache, mirroring the naming and structure of the already-merged `techniqueBackfillStmtCache`/`confidenceFloorStmtCache` pair in `build-edges.ts`.

## Verification

- `npx tsc --noEmit`: clean
- `npm run lint`: clean
- `npm test`: 260 files, 4197 passed, 30 skipped, 2 todo, 0 failed
- Direct smoke test: full native build + touch-one-file incremental rebuild against this repo's own `src/`, confirmed zero `calls` edges with `technique IS NULL` and zero `ts-native` edges below the confidence floor after rebuild — same correctness as before, just fewer redundant `db.prepare()` calls per chunk

No behavior change — this is purely a caching refactor of internal chunk loops, not urgent per the issue but small and low-risk to land.

Closes #1952