### PR TITLE
fix(incremental): mirror Kotlin-reflection and reflection-keyExpr call fallbacks (#1993)

### DIFF
--- a/src/domain/graph/builder/call-resolver.ts
+++ b/src/domain/graph/builder/call-resolver.ts
@@ -150,6 +150,92 @@ export function resolveDefinePropertyAccessorTarget(
     .filter((n) => n.kind === 'function' || n.kind === 'method');
 }
 
+/** Minimal call shape needed by the reflection fallbacks below. */
+type ReflectionCall = {
+  name: string;
+  receiver?: string | null;
+  dynamicKind?: string | null;
+  keyExpr?: string | null;
+};
+
+/**
+ * Shared by both the full-build (build-edges.ts) and incremental
+ * (incremental.ts) paths: RES-4, Kotlin member callable reference —
+ * `Greeter::greet` emits `{ name: 'greet', receiver: 'Greeter', dynamicKind:
+ * 'reflection' }`. The receiver is the class qualifier (not a typeMap
+ * variable), so the primary resolver would find a same-named top-level
+ * function via `byNameAndFile('greet', relPath)` before the qualified form
+ * is tried. Prefer `Greeter.greet` in the same file first; callers fall
+ * through to the normal resolution path only when this returns nothing.
+ */
+export function resolveKotlinReflectionPreQualified(
+  call: ReflectionCall,
+  relPath: string,
+  lookup: CallNodeLookup,
+): ReadonlyArray<{ id: number; file: string; kind?: string }> {
+  if (
+    call.dynamicKind === 'reflection' &&
+    call.receiver &&
+    !call.keyExpr &&
+    !isModuleScopedLanguage(relPath)
+  ) {
+    return lookup
+      .byNameAndFile(`${call.receiver}.${call.name}`, relPath)
+      .filter((n) => n.kind === 'method' || n.kind === 'function');
+  }
+  return [];
+}
+
+/**
+ * Shared by both the full-build (build-edges.ts) and incremental
+ * (incremental.ts) paths: RES-3, reflection with a literal method name —
+ * JVM `getMethod("name")` / `invokeMethod("name")`. Java/Scala/Groovy
+ * methods are stored as class-qualified names (e.g. `Reflection.greet`), so
+ * `lookup.byNameAndFile('greet', relPath)` finds nothing. When
+ * `dynamicKind === 'reflection'` and `keyExpr` is set (a string-literal
+ * method name was captured), try the qualified form:
+ *   1. `typeMap[receiver]` → resolved type → lookup `resolvedType.keyExpr`
+ *      (type-annotated local).
+ *   2. `callerName`'s class prefix → `CallerClass.keyExpr` (same-class
+ *      sibling, e.g. Groovy `obj`).
+ * Scoped to non-JS/TS files to avoid interfering with the JS reflection path.
+ */
+export function resolveReflectionKeyExprFallback(
+  call: ReflectionCall,
+  callerName: string | null,
+  relPath: string,
+  typeMap: Map<string, unknown>,
+  lookup: CallNodeLookup,
+): Array<{ id: number; file: string; kind?: string }> {
+  if (
+    call.dynamicKind !== 'reflection' ||
+    !call.keyExpr ||
+    !call.receiver ||
+    isModuleScopedLanguage(relPath)
+  ) {
+    return [];
+  }
+  const resolvedType = unwrapTypeEntry(typeMap.get(call.receiver));
+  if (resolvedType) {
+    const qualified = lookup
+      .byNameAndFile(`${resolvedType}.${call.keyExpr}`, relPath)
+      .filter((n) => n.kind === 'method' || n.kind === 'function');
+    if (qualified.length > 0) return qualified;
+  }
+  if (callerName != null) {
+    const lastDot = callerName.lastIndexOf('.');
+    if (lastDot > 0) {
+      const prevDot = callerName.lastIndexOf('.', lastDot - 1);
+      const callerClass = callerName.slice(prevDot + 1, lastDot);
+      const qualified = lookup
+        .byNameAndFile(`${callerClass}.${call.keyExpr}`, relPath)
+        .filter((n) => n.kind === 'method' || n.kind === 'function');
+      if (qualified.length > 0) return qualified;
+    }
+  }
+  return [];
+}
+
 // ── Shared resolution functions ──────────────────────────────────────────
 
 /**

--- a/src/domain/graph/builder/incremental.ts
+++ b/src/domain/graph/builder/incremental.ts
@@ -38,7 +38,9 @@ import {
   resolveCallTargets,
   resolveDefinePropertyAccessorTarget,
   resolveHierarchyTargets,
+  resolveKotlinReflectionPreQualified,
   resolveReceiverEdge,
+  resolveReflectionKeyExprFallback,
   resolveSameClassQualifiedMethod,
 } from './call-resolver.js';
 import {
@@ -754,18 +756,22 @@ function buildIncrementalTypeMap(symbols: ExtractorOutput): Map<string, unknown>
  *   2. Same-class bare-call fallback for non-JS/TS class-scoped languages
  *      (e.g. C# static sibling calls: `IsValidEmail()` inside
  *      `Validators.ValidateUser` resolves to `Validators.IsValidEmail`).
- *   3. Object.defineProperty accessor fallback (this-calls inside getter/setter).
+ *   3. Reflection-keyExpr fallback (JVM `getMethod("name")`/`invokeMethod("name")`).
+ *   4. Object.defineProperty accessor fallback (this-calls inside getter/setter).
  *
- * Mirrors the same-class fallback strategies in `resolveFallbackTargets`
- * (stages/build-edges.ts, full-build path). The Kotlin-reflection
- * pre-qualify and reflection-keyExpr fallbacks are intentionally not
- * mirrored here — that narrower, language-specific gap is tracked
- * separately (#1993), not by this function. The broader points-to/CHA/
- * dynamic-sink gap this comment used to reference is now fixed by
- * `buildCallEdges`/`applyChaDispatchPostPass` below (#1852).
+ * Mirrors `resolveFallbackTargets` (stages/build-edges.ts, full-build path)
+ * in both strategy set and order — including the Kotlin-reflection
+ * pre-qualify fallback, which runs before the primary resolution in
+ * `buildCallEdges` below rather than here, since it must pre-empt (not
+ * follow) resolveCallTargets (#1993).
  */
 function applyCallFallbacks(
-  call: { name: string; receiver?: string | null },
+  call: {
+    name: string;
+    receiver?: string | null;
+    dynamicKind?: string | null;
+    keyExpr?: string | null;
+  },
   callerName: string | null,
   relPath: string,
   typeMap: Map<string, unknown>,
@@ -789,7 +795,12 @@ function applyCallFallbacks(
     if (s2.length > 0) return s2;
   }
 
-  // Strategy 3: Object.defineProperty accessor fallback. Shared with the
+  // Strategy 3: reflection-keyExpr fallback (#1993). Shared with the
+  // full-build path via call-resolver.ts.
+  const s3 = resolveReflectionKeyExprFallback(call, callerName, relPath, typeMap, lookup);
+  if (s3.length > 0) return s3;
+
+  // Strategy 4: Object.defineProperty accessor fallback. Shared with the
   // full-build path (stages/build-edges.ts) via call-resolver.ts so both
   // paths apply the same function/method kind filter (issue #1766).
   if (call.receiver === 'this' && callerName != null && definePropertyReceivers) {
@@ -1056,15 +1067,22 @@ function buildCallEdges(
     if (call.receiver && BUILTIN_RECEIVERS.has(call.receiver)) continue;
 
     const caller = findCaller(lookup, call, symbols.definitions, relPath, fileNodeRow);
-    const { targets: initialTargets, importedFrom } = resolveCallTargets(
-      lookup,
-      call,
-      relPath,
-      importedNames,
-      typeMap,
-      caller.callerName,
-      importedOriginalNames,
-    );
+    // Kotlin-reflection pre-qualify (#1993): must pre-empt resolveCallTargets,
+    // not follow it as a fallback — mirrors resolveFallbackTargets'
+    // preQualifiedTargets check in stages/build-edges.ts.
+    const preQualifiedTargets = resolveKotlinReflectionPreQualified(call, relPath, lookup);
+    const { targets: initialTargets, importedFrom } =
+      preQualifiedTargets.length > 0
+        ? { targets: [...preQualifiedTargets], importedFrom: undefined as string | undefined }
+        : resolveCallTargets(
+            lookup,
+            call,
+            relPath,
+            importedNames,
+            typeMap,
+            caller.callerName,
+            importedOriginalNames,
+          );
 
     let targets = applyCallFallbacks(
       call,

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -36,7 +36,6 @@ import type {
 import { computeConfidence } from '../../resolve.js';
 import type { PointsToMap } from '../../resolver/points-to.js';
 import { buildPointsToMapForFile, resolveViaPointsTo } from '../../resolver/points-to.js';
-import { unwrapTypeEntry } from '../../resolver/strategy.js';
 import { enrichTypeMapWithTsc } from '../../resolver/ts-resolver.js';
 import {
   type CallNodeLookup,
@@ -46,7 +45,9 @@ import {
   resolveCallTargets,
   resolveDefinePropertyAccessorTarget,
   resolveHierarchyTargets,
+  resolveKotlinReflectionPreQualified,
   resolveReceiverEdge,
+  resolveReflectionKeyExprFallback,
   resolveSameClassQualifiedMethod,
 } from '../call-resolver.js';
 import type { ChaContext } from '../cha.js';
@@ -1124,33 +1125,6 @@ function makeContextLookup(ctx: PipelineContext, getNodeIdStmt: NodeIdStmt): Cal
 // ── Per-call resolution helpers ─────────────────────────────────────────
 
 /**
- * RES-4: Kotlin member callable reference — `Greeter::greet` emits
- * { name: 'greet', receiver: 'Greeter', dynamicKind: 'reflection' }.
- * The receiver is the class qualifier (not a typeMap variable), so
- * resolveCallTargets would find a same-named top-level function via
- * byNameAndFile('greet', relPath) before the qualified form is tried.
- * Prefer `Greeter.greet` in the same file first; fall through to the
- * normal path only when no qualified match exists.
- */
-function resolveKotlinReflectionPreQualified(
-  call: Call,
-  relPath: string,
-  lookup: CallNodeLookup,
-): ReadonlyArray<{ id: number; file: string; kind?: string }> {
-  if (
-    call.dynamicKind === 'reflection' &&
-    call.receiver &&
-    !call.keyExpr &&
-    !isModuleScopedLanguage(relPath)
-  ) {
-    return lookup
-      .byNameAndFile(`${call.receiver}.${call.name}`, relPath)
-      .filter((n) => n.kind === 'method' || n.kind === 'function');
-  }
-  return [];
-}
-
-/**
  * Same-class `this.method()` fallback: when the call receiver is `this` and
  * resolveCallTargets found nothing, derive the enclosing class name from the
  * caller (e.g. `Logger.info` → class prefix `Logger`) and retry with the
@@ -1185,51 +1159,6 @@ function resolveSameClassBareCallFallback(
 ): Array<{ id: number; file: string; kind?: string }> {
   if (call.receiver || callerName == null || isModuleScopedLanguage(relPath)) return [];
   return resolveSameClassQualifiedMethod(call.name, callerName, relPath, lookup);
-}
-
-/**
- * RES-3: reflection with literal method name — JVM getMethod("name") / invokeMethod("name").
- * Java/Scala/Groovy methods are stored as class-qualified names (e.g. Reflection.greet),
- * so lookup.byNameAndFile('greet', relPath) finds nothing. When dynamicKind='reflection'
- * and keyExpr is set (a string-literal method name was captured), try the qualified form:
- *   1. typeMap[receiver] → resolvedType → lookup `resolvedType.keyExpr` (type-annotated local)
- *   2. callerName class prefix → `CallerClass.keyExpr` (same-class sibling, e.g. Groovy obj)
- * Scoped to non-JS/TS files to avoid interfering with the JS reflection path.
- */
-function resolveReflectionKeyExprFallback(
-  call: Call,
-  callerName: string | null,
-  relPath: string,
-  typeMap: Map<string, TypeMapEntry | string>,
-  lookup: CallNodeLookup,
-): Array<{ id: number; file: string; kind?: string }> {
-  if (
-    call.dynamicKind !== 'reflection' ||
-    !call.keyExpr ||
-    !call.receiver ||
-    isModuleScopedLanguage(relPath)
-  ) {
-    return [];
-  }
-  const resolvedType = unwrapTypeEntry(typeMap.get(call.receiver));
-  if (resolvedType) {
-    const qualified = lookup
-      .byNameAndFile(`${resolvedType}.${call.keyExpr}`, relPath)
-      .filter((n) => n.kind === 'method' || n.kind === 'function');
-    if (qualified.length > 0) return qualified;
-  }
-  if (callerName != null) {
-    const lastDot = callerName.lastIndexOf('.');
-    if (lastDot > 0) {
-      const prevDot = callerName.lastIndexOf('.', lastDot - 1);
-      const callerClass = callerName.slice(prevDot + 1, lastDot);
-      const qualified = lookup
-        .byNameAndFile(`${callerClass}.${call.keyExpr}`, relPath)
-        .filter((n) => n.kind === 'method' || n.kind === 'function');
-      if (qualified.length > 0) return qualified;
-    }
-  }
-  return [];
 }
 
 /**

--- a/tests/unit/call-resolver.test.ts
+++ b/tests/unit/call-resolver.test.ts
@@ -20,7 +20,9 @@ import {
   resolveByMethodOrGlobal,
   resolveCallTargets,
   resolveDefinePropertyAccessorTarget,
+  resolveKotlinReflectionPreQualified,
   resolveReceiverEdge,
+  resolveReflectionKeyExprFallback,
 } from '../../src/domain/graph/builder/call-resolver.js';
 
 function makeLookup(
@@ -793,5 +795,127 @@ describe('resolveCallTargets — constructor attribution through a renaming barr
       null,
     );
     expect(targets).toEqual([classBaz]);
+  });
+});
+
+describe('resolveKotlinReflectionPreQualified — shared between full-build and incremental paths (#1993)', () => {
+  it('prefers the qualified Class.method over a same-named top-level function', () => {
+    const greeterGreet = { id: 1, file: 'Greeter.kt', kind: 'method' };
+    const lookup = makeReceiverLookup({ 'Greeter.greet:Greeter.kt': [greeterGreet] }, {});
+    const targets = resolveKotlinReflectionPreQualified(
+      { name: 'greet', receiver: 'Greeter', dynamicKind: 'reflection' },
+      'Greeter.kt',
+      lookup,
+    );
+    expect(targets).toEqual([greeterGreet]);
+  });
+
+  it('returns [] for JS/TS files (module-scoped guard)', () => {
+    const fn = { id: 2, file: 'a.ts', kind: 'function' };
+    const lookup = makeReceiverLookup({ 'Greeter.greet:a.ts': [fn] }, {});
+    const targets = resolveKotlinReflectionPreQualified(
+      { name: 'greet', receiver: 'Greeter', dynamicKind: 'reflection' },
+      'a.ts',
+      lookup,
+    );
+    expect(targets).toEqual([]);
+  });
+
+  it('returns [] when keyExpr is set (that case belongs to resolveReflectionKeyExprFallback)', () => {
+    const method = { id: 3, file: 'Greeter.kt', kind: 'method' };
+    const lookup = makeReceiverLookup({ 'Greeter.greet:Greeter.kt': [method] }, {});
+    const targets = resolveKotlinReflectionPreQualified(
+      { name: 'greet', receiver: 'Greeter', dynamicKind: 'reflection', keyExpr: 'greet' },
+      'Greeter.kt',
+      lookup,
+    );
+    expect(targets).toEqual([]);
+  });
+
+  it('returns [] when dynamicKind is not reflection', () => {
+    const method = { id: 4, file: 'Greeter.kt', kind: 'method' };
+    const lookup = makeReceiverLookup({ 'Greeter.greet:Greeter.kt': [method] }, {});
+    const targets = resolveKotlinReflectionPreQualified(
+      { name: 'greet', receiver: 'Greeter' },
+      'Greeter.kt',
+      lookup,
+    );
+    expect(targets).toEqual([]);
+  });
+
+  it('returns [] when no qualified match exists, falling through to normal resolution', () => {
+    const lookup = makeReceiverLookup({}, {});
+    const targets = resolveKotlinReflectionPreQualified(
+      { name: 'greet', receiver: 'Greeter', dynamicKind: 'reflection' },
+      'Greeter.kt',
+      lookup,
+    );
+    expect(targets).toEqual([]);
+  });
+});
+
+describe('resolveReflectionKeyExprFallback — shared between full-build and incremental paths (#1993)', () => {
+  it('resolves via typeMap[receiver] to the qualified Type.keyExpr method', () => {
+    const method = { id: 1, file: 'Reflection.java', kind: 'method' };
+    const lookup = makeReceiverLookup({ 'Registry.greet:Reflection.java': [method] }, {});
+    const targets = resolveReflectionKeyExprFallback(
+      { name: 'invokeMethod', receiver: 'obj', dynamicKind: 'reflection', keyExpr: 'greet' },
+      'Reflection.doWork',
+      'Reflection.java',
+      new Map([['obj', 'Registry']]),
+      lookup,
+    );
+    expect(targets).toEqual([method]);
+  });
+
+  it('falls back to the caller class prefix when the receiver has no typeMap entry', () => {
+    const method = { id: 2, file: 'Reflection.java', kind: 'method' };
+    const lookup = makeReceiverLookup({ 'Reflection.greet:Reflection.java': [method] }, {});
+    const targets = resolveReflectionKeyExprFallback(
+      { name: 'invokeMethod', receiver: 'obj', dynamicKind: 'reflection', keyExpr: 'greet' },
+      'Reflection.doWork',
+      'Reflection.java',
+      new Map(), // no typeMap entry for 'obj'
+      lookup,
+    );
+    expect(targets).toEqual([method]);
+  });
+
+  it('returns [] for JS/TS files (module-scoped guard)', () => {
+    const method = { id: 3, file: 'a.ts', kind: 'method' };
+    const lookup = makeReceiverLookup({ 'Registry.greet:a.ts': [method] }, {});
+    const targets = resolveReflectionKeyExprFallback(
+      { name: 'invokeMethod', receiver: 'obj', dynamicKind: 'reflection', keyExpr: 'greet' },
+      'Caller.doWork',
+      'a.ts',
+      new Map([['obj', 'Registry']]),
+      lookup,
+    );
+    expect(targets).toEqual([]);
+  });
+
+  it('returns [] when keyExpr is not set', () => {
+    const method = { id: 4, file: 'Reflection.java', kind: 'method' };
+    const lookup = makeReceiverLookup({ 'Registry.greet:Reflection.java': [method] }, {});
+    const targets = resolveReflectionKeyExprFallback(
+      { name: 'invokeMethod', receiver: 'obj', dynamicKind: 'reflection' },
+      'Reflection.doWork',
+      'Reflection.java',
+      new Map([['obj', 'Registry']]),
+      lookup,
+    );
+    expect(targets).toEqual([]);
+  });
+
+  it('returns [] when neither typeMap nor caller class prefix resolves', () => {
+    const lookup = makeReceiverLookup({}, {});
+    const targets = resolveReflectionKeyExprFallback(
+      { name: 'invokeMethod', receiver: 'obj', dynamicKind: 'reflection', keyExpr: 'greet' },
+      'Reflection.doWork',
+      'Reflection.java',
+      new Map(),
+      lookup,
+    );
+    expect(targets).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

`incremental.ts`'s single-file watch rebuild path mirrors the same-class `this.method()`, same-class bare-call, and `Object.defineProperty` accessor fallback strategies from the full-build path, but was missing two others:

1. **`resolveKotlinReflectionPreQualified`** — Kotlin member callable references (`Greeter::greet`) emit `{ name: 'greet', receiver: 'Greeter', dynamicKind: 'reflection' }`; the receiver is a class qualifier, not a typeMap variable, so the primary resolver would find an unrelated same-named top-level function before trying the qualified `Greeter.greet` form.
2. **`resolveReflectionKeyExprFallback`** — JVM-family reflection with a literal method name (`getMethod("name")`, `invokeMethod("name")` in Java/Scala/Groovy) needs the qualified `Type.methodName` or `CallerClass.methodName` form, since these languages store methods class-qualified.

A single-file `codegraph watch` rebuild of a Kotlin file using `Class::method` references, or a Java/Scala/Groovy file using reflection with a literal method-name argument, previously failed to resolve those specific call sites — even though a full rebuild of the same source resolved them correctly.

## Approach

Per the issue's own suggested approach — "following the same shared pure resolution logic, adapted insertion pattern used to fix #1852" — moved both functions out of `stages/build-edges.ts` (full-build-only) into `call-resolver.ts` (exported), matching the existing pattern already used for `resolveSameClassQualifiedMethod`/`resolveDefinePropertyAccessorTarget`, which are shared by both paths. `build-edges.ts` now imports them instead of defining local duplicates.

Wired both into `incremental.ts`:
- The Kotlin pre-qualify check runs in `buildCallEdges`, before `resolveCallTargets` — it must pre-empt primary resolution (a same-named top-level function would otherwise win), not follow it as a fallback.
- The reflection-keyExpr fallback slots into `applyCallFallbacks` at the same cascade position the full-build path uses: after the same-class fallbacks, before the `Object.defineProperty` accessor fallback.

## Verification

- `npx tsc --noEmit`: clean
- `npm run lint`: clean
- `npm test`: 260 files, 4207 passed (10 new), 30 skipped, 2 todo, 0 failed
- Added direct unit tests for both functions in `tests/unit/call-resolver.test.ts`, covering: the qualified-match case, the JS/TS module-scoped guard, the keyExpr/dynamicKind guards, and the no-match fall-through — for both functions

Closes #1993