### PR TITLE
fix(build-edges): tag super-dispatch distinctly in the WASM/JS inline CHA path (#1996)

### DIFF
--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -1622,7 +1622,12 @@ function emitChaCallEdgesForCall(
         : computeConfidence(relPath, t.file, null) - CHA_DISPATCH_PENALTY;
       if (conf > 0) {
         seenCallEdges.add(edgeKey);
-        allEdgeRows.push([caller.id, t.id, 'calls', conf, 0, 'cha', null]);
+        // Tag super-dispatch edges distinctly, matching buildChaPostPass and
+        // the native-orchestrator path's own this/super handling (#1996) —
+        // super calls are not virtual dispatch, so grouping them under the
+        // generic 'cha' label previously hid that distinction on this path.
+        const technique = call.receiver === 'super' ? 'super-dispatch' : 'cha';
+        allEdgeRows.push([caller.id, t.id, 'calls', conf, 0, technique, null]);
       }
     }
   }

--- a/tests/integration/phase-8.5-cha-dispatch.test.ts
+++ b/tests/integration/phase-8.5-cha-dispatch.test.ts
@@ -39,6 +39,7 @@ interface CallEdgeRow {
   caller_file: string;
   callee_name: string;
   callee_file: string;
+  technique: string | null;
 }
 
 function readCallEdges(dbPath: string): CallEdgeRow[] {
@@ -47,7 +48,7 @@ function readCallEdges(dbPath: string): CallEdgeRow[] {
     return db
       .prepare(
         `SELECT n1.name AS caller_name, n1.file AS caller_file,
-                n2.name AS callee_name, n2.file AS callee_file
+                n2.name AS callee_name, n2.file AS callee_file, e.technique
          FROM edges e
          JOIN nodes n1 ON e.source_id = n1.id
          JOIN nodes n2 ON e.target_id = n2.id
@@ -91,6 +92,13 @@ describe.each(ENGINES)('Phase 8.5 CHA dispatch (%s)', (engine) => {
       edge,
       `Expected dispatch → ConcreteWorker.doWork edge (CHA should expand IWorker dispatch).\nActual edges:\n${JSON.stringify(callEdges, null, 2)}`,
     ).toBeDefined();
+    // #1996: the WASM/JS inline path (emitChaCallEdgesForCall) tags typed-
+    // receiver interface dispatch 'cha'. The native orchestrator's separate
+    // expansion pass still tags the same semantic case 'cha-expanded' — a
+    // known, tracked remaining inconsistency (#1996), not fixed by this
+    // assertion; pinned here so a future alignment fix has a failing test
+    // to flip rather than silently landing unverified.
+    expect(edge?.technique).toBe(engine === 'wasm' ? 'cha' : 'cha-expanded');
   });
 
   it('CHA: emits dispatch → MockWorker.doWork (instantiated implementor)', () => {
@@ -104,6 +112,8 @@ describe.each(ENGINES)('Phase 8.5 CHA dispatch (%s)', (engine) => {
       edge,
       `Expected dispatch → MockWorker.doWork edge (CHA should expand IWorker dispatch).\nActual edges:\n${JSON.stringify(callEdges, null, 2)}`,
     ).toBeDefined();
+    // #1996: see the matching note on the ConcreteWorker.doWork test above.
+    expect(edge?.technique).toBe(engine === 'wasm' ? 'cha' : 'cha-expanded');
   });
 
   // ── RTA filter ─────────────────────────────────────────────────────────
@@ -146,6 +156,10 @@ describe.each(ENGINES)('Phase 8.5 CHA dispatch (%s)', (engine) => {
       edge,
       `Expected Lion.speak → Animal.speak edge (super-dispatch via class hierarchy).\nActual edges:\n${JSON.stringify(callEdges, null, 2)}`,
     ).toBeDefined();
+    // #1996: super-dispatch must be tagged 'super-dispatch', not the generic
+    // 'cha' label typed-receiver interface dispatch uses — both engines
+    // already agree on this label (unlike the CHA-typed-dispatch case above).
+    expect(edge?.technique).toBe('super-dispatch');
   });
 
   it('super-dispatch: does NOT CHA-expand Lion.speak to sibling Tiger.speak', () => {
@@ -174,6 +188,8 @@ describe.each(ENGINES)('Phase 8.5 CHA dispatch (%s)', (engine) => {
       edge,
       `Expected Car.constructor → Vehicle.constructor edge (bare super(...) dispatch via class hierarchy).\nActual edges:\n${JSON.stringify(callEdges, null, 2)}`,
     ).toBeDefined();
+    // #1996: see the matching note on the Lion.speak super-dispatch test above.
+    expect(edge?.technique).toBe('super-dispatch');
   });
 
   // ── transitive multi-level CHA (issue #1311) ───────────────────────────
@@ -201,6 +217,9 @@ describe.each(ENGINES)('Phase 8.5 CHA dispatch (%s)', (engine) => {
         edge,
         `Expected runJob → PrintJob.run edge (transitive CHA through AbstractJob).\nActual edges:\n${JSON.stringify(callEdges, null, 2)}`,
       ).toBeDefined();
+      // #1996: this branch only runs for engine === 'wasm' (native is
+      // it.todo above), so the technique is unconditionally 'cha'.
+      expect(edge?.technique).toBe('cha');
     });
 
     it('CHA transitive: emits runJob → ScanJob.run (3-level hierarchy)', () => {
@@ -214,6 +233,8 @@ describe.each(ENGINES)('Phase 8.5 CHA dispatch (%s)', (engine) => {
         edge,
         `Expected runJob → ScanJob.run edge (transitive CHA through AbstractJob).\nActual edges:\n${JSON.stringify(callEdges, null, 2)}`,
       ).toBeDefined();
+      // #1996: see the matching note on the PrintJob.run test above.
+      expect(edge?.technique).toBe('cha');
     });
   }
 


### PR DESCRIPTION
## Summary

This issue describes three independent `technique`-label inconsistencies for CHA/points-to edges across the WASM inline, native post-pass, and native-orchestrator paths. This PR fixes the first (the one with no correctness risk); the other two need their own follow-up.

### Fixed here: (a) WASM/JS inline CHA path missing the super-dispatch distinction

`emitChaCallEdgesForCall` (`stages/build-edges.ts`, the WASM/JS full-build inline CHA resolution path) tagged every dispatch edge `'cha'` regardless of receiver kind. `buildChaPostPass` (same file, a different integration point) and the native orchestrator's this/super handling both already distinguish `super-dispatch` (not virtual dispatch) from typed-receiver interface dispatch. Added the identical `call.receiver === 'super' ? 'super-dispatch' : 'cha'` check, mirroring `buildChaPostPass` exactly.

Verified against `tests/fixtures/cha-dispatch/` with `--engine wasm`: `Lion.speak -> Animal.speak` and `Car.constructor -> Vehicle.constructor` now correctly get `technique='super-dispatch'`; typed-receiver dispatch (`dispatch -> ConcreteWorker.doWork`/`MockWorker.doWork`) keeps `'cha'`.

### Not fixed here — needs its own follow-up

**(b) Renaming native's `'cha-expanded'` to `'cha'`.** I initially attempted this as a straight string rename (per the issue's own suggestion) but found it breaks a real invariant: `expandChaEdges`'s exclusion filter (`e.technique != 'cha-expanded'`) exists specifically to avoid re-expanding this pass's *own* prior output on a later incremental rebuild, while still treating `'cha'`-tagged this/super-dispatch edges (from `runPostNativeThisDispatch`) as expansion-*eligible input* in the same pass — collapsing both labels to the identical string `'cha'` would make the exclusion filter also exclude the this/super-dispatch edges it's supposed to expand (e.g. the `PostMixin.m → B.m` → sibling-override scenario the code comments describe). Fixing this needs a distinct internal marker (not necessarily the same as the externally-reported label) — a small but real design task, not a mechanical rename.

**(c) Native full-build's own points-to/alias resolution has no technique label at all.** Traced this to the FFI boundary: Rust's `ComputedEdge` struct (`crates/codegraph-core/.../build_edges.rs`) has no `technique` field whatsoever — native never writes `technique` at insert time for *any* edge, resolved via alias or otherwise; it all comes from the later JS-side blanket `'ts-native'` backfill, which has no way to know an edge was points-to-resolved specifically. Giving these edges a distinct `'points-to'` label requires either a new Rust→JS data channel (a list of points-to-specific edge pairs alongside the main edge list) or adding a `technique` field to `ComputedEdge` and threading it through the napi binding — a cross-language interface change, out of scope for a quick fix.

I've left #1996 open (not closing it) so (b) and (c) stay tracked; this PR title/commit uses `Refs #1996` rather than `Closes`.

## Verification

- `npx tsc --noEmit`: clean
- `npm run lint`: clean
- `npm test`: 260 files, 4207 passed, 30 skipped, 2 todo, 0 failed
- Extended `tests/integration/phase-8.5-cha-dispatch.test.ts` with `technique` assertions for both engines — pinning what's now consistent (`super-dispatch`) and explicitly documenting the still-open `cha` vs `cha-expanded` gap (b) as a known, separately-tracked difference rather than silently asserting something untrue