### PR TITLE
fix(leiden): reuse fgetOrZero/igetOrZero to dedupe bounds-check reads

### DIFF
--- a/src/graph/algorithms/leiden/cpm.ts
+++ b/src/graph/algorithms/leiden/cpm.ts
@@ -3,7 +3,7 @@
  * Vendored from ngraph.leiden (MIT) — no external dependencies.
  */
 
-import { fget, iget } from './typed-array-helpers.js';
+import { fget, fgetOrZero, iget } from './typed-array-helpers.js';
 
 /**
  * Minimal view of a partition needed by CPM quality functions.
@@ -50,21 +50,21 @@ export function diffCPM(
         : 0;
     // Self-loop weight appears in both out and in arrays for oldC,
     // making w_old include 2x selfLoop. Correct to match moveNodeToCommunity.
-    selfCorrection = 2 * (fget(g.selfLoop, v) || 0);
+    selfCorrection = 2 * fgetOrZero(g.selfLoop, v);
   } else {
     w_old = part.getNeighborEdgeWeightToCommunity(oldC) || 0;
     w_new = c < g.n ? part.getNeighborEdgeWeightToCommunity(c) || 0 : 0;
   }
   const s_v: number = fget(g.size, v) || 1;
-  const S_old: number = fget(part.communityTotalSize, oldC) || 0;
-  const S_new: number = c < part.communityTotalSize.length ? fget(part.communityTotalSize, c) : 0;
+  const S_old: number = fgetOrZero(part.communityTotalSize, oldC);
+  const S_new: number = fgetOrZero(part.communityTotalSize, c);
   return w_new - w_old + selfCorrection - gamma * s_v * (S_new - S_old + s_v);
 }
 
 export function qualityCPM(part: PartitionView, _g: GraphView, gamma: number = 1.0): number {
   let sum: number = 0;
   for (let c = 0; c < part.communityCount; c++) {
-    const S: number = fget(part.communityTotalSize, c) || 0;
+    const S: number = fgetOrZero(part.communityTotalSize, c);
     sum += fget(part.communityInternalEdgeWeight, c) - (gamma * (S * (S - 1))) / 2;
   }
   return sum;

--- a/src/graph/algorithms/leiden/modularity.ts
+++ b/src/graph/algorithms/leiden/modularity.ts
@@ -3,7 +3,7 @@
  * Vendored from ngraph.leiden (MIT) — no external dependencies.
  */
 
