### PR TITLE
fix(resolve): resolve Rust crate::/self::/super:: module paths to real files

### DIFF
--- a/crates/codegraph-core/src/domain/graph/builder/stages/import_edges.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/import_edges.rs
@@ -67,6 +67,7 @@ impl ImportEdgeContext {
             import_source,
             &self.root_dir,
             &self.aliases,
+            Some(&self.known_files),
             Some(&self.workspaces),
         )
     }

--- a/crates/codegraph-core/src/domain/graph/resolve.rs
+++ b/crates/codegraph-core/src/domain/graph/resolve.rs
@@ -539,7 +539,10 @@ fn walk_rust_module_segments(
 /// the project's directory tree per Rust's module-file conventions (issue
 /// #2007). Returns `None` (falls through to the bare-specifier fallback)
 /// when `known_files` isn't available or no match is found — e.g. `#[path]`
-/// attribute overrides, which this convention-based resolver doesn't model.
+/// attribute overrides, or a Cargo.toml `[[bin]]`/`[[example]]`/`[[test]]`/
+/// `[[bench]]` section declaring a target at a custom, non-conventional
+/// path (issue #2217), neither of which this convention-based,
+/// known-files-only resolver models.
 fn resolve_rust_use_path(
     from_file: &str,
     import_source: &str,

--- a/crates/codegraph-core/src/domain/graph/resolve.rs
+++ b/crates/codegraph-core/src/domain/graph/resolve.rs
@@ -376,18 +376,52 @@ fn rust_module_dir(file: &str) -> String {
     }
 }
 
-/// Find the crate-root .rs file (main.rs or lib.rs) whose directory is an
-/// ancestor of `from_file`, walking up from `from_file`'s directory and
-/// stopping at `root_dir`. Returns the absolute path, or `None` if no crate
-/// root is found among `known_files` — scoping to the nearest ancestor
-/// crate root (rather than a project-wide search) correctly handles a
-/// Cargo workspace with several crates, each resolving `crate::` relative
-/// to its own root.
+/// Cargo directory names whose direct .rs children are each their own,
+/// independent crate root — a separate binary/example/test/bench target,
+/// never sharing a `crate::` module tree with `src/main.rs`/`src/lib.rs` or
+/// with each other. `foo/main.rs` nested one level inside one of these
+/// (a multi-file binary/example) is already handled by the ordinary
+/// main.rs/lib.rs search below and doesn't need this special case.
+const CARGO_STANDALONE_TARGET_DIRS: [&str; 4] = ["bin", "examples", "tests", "benches"];
+
+/// True if `file` is a standalone Cargo target root — a `.rs` file directly
+/// inside `src/bin/`, `examples/`, `tests/`, or `benches/` (not itself
+/// named main.rs/lib.rs, which the ordinary crate-root search already finds).
+fn is_rust_cargo_target_root(file: &str) -> bool {
+    let path = Path::new(file);
+    let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
+    if stem == "main" || stem == "lib" || stem == "mod" {
+        return false;
+    }
+    let Some(parent) = path.parent() else {
+        return false;
+    };
+    let Some(dir_name) = parent.file_name().and_then(|s| s.to_str()) else {
+        return false;
+    };
+    CARGO_STANDALONE_TARGET_DIRS.contains(&dir_name)
+}
+
+/// Find the crate-root .rs file whose directory is an ancestor of
+/// `from_file`, walking up from `from_file`'s directory and stopping at
+/// `root_dir`. Returns the absolute path, or `None` if no crate root is
+/// found among `known_files` — scoping to the nearest ancestor crate root
+/// (rather than a project-wide search) correctly handles a Cargo workspace
+/// with several crates, each resolving `crate::` relative to its own root.
+///
+/// A standalone Cargo target file (`src/bin/foo.rs`, `examples/foo.rs`,
+/// `tests/foo.rs`, `benches/foo.rs`) is its own crate root regardless of
+/// whatever `main.rs`/`lib.rs` exists elsewhere in the ancestor chain —
+/// each such file compiles as an independent crate, so walking further up
+/// would wrongly attribute its `crate::` paths to an unrelated crate.
 fn find_rust_crate_root(
     from_file: &str,
     root_dir: &str,
     known_files: &HashSet<String>,
 ) -> Option<String> {
+    if is_rust_cargo_target_root(from_file) {
+        return Some(from_file.to_string());
+    }
     let mut dir = Path::new(from_file).parent()?.to_path_buf();
     loop {
         for name in ["main.rs", "lib.rs"] {
@@ -408,8 +442,8 @@ fn find_rust_crate_root(
 }
 
 /// The file representing `file`'s parent module (one level up the module
-/// tree), or `None` if `file` is already a crate root or no parent file is
-/// known among `known_files`.
+/// tree), or `None` if `file` is already a crate root (including a
+/// standalone Cargo target) or no parent file is known among `known_files`.
 fn rust_parent_module_file(
     file: &str,
     root_dir: &str,
@@ -417,7 +451,7 @@ fn rust_parent_module_file(
 ) -> Option<String> {
     let path = Path::new(file);
     let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
-    if stem == "main" || stem == "lib" {
+    if stem == "main" || stem == "lib" || is_rust_cargo_target_root(file) {
         return None;
     }
     let dir = path.parent()?;
@@ -1479,6 +1513,53 @@ mod tests {
             Some(&known),
         );
         assert_eq!(resolved, Some("validator.rs".to_string()));
+    }
+
+    #[test]
+    fn is_rust_cargo_target_root_recognizes_standalone_target_directories() {
+        assert!(is_rust_cargo_target_root("/project/src/bin/tool.rs"));
+        assert!(is_rust_cargo_target_root("/project/examples/demo.rs"));
+        assert!(is_rust_cargo_target_root("/project/tests/integration.rs"));
+        assert!(is_rust_cargo_target_root("/project/benches/bench1.rs"));
+        // main.rs/lib.rs/mod.rs are found by the ordinary search, not this path.
+        assert!(!is_rust_cargo_target_root("/project/src/bin/tool/main.rs"));
+        assert!(!is_rust_cargo_target_root("/project/src/main.rs"));
+        assert!(!is_rust_cargo_target_root("/project/src/lib.rs"));
+        assert!(!is_rust_cargo_target_root("/project/src/foo/mod.rs"));
+        // Not one of the special directory names.
+        assert!(!is_rust_cargo_target_root("/project/src/service.rs"));
+    }
+
+    #[test]
+    fn crate_use_path_resolves_from_a_standalone_bin_target_to_itself() {
+        // src/bin/tool.rs is its own crate root — must NOT walk up and
+        // wrongly attribute crate:: to an unrelated src/main.rs or src/lib.rs
+        // elsewhere in the project.
+        let mut known = HashSet::new();
+        known.insert("src/main.rs".to_string());
+        known.insert("src/bin/tool.rs".to_string());
+        known.insert("src/bin/helper.rs".to_string());
+        let resolved = resolve_rust_use_path(
+            "/project/src/bin/tool.rs",
+            "crate::helper",
+            "/project",
+            Some(&known),
+        );
+        assert_eq!(resolved, Some("src/bin/helper.rs".to_string()));
+    }
+
+    #[test]
+    fn super_use_path_returns_none_from_a_standalone_cargo_target_root() {
+        // A standalone target file has no parent module to walk up to.
+        let mut known = HashSet::new();
+        known.insert("tests/integration.rs".to_string());
+        let resolved = resolve_rust_use_path(
+            "/project/tests/integration.rs",
+            "super::helper",
+            "/project",
+            Some(&known),
+        );
+        assert_eq!(resolved, None);
     }
 
     #[test]

--- a/crates/codegraph-core/src/domain/graph/resolve.rs
+++ b/crates/codegraph-core/src/domain/graph/resolve.rs
@@ -305,11 +305,18 @@ fn is_workspace_resolved(path: &str) -> bool {
 }
 
 /// Resolve a single import path, mirroring `resolveImportPath()` in builder.js.
+///
+/// `known_files` enables Rust `crate::`/`self::`/`super::` module-path
+/// resolution (issue #2007) — without it, those paths fall through to the
+/// unresolved bare-specifier fallback. Callers that already have a project
+/// file list (e.g. `ImportEdgeContext`'s batch-cache-miss fallback) should
+/// pass it; `None` preserves the old behavior for callers that don't.
 pub fn resolve_import_path(
     from_file: &str,
     import_source: &str,
     root_dir: &str,
     aliases: &PathAliases,
+    known_files: Option<&HashSet<String>>,
     workspaces: Option<&HashMap<String, WorkspaceEntry>>,
 ) -> String {
     resolve_import_path_inner(
@@ -317,7 +324,7 @@ pub fn resolve_import_path(
         import_source,
         root_dir,
         aliases,
-        None,
+        known_files,
         workspaces,
     )
 }
@@ -335,14 +342,222 @@ fn relativize_to_root(candidate: &str, root_dir: &str) -> String {
     }
 }
 
-/// Resolve a non-relative (alias, workspace, or bare) import source. Returns
-/// the resolved path or the raw source if nothing matches (bare specifier).
+// ── Rust `crate::`/`self::`/`super::` module-path resolution ────────
+// Mirrors resolve.ts's resolveRustUsePath and its helpers (issue #2007).
+
+/// True if `import_source` is a Rust path-qualified `use` path
+/// (`crate::...`, `self::...`, or `super::...`) — the only import syntax
+/// Rust's module system produces (Rust has no relative-import syntax). No
+/// other supported language emits this exact `::`-delimited
+/// keyword-prefixed shape, so this signal alone is enough to gate
+/// Rust-specific resolution without needing a language/extension parameter
+/// threaded through.
+fn is_rust_qualified_path(import_source: &str) -> bool {
+    import_source == "crate"
+        || import_source.starts_with("crate::")
+        || import_source == "self"
+        || import_source.starts_with("self::")
+        || import_source == "super"
+        || import_source.starts_with("super::")
+}
+
+/// Directory where `file`'s own submodules would live, per Rust convention:
+/// mod.rs/lib.rs/main.rs's submodules live in the same directory as the
+/// file itself; any other foo.rs's submodules live in a sibling foo/
+/// directory.
+fn rust_module_dir(file: &str) -> String {
+    let path = Path::new(file);
+    let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
+    let dir = path.parent().unwrap_or_else(|| Path::new(""));
+    if stem == "mod" || stem == "lib" || stem == "main" {
+        dir.display().to_string()
+    } else {
+        dir.join(stem).display().to_string()
+    }
+}
+
+/// Find the crate-root .rs file (main.rs or lib.rs) whose directory is an
+/// ancestor of `from_file`, walking up from `from_file`'s directory and
+/// stopping at `root_dir`. Returns the absolute path, or `None` if no crate
+/// root is found among `known_files` — scoping to the nearest ancestor
+/// crate root (rather than a project-wide search) correctly handles a
+/// Cargo workspace with several crates, each resolving `crate::` relative
+/// to its own root.
+fn find_rust_crate_root(
+    from_file: &str,
+    root_dir: &str,
+    known_files: &HashSet<String>,
+) -> Option<String> {
+    let mut dir = Path::new(from_file).parent()?.to_path_buf();
+    loop {
+        for name in ["main.rs", "lib.rs"] {
+            let candidate = dir.join(name).display().to_string().replace('\\', "/");
+            if file_exists(&candidate, Some(known_files), root_dir) {
+                return Some(candidate);
+            }
+        }
+        if !dir.starts_with(root_dir) {
+            return None;
+        }
+        let parent = dir.parent()?;
+        if parent == dir {
+            return None;
+        }
+        dir = parent.to_path_buf();
+    }
+}
+
+/// The file representing `file`'s parent module (one level up the module
+/// tree), or `None` if `file` is already a crate root or no parent file is
+/// known among `known_files`.
+fn rust_parent_module_file(
+    file: &str,
+    root_dir: &str,
+    known_files: &HashSet<String>,
+) -> Option<String> {
+    let path = Path::new(file);
+    let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
+    if stem == "main" || stem == "lib" {
+        return None;
+    }
+    let dir = path.parent()?;
+    let search_dir = if stem == "mod" { dir.parent()? } else { dir };
+
+    for candidate in [
+        format!("{}.rs", search_dir.display()).replace('\\', "/"),
+        search_dir
+            .join("mod.rs")
+            .display()
+            .to_string()
+            .replace('\\', "/"),
+    ] {
+        if file_exists(&candidate, Some(known_files), root_dir) {
+            return Some(candidate);
+        }
+    }
+    for name in ["main.rs", "lib.rs"] {
+        let candidate = search_dir
+            .join(name)
+            .display()
+            .to_string()
+            .replace('\\', "/");
+        if file_exists(&candidate, Some(known_files), root_dir) {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// Walk `segments` (module-path components after the crate::/self::/super::
+/// prefix) from `start_dir`, treating each as a submodule file (`seg.rs` or
+/// `seg/mod.rs`) if one exists among `known_files`. The final segment may
+/// instead be a leaf item name (function/type/const) rather than a module —
+/// if it doesn't match a real file, resolution stops one level early and
+/// returns the last successfully resolved module file (mirroring how
+/// `crate::service::build_service` resolves to service.rs even though
+/// build_service itself has no file of its own — the Rust extractor's
+/// single-item `use` shape appends the item name to `source`, while the
+/// braced-list shape doesn't, so this must handle both).
+fn walk_rust_module_segments(
+    start_dir: &str,
+    start_file: &str,
+    segments: &[&str],
+    root_dir: &str,
+    known_files: &HashSet<String>,
+) -> Option<String> {
+    let mut current_dir = PathBuf::from(start_dir);
+    let mut current_file = start_file.to_string();
+
+    for (i, seg) in segments.iter().enumerate() {
+        let file_candidate = current_dir
+            .join(format!("{seg}.rs"))
+            .display()
+            .to_string()
+            .replace('\\', "/");
+        let mod_candidate = current_dir
+            .join(seg)
+            .join("mod.rs")
+            .display()
+            .to_string()
+            .replace('\\', "/");
+
+        if file_exists(&file_candidate, Some(known_files), root_dir) {
+            current_file = file_candidate;
+            current_dir = current_dir.join(seg);
+            continue;
+        }
+        if file_exists(&mod_candidate, Some(known_files), root_dir) {
+            current_file = mod_candidate;
+            current_dir = current_dir.join(seg);
+            continue;
+        }
+        if i == segments.len() - 1 {
+            break;
+        }
+        return None;
+    }
+    Some(current_file)
+}
+
+/// Resolve a Rust `use crate::a::b::c` / `self::a::b` / `super::a` path to
+/// the real file that declares its target module (or, for the trailing
+/// item-name case, the module file that item is declared in), by walking
+/// the project's directory tree per Rust's module-file conventions (issue
+/// #2007). Returns `None` (falls through to the bare-specifier fallback)
+/// when `known_files` isn't available or no match is found — e.g. `#[path]`
+/// attribute overrides, which this convention-based resolver doesn't model.
+fn resolve_rust_use_path(
+    from_file: &str,
+    import_source: &str,
+    root_dir: &str,
+    known_files: Option<&HashSet<String>>,
+) -> Option<String> {
+    let known_files = known_files?;
+    let segments: Vec<&str> = import_source.split("::").collect();
+    if segments.is_empty() {
+        return None;
+    }
+
+    let (start_dir, start_file, rest): (String, String, &[&str]) = match segments[0] {
+        "crate" => {
+            let root_file = find_rust_crate_root(from_file, root_dir, known_files)?;
+            let dir = Path::new(&root_file).parent()?.display().to_string();
+            (dir, root_file, &segments[1..])
+        }
+        "self" => {
+            let dir = rust_module_dir(from_file);
+            (dir, from_file.to_string(), &segments[1..])
+        }
+        "super" => {
+            let mut cur = from_file.to_string();
+            let mut i = 0;
+            while i < segments.len() && segments[i] == "super" {
+                cur = rust_parent_module_file(&cur, root_dir, known_files)?;
+                i += 1;
+            }
+            let dir = rust_module_dir(&cur);
+            (dir, cur, &segments[i..])
+        }
+        _ => return None,
+    };
+
+    let resolved =
+        walk_rust_module_segments(&start_dir, &start_file, rest, root_dir, known_files)?;
+    Some(relativize_to_root(&resolved, root_dir))
+}
+
+/// Resolve a non-relative (alias, Rust module-path, workspace, or bare)
+/// import source. Returns the resolved path or the raw source if nothing
+/// matches (bare specifier).
 ///
 /// Order mirrors `resolveImportPathJS()`: aliases take priority (tsconfig/
-/// jsconfig path mappings), then workspace packages ("workspace packages
-/// take priority over node_modules" — resolve.ts), then the raw specifier is
-/// returned unresolved.
+/// jsconfig path mappings), then Rust `crate::`/`self::`/`super::` paths
+/// (unambiguous keyword-prefixed signal, checked before the npm-oriented
+/// workspace/bare-specifier fallbacks), then workspace packages ("workspace
+/// packages take priority over node_modules" — resolve.ts), then the raw
+/// specifier is returned unresolved.
 fn resolve_non_relative_import(
+    from_file: &str,
     import_source: &str,
     root_dir: &str,
     aliases: &PathAliases,
@@ -351,6 +566,13 @@ fn resolve_non_relative_import(
 ) -> String {
     if let Some(alias_resolved) = resolve_via_alias(import_source, aliases, root_dir, known_files) {
         return relativize_to_root(&alias_resolved, root_dir);
+    }
+    if is_rust_qualified_path(import_source) && from_file.ends_with(".rs") {
+        if let Some(rust_resolved) =
+            resolve_rust_use_path(from_file, import_source, root_dir, known_files)
+        {
+            return rust_resolved;
+        }
     }
     if let Some(workspaces) = workspaces {
         if let Some(ws_resolved) =
@@ -434,6 +656,7 @@ fn resolve_import_path_inner(
 ) -> String {
     if !import_source.starts_with('.') {
         return resolve_non_relative_import(
+            from_file,
             import_source,
             root_dir,
             aliases,
@@ -1052,6 +1275,7 @@ mod tests {
             paths: vec![],
         };
         let resolved = resolve_non_relative_import(
+            "/project/src/main.js",
             "@myorg/lib",
             "/project",
             &aliases,
@@ -1068,8 +1292,14 @@ mod tests {
             base_url: None,
             paths: vec![],
         };
-        let resolved =
-            resolve_non_relative_import("lodash", "/project", &aliases, None, Some(&workspaces));
+        let resolved = resolve_non_relative_import(
+            "/project/src/main.js",
+            "lodash",
+            "/project",
+            &aliases,
+            None,
+            Some(&workspaces),
+        );
         assert_eq!(resolved, "lodash");
     }
 
@@ -1106,6 +1336,7 @@ mod tests {
                 "@myorg/lib",
                 "/project",
                 &aliases,
+                None,
                 Some(&workspaces),
             );
             assert_eq!(resolved, "packages/lib/src/index.js");
@@ -1146,5 +1377,188 @@ mod tests {
             reset_workspace_resolved_paths();
             assert!(!is_workspace_resolved("packages/lib/src/index.js"));
         });
+    }
+
+    // Regression tests for #2007: `crate::`/`self::`/`super::` Rust module
+    // paths previously fell through resolve_non_relative_import's bare
+    // fallback, returning the literal unresolved path string. Fixture
+    // mirrors tests/benchmarks/resolution/fixtures/rust/ (main.rs at the
+    // crate root, mod models/repository/service/validator declared there).
+
+    fn rust_fixture_known_files() -> HashSet<String> {
+        ["main.rs", "models.rs", "repository.rs", "service.rs", "validator.rs"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect()
+    }
+
+    #[test]
+    fn is_rust_qualified_path_recognizes_all_three_prefixes() {
+        assert!(is_rust_qualified_path("crate::service::build_service"));
+        assert!(is_rust_qualified_path("self::helper"));
+        assert!(is_rust_qualified_path("super::validator"));
+        assert!(is_rust_qualified_path("crate"));
+        assert!(!is_rust_qualified_path("./relative"));
+        assert!(!is_rust_qualified_path("lodash"));
+        assert!(!is_rust_qualified_path("std::collections::HashMap"));
+    }
+
+    #[test]
+    fn crate_use_path_resolves_single_item_form_to_declaring_file() {
+        // `use crate::service::build_service;` — source includes the
+        // trailing item name (build_service has no file of its own).
+        let known = rust_fixture_known_files();
+        let resolved = resolve_rust_use_path(
+            "/project/main.rs",
+            "crate::service::build_service",
+            "/project",
+            Some(&known),
+        );
+        assert_eq!(resolved, Some("service.rs".to_string()));
+    }
+
+    #[test]
+    fn crate_use_path_resolves_braced_list_form_to_declaring_file() {
+        // `use crate::models::{create_user, Repository};` — source is the
+        // module path alone, no trailing item name.
+        let known = rust_fixture_known_files();
+        let resolved =
+            resolve_rust_use_path("/project/main.rs", "crate::models", "/project", Some(&known));
+        assert_eq!(resolved, Some("models.rs".to_string()));
+    }
+
+    #[test]
+    fn crate_use_path_resolves_from_a_non_root_file() {
+        // service.rs itself resolves `crate::validator::validate_all`,
+        // proving crate-root lookup doesn't depend on from_file being the
+        // crate root.
+        let known = rust_fixture_known_files();
+        let resolved = resolve_rust_use_path(
+            "/project/service.rs",
+            "crate::validator::validate_all",
+            "/project",
+            Some(&known),
+        );
+        assert_eq!(resolved, Some("validator.rs".to_string()));
+    }
+
+    #[test]
+    fn self_use_path_resolves_sibling_submodule() {
+        let mut known = rust_fixture_known_files();
+        known.insert("service/nested.rs".to_string());
+        let resolved = resolve_rust_use_path(
+            "/project/service.rs",
+            "self::nested",
+            "/project",
+            Some(&known),
+        );
+        assert_eq!(resolved, Some("service/nested.rs".to_string()));
+    }
+
+    #[test]
+    fn super_use_path_resolves_from_nested_submodule_to_sibling() {
+        let mut known = rust_fixture_known_files();
+        known.insert("service/nested.rs".to_string());
+        known.insert("service/helper.rs".to_string());
+        let resolved = resolve_rust_use_path(
+            "/project/service/nested.rs",
+            "super::helper",
+            "/project",
+            Some(&known),
+        );
+        assert_eq!(resolved, Some("service/helper.rs".to_string()));
+    }
+
+    #[test]
+    fn super_use_path_resolves_from_top_level_module_to_crate_root_sibling() {
+        let known = rust_fixture_known_files();
+        let resolved = resolve_rust_use_path(
+            "/project/service.rs",
+            "super::validator",
+            "/project",
+            Some(&known),
+        );
+        assert_eq!(resolved, Some("validator.rs".to_string()));
+    }
+
+    #[test]
+    fn crate_use_path_returns_none_on_dead_end_mid_path() {
+        let known = rust_fixture_known_files();
+        let resolved = resolve_rust_use_path(
+            "/project/main.rs",
+            "crate::nonexistent::foo",
+            "/project",
+            Some(&known),
+        );
+        assert_eq!(resolved, None);
+    }
+
+    #[test]
+    fn crate_use_path_returns_none_without_known_files() {
+        let resolved =
+            resolve_rust_use_path("/project/main.rs", "crate::service::build_service", "/project", None);
+        assert_eq!(resolved, None);
+    }
+
+    #[test]
+    fn resolve_non_relative_import_resolves_rust_crate_path_end_to_end() {
+        let known = rust_fixture_known_files();
+        let aliases = PathAliases {
+            base_url: None,
+            paths: vec![],
+        };
+        let resolved = resolve_non_relative_import(
+            "/project/main.rs",
+            "crate::service::build_service",
+            "/project",
+            &aliases,
+            Some(&known),
+            None,
+        );
+        assert_eq!(resolved, "service.rs");
+    }
+
+    #[test]
+    fn resolve_import_path_resolves_rust_crate_path_via_known_files() {
+        // Regression test for #2007: the public single-import entry point
+        // used to hardcode known_files to None, making Rust crate::/self::/
+        // super:: resolution structurally impossible on this path even when
+        // the caller (e.g. ImportEdgeContext's batch-cache-miss fallback)
+        // has a real known_files set available.
+        let known = rust_fixture_known_files();
+        let aliases = PathAliases {
+            base_url: None,
+            paths: vec![],
+        };
+        let resolved = resolve_import_path(
+            "/project/main.rs",
+            "crate::service::build_service",
+            "/project",
+            &aliases,
+            Some(&known),
+            None,
+        );
+        assert_eq!(resolved, "service.rs");
+    }
+
+    #[test]
+    fn resolve_non_relative_import_does_not_treat_non_rust_files_as_rust_paths() {
+        // A `.ts` file importing a literal string that happens to look like
+        // a Rust path must not be hijacked by the Rust resolver — falls
+        // through to the ordinary bare-specifier fallback.
+        let known = rust_fixture_known_files();
+        let aliases = PathAliases {
+            base_url: None,
+            paths: vec![],
+        };
+        let resolved = resolve_non_relative_import(
+            "/project/main.ts",
+            "crate::service::build_service",
+            "/project",
+            &aliases,
+            Some(&known),
+            None,
+        );
+        assert_eq!(resolved, "crate::service::build_service");
     }
 }

--- a/crates/codegraph-core/src/lib.rs
+++ b/crates/codegraph-core/src/lib.rs
@@ -97,6 +97,10 @@ pub fn parse_files_full(
 /// packages (see `detectWorkspaces()`/`setWorkspaces()` in
 /// `src/infrastructure/config.ts` — the native engine has no workspace
 /// *detection* of its own, only resolution against a supplied map; issue #1927).
+///
+/// `known_files` enables Rust `crate::`/`self::`/`super::` module-path
+/// resolution (issue #2007); pass the project's known relative file paths
+/// when available.
 #[napi]
 pub fn resolve_import(
     from_file: String,
@@ -104,17 +108,21 @@ pub fn resolve_import(
     root_dir: String,
     aliases: Option<PathAliases>,
     workspaces: Option<Vec<WorkspacePackage>>,
+    known_files: Option<Vec<String>>,
 ) -> String {
     let aliases = aliases.unwrap_or(PathAliases {
         base_url: None,
         paths: vec![],
     });
+    let known_set =
+        known_files.map(|v| v.into_iter().collect::<std::collections::HashSet<String>>());
     let workspace_map = workspaces.map(|w| domain::graph::resolve::workspaces_from_packages(&w));
     domain::graph::resolve::resolve_import_path(
         &from_file,
         &import_source,
         &root_dir,
         &aliases,
+        known_set.as_ref(),
         workspace_map.as_ref(),
     )
 }

--- a/src/domain/graph/builder/stages/resolve-imports.ts
+++ b/src/domain/graph/builder/stages/resolve-imports.ts
@@ -56,7 +56,7 @@ function findBarrelCandidates(
   fromRelPaths: readonly string[],
   firstPass: boolean,
 ): Array<{ file: string }> {
-  const { db, fileSymbols, rootDir, aliases } = ctx;
+  const { db, fileSymbols, rootDir, aliases, allFiles } = ctx;
 
   if (fromRelPaths.length <= ctx.config.build.smallFilesThreshold) {
     const allBarrelFiles = new Set(
@@ -83,7 +83,8 @@ function findBarrelCandidates(
           `${normalizePath(path.join(rootDir, relPath))}|${imp.source}`,
         );
         const target =
-          resolved ?? resolveImportPath(path.join(rootDir, relPath), imp.source, rootDir, aliases);
+          resolved ??
+          resolveImportPath(path.join(rootDir, relPath), imp.source, rootDir, aliases, allFiles);
         if (allBarrelFiles.has(target)) barrels.add(target);
       }
     }
@@ -257,7 +258,7 @@ export function getResolved(ctx: PipelineContext, absFile: string, importSource:
     const hit = ctx.batchResolved.get(key);
     if (hit !== undefined) return hit;
   }
-  return resolveImportPath(absFile, importSource, ctx.rootDir, ctx.aliases);
+  return resolveImportPath(absFile, importSource, ctx.rootDir, ctx.aliases, ctx.allFiles);
 }
 
 export function isBarrelFile(ctx: PipelineContext, relPath: string): boolean {

--- a/src/domain/graph/resolve.ts
+++ b/src/domain/graph/resolve.ts
@@ -464,18 +464,46 @@ function rustModuleDir(file: string): string {
 }
 
 /**
- * Find the crate-root .rs file (main.rs or lib.rs) whose directory is an
- * ancestor of `fromFile`, walking up from fromFile's directory and stopping
- * at `rootDir`. Returns the absolute path, or null if none is found among
+ * Cargo directory names whose direct .rs children are each their own,
+ * independent crate root — a separate binary/example/test/bench target,
+ * never sharing a `crate::` module tree with `src/main.rs`/`src/lib.rs` or
+ * with each other. `foo/main.rs` nested one level inside one of these
+ * (a multi-file binary/example) is already handled by the ordinary
+ * main.rs/lib.rs search below and doesn't need this special case.
+ */
+const CARGO_STANDALONE_TARGET_DIRS = new Set(['bin', 'examples', 'tests', 'benches']);
+
+/**
+ * True if `file` is a standalone Cargo target root — a `.rs` file directly
+ * inside `src/bin/`, `examples/`, `tests/`, or `benches/` (not itself named
+ * main.rs/lib.rs, which the ordinary crate-root search already finds).
+ */
+function isRustCargoTargetRoot(file: string): boolean {
+  const base = path.basename(file, '.rs');
+  if (base === 'main' || base === 'lib' || base === 'mod') return false;
+  return CARGO_STANDALONE_TARGET_DIRS.has(path.basename(path.dirname(file)));
+}
+
+/**
+ * Find the crate-root .rs file whose directory is an ancestor of
+ * `fromFile`, walking up from fromFile's directory and stopping at
+ * `rootDir`. Returns the absolute path, or null if none is found among
  * `knownFiles` — scoping to the nearest ancestor crate root (rather than a
  * project-wide search) correctly handles a Cargo workspace with several
  * crates, each resolving `crate::` relative to its own root.
+ *
+ * A standalone Cargo target file (`src/bin/foo.rs`, `examples/foo.rs`,
+ * `tests/foo.rs`, `benches/foo.rs`) is its own crate root regardless of
+ * whatever `main.rs`/`lib.rs` exists elsewhere in the ancestor chain —
+ * each such file compiles as an independent crate, so walking further up
+ * would wrongly attribute its `crate::` paths to an unrelated crate.
  */
 function findRustCrateRoot(
   fromFile: string,
   rootDir: string,
   knownFiles: Set<string>,
 ): string | null {
+  if (isRustCargoTargetRoot(fromFile)) return fromFile;
   let dir = path.dirname(fromFile);
   for (;;) {
     for (const name of ['main.rs', 'lib.rs']) {
@@ -492,8 +520,8 @@ function findRustCrateRoot(
 
 /**
  * The file representing `file`'s parent module (one level up the module
- * tree), or null if `file` is already a crate root or no parent file is
- * known among `knownFiles`.
+ * tree), or null if `file` is already a crate root (including a standalone
+ * Cargo target) or no parent file is known among `knownFiles`.
  */
 function rustParentModuleFile(
   file: string,
@@ -501,7 +529,7 @@ function rustParentModuleFile(
   knownFiles: Set<string>,
 ): string | null {
   const base = path.basename(file, '.rs');
-  if (base === 'main' || base === 'lib') return null;
+  if (base === 'main' || base === 'lib' || isRustCargoTargetRoot(file)) return null;
   const dir = path.dirname(file);
   const searchDir = base === 'mod' ? path.dirname(dir) : dir;
 

--- a/src/domain/graph/resolve.ts
+++ b/src/domain/graph/resolve.ts
@@ -596,8 +596,10 @@ function walkRustModuleSegments(
  * item-name case, the module file that item is declared in), by walking the
  * project's directory tree per Rust's module-file conventions (issue
  * #2007). Returns null (falls through to the bare-specifier fallback) when
- * no match is found — e.g. `#[path]` attribute overrides, which this
- * convention-based resolver doesn't model.
+ * no match is found — e.g. `#[path]` attribute overrides, or a Cargo.toml
+ * `[[bin]]`/`[[example]]`/`[[test]]`/`[[bench]]` section declaring a target
+ * at a custom, non-conventional path (issue #2217), neither of which this
+ * convention-based, known-files-only resolver models.
  */
 function resolveRustUsePath(
   fromFile: string,

--- a/src/domain/graph/resolve.ts
+++ b/src/domain/graph/resolve.ts
@@ -430,17 +430,224 @@ function resolveViaAlias(
   return null;
 }
 
+// ── Rust `crate::`/`self::`/`super::` module-path resolution ────────
+
+/**
+ * True if `importSource` is a Rust path-qualified `use` path (`crate::...`,
+ * `self::...`, or `super::...`) — the only import syntax Rust's module
+ * system produces (Rust has no relative-import syntax). No other supported
+ * language emits this exact `::`-delimited keyword-prefixed shape, so this
+ * signal alone is enough to gate Rust-specific resolution without needing a
+ * language/extension parameter threaded through resolveImportPathJS.
+ */
+function isRustQualifiedPath(importSource: string): boolean {
+  return (
+    importSource === 'crate' ||
+    importSource.startsWith('crate::') ||
+    importSource === 'self' ||
+    importSource.startsWith('self::') ||
+    importSource === 'super' ||
+    importSource.startsWith('super::')
+  );
+}
+
+/**
+ * Directory where `file`'s own submodules would live, per Rust convention:
+ * mod.rs/lib.rs/main.rs's submodules live in the same directory as the file
+ * itself; any other foo.rs's submodules live in a sibling foo/ directory.
+ */
+function rustModuleDir(file: string): string {
+  const base = path.basename(file, '.rs');
+  const dir = path.dirname(file);
+  if (base === 'mod' || base === 'lib' || base === 'main') return dir;
+  return path.join(dir, base);
+}
+
+/**
+ * Find the crate-root .rs file (main.rs or lib.rs) whose directory is an
+ * ancestor of `fromFile`, walking up from fromFile's directory and stopping
+ * at `rootDir`. Returns the absolute path, or null if none is found among
+ * `knownFiles` — scoping to the nearest ancestor crate root (rather than a
+ * project-wide search) correctly handles a Cargo workspace with several
+ * crates, each resolving `crate::` relative to its own root.
+ */
+function findRustCrateRoot(
+  fromFile: string,
+  rootDir: string,
+  knownFiles: Set<string>,
+): string | null {
+  let dir = path.dirname(fromFile);
+  for (;;) {
+    for (const name of ['main.rs', 'lib.rs']) {
+      const candidate = path.join(dir, name);
+      const rel = normalizePath(path.relative(rootDir, candidate));
+      if (knownFiles.has(rel)) return candidate;
+    }
+    if (!dir.startsWith(rootDir)) return null;
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+/**
+ * The file representing `file`'s parent module (one level up the module
+ * tree), or null if `file` is already a crate root or no parent file is
+ * known among `knownFiles`.
+ */
+function rustParentModuleFile(
+  file: string,
+  rootDir: string,
+  knownFiles: Set<string>,
+): string | null {
+  const base = path.basename(file, '.rs');
+  if (base === 'main' || base === 'lib') return null;
+  const dir = path.dirname(file);
+  const searchDir = base === 'mod' ? path.dirname(dir) : dir;
+
+  for (const candidate of [`${searchDir}.rs`, path.join(searchDir, 'mod.rs')]) {
+    const rel = normalizePath(path.relative(rootDir, candidate));
+    if (knownFiles.has(rel)) return candidate;
+  }
+  for (const name of ['main.rs', 'lib.rs']) {
+    const candidate = path.join(searchDir, name);
+    const rel = normalizePath(path.relative(rootDir, candidate));
+    if (knownFiles.has(rel)) return candidate;
+  }
+  return null;
+}
+
+/**
+ * Walk `segments` (module-path components after the crate::/self::/super::
+ * prefix) from `startDir`, treating each as a submodule file (`seg.rs` or
+ * `seg/mod.rs`) if one exists among `knownFiles`. The final segment may
+ * instead be a leaf item name (function/type/const) rather than a module —
+ * if it doesn't match a real file, resolution stops one level early and
+ * returns the last successfully resolved module file (mirroring how
+ * `crate::service::build_service` resolves to service.rs even though
+ * build_service itself has no file of its own — the Rust extractor's
+ * single-item `use` shape appends the item name to `source`, while the
+ * braced-list shape doesn't, so this must handle both).
+ */
+function walkRustModuleSegments(
+  startDir: string,
+  startFile: string,
+  segments: string[],
+  rootDir: string,
+  knownFiles: Set<string>,
+): string | null {
+  let currentDir = startDir;
+  let currentFile = startFile;
+
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i]!;
+    const fileCandidate = path.join(currentDir, `${seg}.rs`);
+    const modCandidate = path.join(currentDir, seg, 'mod.rs');
+    const fileRel = normalizePath(path.relative(rootDir, fileCandidate));
+    const modRel = normalizePath(path.relative(rootDir, modCandidate));
+
+    if (knownFiles.has(fileRel)) {
+      currentFile = fileCandidate;
+      currentDir = path.join(currentDir, seg);
+      continue;
+    }
+    if (knownFiles.has(modRel)) {
+      currentFile = modCandidate;
+      currentDir = path.join(currentDir, seg);
+      continue;
+    }
+    if (i === segments.length - 1) break;
+    return null;
+  }
+  return currentFile;
+}
+
+/**
+ * Resolve a Rust `use crate::a::b::c` / `self::a::b` / `super::a` path to
+ * the real file that declares its target module (or, for the trailing
+ * item-name case, the module file that item is declared in), by walking the
+ * project's directory tree per Rust's module-file conventions (issue
+ * #2007). Returns null (falls through to the bare-specifier fallback) when
+ * no match is found — e.g. `#[path]` attribute overrides, which this
+ * convention-based resolver doesn't model.
+ */
+function resolveRustUsePath(
+  fromFile: string,
+  importSource: string,
+  rootDir: string,
+  knownFiles: Set<string>,
+): string | null {
+  const segments = importSource.split('::');
+  if (segments.length === 0) return null;
+
+  let startDir: string;
+  let startFile: string;
+  let rest: string[];
+
+  if (segments[0] === 'crate') {
+    const rootFile = findRustCrateRoot(fromFile, rootDir, knownFiles);
+    if (!rootFile) return null;
+    startDir = path.dirname(rootFile);
+    startFile = rootFile;
+    rest = segments.slice(1);
+  } else if (segments[0] === 'self') {
+    startDir = rustModuleDir(fromFile);
+    startFile = fromFile;
+    rest = segments.slice(1);
+  } else if (segments[0] === 'super') {
+    let cur = fromFile;
+    let i = 0;
+    while (i < segments.length && segments[i] === 'super') {
+      const parent = rustParentModuleFile(cur, rootDir, knownFiles);
+      if (!parent) return null;
+      cur = parent;
+      i++;
+    }
+    startDir = rustModuleDir(cur);
+    startFile = cur;
+    rest = segments.slice(i);
+  } else {
+    return null;
+  }
+
+  const resolved = walkRustModuleSegments(startDir, startFile, rest, rootDir, knownFiles);
+  return resolved ? normalizePath(path.relative(rootDir, resolved)) : null;
+}
+
+/** Cache: knownFiles array identity → Set, so repeated resolutions against
+ * the same project file list (e.g. every Rust `use` statement in a build)
+ * don't each rebuild the Set from scratch. */
+const _knownFilesSetCache = new WeakMap<readonly string[], Set<string>>();
+
+function toKnownFilesSet(knownFiles: readonly string[] | null | undefined): Set<string> | null {
+  if (!knownFiles) return null;
+  let set = _knownFilesSetCache.get(knownFiles);
+  if (!set) {
+    set = new Set(knownFiles);
+    _knownFilesSetCache.set(knownFiles, set);
+  }
+  return set;
+}
+
 function resolveImportPathJS(
   fromFile: string,
   importSource: string,
   rootDir: string,
   aliases: PathAliases | null,
+  knownFiles?: readonly string[] | null,
 ): string {
   if (!importSource.startsWith('.') && aliases) {
     const aliasResolved = resolveViaAlias(importSource, aliases, rootDir);
     if (aliasResolved) return normalizePath(path.relative(rootDir, aliasResolved));
   }
   if (!importSource.startsWith('.')) {
+    if (isRustQualifiedPath(importSource) && fromFile.endsWith('.rs')) {
+      const knownFilesSet = toKnownFilesSet(knownFiles);
+      if (knownFilesSet) {
+        const rustResolved = resolveRustUsePath(fromFile, importSource, rootDir, knownFilesSet);
+        if (rustResolved) return rustResolved;
+      }
+    }
     // Workspace packages take priority over node_modules
     const wsResolved = resolveViaWorkspace(importSource, rootDir);
     if (wsResolved) {
@@ -654,6 +861,7 @@ export function resolveImportPath(
   importSource: string,
   rootDir: string,
   aliases: PathAliases | null,
+  knownFiles?: readonly string[] | null,
 ): string {
   const native = loadNative();
   if (native) {
@@ -664,6 +872,7 @@ export function resolveImportPath(
         rootDir,
         convertAliasesForNative(aliases),
         getWorkspacesForNative(rootDir),
+        knownFiles || null,
       );
       const normalized = normalizePath(path.normalize(result));
       // The native resolver's .js → .ts remap fails when paths contain
@@ -676,7 +885,7 @@ export function resolveImportPath(
       );
     }
   }
-  return resolveImportPathJS(fromFile, importSource, rootDir, aliases);
+  return resolveImportPathJS(fromFile, importSource, rootDir, aliases, knownFiles);
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -2376,6 +2376,7 @@ export interface NativeAddon {
     rootDir: string,
     aliases: unknown,
     workspaces?: NativeWorkspacePackage[] | null,
+    knownFiles?: readonly string[] | null,
   ): string;
   resolveImports(
     items: Array<{ fromFile: string; importSource: string }>,

--- a/tests/unit/resolve.test.ts
+++ b/tests/unit/resolve.test.ts
@@ -927,4 +927,51 @@ describe('resolveImportPathJS - Rust crate::/self::/super:: paths (#2007)', () =
     );
     expect(result).toBe('crate::service::build_service');
   });
+
+  describe('standalone Cargo targets (src/bin/, examples/, tests/, benches/)', () => {
+    let targetsDir: string;
+    const targetKnownFiles = [
+      'src/main.rs',
+      'src/bin/tool.rs',
+      'src/bin/helper.rs',
+      'tests/integration.rs',
+    ];
+
+    beforeAll(() => {
+      targetsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-resolve-rust-targets-'));
+      fs.mkdirSync(path.join(targetsDir, 'src', 'bin'), { recursive: true });
+      fs.mkdirSync(path.join(targetsDir, 'tests'), { recursive: true });
+      for (const rel of targetKnownFiles) {
+        fs.writeFileSync(path.join(targetsDir, rel), '');
+      }
+    });
+
+    afterAll(() => {
+      if (targetsDir) fs.rmSync(targetsDir, { recursive: true, force: true });
+    });
+
+    it('resolves crate:: from a standalone src/bin/ target to a sibling in the same target, not src/main.rs', () => {
+      const fromFile = path.join(targetsDir, 'src', 'bin', 'tool.rs');
+      const result = resolveImportPathJS(
+        fromFile,
+        'crate::helper',
+        targetsDir,
+        null,
+        targetKnownFiles,
+      );
+      expect(result).toBe('src/bin/helper.rs');
+    });
+
+    it('returns the raw specifier for super:: from a standalone target (no parent module to walk up to)', () => {
+      const fromFile = path.join(targetsDir, 'tests', 'integration.rs');
+      const result = resolveImportPathJS(
+        fromFile,
+        'super::helper',
+        targetsDir,
+        null,
+        targetKnownFiles,
+      );
+      expect(result).toBe('super::helper');
+    });
+  });
 });

--- a/tests/unit/resolve.test.ts
+++ b/tests/unit/resolve.test.ts
@@ -823,3 +823,108 @@ describe('computeConfidenceJS — cross-language rejection (#1783)', () => {
     expect(conf).toBeGreaterThan(0);
   });
 });
+
+// ─── Rust crate::/self::/super:: module-path resolution (#2007) ────────
+
+describe('resolveImportPathJS - Rust crate::/self::/super:: paths (#2007)', () => {
+  let rustDir: string;
+  const knownFiles = [
+    'main.rs',
+    'models.rs',
+    'repository.rs',
+    'service.rs',
+    'validator.rs',
+    'service/nested.rs',
+    'service/helper.rs',
+  ];
+
+  beforeAll(() => {
+    rustDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-resolve-rust-'));
+    fs.mkdirSync(path.join(rustDir, 'service'), { recursive: true });
+    for (const rel of knownFiles) {
+      fs.writeFileSync(path.join(rustDir, rel), '');
+    }
+  });
+
+  afterAll(() => {
+    if (rustDir) fs.rmSync(rustDir, { recursive: true, force: true });
+  });
+
+  it('resolves crate:: single-item form (trailing item name, no file of its own) to its declaring file', () => {
+    const fromFile = path.join(rustDir, 'main.rs');
+    const result = resolveImportPathJS(
+      fromFile,
+      'crate::service::build_service',
+      rustDir,
+      null,
+      knownFiles,
+    );
+    expect(result).toBe('service.rs');
+  });
+
+  it('resolves crate:: braced-list form (module path only, no trailing item) to its declaring file', () => {
+    const fromFile = path.join(rustDir, 'main.rs');
+    const result = resolveImportPathJS(fromFile, 'crate::models', rustDir, null, knownFiles);
+    expect(result).toBe('models.rs');
+  });
+
+  it('resolves crate:: from a non-root file (crate-root lookup does not require fromFile === crate root)', () => {
+    const fromFile = path.join(rustDir, 'service.rs');
+    const result = resolveImportPathJS(
+      fromFile,
+      'crate::validator::validate_all',
+      rustDir,
+      null,
+      knownFiles,
+    );
+    expect(result).toBe('validator.rs');
+  });
+
+  it('resolves self:: to a sibling submodule of the current file', () => {
+    const fromFile = path.join(rustDir, 'service.rs');
+    const result = resolveImportPathJS(fromFile, 'self::nested', rustDir, null, knownFiles);
+    expect(result).toBe('service/nested.rs');
+  });
+
+  it('resolves super:: from a nested submodule back up to a sibling', () => {
+    const fromFile = path.join(rustDir, 'service', 'nested.rs');
+    const result = resolveImportPathJS(fromFile, 'super::helper', rustDir, null, knownFiles);
+    expect(result).toBe('service/helper.rs');
+  });
+
+  it('resolves super:: from a top-level module to a crate-root sibling', () => {
+    const fromFile = path.join(rustDir, 'service.rs');
+    const result = resolveImportPathJS(fromFile, 'super::validator', rustDir, null, knownFiles);
+    expect(result).toBe('validator.rs');
+  });
+
+  it('falls back to the raw specifier on a dead-end mid-path (no matching module)', () => {
+    const fromFile = path.join(rustDir, 'main.rs');
+    const result = resolveImportPathJS(
+      fromFile,
+      'crate::nonexistent::foo',
+      rustDir,
+      null,
+      knownFiles,
+    );
+    expect(result).toBe('crate::nonexistent::foo');
+  });
+
+  it('falls back to the raw specifier when no knownFiles are provided', () => {
+    const fromFile = path.join(rustDir, 'main.rs');
+    const result = resolveImportPathJS(fromFile, 'crate::service::build_service', rustDir, null);
+    expect(result).toBe('crate::service::build_service');
+  });
+
+  it('does not treat a non-.rs file importing a crate::-shaped string as a Rust path', () => {
+    const fromFile = path.join(rustDir, 'main.ts');
+    const result = resolveImportPathJS(
+      fromFile,
+      'crate::service::build_service',
+      rustDir,
+      null,
+      knownFiles,
+    );
+    expect(result).toBe('crate::service::build_service');
+  });
+});


### PR DESCRIPTION
## Summary

`resolveImportPathJS` (and the mirrored native `resolve_import_path_inner`) had no handling for Rust's `use`-path syntax. Any non-relative import source (which covers every Rust `use` path — Rust has no relative-import syntax) fell straight through workspace/`exports` resolution (npm-package semantics) and, finding no match, returned the literal unresolved string as if it were a resolved file path. This broke cross-file return-type propagation (Phase 8.2) for any bare function call whose target was imported via `use crate::...`, since the resolver never learned which file actually declared it.

## Changes

- Adds `crate::`/`self::`/`super::` resolution to both engines (`src/domain/graph/resolve.ts` and `crates/codegraph-core/src/domain/graph/resolve.rs`), walking the project's directory tree per Rust's module-file conventions (`mod.rs`/`lib.rs`/`main.rs` vs. sibling `foo/` directories), gated on the project's known-files list.
- Handles both extractor shapes for `use` sources: the single-item form (`crate::service::build_service`, trailing item name with no file of its own) and the braced-list form (`crate::models`, module path only).
- Also fixes the native `resolve_import_path` singular entry point (and its `resolve_import` FFI binding), which unconditionally dropped `known_files` even when the caller had a real set available (`ImportEdgeContext` already holds one) — making Rust path resolution structurally impossible on that code path regardless of the batch-path fix.
- Threads `ctx.allFiles` through the two TS call sites where it's cheaply available (`getResolved`, `findBarrelCandidates` in `resolve-imports.ts`).

## Verification

Rebuilt both `dist/` and the native `.node` addon, then verified end-to-end against `tests/benchmarks/resolution/fixtures/rust/` on both engines directly (not just the threshold-gated benchmark test, which was already passing at the old 83.3% recall):

- **Before**: 20/24 expected edges matched (83.3% recall) on both engines.
- **After**: 23/24 matched (95.8% recall) on both engines, zero precision regression (0 spurious extra edges), full dual-engine parity maintained (both engines produce identical results).

The one remaining gap (`main -> User.display_name`) needs method-call return-type propagation through `if let Some(x) = ...` pattern bindings — a distinct mechanism from import-path resolution. Filed as #2214.

## Test plan
- [x] New Rust unit tests in `resolve.rs` (12 new, incl. crate/self/super, braced vs. single-item shapes, dead-end fallback, the singular-path regression) — `cargo test --lib domain::graph::resolve`: 57/57 pass
- [x] New TS unit tests in `tests/unit/resolve.test.ts` (9 new) — 77/77 pass
- [x] Full Rust suite — `cargo test --lib`: 682/682 pass
- [x] `cargo clippy --lib` — no new warnings
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — full suite, 261 files / 4272 tests pass (includes the full 34-language resolution benchmark)
- [x] Direct end-to-end verification against the Rust fixture on both engines (see above)

Closes #2007