### PR TITLE
fix(native): remove dead same-file suffix-scan fallback from resolveByGlobal (#1999)

### DIFF
--- a/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
@@ -150,7 +150,6 @@ struct DefWithId<'a> {
 struct EdgeContext<'a> {
     nodes_by_name: HashMap<&'a str, Vec<&'a NodeInfo>>,
     nodes_by_name_and_file: HashMap<(&'a str, &'a str), Vec<&'a NodeInfo>>,
-    nodes_by_file: HashMap<&'a str, Vec<&'a NodeInfo>>,
     builtin_set: HashSet<&'a str>,
     receiver_kinds: HashSet<&'a str>,
     /// Property/method names ever invoked via member-call syntax
@@ -167,14 +166,12 @@ impl<'a> EdgeContext<'a> {
     ) -> Self {
         let mut nodes_by_name: HashMap<&str, Vec<&NodeInfo>> = HashMap::new();
         let mut nodes_by_name_and_file: HashMap<(&str, &str), Vec<&NodeInfo>> = HashMap::new();
-        let mut nodes_by_file: HashMap<&str, Vec<&NodeInfo>> = HashMap::new();
         for node in all_nodes {
             nodes_by_name.entry(&node.name).or_default().push(node);
             nodes_by_name_and_file
                 .entry((&node.name, &node.file))
                 .or_default()
                 .push(node);
-            nodes_by_file.entry(&node.file).or_default().push(node);
         }
         let builtin_set: HashSet<&str> = builtin_receivers.iter().map(|s| s.as_str()).collect();
         let receiver_kinds: HashSet<&str> = ["class", "struct", "interface", "type", "module"]
@@ -182,7 +179,6 @@ impl<'a> EdgeContext<'a> {
         Self {
             nodes_by_name,
             nodes_by_name_and_file,
-            nodes_by_file,
             builtin_set,
             receiver_kinds,
             invoked_property_names: collect_invoked_property_names(files),
@@ -1360,30 +1356,16 @@ fn resolve_call_targets_core<'a>(
             }
         }
 
-        // Broader fallback: same-file suffix scan.  Only for this/self/super (not no-receiver
-        // plain calls) to avoid false positives on global function calls inside class methods.
-        // Always restricts to the caller's own class prefix to avoid false edges to unrelated
-        // classes in the same file (e.g. this.area() inside Shape.describe must never yield
-        // Calculator.area, even when Calculator.area is the only method with that name).
-        if call.receiver.is_some() {
-            let suffix = format!(".{}", call.name);
-            if let Some(file_nodes) = ctx.nodes_by_file.get(rel_path) {
-                let same_file_methods: Vec<&NodeInfo> = file_nodes.iter()
-                    .filter(|n| n.kind == "method" && n.name.ends_with(&suffix))
-                    .copied()
-                    .collect();
-                if !same_file_methods.is_empty() {
-                    if let Some(dot_pos) = caller_name.find('.') {
-                        let caller_prefix = format!("{}.", &caller_name[..dot_pos]);
-                        let caller_scoped: Vec<&NodeInfo> = same_file_methods.iter()
-                            .filter(|n| n.name.starts_with(&caller_prefix))
-                            .copied()
-                            .collect();
-                        if !caller_scoped.is_empty() { return caller_scoped; }
-                    }
-                }
-            }
-        }
+        // No equivalent step exists in the WASM/TS engine's resolveByGlobal
+        // (src/domain/graph/resolver/strategy.ts) — removed a native-only
+        // "same-file suffix scan" fallback here (#1999). Verified via a direct
+        // native-vs-native (fallback enabled vs disabled) build comparison
+        // across every tests/benchmarks/resolution/fixtures/<lang> project:
+        // zero edge differences in any of the 34 language fixtures, meaning
+        // steps 1-3 above already find everything real code needs; this tier
+        // never actually fired. Removed rather than ported to keep both
+        // engines' resolveByGlobal cascades identical per this repo's
+        // dual-engine parity requirement.
         return exact; // empty
     }
 


### PR DESCRIPTION
## Summary

The native Rust engine's mirror of `resolveByGlobal` (`crates/codegraph-core/.../build_edges.rs`) had an extra resolution tier — "Broader fallback: same-file suffix scan" — for `this`/`self`/`super` receivers, with no equivalent in the WASM/TS engine (`src/domain/graph/resolver/strategy.ts`'s `resolveByGlobal`). Pre-existing divergence from the native-engine mirroring refactor (commit `f8140671`, PR #1463), unrelated to #1863's `resolveByGlobal` fan-out fix that surfaced it.

## Investigation

Per the issue's own suggested resolution path — port the tier to TS, or determine it's a native-only addition safe to remove — I verified empirically rather than guessing:

- Built every one of the 34 `tests/benchmarks/resolution/fixtures/<lang>` projects with the native engine **twice**: once with the fallback tier active (current `main`), once with it disabled.
- Diffed the resulting `calls`/`receiver` edges for every fixture: **zero differences anywhere.**

This means steps 1-3 of the cascade (`Object.defineProperty` accessor this-dispatch, exact global name lookup, class-scoped exact lookup) already find everything real code in these fixtures needs — the fourth tier never actually fired for any hand-annotated case across 34 languages. Structurally, it's also a plausible bug-masking tier rather than a legitimate need: it extracts the caller's class prefix via the *first* dot in `caller_name` (`caller_name.find('.')`), while step 3 (and TS's own equivalent) correctly use the *last* dot (`rfind`) to get the innermost enclosing class for nested/qualified names — the two would disagree for any deeply-qualified caller name.

Removed the tier entirely (restoring cascade parity with TS) rather than porting it, since porting would add complexity for a fallback with no demonstrated practical benefit and a structurally questionable design. Also removed `nodes_by_file`, the `EdgeContext` field this tier was the sole consumer of — otherwise it would have been dead code emitting a compiler warning.

## Verification

- `cargo test --release` (crates/codegraph-core): 669 passed
- `npm test`: 260 files, 4207 passed, 30 skipped, 2 todo, 0 failed
- `npm run lint`: clean
- `cargo build --release`: no warnings (confirmed `nodes_by_file` removal left no dead code)

Closes #1999