### PR TITLE
test(docs): verify docs/examples/MCP.md json blocks parse as valid JSON

### DIFF
--- a/docs/examples/MCP.md
+++ b/docs/examples/MCP.md
@@ -903,9 +903,9 @@ Accept a list of targets and return all results in one JSON payload — enables 
 ```json
 {
   "results": [
-    { "target": "buildGraph", "context": { "..." }, "impact": { "..." } },
-    { "target": "openDb", "context": { "..." }, "impact": { "..." } },
-    { "target": "parseFile", "context": { "..." }, "impact": { "..." } }
+    { "target": "buildGraph", "context": "...", "impact": "..." },
+    { "target": "openDb", "context": "...", "impact": "..." },
+    { "target": "parseFile", "context": "...", "impact": "..." }
   ],
   "total": 3,
   "errors": []

--- a/tests/unit/docs-examples-json-validity.test.ts
+++ b/tests/unit/docs-examples-json-validity.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Regression test for issue #2005: docs/examples/MCP.md's fenced ```json
+ * blocks (tool-call arguments and JSON-shaped tool responses) were
+ * hand-transcribed with no automated check that they're even syntactically
+ * valid JSON, which is very likely how they drifted out of sync with the
+ * real MCP tool output in the first place (see #1873).
+ *
+ * This doesn't verify the examples match real tool output (that would
+ * require running the MCP server against a fixture graph — a larger,
+ * separately-tracked effort), only that every ```json block parses. That's
+ * a cheap, mechanical floor: a hand-edited example that regresses to broken
+ * JSON syntax (e.g. an unquoted placeholder like `{ ... }`) fails immediately
+ * instead of drifting silently.
+ */
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = path.join(__dirname, '../..');
+const MCP_DOC_PATH = path.join(REPO_ROOT, 'docs/examples/MCP.md');
+
+/** Extract the content of every ` ```json ` fenced block in a markdown doc. */
+function jsonBlocks(doc: string): string[] {
+  return [...doc.matchAll(/```json\n([\s\S]*?)```/g)].map((match) => match[1]);
+}
+
+describe('docs/examples/MCP.md ```json blocks are valid JSON (#2005)', () => {
+  const doc = readFileSync(MCP_DOC_PATH, 'utf-8');
+  const blocks = jsonBlocks(doc);
+
+  it('finds a non-trivial number of ```json blocks (extraction sanity check)', () => {
+    expect(blocks.length).toBeGreaterThan(40);
+  });
+
+  blocks.forEach((block, i) => {
+    it(`block ${i + 1}/${blocks.length} parses as valid JSON`, () => {
+      expect(() => JSON.parse(block)).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds a regression test that extracts every ` ```json ` fenced block in `docs/examples/MCP.md` and asserts it parses as valid JSON. This is a cheap, mechanical floor against the exact class of drift that let the docs go stale in the first place (#1873) — a hand-transcribed example that regresses to broken JSON syntax now fails immediately instead of drifting silently.

The test caught a real bug on its first run: the `batch_query` response example used an unquoted `{ "..." }` elision placeholder, which is not valid JSON syntax. Fixed to `"context": "...", "impact": "..."`.

`docs/examples/CLI.md` is intentionally out of scope here — its one ` ```json ` block uses a bare `{ ... }` placeholder (illustrative pseudo-JSON, not meant to be literal), and its other examples are plain-text terminal output rather than JSON. Full output-content diffing against real CLI/MCP output (not just JSON-syntax validity, and covering CLI.md too) is a materially larger, separately-tracked effort — filed as #2212.

## Test plan
- [x] `npx vitest run tests/unit/docs-examples-json-validity.test.ts` — 56/56 pass
- [x] `npm test` — full suite, 4263/4263 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean

Closes #2005