### PR TITLE
chore: remove dead maxCyclomatic/maxBlastRadius fields on CheckCliOpts (#1985)

### DIFF
--- a/src/presentation/check.ts
+++ b/src/presentation/check.ts
@@ -13,8 +13,6 @@ interface CheckCliOpts {
   cycles?: string;
   blastRadius?: number;
   depth?: number;
-  maxCyclomatic?: number;
-  maxBlastRadius?: number;
   boundaries?: boolean;
   signatures?: boolean;
   config?: unknown;


### PR DESCRIPTION
## Summary

`CheckCliOpts` in `src/presentation/check.ts` declared `maxCyclomatic?: number` and `maxBlastRadius?: number`, but neither field was ever read anywhere in the file or elsewhere. The real blast-radius predicate uses the existing `blastRadius` field, populated from the actual `--blast-radius <n>` CLI flag. There is no `--max-cyclomatic`/`--max-complexity` predicate wired into `check` at all — `features/check.ts`'s `resolveCheckFlags`/`runPredicates` only implement `cycles`, `blastRadius`, `signatures`, `boundaries`. Confirmed via grep that neither field is referenced anywhere in `src/` or `tests/`.

## Verification

- `npx tsc --noEmit`: clean
- `npm run lint`: clean
- `npm test`: 260 files, 4197 passed, 30 skipped, 2 todo, 0 failed
- `codegraph diff-impact --staged`: no function-level changes (interface-only removal)

Closes #1985