### PR TITLE
fix(native): exclude dynamic-sink edges from ts-native technique backfill (#1995)

### DIFF
--- a/src/domain/graph/builder/stages/native-orchestrator.ts
+++ b/src/domain/graph/builder/stages/native-orchestrator.ts
@@ -2104,6 +2104,13 @@ function findOneHopReverseDepFiles(db: BetterSqlite3Database, files: readonly st
  * correct.  For incremental builds, only changed-file source nodes — plus
  * their one-hop reverse dependents (#1744) — are updated to avoid overwriting
  * previously-set technique values on unchanged edges.
+ *
+ * `AND dynamic_kind IS NULL` excludes flag-only dynamic-call sink edges
+ * (`eval`, `computed-key`, `reflection`, `unresolved-dynamic` — confidence=0,
+ * `dynamic_kind` set) from the backfill (#1995). Those intentionally keep
+ * `technique = NULL` forever, matching the WASM/JS full-build path's own
+ * sink-edge insertion — without this guard, the blanket UPDATE mislabels an
+ * unresolved dynamic call as a resolved direct one.
  */
 // Chunk-size-keyed statement caches for backfillEdgeTechniquesAfterNativeOrchestrator's
 // incremental-path technique/confidence-floor UPDATEs below, scoped per db like the
@@ -2131,7 +2138,7 @@ function backfillEdgeTechniquesAfterNativeOrchestrator(
   }
   if (isFullBuild || !changedFiles) {
     db.prepare(
-      "UPDATE edges SET technique = 'ts-native' WHERE kind = 'calls' AND technique IS NULL",
+      "UPDATE edges SET technique = 'ts-native' WHERE kind = 'calls' AND technique IS NULL AND dynamic_kind IS NULL",
     ).run();
     // Lift resolved ts-native edges below the confidence floor.
     db.prepare(
@@ -2160,7 +2167,7 @@ function backfillEdgeTechniquesAfterNativeOrchestrator(
         chunkSize,
         (n) =>
           `UPDATE edges SET technique = 'ts-native'
-           WHERE kind = 'calls' AND technique IS NULL
+           WHERE kind = 'calls' AND technique IS NULL AND dynamic_kind IS NULL
            AND source_id IN (
              SELECT id FROM nodes WHERE file IN (${Array.from({ length: n }, () => '?').join(',')})
            )`,

--- a/tests/integration/issue-1852-watch-cha-pts-dynamic-sink.test.ts
+++ b/tests/integration/issue-1852-watch-cha-pts-dynamic-sink.test.ts
@@ -342,6 +342,16 @@ function runDynamicSinkScenario(engine: EngineMode): void {
         const reference = readCallEdges(path.join(refDir, '.codegraph', 'graph.db'));
         const incremental = readCallEdges(path.join(tmpDir, '.codegraph', 'graph.db'));
         expect(withoutTechnique(incremental)).toEqual(withoutTechnique(reference));
+
+        // #1995: a from-scratch full build must leave the sink edge's technique
+        // NULL, not backfill it to 'ts-native' — the native orchestrator's
+        // blanket technique backfill previously had no dynamic_kind guard, so
+        // it mislabeled this unresolved dynamic call as a resolved direct one.
+        const sinkEdge = reference.find(
+          (e) => e.src === 'runEval' && e.tgt === 'dynamic.js' && e.dynamicKind === 'eval',
+        );
+        expect(sinkEdge, `Reference edges:\n${JSON.stringify(reference, null, 2)}`).toBeDefined();
+        expect(sinkEdge?.technique).toBeNull();
       } finally {
         fs.rmSync(refDir, { recursive: true, force: true });
       }


### PR DESCRIPTION
## Summary

`backfillEdgeTechniquesAfterNativeOrchestrator` (`src/domain/graph/builder/stages/native-orchestrator.ts`) backfills `technique = 'ts-native'` on every `calls` edge left with `technique IS NULL` after a native-engine build. Both its branches (full-build global UPDATE and incremental changed-files-scoped UPDATE) had no `dynamic_kind IS NULL` guard, so the blanket UPDATE also caught flag-only dynamic-call sink edges (`eval`, `computed-key`, `reflection`, `unresolved-dynamic` — confidence=0.0, target=the file node, `dynamic_kind` set, `technique` intentionally left NULL by design).

The WASM/JS full-build path's own sink-edge insertion always inserts these with `technique = NULL` and relies on `dynamic_kind` alone to mark them. The native orchestrator's separate backfill didn't respect that, so a native full build's dynamic-sink edge looked like a resolved direct call by `technique` alone, contradicted only by its `confidence=0`/`dynamic_kind`.

## Fix

Added `AND dynamic_kind IS NULL` to both UPDATE statements, mirroring the identical guard already present in `backfillIncrementalEdgeTechniques` (`incremental.ts`, from #1852) for the same root cause.

## Verification

- Reproduced the issue's own repro exactly: built an `eval()` fixture with `--engine native --no-incremental`, confirmed the sink edge had `technique='ts-native'` before the fix
- After the fix: the same repro produces `technique=null`, matching the WASM engine's output for the identical fixture
- Extended the existing `tests/integration/issue-1852-watch-cha-pts-dynamic-sink.test.ts` (native engine coverage) with an assertion that a from-scratch full build leaves the sink edge's `technique` NULL
- `npx tsc --noEmit`: clean
- `npm run lint`: clean
- `npm test`: 260 files, 4207 passed, 30 skipped, 2 todo, 0 failed

Closes #1995