-import { fget, iget } from './typed-array-helpers.js';
+import { fget, fgetOrZero, iget } from './typed-array-helpers.js';
 
 /**
  * Minimal view of a partition needed by modularity quality functions.
@@ -46,8 +46,7 @@ export function diffModularity(
   const m2: number = g.totalWeight;
   const k_v_in_new: number = part.getNeighborEdgeWeightToCommunity(c) || 0;
   const k_v_in_old: number = part.getNeighborEdgeWeightToCommunity(oldC) || 0;
-  const wTot_new: number =
-    c < part.communityTotalStrength.length ? fget(part.communityTotalStrength, c) : 0;
+  const wTot_new: number = fgetOrZero(part.communityTotalStrength, c);
   const wTot_old: number = fget(part.communityTotalStrength, oldC);
   const gain_remove: number = -(k_v_in_old / m2 - (gamma * (k_v * wTot_old)) / (m2 * m2));
   const gain_add: number = k_v_in_new / m2 - (gamma * (k_v * wTot_new)) / (m2 * m2);
@@ -70,17 +69,15 @@ export function diffModularityDirected(
   const w_new_out: number = c < g.n ? part.getOutEdgeWeightToCommunity(c) || 0 : 0;
   const w_old_in: number = part.getInEdgeWeightFromCommunity(oldC) || 0;
   const w_old_out: number = part.getOutEdgeWeightToCommunity(oldC) || 0;
-  const T_new: number =
-    c < part.communityTotalInStrength.length ? fget(part.communityTotalInStrength, c) : 0;
-  const F_new: number =
-    c < part.communityTotalOutStrength.length ? fget(part.communityTotalOutStrength, c) : 0;
+  const T_new: number = fgetOrZero(part.communityTotalInStrength, c);
+  const F_new: number = fgetOrZero(part.communityTotalOutStrength, c);
   const T_old: number = fget(part.communityTotalInStrength, oldC);
   const F_old: number = fget(part.communityTotalOutStrength, oldC);
   // Self-loop correction: the self-loop edge (v->v) appears in both
   // outEdgeWeightToCommunity[oldC] and inEdgeWeightFromCommunity[oldC],
   // making w_old include 2x selfLoop. Since the self-loop moves with the
   // node, add it back to match moveNodeToCommunity's directed accounting.
-  const selfW: number = fget(g.selfLoop, v) || 0;
+  const selfW: number = fgetOrZero(g.selfLoop, v);
   const deltaInternal: number = (w_new_in + w_new_out - w_old_in - w_old_out + 2 * selfW) / m;
   // The full delta(F*T) expansion includes a constant 2*k_out*k_in term that
   // doesn't depend on the target community but does affect the move-vs-stay

--- a/src/graph/algorithms/leiden/partition.ts
+++ b/src/graph/algorithms/leiden/partition.ts
@@ -255,12 +255,10 @@ function applyMoveInternalEdgeWeightDeltaDirected(
   newC: number,
   selfLoopWeight: number,
 ): void {
-  const outToOld: number = fget(s.outEdgeWeightToCommunity, oldC) || 0;
-  const inFromOld: number = fget(s.inEdgeWeightFromCommunity, oldC) || 0;
-  const outToNew: number =
-    newC < s.outEdgeWeightToCommunity.length ? fget(s.outEdgeWeightToCommunity, newC) || 0 : 0;
-  const inFromNew: number =
-    newC < s.inEdgeWeightFromCommunity.length ? fget(s.inEdgeWeightFromCommunity, newC) || 0 : 0;
+  const outToOld: number = fgetOrZero(s.outEdgeWeightToCommunity, oldC);
+  const inFromOld: number = fgetOrZero(s.inEdgeWeightFromCommunity, oldC);
+  const outToNew: number = fgetOrZero(s.outEdgeWeightToCommunity, newC);
+  const inFromNew: number = fgetOrZero(s.inEdgeWeightFromCommunity, newC);
   // outToOld/inFromOld already include the self-loop weight (self-loops are
   // in outEdges/inEdges), so subtract it once to avoid triple-counting.
   s.communityInternalEdgeWeight[oldC] =
@@ -276,8 +274,8 @@ function applyMoveInternalEdgeWeightDeltaUndirected(
   newC: number,
   selfLoopWeight: number,
 ): void {
-  const weightToOld: number = fget(s.neighborEdgeWeightToCommunity, oldC) || 0;
-  const weightToNew: number = fget(s.neighborEdgeWeightToCommunity, newC) || 0;
+  const weightToOld: number = fgetOrZero(s.neighborEdgeWeightToCommunity, oldC);
+  const weightToNew: number = fgetOrZero(s.neighborEdgeWeightToCommunity, newC);
   s.communityInternalEdgeWeight[oldC] =
     fget(s.communityInternalEdgeWeight, oldC) - (2 * weightToOld + selfLoopWeight);
   s.communityInternalEdgeWeight[newC] =


### PR DESCRIPTION
## Summary
Replaces the hand-rolled `fget(a, i) || 0` and `i < a.length ? fget(a, i) : 0` guards in `cpm.ts`, `modularity.ts`, and `partition.ts` with the shared `fgetOrZero`/`igetOrZero` helpers introduced for `makePartition` (#1871), matching the precedent already set by `fget`/`iget`/`u8get`/`taAdd` being shared rather than copy-pasted per file.

Behavior-preserving: typed arrays return `undefined` for an out-of-range index, and `undefined || 0` collapses to the same `0` as the bounds-check ternary guard.

## Test plan
- [x] `npx vitest run tests/graph/algorithms/leiden.test.ts tests/graph/algorithms/leiden-partition.test.ts tests/graph/algorithms/leiden-typed-array-helpers.test.ts tests/graph/algorithms/leiden-native-parity.test.ts tests/integration/communities.test.ts tests/integration/issue-1734-communities-determinism.test.ts` — 60/60 pass
- [x] `npm test` — full suite, 4207/4207 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean

Closes #2003