### PR TITLE
fix(docs): re-sync claude-code-skills mirrors and titan-paradigm.md

### DIFF
--- a/.claude/skills/titan-close/SKILL.md
+++ b/.claude/skills/titan-close/SKILL.md
@@ -611,16 +611,22 @@ Write `.codegraph/titan/close-summary.json`:
    git branch --list 'refactor/titan-*' 'docs/titan-*'
    ```
 
-   Delete locally (force-delete is safe — all work is in the created PR branches). The current worktree branch cannot be deleted while checked out; it will be cleaned up when the worktree is torn down. Skip it gracefully with `|| true`:
+   Capture the branch names once, before any deletion — querying `git branch --list` again after the local delete would find nothing, silently turning the remote cleanup below into a no-op:
    ```bash
-   git branch --list 'refactor/titan-*' | xargs -r -I{} git branch -D {} || true
-   git branch --list 'docs/titan-*' | xargs -r -I{} git branch -D {} || true
+   REFACTOR_BRANCHES=$(git branch --list 'refactor/titan-*' | sed 's/^[* ]*//')
+   DOCS_BRANCHES=$(git branch --list 'docs/titan-*' | sed 's/^[* ]*//')
    ```
 
-   Delete from remote:
+   Delete locally (force-delete is safe — all work is in the created PR branches). The current worktree branch cannot be deleted while checked out; it will be cleaned up when the worktree is torn down. Skip it gracefully with `|| true`:
    ```bash
-   git branch --list 'refactor/titan-*' | sed 's/^[* ]*//' | xargs -r git push origin --delete 2>/dev/null || true
-   git branch --list 'docs/titan-*' | sed 's/^[* ]*//' | xargs -r git push origin --delete 2>/dev/null || true
+   echo "$REFACTOR_BRANCHES" | xargs -r -I{} git branch -D {} || true
+   echo "$DOCS_BRANCHES" | xargs -r -I{} git branch -D {} || true
+   ```
+
+   Delete from remote, reusing the names captured above:
+   ```bash
+   echo "$REFACTOR_BRANCHES" | xargs -r git push origin --delete 2>/dev/null || true
+   echo "$DOCS_BRANCHES" | xargs -r git push origin --delete 2>/dev/null || true
    ```
 
    Print count of branches deleted.

--- a/.claude/skills/titan-reset/SKILL.md
+++ b/.claude/skills/titan-reset/SKILL.md
@@ -68,17 +68,23 @@ This removes:
 
 Delete all local titan working branches. These accumulate across runs and leave orphaned commits that never reach main. The actual PR content lives on focused PR branches created by `/titan-close` — the working branches are safe to remove.
 
+Capture the branch names once, before any deletion — querying `git branch --list` again after the local delete would find nothing, silently turning the remote cleanup below into a no-op:
 ```bash
-git branch --list 'refactor/titan-*' | xargs -r -I{} git branch -D {} || true
-git branch --list 'docs/titan-*' | xargs -r -I{} git branch -D {} || true
+REFACTOR_BRANCHES=$(git branch --list 'refactor/titan-*' | sed 's/^[* ]*//')
+DOCS_BRANCHES=$(git branch --list 'docs/titan-*' | sed 's/^[* ]*//')
+```
+
+```bash
+echo "$REFACTOR_BRANCHES" | xargs -r -I{} git branch -D {} || true
+echo "$DOCS_BRANCHES" | xargs -r -I{} git branch -D {} || true
 ```
 
 > **Note:** `-I{}` ensures each branch is deleted individually so a failure on one (e.g. the currently checked-out worktree branch, which git refuses to delete in-place) is skipped rather than aborting the entire pipeline. The current worktree branch is cleaned up when the worktree itself is torn down.
 
-Delete from remote (best-effort — failures are non-fatal):
+Delete from remote, reusing the names captured above (best-effort — failures are non-fatal):
 ```bash
-git branch --list 'refactor/titan-*' | sed 's/^[* ]*//' | xargs -r git push origin --delete 2>/dev/null || true
-git branch --list 'docs/titan-*' | sed 's/^[* ]*//' | xargs -r git push origin --delete 2>/dev/null || true
+echo "$REFACTOR_BRANCHES" | xargs -r git push origin --delete 2>/dev/null || true
+echo "$DOCS_BRANCHES" | xargs -r git push origin --delete 2>/dev/null || true
 ```
 
 Print how many branches were removed.

--- a/docs/examples/claude-code-skills/README.md
+++ b/docs/examples/claude-code-skills/README.md
@@ -114,7 +114,7 @@ If GAUNTLET or FORGE runs out of context, just re-invoke — they resume from wh
 
 ## Artifacts
 
-All artifacts are written to `.codegraph/titan/` (6 files, no redundancy):
+All artifacts are written to `.codegraph/titan/` (11 files, no redundancy), plus the final report committed separately to `generated/titan/`:
 
 | File | Format | Written by | Read by |
 |------|--------|-----------|---------|
@@ -125,6 +125,8 @@ All artifacts are written to `.codegraph/titan/` (6 files, no redundancy):
 | `sync.json` | JSON | SYNC | RUN, FORGE (diff review), GATE |
 | `arch-snapshot.json` | JSON | RUN (pre-forge) | GATE (architectural comparison) |
 | `gate-log.ndjson` | NDJSON | GATE | RUN, CLOSE, Audit trail |
+| `grind-targets.ndjson` | NDJSON | GRIND | CLOSE (adoption metrics + report) |
+| `issues.ndjson` | NDJSON | RECON, GAUNTLET, SYNC, GRIND (any phase logging bugs/anomalies) | CLOSE (issue tracker + report) |
 | `drift-report.json` | JSON | GAUNTLET, SYNC, CLOSE | RUN, CLOSE |
 | `close-summary.json` | JSON | CLOSE | — |
 | `generated/titan/titan-report-*.md` | Markdown | CLOSE | — (committed to repo) |

--- a/docs/examples/claude-code-skills/titan-close/SKILL.md
+++ b/docs/examples/claude-code-skills/titan-close/SKILL.md
@@ -611,16 +611,22 @@ Write `.codegraph/titan/close-summary.json`:
    git branch --list 'refactor/titan-*' 'docs/titan-*'
    ```
 
-   Delete locally (force-delete is safe — all work is in the created PR branches). The current worktree branch cannot be deleted while checked out; it will be cleaned up when the worktree is torn down. Skip it gracefully with `|| true`:
+   Capture the branch names once, before any deletion — querying `git branch --list` again after the local delete would find nothing, silently turning the remote cleanup below into a no-op:
    ```bash
-   git branch --list 'refactor/titan-*' | xargs -r -I{} git branch -D {} || true
-   git branch --list 'docs/titan-*' | xargs -r -I{} git branch -D {} || true
+   REFACTOR_BRANCHES=$(git branch --list 'refactor/titan-*' | sed 's/^[* ]*//')
+   DOCS_BRANCHES=$(git branch --list 'docs/titan-*' | sed 's/^[* ]*//')
    ```
 
-   Delete from remote:
+   Delete locally (force-delete is safe — all work is in the created PR branches). The current worktree branch cannot be deleted while checked out; it will be cleaned up when the worktree is torn down. Skip it gracefully with `|| true`:
    ```bash
-   git branch --list 'refactor/titan-*' | sed 's/^[* ]*//' | xargs -r git push origin --delete 2>/dev/null || true
-   git branch --list 'docs/titan-*' | sed 's/^[* ]*//' | xargs -r git push origin --delete 2>/dev/null || true
+   echo "$REFACTOR_BRANCHES" | xargs -r -I{} git branch -D {} || true
+   echo "$DOCS_BRANCHES" | xargs -r -I{} git branch -D {} || true
+   ```
+
+   Delete from remote, reusing the names captured above:
+   ```bash
+   echo "$REFACTOR_BRANCHES" | xargs -r git push origin --delete 2>/dev/null || true
+   echo "$DOCS_BRANCHES" | xargs -r git push origin --delete 2>/dev/null || true
    ```
 
    Print count of branches deleted.

--- a/docs/examples/claude-code-skills/titan-close/SKILL.md
+++ b/docs/examples/claude-code-skills/titan-close/SKILL.md
@@ -65,6 +65,7 @@ Your goal: analyze all commits on the current branch, split them into focused PR
    - `.codegraph/titan/issues.ndjson` — issue tracker from all phases
    - `.codegraph/titan/arch-snapshot.json` — pre-forge architectural snapshot (communities, structure, drift). Use for before/after comparison in the Metrics section. May not exist if capture failed.
    - `.codegraph/titan/drift-report.json` — cumulative drift reports from all phases. May not exist if no drift was detected.
+   - `.codegraph/titan/grind-targets.ndjson` — grind phase adoption targets and outcomes. Each line: `{target, file, phase, classification, reason, consumers, pattern, timestamp}`. May not exist if grind wasn't run.
 
    If `titan-state.json` is missing after the search, stop: "No Titan session found. Run `/titan-recon` first."
 
@@ -146,6 +147,9 @@ Use `sync.json` execution phases as the primary guide if available:
    - Group by domain: `fix: address quality issues in <domain>`
 6. **Warning improvements** — commits addressing warn-level issues
    - Group by domain: `refactor: improve code quality in <domain>`
+7. **Helper adoption** — commits from grind phase adopting dead helpers into callsites
+   - PR title: `refactor: adopt dead helpers in <domain>`
+   - Look for `grind(...)` commit prefixes or commits touching files listed in `grind-targets.ndjson`
 
 ### Fallback grouping (if no sync.json)
 
@@ -164,7 +168,7 @@ Record the grouping plan:
   {
     "pr": 1,
     "title": "...",
-    "concern": "dead_code|abstraction|cycle_break|decomposition|quality_fix|warning",
+    "concern": "dead_code|abstraction|cycle_break|decomposition|quality_fix|warning|adoption",
     "domain": "<domain name>",
     "commits": ["<sha1>", "<sha2>"],
     "files": ["<file1>", "<file2>"],
@@ -202,6 +206,17 @@ codegraph complexity --health --sort mi -T --json --limit 10
 
 If `.codegraph/titan/arch-snapshot.json` was captured before forge, compare its `structure` data against current `codegraph structure --depth 2 --json` output. Report cohesion changes per directory (improved / degraded / unchanged). Include in the "Metrics: Before & After" section of the report.
 
+### Grind metrics (if grind-targets.ndjson exists)
+
+If `.codegraph/titan/grind-targets.ndjson` exists, parse it and cross-reference with `titan-state.json → grind`:
+- **Targets processed:** count entries in `grind.processedTargets` (from titan-state.json)
+- **Targets failed:** count entries in `grind.failedTargets` (from titan-state.json)
+- **False positives identified:** count entries with `classification: "false-positive"` in grind-targets.ndjson (or from `grind.falsePositives` in titan-state.json)
+- **Adopted:** count entries with `classification: "adopt"` in grind-targets.ndjson
+- **Dead symbol delta:** from `grind.deadSymbolDelta` in titan-state.json (or compute from baseline vs final dead symbol counts)
+
+Include these in the Metrics: Before & After section and the Grind Results report section.
+
 ### Compute deltas
 
 Compare final metrics against `titan-state.json` baseline:
@@ -216,7 +231,7 @@ Compare final metrics against `titan-state.json` baseline:
 
 ---
 
-## Step 5 — Compile the issue tracker
+## Step 5 — Compile the issue tracker and open GitHub issues
 
 Read `.codegraph/titan/issues.ndjson`. Each line is a JSON object:
 
@@ -229,6 +244,47 @@ Group issues by category and severity. Summarize:
 - **Tooling issues:** problems with the Titan pipeline or other tools
 - **Process notes:** suggestions for improving the Titan workflow
 - **Codebase observations:** structural concerns beyond what the audit covered
+
+### 5b. Open GitHub issues
+
+**Pre-check:** Verify `gh` is available and authenticated before attempting issue creation:
+```bash
+gh auth status 2>&1 || echo "GH_UNAVAILABLE"
+```
+If `GH_UNAVAILABLE`, skip issue creation entirely and note in the report: "GitHub issues were not created — `gh` CLI is not available or not authenticated. Create them manually from the Issues section below."
+
+For each issue with severity `bug` or `limitation`, create a GitHub issue using `gh`:
+
+```bash
+BODY=$(mktemp)
+cat > "$BODY" <<'ISSUE_BODY'
+## Context
+Discovered during Titan audit (phase: <phase>, date: <timestamp>).
+
+## Description
+<description>
+
+## Additional Context
+<context field, if present>
+
+## Source
+- **Titan phase:** <phase>
+- **Severity:** <severity>
+- **Category:** <category>
+ISSUE_BODY
+gh issue create --title "<category>: <short description>" --body-file "$BODY" --label "titan-audit"
+rm -f "$BODY"
+```
+
+Using `--body-file` with a temp file avoids quoting/expansion issues that can arise when issue descriptions contain backticks, `$()` sequences, or literal `EOF` strings.
+
+**Rules for issue creation:**
+- **Only open issues for `bug` and `limitation` severity.** Suggestions and observations go in the report only — they are not actionable enough for standalone issues.
+- **Check for duplicates first:** Run `gh issue list --search "<short description>" --state open --limit 5` before creating. If a matching open issue exists, skip it and note "existing issue #N" in the report.
+- **Label:** Use `titan-audit` label. If the label doesn't exist, create it: `gh label create titan-audit --description "Issues discovered during Titan audit" --color "d4c5f9" 2>/dev/null || true`
+- **Record each created issue number** for inclusion in the report's Issues section.
+
+For `suggestion` severity entries and entries with `category: "codebase"`, include them in the report's Issues section but do NOT create GitHub issues.
 
 ---
 
@@ -243,6 +299,14 @@ Read `.codegraph/titan/gate-log.ndjson`. Summarize:
 ---
 
 ## Step 7 — Generate the report
+
+### Record CLOSE completion timestamp
+
+Before writing the report, record `phaseTimestamps.close.completedAt` so the Pipeline Timeline has accurate data for the CLOSE row. (titan-run also records this after titan-close returns as a safety backstop, but by then the report is already written.)
+
+```bash
+node -e "const fs=require('fs');const s=JSON.parse(fs.readFileSync('.codegraph/titan/titan-state.json','utf8'));s.phaseTimestamps=s.phaseTimestamps||{};s.phaseTimestamps['close']=s.phaseTimestamps['close']||{};s.phaseTimestamps['close'].completedAt=new Date().toISOString();fs.writeFileSync('.codegraph/titan/titan-state.json',JSON.stringify(s,null,2));"
+```
 
 ### Report path
 
@@ -283,13 +347,22 @@ Write the report as Markdown:
 
 ## Pipeline Timeline
 
-| Phase | Started | Completed | Duration |
-|-------|---------|-----------|----------|
-| RECON | <from state> | <from state> | — |
-| GAUNTLET | — | — | — |
-| SYNC | — | — | — |
-| GATE (runs) | — | — | — |
-| CLOSE | <now> | <now> | — |
+Read `titan-state.json → phaseTimestamps` for real wall-clock data. If `phaseTimestamps` exists, use the recorded ISO 8601 timestamps to compute durations. If it does not exist (older pipeline run), derive timing from git commit timestamps as a fallback — **never invent or guess timestamps.**
+
+**Duration computation:** For each phase with `startedAt` and `completedAt`, compute duration as the difference in minutes/hours. For forge, also note the first and last commit timestamps from `git log`.
+
+| Phase | Duration | Notes |
+|-------|----------|-------|
+| RECON | <computed from phaseTimestamps.recon> | — |
+| GAUNTLET | <computed from phaseTimestamps.gauntlet> | <iterations count if resuming> |
+| SYNC | <computed from phaseTimestamps.sync> | — |
+| FORGE | <computed from phaseTimestamps.forge> | <commit count>, first at <time>, last at <time> |
+| GRIND | <computed from phaseTimestamps.grind> | <targets processed>, <adoptions made> |
+| GATE | across forge/grind | <total runs> inline with forge/grind commits |
+| CLOSE | <computed from phaseTimestamps.close> | — |
+| **Total** | <sum of all phases> | — |
+
+**If `phaseTimestamps` is missing:** Fall back to git log timestamps. Use the earliest and latest commit timestamps from `git log main..HEAD --format="%ai"` to bound the forge phase. For analysis phases (recon, gauntlet, sync), use `titan-state.json → initialized` and `lastUpdated` as rough bounds. Mark the durations as "~approximate" in the table.
 
 ---
 
@@ -333,6 +406,22 @@ Write the report as Markdown:
 ### Most Common Violations
 
 <Top 5 violation types with counts>
+
+---
+
+## Grind Results (if grind ran)
+
+**Targets processed:** <N> | **Adopted:** <N> | **Failed:** <N> | **False positives:** <N>
+
+### Adoption Summary
+
+<Table: target name, dead symbols before, dead symbols after, delta, files modified>
+
+### False Positives Logged
+
+<Table: target name, reason (dynamic import / re-export / closure-local / type noise), logged to issues.ndjson>
+
+> Omit this section entirely if `grind-targets.ndjson` does not exist.
 
 ---
 
@@ -494,6 +583,7 @@ Write `.codegraph/titan/close-summary.json`:
   },
   "audit": { "totalAudited": 0, "pass": 0, "warn": 0, "fail": 0, "decompose": 0 },
   "gate": { "totalRuns": 0, "pass": 0, "warn": 0, "fail": 0, "rollbacks": 0 },
+  "grind": { "targetsProcessed": 0, "adopted": 0, "failed": 0, "falsePositives": 0, "deadSymbolDelta": 0 },
   "issues": { "codegraph": 0, "tooling": 0, "process": 0, "codebase": 0 },
   "prs": [
     { "number": 0, "url": "<url>", "title": "<title>", "concern": "<type>", "domain": "<domain>", "commits": 0 }
@@ -514,7 +604,28 @@ Write `.codegraph/titan/close-summary.json`:
    ```
    Delete any remaining batch snapshots.
 
-3. **Titan reports are committed to the repo** (not gitignored). The `generated/titan/` directory is tracked so reports are preserved in git history.
+3. **Branch cleanup:** Delete all titan working branches now that their content lives in focused PR branches. These branches accumulate indefinitely without this step and leave hundreds of orphaned commits that never reach main.
+
+   List what will be deleted:
+   ```bash
+   git branch --list 'refactor/titan-*' 'docs/titan-*'
+   ```
+
+   Delete locally (force-delete is safe — all work is in the created PR branches). The current worktree branch cannot be deleted while checked out; it will be cleaned up when the worktree is torn down. Skip it gracefully with `|| true`:
+   ```bash
+   git branch --list 'refactor/titan-*' | xargs -r -I{} git branch -D {} || true
+   git branch --list 'docs/titan-*' | xargs -r -I{} git branch -D {} || true
+   ```
+
+   Delete from remote:
+   ```bash
+   git branch --list 'refactor/titan-*' | sed 's/^[* ]*//' | xargs -r git push origin --delete 2>/dev/null || true
+   git branch --list 'docs/titan-*' | sed 's/^[* ]*//' | xargs -r git push origin --delete 2>/dev/null || true
+   ```
+
+   Print count of branches deleted.
+
+4. **Titan reports are committed to the repo** (not gitignored). The `generated/titan/` directory is tracked so reports are preserved in git history.
 
 ---
 

--- a/docs/examples/claude-code-skills/titan-forge/SKILL.md
+++ b/docs/examples/claude-code-skills/titan-forge/SKILL.md
@@ -30,11 +30,23 @@ Your goal: read `sync.json`, find the next incomplete execution phase, make the 
    ```
    If not in a worktree, stop: "Run `/worktree` first."
 
-2. **Sync with main:**
+2. **Sync with main (conditional):**
    ```bash
-   git fetch origin main && git merge origin/main --no-edit
+   git fetch origin main
+   behind=$(git rev-list HEAD..origin/main --count)
    ```
-   If there are merge conflicts, stop: "Merge conflict detected. Resolve conflicts and re-run `/titan-forge`."
+   - If `behind == 0` → already up to date, skip the merge entirely and print "Already up to date with origin/main."
+   - If `behind > 0` → merge:
+     ```bash
+     git merge origin/main --no-edit
+     ```
+     If there are merge conflicts, stop: "Merge conflict detected. Resolve conflicts and re-run `/titan-forge`."
+
+     After a successful merge, run a **duplicate-commit check** to detect re-applied work:
+     ```bash
+     git log origin/main..HEAD --no-merges --format="%s" | sort | uniq -d
+     ```
+     If any subjects are duplicated, print a warning listing them: "WARNING: Duplicate commit subjects found after merge — prior work may have been re-applied. Step 5 will auto-recover completed targets from git log so they are skipped." Do not stop — proceed to Step 3.
 
 3. **Load artifacts.** Read:
    - `.codegraph/titan/sync.json` — execution plan (if missing: "Run `/titan-sync` first.")
@@ -44,22 +56,33 @@ Your goal: read `sync.json`, find the next incomplete execution phase, make the 
 
 4. **Validate state.** If `titan-state.json` has `currentPhase` other than `"sync"` and no existing `execution` block, stop: "State not ready. Run `/titan-sync` first."
 
-5. **Initialize execution state** (if first run). Add to `titan-state.json`:
+5. **Initialize execution state** (if first run). Before writing a blank `execution` block, **recover already-completed work from the branch's git log** to prevent re-doing commits that are already on the branch:
+
+   ```bash
+   git log origin/main..HEAD --no-merges --format="%s"
+   ```
+
+   Cross-reference each subject line against `sync.json → executionOrder[*].targets[*].commitMessage`. For every match, mark that target as already completed and its phase as completed if all targets in the phase matched.
+
+   Then write `titan-state.json` with the recovered state (pre-populated `completedTargets`, `completedPhases`, and `commits` from `git log origin/main..HEAD --no-merges --format="%H %s"`):
+
    ```json
    {
      "execution": {
-       "currentPhase": 1,
-       "completedPhases": [],
+       "currentPhase": <lowest incomplete phase, or 1 if none recovered>,
+       "completedPhases": [<phases where all targets matched>],
        "currentTarget": null,
-       "completedTargets": [],
+       "completedTargets": [<targets whose commit subjects appeared in git log>],
        "failedTargets": [],
-       "commits": [],
+       "commits": [<SHAs of matched commits>],
        "currentSubphase": null,
        "completedSubphases": [],
        "diffWarnings": []
      }
    }
    ```
+
+   If any targets were recovered, print: "Recovered N completed targets from branch git log — skipping re-application."
 
 6. **Determine next phase.** Use `--phase N` if provided, otherwise find the lowest phase number not in `completedPhases`.
 

--- a/docs/examples/claude-code-skills/titan-gauntlet/SKILL.md
+++ b/docs/examples/claude-code-skills/titan-gauntlet/SKILL.md
@@ -17,33 +17,126 @@ Your goal: audit every high-priority target from the RECON phase against 4 pilla
 
 ---
 
-## Step 0 — Pre-flight
+## Step 0 — Pre-flight: find or create the Titan worktree
 
-1. **Worktree check:**
+1. **Locate the Titan session.** A prior phase (RECON) may have run in a different worktree or branch. Search for it:
+
+   ```bash
+   git worktree list
+   ```
+
+   For each worktree, check if it contains Titan artifacts:
+   ```bash
+   ls <worktree-path>/.codegraph/titan/titan-state.json 2>/dev/null
+   ```
+
+   Also check branches for titan state:
+   ```bash
+   git branch -a --list '*titan*'
+   ```
+
+   **Decision logic:**
+   - **Found exactly one worktree with `titan-state.json`:** Read the state. If `currentPhase` is `"recon"` (RECON completed), this is the right one. Switch to it or merge its branch into your worktree.
+   - **Found a worktree but `currentPhase` is NOT `"recon"`:** This worktree may be mid-phase or from a different pipeline run. Keep searching other worktrees/branches. If no better match, ask the user: "Found Titan state at `<path>` but phase is `<phase>`. Is this the session to continue?"
+   - **Found multiple worktrees with `titan-state.json`:** List them with their `currentPhase` and `lastUpdated`. Ask the user: "Multiple Titan sessions found. Which one should GAUNTLET continue?"
+   - **Found a branch (not worktree) with titan artifacts:** Merge it into your current worktree:
+     ```bash
+     git merge <titan-branch> --no-edit
+     ```
+   - **Found nothing:** Warn: "No RECON artifacts found in any worktree or branch. Run `/titan-recon` first for best results." Fall back: `codegraph triage -T --limit 50 --json` for a minimal queue.
+
+2. **Ensure worktree isolation:**
    ```bash
    git rev-parse --show-toplevel && git worktree list
    ```
-   If not in a worktree, stop: "Run `/worktree` first."
+   If you are NOT in a worktree, stop: "Run `/worktree` first."
 
-2. **Sync with main:**
+3. **Sync with main:**
    ```bash
    git fetch origin main && git merge origin/main --no-edit
    ```
    If there are merge conflicts, stop: "Merge conflict detected. Resolve conflicts and re-run `/titan-gauntlet`."
 
-3. **Load state.** Read `.codegraph/titan/titan-state.json`. If missing:
-   - Warn: "No RECON artifacts. Run `/titan-recon` first for best results."
-   - Fall back: `codegraph triage -T --limit 50 --json` for a minimal queue.
+4. **Load state.** Read `.codegraph/titan/titan-state.json`.
 
-4. **Load architecture.** Read `.codegraph/titan/GLOBAL_ARCH.md` for domain context.
+5. **Load architecture.** Read `.codegraph/titan/GLOBAL_ARCH.md` for domain context.
 
-5. **Resume logic.** If `titan-state.json` has completed batches, skip them. Start from the first `pending` batch.
+6. **Resume logic.** If `titan-state.json` has completed batches, skip them. Start from the first `pending` batch.
 
-6. **Validate state.** If `titan-state.json` fails to parse, stop: "State file corrupted. Run `/titan-reset` to start over, or `/titan-recon` to rebuild."
+7. **Validate state.** If `titan-state.json` fails to parse, stop: "State file corrupted. Run `/titan-reset` to start over, or `/titan-recon` to rebuild."
 
 ---
 
-## Step 1 — The Four Pillars
+## Step 1 — Drift detection: has main moved since the last phase?
+
+The codebase may have changed significantly since RECON ran. Detect this before auditing stale data.
+
+1. **Compare main SHA:**
+   ```bash
+   git rev-parse origin/main
+   ```
+   Compare against `titan-state.json → mainSHA`. If identical, skip to Step 2.
+
+2. **If main has advanced**, find what changed:
+   ```bash
+   git diff --name-only <mainSHA>..origin/main
+   ```
+
+3. **Cross-reference with Titan targets.** Check which changed files overlap with:
+   - Files in the priority queue (`titan-state.json → priorityQueue`)
+   - Files in pending batches (`titan-state.json → batches`)
+   - Hot files (`titan-state.json → hotFiles`)
+   - Core symbols (`titan-state.json → roles.coreCount` files)
+
+4. **Run structural diff** to detect architecture-level changes:
+   ```bash
+   codegraph diff-impact <mainSHA>..origin/main -T --json 2>/dev/null || echo "DIFF_UNAVAILABLE"
+   ```
+   If unavailable (e.g., old SHA not in graph), fall back to file-count heuristics.
+
+5. **Classify staleness:**
+
+   | Level | Condition | Action |
+   |-------|-----------|--------|
+   | **none** | main unchanged | Continue normally |
+   | **low** | main changed but <5 files, none in priority queue | Continue — note in issues.ndjson |
+   | **moderate** | Some overlap: changed files appear in priority queue or batches (<20% of batches affected) | Continue but **mark affected batches for re-audit** |
+   | **high** | >20% of batches affected OR core symbols changed | **Warn user:** "Significant changes on main since RECON. Recommend re-running affected batches or `/titan-recon`." |
+   | **critical** | New files in src/, deleted files that were in batches, or >50% of priority queue affected | **Stop and recommend:** "Main has diverged significantly. Run `/titan-recon` to rebuild the baseline." |
+
+6. **Append drift report** to `.codegraph/titan/drift-report.json` (the file is a JSON array — read existing entries first, push the new entry, write back):
+
+   ```json
+   {
+     "timestamp": "<ISO 8601>",
+     "detectedBy": "gauntlet",
+     "mainAtLastPhase": "<stored SHA>",
+     "mainNow": "<current SHA>",
+     "commitsBehind": 0,
+     "changedFiles": ["<files changed on main>"],
+     "impactedTargets": ["<priority queue targets in changed files>"],
+     "impactedBatches": [1, 3],
+     "impactedDomains": ["<domains containing changed files>"],
+     "staleness": "none|low|moderate|high|critical",
+     "recommendation": "continue|reassess-targets|rerun-gauntlet|rerun-recon",
+     "reassessmentScope": {
+       "targets": ["<specific targets to re-audit>"],
+       "batches": [1, 3],
+       "files": ["<specific files to re-check>"],
+       "fullRecon": false
+     }
+   }
+   ```
+
+7. **Update state:** Set `titan-state.json → mainSHA` to current `origin/main` after merging.
+
+8. **If `moderate`:** Mark impacted batches as `"stale"` in `titan-state.json` (change status from `"completed"` to `"stale"` or from `"pending"` to `"pending-reassess"`). These get re-audited during the batch loop.
+
+9. **If re-running GAUNTLET** and a previous `drift-report.json` exists with `reassessmentScope`, **only re-audit the targets listed** — don't repeat the entire pipeline. Clear completed targets from the scope as you go.
+
+---
+
+## Step 2 — The Four Pillars
 
 Every file must be checked against all four pillars. A file **FAILS** if it has any fail-level violation.
 
@@ -147,7 +240,9 @@ codegraph co-change <f> -T --json
 ```
 Find semantically similar functions. If `codegraph search` fails (no embeddings), use grep for function signature patterns. **Warn:** similar patterns. **Fail:** near-verbatim copy.
 
-> Note: requires embeddings from `/titan-recon`. If `titan-state.json → embeddingsAvailable` is false, skip semantic search and note it.
+> **Don't trust `embeddingsAvailable` blindly — verify it against the current worktree.** `.codegraph/` is gitignored, so `graph.db` and its embeddings are local, per-worktree filesystem state; they are never carried over by a branch merge or a "switch to that worktree's state" step in Step 0. A `titan-state.json` merged in from a different worktree/session can say `embeddingsAvailable: true` while the graph.db actually open right now has none — `codegraph search` will then run without erroring and silently return empty results, so Rule 11 looks clean when it never actually checked anything.
+>
+> Before relying on `embeddingsAvailable`, do a deterministic identity check first: compare `git rev-parse --show-toplevel` (this worktree) against `titan-state.json → embeddingsWorktreePath` (the worktree RECON actually ran `codegraph embed` in). Any mismatch — or a missing `embeddingsWorktreePath` from an older state file — means `embeddingsAvailable` cannot be trusted as-is; treat it as `false` until re-verified. Then, at the start of Step 2 (not per-file), run a one-time smoke-test: `codegraph search "test query" --json`. Treat only an explicit error or `ENGINE_UNAVAILABLE` as failure — the same concrete criterion RECON uses — not a subjective "no hit where one seemed likely" judgment call, since a generic query legitimately returning zero results is not itself proof of a broken engine. If either check fails, regenerate for **this** worktree — `codegraph embed -m minilm` — and update both `titan-state.json → embeddingsAvailable` and `embeddingsWorktreePath` before trusting it for any Rule 11 check this run. If regeneration also fails, fall back to grep-only DRY checks and log it to `issues.ndjson` rather than proceeding on a false green.
 
 #### Rule 12 — Naming symmetry
 ```bash
@@ -208,11 +303,11 @@ Codegraph provides all the data needed for a verifiable audit — no need to man
 
 ---
 
-## Step 2 — Batch audit loop
+## Step 3 — Batch audit loop
 
 For each pending batch (from `titan-state.json`):
 
-### 2a. Save pre-batch snapshot
+### 3a. Save pre-batch snapshot
 ```bash
 codegraph snapshot save titan-batch-<N>
 ```
@@ -221,7 +316,7 @@ Delete the previous batch snapshot if it exists:
 codegraph snapshot delete titan-batch-<N-1>
 ```
 
-### 2b. Collect all metrics in one call
+### 3b. Collect all metrics in one call
 ```bash
 codegraph batch complexity <target1> <target2> ... -T --json
 ```
@@ -232,7 +327,7 @@ For deeper context on high-risk targets:
 codegraph batch context <target1> <target2> ... -T --json
 ```
 
-### 2c. Run Pillar I checks
+### 3c. Run Pillar I checks
 For each file in the batch:
 - Parse complexity metrics from batch output (Rule 1 — all 7 metric thresholds)
 - Run AST queries for async hygiene (Rule 2), resource cleanup (Rule 5)
@@ -240,25 +335,25 @@ For each file in the batch:
 - Check dead code (Rule 4): `codegraph roles --role dead --file <f> -T --json`
 - Check immutability (Rule 6): `codegraph dataflow` + grep
 
-### 2d. Run Pillar II checks
+### 3d. Run Pillar II checks
 For each file:
 - Magic values (Rule 7): `codegraph ast --kind string` + grep
 - Boundary validation (Rule 8): check entry points
 - Secret hygiene (Rule 9): grep
 - Empty catches (Rule 10): grep
 
-### 2e. Run Pillar III checks
+### 3e. Run Pillar III checks
 - DRY (Rule 11): `codegraph search` (if embeddings available) + `co-change`
 - Naming symmetry (Rule 12): `codegraph where --file`
 - Config over code (Rule 13): `codegraph deps` + grep
 
-### 2f. Run Pillar IV checks
+### 3f. Run Pillar IV checks
 - Naming quality (Rule 14): `codegraph where --file`
 - Structured logging (Rule 15): `codegraph ast --kind call` + grep
 - Testability (Rule 16): `codegraph fn-impact` + test file mock count
 - Critical path coverage (Rule 17): `codegraph roles --role core`
 
-### 2g. Score each target
+### 3g. Score each target
 
 | Verdict | Condition |
 |---------|-----------|
@@ -272,7 +367,7 @@ For FAIL/DECOMPOSE targets, capture blast radius:
 codegraph fn-impact <target> -T --json
 ```
 
-### 2h. Write batch results
+### 3h. Write batch results
 
 Append to `.codegraph/titan/gauntlet.ndjson` (one line per target):
 
@@ -280,7 +375,7 @@ Append to `.codegraph/titan/gauntlet.ndjson` (one line per target):
 {"target": "<name>", "file": "<path>", "verdict": "FAIL", "pillarVerdicts": {"I": "fail", "II": "warn", "III": "pass", "IV": "pass"}, "metrics": {"cognitive": 35, "cyclomatic": 15, "maxNesting": 4, "mi": 32, "halsteadEffort": 12000, "halsteadBugs": 1.2, "sloc": 85}, "violations": [{"rule": 1, "pillar": "I", "metric": "cognitive", "detail": "35 > 30 threshold", "level": "fail"}], "blastRadius": {"direct": 5, "transitive": 18}, "recommendation": "Split: halstead.bugs 1.2 suggests ~1 defect. Separate validation from I/O."}
 ```
 
-### 2i. Update state machine
+### 3i. Update state machine
 
 Update `titan-state.json`:
 - Set batch status to `"completed"`
@@ -289,7 +384,7 @@ Update `titan-state.json`:
 - Update `snapshots.lastBatch`
 - Update `lastUpdated`
 
-### 2j. Progress check
+### 3j. Progress check
 
 Print: `Batch N/M: X pass, Y warn, Z fail`
 
@@ -300,7 +395,7 @@ Print: `Batch N/M: X pass, Y warn, Z fail`
 
 ---
 
-## Step 3 — Clean up batch snapshots
+## Step 4 — Clean up batch snapshots
 
 After all batches complete, delete the last batch snapshot:
 ```bash
@@ -312,7 +407,7 @@ If stopping early for context, keep the last batch snapshot for safety.
 
 ---
 
-## Step 4 — Aggregate and report
+## Step 5 — Aggregate and report
 
 Compute from `gauntlet.ndjson`:
 - Pass / Warn / Fail / Decompose counts
@@ -342,6 +437,25 @@ Print summary to user:
 
 ---
 
+## Issue Tracking
+
+Throughout this phase, if you encounter any of the following, append a JSON line to `.codegraph/titan/issues.ndjson`:
+
+- **Codegraph bugs:** wrong metrics, incorrect role classification, missing symbols, parse failures
+- **Tooling issues:** batch command failures, AST query errors, embedding unavailability
+- **Process suggestions:** threshold adjustments, missing rules, pillar improvements
+- **Codebase observations:** patterns not covered by the manifesto, architectural smells
+
+Format (one JSON object per line, append-only):
+
+```json
+{"phase": "gauntlet", "timestamp": "<ISO 8601>", "severity": "bug|limitation|suggestion", "category": "codegraph|tooling|process|codebase", "description": "<what happened>", "context": "<command, target, or file involved>"}
+```
+
+Log issues as they happen — don't batch them. The `/titan-close` phase compiles these into the final report.
+
+---
+
 ## Rules
 
 - **Batch processing is mandatory.** Never audit more than `$ARGUMENTS` targets at once.
@@ -353,6 +467,7 @@ Print summary to user:
 - **Lint runs once in GATE**, not per-batch here. Don't run `npm run lint`.
 - Advisory rules (12, 14, 17) produce warnings, never failures.
 - Dead symbols from RECON should be flagged for removal, not skipped.
+- If any command fails or produces unexpected output, **log it to `issues.ndjson`** before continuing.
 
 ## Self-Improvement
 

--- a/docs/examples/claude-code-skills/titan-grind/SKILL.md
+++ b/docs/examples/claude-code-skills/titan-grind/SKILL.md
@@ -109,7 +109,7 @@ Forge shapes the metal. Grind smooths the rough edges. Your goal: find helpers t
 
 12. **Capture dead-symbol baseline** (only if `grind.deadSymbolBaseline` is null):
     ```bash
-    codegraph roles --role dead -T --json | node -e "const d=[];process.stdin.on('data',c=>d.push(c));process.stdin.on('end',()=>{const data=JSON.parse(Buffer.concat(d));console.log(JSON.stringify({total:data.count,byRole:data.summary}));})"
+    codegraph roles --role dead -T --json | node -e "const d=[];process.stdin.on('data',c=>d.push(c));process.stdin.on('end',()=>{try{const data=JSON.parse(Buffer.concat(d));console.log(JSON.stringify({total:data.count??0,byRole:data.summary??{}}));}catch(e){console.error('Failed to parse roles --json output: '+e.message);process.exit(1);}})"
     ```
     `codegraph roles --json` returns `{ count, summary, symbols }` (not a bare array) — `summary` is already the per-role breakdown (e.g. `dead-leaf`, `dead-entry`, `dead-ffi`, `dead-unresolved`), so no manual reduce is needed.
     Store the total in `grind.deadSymbolBaseline`. Write `titan-state.json` immediately.
@@ -580,7 +580,7 @@ After all targets in the phase are processed:
 
 ```bash
 codegraph build
-codegraph roles --role dead -T --json | node -e "const d=[];process.stdin.on('data',c=>d.push(c));process.stdin.on('end',()=>{const data=JSON.parse(Buffer.concat(d));console.log(JSON.stringify({total:data.count,byRole:data.summary}));})"
+codegraph roles --role dead -T --json | node -e "const d=[];process.stdin.on('data',c=>d.push(c));process.stdin.on('end',()=>{try{const data=JSON.parse(Buffer.concat(d));console.log(JSON.stringify({total:data.count??0,byRole:data.summary??{}}));}catch(e){console.error('Failed to parse roles --json output: '+e.message);process.exit(1);}})"
 ```
 
 Store in `grind.deadSymbolCurrent`. Write `titan-state.json`.

--- a/docs/examples/claude-code-skills/titan-recon/SKILL.md
+++ b/docs/examples/claude-code-skills/titan-recon/SKILL.md
@@ -29,6 +29,12 @@ Your goal: map the dependency graph, identify structural hotspots, name logical 
    ```
    If there are merge conflicts, stop and ask the user to resolve them.
 
+3. **Record the main anchor SHA:**
+   ```bash
+   git rev-parse origin/main
+   ```
+   Store this as `mainSHA` in `titan-state.json`. All downstream phases use this to detect codebase drift — if main advances between phases, the drift detection mechanism (Step 0.5 in each phase) compares against this anchor to determine what's stale and what needs reassessment.
+
 ---
 
 ## Step 1 — Build the graph
@@ -48,6 +54,14 @@ codegraph embed -m minilm
 ```
 
 This enables `codegraph search` for duplicate code detection in downstream phases. If it fails (e.g., missing model), note it and continue — DRY checks will be grep-only.
+
+**Verify, don't assume.** `.codegraph/` is gitignored — `graph.db` (and its embeddings) is local filesystem state, per worktree. It is never carried over by `git merge`, a branch switch, or a snapshot restore. Before setting `embeddingsAvailable` in `titan-state.json`, smoke-test the current worktree's DB directly:
+
+```bash
+codegraph search "test query" --json
+```
+
+Only set `embeddingsAvailable: true` if this returns results (or a valid empty match, not an error/`ENGINE_UNAVAILABLE`). Alongside the flag, record `embeddingsWorktreePath` in `titan-state.json` as the output of `git rev-parse --show-toplevel` — this gives downstream phases a deterministic identity to compare against instead of having to re-derive trust from a smoke test alone. If a downstream phase (e.g. GAUNTLET) ends up operating in a **different worktree** than the one RECON ran `codegraph embed` in — including via "merge the other worktree's branch into mine" — its `graph.db` will not have embeddings even though a stale `titan-state.json` from elsewhere claims `embeddingsAvailable: true`; a mismatch between `embeddingsWorktreePath` and that worktree's own `git rev-parse --show-toplevel` is the unambiguous signal for this. Re-run `codegraph embed -m minilm` for the worktree actually being used, update both `embeddingsAvailable` and `embeddingsWorktreePath`, and re-verify with the smoke-test above, whenever the operating worktree changes.
 
 ---
 
@@ -182,7 +196,8 @@ Write `.codegraph/titan/GLOBAL_ARCH.md`:
 
 ## Step 10 — Propose work batches
 
-Decompose the priority queue into **work batches** of ~5-15 files each:
+Decompose the priority queue into **work batches** of **at most 5 files each**:
+- **Hard limit: 5 files per batch.** If a domain has more than 5 files, split it into multiple batches (e.g., "domain-parser-1", "domain-parser-2"). This keeps each gauntlet iteration focused and prevents context overload in sub-agents.
 - Stay within a single domain where possible
 - Group tightly-coupled files together (from communities)
 - Order by priority: highest-risk domains first
@@ -208,6 +223,14 @@ Create `.codegraph/titan/titan-state.json` — the single source of truth for th
 mkdir -p .codegraph/titan
 ```
 
+**Important:** Before writing, check if `titan-state.json` already exists (the orchestrator may have written `phaseTimestamps.recon.startedAt` before dispatching this sub-agent). If it does, read the existing `phaseTimestamps` and merge them into the new state object so the start timestamp is preserved:
+
+```bash
+node -e "const fs=require('fs');const p='.codegraph/titan/titan-state.json';let existing={};try{existing=JSON.parse(fs.readFileSync(p,'utf8'));}catch{}console.log(JSON.stringify(existing.phaseTimestamps||{}));"
+```
+
+Include the preserved `phaseTimestamps` in the state file below.
+
 ```json
 {
   "version": 1,
@@ -215,11 +238,13 @@ mkdir -p .codegraph/titan
   "lastUpdated": "<ISO 8601>",
   "target": "<resolved path>",
   "currentPhase": "recon",
+  "mainSHA": "<git rev-parse origin/main>",
   "snapshots": {
     "baseline": "titan-baseline",
     "lastBatch": null
   },
   "embeddingsAvailable": true,
+  "embeddingsWorktreePath": "<git rev-parse --show-toplevel>",
   "stats": {
     "totalFiles": 0,
     "totalNodes": 0,
@@ -274,6 +299,7 @@ mkdir -p .codegraph/titan
   },
   "hotFiles": ["<top 30>"],
   "tangledDirs": ["<cohesion < 0.3>"],
+  "phaseTimestamps": "<merged from existing file — see above>",
   "fileAudits": {},
   "progress": {
     "totalFiles": 0,
@@ -303,12 +329,31 @@ Print a concise summary:
 
 ---
 
+## Issue Tracking
+
+Throughout this phase, if you encounter any of the following, append a JSON line to `.codegraph/titan/issues.ndjson`:
+
+- **Codegraph bugs:** wrong output, crashes, missing features, unexpected behavior
+- **Tooling issues:** problems with commands, WASM failures, embedding errors
+- **Process suggestions:** ideas for improving the Titan workflow
+- **Codebase observations:** structural concerns beyond what metrics capture
+
+Format (one JSON object per line, append-only):
+
+```json
+{"phase": "recon", "timestamp": "<ISO 8601>", "severity": "bug|limitation|suggestion", "category": "codegraph|tooling|process|codebase", "description": "<what happened>", "context": "<command that triggered it, file involved, or other detail>"}
+```
+
+Log issues as they happen — don't batch them. The `/titan-close` phase compiles these into the final report.
+
+---
+
 ## Rules
 
 - **Always use `--json` and `-T`** on codegraph commands.
 - **Never paste raw JSON** into your response — parse and extract.
 - **Write artifacts before reporting.**
-- If any command fails, note it and continue with partial data.
+- If any command fails, **log it to `issues.ndjson`** and continue with partial data.
 - **Domain naming** uses the codebase's own vocabulary.
 
 ## Self-Improvement

--- a/docs/examples/claude-code-skills/titan-reset/SKILL.md
+++ b/docs/examples/claude-code-skills/titan-reset/SKILL.md
@@ -27,6 +27,12 @@ This restores the graph database to its pre-GAUNTLET state.
 codegraph snapshot delete titan-baseline 2>/dev/null
 ```
 
+Delete the grind baseline snapshot (if it exists):
+
+```bash
+codegraph snapshot delete titan-grind-baseline 2>/dev/null
+```
+
 Also delete any batch snapshots dynamically:
 
 ```bash
@@ -50,10 +56,36 @@ This removes:
 - `gauntlet-summary.json` — aggregated results
 - `sync.json` — execution plan
 - `gate-log.ndjson` — gate audit trail
+- `issues.ndjson` — cross-phase issue tracker
+- `close-summary.json` — close phase summary
+- `drift-report.json` — staleness detection across phases
+- `grind-targets.ndjson` — grind phase adoption targets and outcomes
+- `arch-snapshot.json` — pre-forge architectural snapshot
 
 ---
 
-## Step 4 — Rebuild graph (unless --keep-graph)
+## Step 4 — Delete titan working branches
+
+Delete all local titan working branches. These accumulate across runs and leave orphaned commits that never reach main. The actual PR content lives on focused PR branches created by `/titan-close` — the working branches are safe to remove.
+
+```bash
+git branch --list 'refactor/titan-*' | xargs -r -I{} git branch -D {} || true
+git branch --list 'docs/titan-*' | xargs -r -I{} git branch -D {} || true
+```
+
+> **Note:** `-I{}` ensures each branch is deleted individually so a failure on one (e.g. the currently checked-out worktree branch, which git refuses to delete in-place) is skipped rather than aborting the entire pipeline. The current worktree branch is cleaned up when the worktree itself is torn down.
+
+Delete from remote (best-effort — failures are non-fatal):
+```bash
+git branch --list 'refactor/titan-*' | sed 's/^[* ]*//' | xargs -r git push origin --delete 2>/dev/null || true
+git branch --list 'docs/titan-*' | sed 's/^[* ]*//' | xargs -r git push origin --delete 2>/dev/null || true
+```
+
+Print how many branches were removed.
+
+---
+
+## Step 5 — Rebuild graph (unless --keep-graph)
 
 If `$ARGUMENTS` does NOT contain `--keep-graph`:
 
@@ -67,13 +99,15 @@ If `$ARGUMENTS` contains `--keep-graph`, skip this step.
 
 ---
 
-## Step 5 — Report
+## Step 6 — Report
 
 ```
 Titan pipeline reset complete.
   - Baseline snapshot: restored and deleted
+  - Grind snapshot: deleted
   - Batch snapshots: deleted
   - Artifacts: removed (.codegraph/titan/)
+  - Titan branches deleted: N local, N remote
   - Graph: rebuilt (clean state)
 
 To start a fresh Titan pipeline, run /titan-recon

--- a/docs/examples/claude-code-skills/titan-reset/SKILL.md
+++ b/docs/examples/claude-code-skills/titan-reset/SKILL.md
@@ -68,17 +68,23 @@ This removes:
 
 Delete all local titan working branches. These accumulate across runs and leave orphaned commits that never reach main. The actual PR content lives on focused PR branches created by `/titan-close` — the working branches are safe to remove.
 
+Capture the branch names once, before any deletion — querying `git branch --list` again after the local delete would find nothing, silently turning the remote cleanup below into a no-op:
 ```bash
-git branch --list 'refactor/titan-*' | xargs -r -I{} git branch -D {} || true
-git branch --list 'docs/titan-*' | xargs -r -I{} git branch -D {} || true
+REFACTOR_BRANCHES=$(git branch --list 'refactor/titan-*' | sed 's/^[* ]*//')
+DOCS_BRANCHES=$(git branch --list 'docs/titan-*' | sed 's/^[* ]*//')
+```
+
+```bash
+echo "$REFACTOR_BRANCHES" | xargs -r -I{} git branch -D {} || true
+echo "$DOCS_BRANCHES" | xargs -r -I{} git branch -D {} || true
 ```
 
 > **Note:** `-I{}` ensures each branch is deleted individually so a failure on one (e.g. the currently checked-out worktree branch, which git refuses to delete in-place) is skipped rather than aborting the entire pipeline. The current worktree branch is cleaned up when the worktree itself is torn down.
 
-Delete from remote (best-effort — failures are non-fatal):
+Delete from remote, reusing the names captured above (best-effort — failures are non-fatal):
 ```bash
-git branch --list 'refactor/titan-*' | sed 's/^[* ]*//' | xargs -r git push origin --delete 2>/dev/null || true
-git branch --list 'docs/titan-*' | sed 's/^[* ]*//' | xargs -r git push origin --delete 2>/dev/null || true
+echo "$REFACTOR_BRANCHES" | xargs -r git push origin --delete 2>/dev/null || true
+echo "$DOCS_BRANCHES" | xargs -r git push origin --delete 2>/dev/null || true
 ```
 
 Print how many branches were removed.

--- a/docs/examples/claude-code-skills/titan-run/SKILL.md
+++ b/docs/examples/claude-code-skills/titan-run/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: titan-run
-description: Run the full Titan Paradigm pipeline end-to-end by dispatching each phase to sub-agents with fresh context windows. Orchestrates recon → gauntlet → sync → forge automatically.
-argument-hint: <path (default: .)> <--skip-recon> <--skip-gauntlet> <--start-from recon|gauntlet|sync|forge> <--gauntlet-batch-size 5> <--yes>
+description: Run the full Titan Paradigm pipeline end-to-end by dispatching each phase to sub-agents with fresh context windows. Orchestrates recon → gauntlet → sync → forge → grind (+ repo-provided parity audit) automatically.
+argument-hint: <path (default: .)> <--skip-recon> <--skip-gauntlet> <--start-from recon|gauntlet|sync|forge|grind|parity|close> <--gauntlet-batch-size 5> <--yes>
 allowed-tools: Agent, Read, Bash, Glob, Write, Edit
 ---
 
@@ -16,7 +16,7 @@ You are the **orchestrator** for the full Titan Paradigm pipeline. Your job is t
 - `<path>` → target path (passed to recon)
 - `--skip-recon` → skip recon (assumes artifacts exist)
 - `--skip-gauntlet` → skip gauntlet (assumes artifacts exist)
-- `--start-from <phase>` → jump to phase: `recon`, `gauntlet`, `sync`, `forge`
+- `--start-from <phase>` → jump to phase: `recon`, `gauntlet`, `sync`, `forge`, `grind`, `parity`, `close`
 - `--gauntlet-batch-size <N>` → batch size for gauntlet (default: 5)
 - `--yes` → skip all confirmation prompts in the orchestrator (pre-pipeline, forge checkpoint, and resume prompts) and in forge (per-phase confirmation)
 
@@ -40,22 +40,92 @@ You are the **orchestrator** for the full Titan Paradigm pipeline. Your job is t
    - If state exists and `--start-from` not specified, ask user: "Existing Titan state found (phase: `<currentPhase>`). Resume from current state, or start fresh with `/titan-reset` first?"
    - If `--yes` is set, resume automatically.
 
-4. **Sync with main** (once, before any sub-agent runs):
+   **Initialize the phase timestamps helper.** Throughout the pipeline, you will record wall-clock timestamps for each phase. Use this helper to write them into `titan-state.json`:
+
+   ```bash
+   # Record phase start (safe for resume — only sets startedAt if not already present):
+   node -e "const fs=require('fs');const s=JSON.parse(fs.readFileSync('.codegraph/titan/titan-state.json','utf8'));s.phaseTimestamps=s.phaseTimestamps||{};s.phaseTimestamps['<PHASE>']=s.phaseTimestamps['<PHASE>']||{};if(!s.phaseTimestamps['<PHASE>'].startedAt){s.phaseTimestamps['<PHASE>'].startedAt=new Date().toISOString();fs.writeFileSync('.codegraph/titan/titan-state.json',JSON.stringify(s,null,2));}"
+
+   # Record phase completion:
+   node -e "const fs=require('fs');const s=JSON.parse(fs.readFileSync('.codegraph/titan/titan-state.json','utf8'));s.phaseTimestamps=s.phaseTimestamps||{};s.phaseTimestamps['<PHASE>']=s.phaseTimestamps['<PHASE>']||{};s.phaseTimestamps['<PHASE>'].completedAt=new Date().toISOString();fs.writeFileSync('.codegraph/titan/titan-state.json',JSON.stringify(s,null,2));"
+   ```
+
+   Replace `<PHASE>` with `recon`, `gauntlet`, `sync`, `forge`, `grind`, `parity`, or `close`. **Run the start command immediately before dispatching each phase's first sub-agent, and the completion command immediately after post-phase validation passes.** If resuming a phase (e.g., gauntlet loop iteration 2+), do NOT overwrite `startedAt` — only set it if it doesn't already exist.
+
+   **Timestamp validation:** After recording `completedAt` for any phase, verify `startedAt < completedAt`:
+   ```bash
+   node -e "const s=JSON.parse(require('fs').readFileSync('.codegraph/titan/titan-state.json','utf8'));const p=s.phaseTimestamps?.['<PHASE>'];if(p?.startedAt&&p?.completedAt){const start=new Date(p.startedAt),end=new Date(p.completedAt);if(end<=start){console.log('WARNING: <PHASE> completedAt ('+p.completedAt+') is not after startedAt ('+p.startedAt+')');process.exit(0);}console.log('<PHASE> duration: '+((end-start)/60000).toFixed(1)+' min');}else{console.log('WARNING: <PHASE> missing startedAt or completedAt');}"
+   ```
+   If the check fails, log a warning but do not stop the pipeline — clock skew or immediate completion of short phases can cause this.
+
+4. **Install latest codegraph** (once, before any sub-agent runs):
+   ```bash
+   npm install -g @optave/codegraph@latest
+   ```
+   Log the installed version:
+   ```bash
+   codegraph --version
+   ```
+   If the install fails, warn the user but continue with whichever version is currently available.
+
+5. **Sync with main** (once, before any sub-agent runs):
    ```bash
    git fetch origin main && git merge origin/main --no-edit
    ```
    If merge conflict → stop: "Merge conflict after syncing with main. Resolve conflicts and re-run `/titan-run`."
 
-5. **Print plan:**
+6. **Bootstrap worktree environment** (run when `pwd` contains `.claude/worktrees/` or `node_modules` is absent/stale):
+
+   **E1. Node dependencies:** Check whether `node_modules` needs installing:
+   ```bash
+   if [ ! -f node_modules/.package-lock.json ] || [ package.json -nt node_modules/.package-lock.json ]; then
+     npm install --prefer-offline 2>&1 | tail -5
+   fi
+   ```
+   This also builds WASM grammars (via the `prepare` script). After this step, all subsequent agent prompts must use `TEST_CMD="npx vitest run --config vitest.config.worktree.ts"` (see E2).
+
+   **E2. Vitest worktree config:** The default `vitest.config.ts` excludes `**/.claude/**`, matching this path and silently breaking test discovery. Write an override if absent:
+   ```bash
+   if [ ! -f vitest.config.worktree.ts ]; then
+     node -e "
+       const fs = require('fs');
+       const src = fs.readFileSync('vitest.config.ts', 'utf8');
+       fs.writeFileSync('vitest.config.worktree.ts',
+         src.replace(/'\*\*\/\.claude\/\*\*',?\s*/g, ''));
+       console.log('vitest.config.worktree.ts written');
+     "
+   fi
+   ```
+   All test runs in forge/grind/gate agent prompts must reference this file: `npx vitest run --config vitest.config.worktree.ts`.
+
+   **E3. Native binary freshness** (only if `crates/` exists):
+   ```bash
+   NODE_BINARY=$(find node_modules/@optave -name "codegraph-core.node" 2>/dev/null | head -1)
+   if [ -n "$NODE_BINARY" ]; then
+     NEWER_RUST=$(find crates -name "*.rs" -newer "$NODE_BINARY" 2>/dev/null | head -1)
+     if [ -n "$NEWER_RUST" ]; then
+       echo "Rust source newer than binary — rebuilding native addon..."
+       npx napi build --platform --release --manifest-path crates/codegraph-core/Cargo.toml --output-dir .
+       PLATFORM=$(node -e "const os=require('os');const arch=os.arch()==='arm64'?'arm64':'x64';console.log(os.platform()+'-'+arch)")
+       codesign --sign - --force codegraph-core.node 2>/dev/null || true
+       cp codegraph-core.node "node_modules/@optave/codegraph-${PLATFORM}/codegraph-core.node"
+       echo "Native binary rebuilt."
+     fi
+   fi
+   ```
+   If any bootstrap step fails, warn but continue — the pipeline can still proceed, and forge/grind agents will catch environment issues at test-run time.
+
+7. **Print plan:**
    ```
    Titan Pipeline — End-to-End Run
    Target: <path>
    Starting from: <phase>
    Gauntlet batch size: <N>
 
-   Phases: recon → gauntlet (loop) → sync → [PAUSE] → forge (loop)
+   Phases: recon → gauntlet (loop) → sync → [PAUSE] → forge (loop) → grind (loop) → close
    Each phase runs in a sub-agent with a fresh context window.
    Forge requires explicit confirmation (analysis phases are safe to automate).
+   Grind runs after forge to adopt extracted helpers into consumers.
    ```
 
    Start immediately — do NOT ask for confirmation before analysis phases. The user invoked `/titan-run`; that is the confirmation. Analysis phases (recon, gauntlet, sync) are read-only and safe to automate. The forge checkpoint (Step 3.5b) still applies unless `--yes` is set.
@@ -113,6 +183,8 @@ For each phase BEFORE `startPhase`, run the corresponding V-checks:
 | `recon` | V1 structural fields only (domains, batches, priorityQueue, stats — skip `currentPhase == "recon"` check since later phases advance it), V2 (GLOBAL_ARCH.md), V3 (snapshot exists — WARN if missing), V4 (cross-check counts) |
 | `gauntlet` | V5 (coverage ≥ 50%), V6 (entry completeness sample), V7 (summary consistency); also run NDJSON integrity check (2c) |
 | `sync` | V8 (sync.json structure), V9 (targets trace to gauntlet), V10 (dependency order) |
+| `forge` | V14 (final state consistency), V15 (gate log consistency); execution block must exist in titan-state.json |
+| `grind` | V14, V15; `execution.completedPhases` must be non-empty in titan-state.json (forge must have run at least one phase) |
 
 If ANY required artifact is **missing** → stop: "Cannot start from `<phase>` — `<artifact>` is missing. Run the full pipeline or start from an earlier phase."
 
@@ -127,6 +199,17 @@ WARN-level V-checks from skipped phases are surfaced as prefixed warnings: "[ski
 **Skip if:** `--skip-recon`, `--start-from` is after recon, or `titan-state.json` already has `currentPhase` beyond `"recon"`.
 
 ### 1a. Run Pre-Agent Gate (G1-G4)
+
+### 1a.1. Record phase start timestamp
+Record `phaseTimestamps.recon.startedAt` (only if not already set — it may exist from a prior crashed run).
+
+**Note:** On a fresh run, `titan-state.json` does not yet exist (titan-recon creates it in Step 12). Use this safe variant that creates a minimal stub if the file is missing:
+
+```bash
+node -e "const fs=require('fs');const p='.codegraph/titan/titan-state.json';let s;try{s=JSON.parse(fs.readFileSync(p,'utf8'));}catch{fs.mkdirSync('.codegraph/titan',{recursive:true});s={};}s.phaseTimestamps=s.phaseTimestamps||{};s.phaseTimestamps['recon']=s.phaseTimestamps['recon']||{};if(!s.phaseTimestamps['recon'].startedAt){s.phaseTimestamps['recon'].startedAt=new Date().toISOString();fs.writeFileSync(p,JSON.stringify(s,null,2));}"
+```
+
+This ensures `recon.startedAt` is recorded even on first-time runs. titan-recon Step 12 merges any existing `phaseTimestamps` into the full state file it writes.
 
 ### 1b. Dispatch sub-agent
 
@@ -177,10 +260,13 @@ If `NO_SNAPSHOT` → **WARN** (not fatal, but note it: "No baseline snapshot —
 **V4. Cross-check counts:**
 - `titan-state.json → stats.totalFiles` should roughly match the number of targets across all batches (batches are subsets of files, so `sum(batch.files.length)` should be ≤ `totalFiles`)
 - `priorityQueue.length` should be > 0 and ≤ `totalNodes`
+- **Batch size check:** Every batch must have ≤ 5 files. If any batch exceeds 5, **WARN**: "Batch <id> has <N> files (max 5). Large batches cause context overload in gauntlet sub-agents."
 
 If wildly inconsistent (e.g., 0 batches but 500 nodes) → **WARN** with details.
 
 Print: `RECON validated. Domains: <count>, Batches: <count>, Priority targets: <count>, Quality score: <score>`
+
+Record `phaseTimestamps.recon.completedAt`.
 
 ---
 
@@ -189,6 +275,8 @@ Print: `RECON validated. Domains: <count>, Batches: <count>, Priority targets: <
 **Skip if:** `--skip-gauntlet` or `--start-from` is after gauntlet.
 
 ### 2a. Pre-loop check
+
+Record `phaseTimestamps.gauntlet.startedAt` (only if not already set — gauntlet may be resuming).
 
 Read `.codegraph/titan/gauntlet-summary.json` if it exists:
 - If `"complete": true` → run gauntlet post-validation (2d) and skip loop if it passes
@@ -298,6 +386,8 @@ If mismatched → **WARN** with details (not fatal — the NDJSON is the source 
 
 Print: `GAUNTLET validated. Audited: <N>/<M> targets. Pass: <N>, Warn: <N>, Fail: <N>, Decompose: <N>. NDJSON integrity: <valid>/<total> lines OK.`
 
+Record `phaseTimestamps.gauntlet.completedAt`.
+
 ---
 
 ## Step 3 — SYNC
@@ -305,6 +395,9 @@ Print: `GAUNTLET validated. Audited: <N>/<M> targets. Pass: <N>, Warn: <N>, Fail
 **Skip if:** `--start-from` is after sync, or `titan-state.json` has `currentPhase: "sync"` with existing `sync.json`.
 
 ### 3a. Run Pre-Agent Gate (G1-G4)
+
+### 3a.1. Record phase start timestamp
+Record `phaseTimestamps.sync.startedAt`.
 
 ### 3b. Dispatch sub-agent
 
@@ -316,6 +409,12 @@ Agent → "Run /titan-sync. Read .claude/skills/titan-sync/SKILL.md and follow i
 
 ### 3c. Post-phase validation
 
+**Pre-V8. Validate sync.json is parseable JSON:**
+```bash
+node -e "try { JSON.parse(require('fs').readFileSync('.codegraph/titan/sync.json','utf8')); console.log('JSON OK'); } catch(e) { console.log('JSON INVALID: '+e.message); process.exit(1); }"
+```
+If this fails → **VALIDATION FAILED.** Stop: "SYNC produced invalid JSON in sync.json (likely a mismatched bracket/brace). Re-run with `/titan-run --start-from sync`."
+
 **V8. sync.json structure:**
 Read `.codegraph/titan/sync.json` and verify:
 - `phase` — must equal `"sync"`
@@ -326,16 +425,30 @@ Read `.codegraph/titan/sync.json` and verify:
 
 If missing or structurally invalid → **VALIDATION FAILED.** Stop: "SYNC produced invalid plan. Re-run with `/titan-run --start-from sync`."
 
-**V9. Sync targets trace back to gauntlet:**
-Collect all target names from `sync.json → executionOrder[*].targets` (flatten).
-For each, verify it appears in `gauntlet.ndjson` as a `target` field, OR in `titan-state.json → roles.deadSymbols` (dead code targets come from recon, not gauntlet).
+**V9. Sync targets trace back to gauntlet batches:**
+Collect all file paths from `titan-state.json → batches[*].files` (the ground-truth set gauntlet audited).
+Flatten all targets from `sync.json → executionOrder[*].targets` and check each against that set.
 
-If > 20% of sync targets have no gauntlet entry and aren't dead symbols → **WARN**: "SYNC references <N> targets not found in gauntlet results. The sub-agent may have hallucinated targets."
+```javascript
+const state = JSON.parse(fs.readFileSync('.codegraph/titan/titan-state.json','utf8'));
+const batchFiles = new Set((state.batches || []).flatMap(b => b.files || []));
+const allSyncTargets = sync.executionOrder.flatMap(e => e.targets);
+if (allSyncTargets.length === 0) { console.log('V9 FAIL: sync.json has no targets — execution plan is empty'); process.exit(1); }
+const missingCount = allSyncTargets.filter(t => !batchFiles.has(t)).length;
+const pct = missingCount / allSyncTargets.length;
+if (pct > 0.2) console.log('V9 WARN:', missingCount + '/' + allSyncTargets.length,
+  'sync targets not in any gauntlet batch (' + (pct*100).toFixed(0) + '%) — agent may have hallucinated targets');
+else console.log('V9 OK —', allSyncTargets.length, 'targets, all traced to gauntlet batches');
+```
+
+Note: sync targets are **file-level paths** (`src/foo.ts`). Do NOT compare against `gauntlet.ndjson → target` fields — those are function-level names and will never match.
 
 **V10. Execution order dependency check:**
 For entries with `dependencies` arrays, verify that each dependency phase number exists in `executionOrder` and has a lower phase number. Circular dependencies in the execution plan → **VALIDATION FAILED.**
 
 Print: `SYNC validated. Execution phases: <N>, Total targets: <N>, Estimated commits: <N>.`
+
+Record `phaseTimestamps.sync.completedAt`.
 
 ---
 
@@ -453,6 +566,8 @@ Once the user confirms (or `--yes` was set), `autoConfirm` is already `true` (se
 
 ### 4a. Pre-loop check
 
+Record `phaseTimestamps.forge.startedAt` (only if not already set — forge may be resuming).
+
 Read `.codegraph/titan/sync.json` → count total phases in `executionOrder`.
 Read `.codegraph/titan/titan-state.json` → check `execution.completedPhases` (may not exist yet if forge hasn't started).
 
@@ -550,10 +665,39 @@ while iteration < maxIterations:
         else:
             Run: <testCmd> 2>&1
             if tests fail:
-                Print: "CRITICAL: Test suite fails after forge phase <nextPhase>. Stopping pipeline."
+                Print: "WARNING: Test suite has failures after forge phase <nextPhase>. Auto-spawning regression-fix agent."
+                Print: "Failing tests: <list of failing test files>"
                 Print: "Commits from this phase: git log --oneline <headBefore>..<headAfter>"
-                Print: "Consider reverting: git revert <headBefore>..<headAfter>"
-                Stop.
+
+                # Run Pre-Agent Gate (G1-G4) and back up state
+                # Then dispatch fix agent:
+                Agent → "Investigate and fix test regressions introduced by the last forge phase.
+                         Commits in scope: git log --oneline <headBefore>..<headAfter>
+                         Failing tests: <list>
+                         
+                         Steps:
+                         1. Read the failing tests to understand what they expect
+                         2. Identify which committed change broke them (git diff <headBefore>..<headAfter>)
+                         3. Fix the root cause — prefer targeted fixes over reverts
+                         4. If Rust source changed: rebuild the native addon before running tests
+                            npx napi build --platform --release --manifest-path crates/codegraph-core/Cargo.toml --output-dir .
+                            PLATFORM=$(node -e "const os=require('os');const arch=os.arch()==='arm64'?'arm64':'x64';console.log(os.platform()+'-'+arch)")
+                            if [[ "$(uname)" == "Darwin" ]]; then codesign --sign - --force codegraph-core.node; fi
+                            cp codegraph-core.node "node_modules/@optave/codegraph-${PLATFORM}/codegraph-core.node"
+                         5. Verify with: <testCmd>
+                         6. Commit fixes with: 'fix: correct regressions from forge phase <N>'
+                         7. Do NOT stage: package-lock.json, vitest.config.worktree.ts, tests/benchmarks/resolution/fixtures/python/__pycache__/
+                         
+                         Run all commands INLINE (not in background)."
+                
+                # After fix agent returns, re-run tests:
+                Run: <testCmd> 2>&1
+                if tests still fail:
+                    Print: "CRITICAL: Regression-fix agent could not resolve test failures after forge phase <nextPhase>. Manual intervention required."
+                    Print: "Consider reverting: git revert <headBefore>..HEAD"
+                    Stop.
+                else:
+                    Print: "V13: Regressions resolved by fix agent. Continuing pipeline."
 ```
 
 ### 4c. Post-loop validation
@@ -575,6 +719,202 @@ If `.codegraph/titan/gate-log.ndjson` exists:
 
 Print forge summary.
 
+Record `phaseTimestamps.forge.completedAt`.
+
+---
+
+## Step 4.5 — GRIND (loop)
+
+Grind runs after forge to close the adoption loop. Forge extracts helpers; grind wires them into consumers and removes dead code. Without grind, the dead symbol count inflates with every forge phase.
+
+**Skip if:** `--start-from` is `parity` or `close`, or `titan-state.json → grind.completedPhases` already covers all forge phases.
+
+### 4.5a. Pre-loop check
+
+Record `phaseTimestamps.grind.startedAt` (only if not already set — grind may be resuming).
+
+Read `.codegraph/titan/sync.json` → count total phases in `executionOrder`.
+Read `.codegraph/titan/titan-state.json` → check `grind.completedPhases` (may not exist yet if grind hasn't started).
+
+### 4.5b. Grind loop
+
+Set `maxIterations = 20` (safety limit — same as forge).
+Set `stallCount = 0`, `maxStalls = 2`.
+
+```
+previousGrindPhases = grind.completedPhases (or [])
+iteration = 0
+
+while iteration < maxIterations:
+    iteration += 1
+
+    # Run Pre-Agent Gate (G1-G4)
+
+    # Determine next forge phase to grind
+    Read .codegraph/titan/titan-state.json
+    grindCompleted = grind.completedPhases (or [])
+    forgePhases = execution.completedPhases (or [])
+    ungroundPhases = forgePhases.filter(p => !grindCompleted.includes(p))
+    if len(ungroundPhases) == 0 → break
+
+    nextPhase = ungroundPhases[0]
+
+    headBefore = $(git rev-parse HEAD)
+
+    yesFlag = "--yes" if autoConfirm else ""
+    Agent → "Run /titan-grind --phase <nextPhase> <yesFlag>.
+             Read .claude/skills/titan-grind/SKILL.md and follow it exactly.
+             Skip worktree check and main sync — already handled.
+
+             For each dead helper from forge phase <nextPhase>:
+             1. Classify: adopt / re-export / promote / false-positive / intentionally-private / remove
+             2. For adopt/re-export/promote: wire consumers, stage, run /titan-gate, commit
+             3. For remove: delete, stage, run /titan-gate, commit
+             4. Gate on dead-symbol delta at phase end"
+
+    # Post-agent checks
+    headAfter = $(git rev-parse HEAD)
+
+    Read .codegraph/titan/titan-state.json
+    newGrindPhases = grind.completedPhases (or [])
+
+    if newGrindPhases == previousGrindPhases:
+        stallCount += 1
+        Print: "WARNING: Grind iteration <iteration> made no progress (stall <stallCount>/<maxStalls>)"
+        if stallCount >= maxStalls:
+            Stop: "Grind stalled on phase <nextPhase>. Check titan-state.json → grind for details."
+    else:
+        stallCount = 0
+
+    previousGrindPhases = newGrindPhases
+
+    # V16. Commit audit
+    if headAfter != headBefore:
+        git log --oneline <headBefore>..<headAfter>
+        commitCount = number of commits
+        Print: "Grind phase <nextPhase>: <commitCount> adoption commits"
+    else:
+        Print: "Grind phase <nextPhase>: no adoptions needed (forge wired everything correctly)"
+
+    # V17. Test suite still green (same as forge V13)
+    if headAfter != headBefore:
+        testCmd = <same detection as forge V13>
+        if testCmd != "NO_TEST_SCRIPT":
+            Run: <testCmd> 2>&1
+            if tests fail:
+                Print: "WARNING: Test suite has failures after grind phase <nextPhase>. Auto-spawning regression-fix agent."
+                Print: "Failing tests: <list of failing test files>"
+                Print: "Commits from this phase: git log --oneline <headBefore>..<headAfter>"
+
+                # Run Pre-Agent Gate (G1-G4) and back up state
+                # Then dispatch fix agent:
+                Agent → "Investigate and fix test regressions introduced by the last grind phase.
+                         Commits in scope: git log --oneline <headBefore>..<headAfter>
+                         Failing tests: <list>
+                         
+                         Steps:
+                         1. Read the failing tests to understand what they expect
+                         2. Identify which committed change broke them (git diff <headBefore>..<headAfter>)
+                         3. Fix the root cause — prefer targeted fixes over reverts
+                         4. If Rust source changed: rebuild the native addon before running tests
+                            npx napi build --platform --release --manifest-path crates/codegraph-core/Cargo.toml --output-dir .
+                            PLATFORM=$(node -e "const os=require('os');const arch=os.arch()==='arm64'?'arm64':'x64';console.log(os.platform()+'-'+arch)")
+                            if [[ "$(uname)" == "Darwin" ]]; then codesign --sign - --force codegraph-core.node; fi
+                            cp codegraph-core.node "node_modules/@optave/codegraph-${PLATFORM}/codegraph-core.node"
+                         5. Verify with: <testCmd>
+                         6. Commit fixes with: 'fix: correct regressions from grind phase <N>'
+                         7. Do NOT stage: package-lock.json, vitest.config.worktree.ts, tests/benchmarks/resolution/fixtures/python/__pycache__/
+                         
+                         Run all commands INLINE (not in background)."
+                
+                # After fix agent returns, re-run tests:
+                Run: <testCmd> 2>&1
+                if tests still fail:
+                    Print: "CRITICAL: Regression-fix agent could not resolve test failures after grind phase <nextPhase>. Manual intervention required."
+                    Print: "Consider reverting: git revert <headBefore>..HEAD"
+                    Stop.
+                else:
+                    Print: "V17: Regressions resolved by fix agent. Continuing pipeline."
+```
+
+### 4.5c. Post-loop validation
+
+**V18. Dead-symbol delta:**
+Read `grind.deadSymbolBaseline` and `grind.deadSymbolCurrent` from `titan-state.json`.
+- If delta > 10: **WARN** "Grind could not fully adopt forge's helpers. <delta> new dead symbols remain."
+- Otherwise: Print summary.
+
+**V19. Grind coverage:**
+- Count forge phases processed vs total forge phases
+- If < 100%: **WARN** with details
+
+Print grind summary:
+```
+GRIND complete.
+Dead symbols: <baseline> → <current> (delta: <+/-N>)
+Adoptions: <N> helpers wired, <N> removed, <N> false positives logged
+Phases ground: <N>/<M>
+```
+
+Record `phaseTimestamps.grind.completedAt`.
+
+---
+
+## Step 4.6 — PARITY (conditional, repo-provided)
+
+Some repos ship multiple implementations of the same logic that must stay in lockstep (e.g. a dual native/WASM engine, a client and server copy of a validator). Forge and grind edit code across the tree; this step verifies those edits didn't leave one implementation behind.
+
+**titan-run is repo-agnostic** — never assume the target repo has engines, fixtures, or any parity surface. The contract: a repo opts in by shipping its own `/parity` skill at `.claude/skills/parity/SKILL.md` (wrapping whatever audit mechanism it uses internally). No skill → no parity phase.
+
+### 4.6a. Detect the repo's parity mechanism
+
+```bash
+test -f .claude/skills/parity/SKILL.md && echo "PARITY SKILL FOUND" || echo "NO PARITY SKILL"
+```
+
+- **NO PARITY SKILL** → print `"PARITY skipped — repo provides no /parity skill."` and continue to Step 5. Absence is normal for most repos; do not warn.
+- **PARITY SKILL FOUND** → continue below.
+
+**Skip also if:** `--start-from` is `close`, or the pipeline made no code changes this run (`titan-state.json → execution.commits` empty/absent AND no grind adoption commits) — unless `--start-from parity` was given explicitly, which always runs the audit.
+
+### 4.6b. Record phase start
+
+Record `phaseTimestamps.parity.startedAt`.
+
+```bash
+headBefore=$(git rev-parse HEAD)
+```
+
+### 4.6c. Run Pre-Agent Gate (G1-G4)
+
+### 4.6d. Dispatch sub-agent
+
+```
+Agent → "Run /parity. Read .claude/skills/parity/SKILL.md and follow it exactly.
+         Skip worktree check — already handled.
+         Audit every surface the skill covers. Fix any divergence introduced by
+         recent commits at the root cause, commit the fixes, and re-verify until
+         the audit is clean. If a divergence pre-dates this run (verify via
+         git log on the relevant files), follow the skill's and repo's rules for
+         pre-existing findings (typically: file an issue, don't expand scope)."
+```
+
+### 4.6e. Post-phase validation
+
+After the agent returns:
+
+```bash
+headAfter=$(git rev-parse HEAD)
+```
+
+- `git status --short` → the working tree must be clean. The sub-agent commits its fixes; uncommitted changes mean it stopped mid-fix → **stop** and report.
+- If the agent fixed divergences, run V16-style commit audit: `git log --oneline $headBefore..$headAfter` and print the parity-fix commits.
+- If the agent reports divergences introduced by THIS run that it could not fix → **stop**: "PARITY failed — this run introduced implementation drift. Fix before CLOSE or revert the offending commits." Pre-existing divergences filed as issues are not blockers; print the issue URLs.
+
+Print: `"PARITY complete: <clean | N divergences fixed | N pre-existing filed as issues>"`
+
+Record `phaseTimestamps.parity.completedAt`.
+
 ---
 
 ## Step 5 — CLOSE (report + PRs)
@@ -582,6 +922,9 @@ Print forge summary.
 After forge completes, dispatch `/titan-close` to produce the final report with before/after metrics and split commits into focused PRs.
 
 ### 5a. Run Pre-Agent Gate (G1-G4)
+
+### 5a.1. Record phase start timestamp
+Record `phaseTimestamps.close.startedAt`.
 
 ### 5b. Dispatch sub-agent
 
@@ -598,6 +941,118 @@ After the agent returns, verify:
 
 If the agent created PRs, print the PR URLs.
 
+**Commit hygiene check:** If `.claude/skills/` files were modified during this run (e.g., by a V13 regression-fix agent), they must NOT share a commit with `.codegraph/titan/` artifacts. Check:
+```bash
+git status --short | grep -E "\.claude/skills/|generated/titan/|\.codegraph/titan/"
+```
+If both are dirty, commit them separately before proceeding to the retrospective.
+
+Record `phaseTimestamps.close.completedAt`.
+
+---
+
+## Step 6 — RETROSPECTIVE (automatic)
+
+After CLOSE, run a brief retrospective on this pipeline execution and offer to apply findings as skill improvements.
+
+### 6a. Collect run data
+
+Read from disk (no sub-agent needed):
+```bash
+node -e "
+const fs = require('fs');
+const s = JSON.parse(fs.readFileSync('.codegraph/titan/titan-state.json','utf8'));
+const ts = s.phaseTimestamps || {};
+const phases = ['recon','gauntlet','sync','forge','grind','parity','close'];
+for (const p of phases) {
+  if (ts[p]?.startedAt && ts[p]?.completedAt) {
+    const dur = ((new Date(ts[p].completedAt) - new Date(ts[p].startedAt))/60000).toFixed(1);
+    console.log(p + ': ' + dur + ' min');
+  }
+}
+const stalls = s.gauntletStalls || 0;
+const forgeStalls = s.execution?.stallCount || 0;
+const failed = (s.execution?.failedTargets || []).length;
+const grindDelta = (s.grind?.deadSymbolCurrent || 0) - (s.grind?.deadSymbolBaseline || 0);
+console.log('gauntlet stalls:', stalls, '| forge stalls:', forgeStalls, '| failed targets:', failed, '| grind delta:', grindDelta);
+"
+```
+
+### 6b. Dispatch retrospective agent
+
+```
+Agent → "Analyze this Titan pipeline run and produce a retrospective.
+
+Read:
+  - .codegraph/titan/titan-state.json  (phase timestamps, stalls, failed targets)
+  - .codegraph/titan/gate-log.ndjson   (PASS/WARN/FAIL verdicts per commit)
+  - .codegraph/titan/gauntlet-summary.json
+  - .codegraph/titan/issues.ndjson     (bugs and anomalies logged during the run)
+
+Produce a JSON file at .codegraph/titan/retrospective.json:
+{
+  'wentWell': [string],       // phases/outcomes that ran cleanly
+  'anomalies': [              // anything that required retries, fixes, or manual intervention
+    { phase: string, description: string }
+  ],
+  'skillRecs': [              // concrete skill improvements, highest-impact first
+    { priority: 'P1'|'P2'|'P3', area: string, problem: string, fix: string }
+  ]
+}
+
+Keep skillRecs to 3-5 items max. Focus on structural issues (things that would affect every run), not one-off incidents."
+```
+
+### 6c. Print retrospective summary
+
+After the agent writes `retrospective.json`, read and print it:
+```bash
+node -e "
+const fs = require('fs');
+if (!fs.existsSync('.codegraph/titan/retrospective.json')) { console.log('retrospective.json not written — skipping summary'); process.exit(0); }
+const r = JSON.parse(fs.readFileSync('.codegraph/titan/retrospective.json','utf8'));
+console.log('\n=== Titan Retrospective ===');
+console.log('\nWent well:');
+(r.wentWell || []).forEach(w => console.log('  ✓', w));
+if ((r.anomalies||[]).length) {
+  console.log('\nAnomalies:');
+  r.anomalies.forEach(a => console.log('  ⚠', a.phase + ':', a.description));
+}
+if ((r.skillRecs||[]).length) {
+  console.log('\nSkill improvement recommendations:');
+  r.skillRecs.forEach(rec => console.log('  ' + rec.priority + ' [' + rec.area + '] ' + rec.fix));
+}
+console.log('');
+"
+```
+
+### 6d. Offer skill improvement
+
+Ask the user:
+```
+Would you like me to apply these recommendations to improve the /titan-run skill? [y/n]
+```
+
+If `--yes` is set → apply automatically without asking.
+
+**If yes (or --yes):**
+
+Run Pre-Agent Gate (G1-G4), back up state, then:
+
+```
+Agent → "Improve .claude/skills/titan-run/SKILL.md based on these recommendations:
+         <paste skillRecs from retrospective.json>
+
+         Rules:
+         - Use the Edit tool — make targeted changes only, do not rewrite unrelated sections
+         - One logical change per edit call
+         - After editing, verify the file is internally consistent (read the changed sections)
+         - Commit with: 'fix(titan-run): <one-line summary of improvements applied>'
+         - Do NOT stage: package-lock.json, vitest.config.worktree.ts, .codegraph/titan/"
+```
+
+**If no:** Print `"Retrospective saved to .codegraph/titan/retrospective.json — apply recommendations later by editing .claude/skills/titan-run/SKILL.md."` and finish.
+
 ---
 
 ## Error Handling
@@ -607,7 +1062,8 @@ If the agent created PRs, print the PR URLs.
 - **State file corrupt (JSON parse error):** Attempt restore from `.bak`. If no backup → stop: "State file corrupted. Run `/titan-reset` and start over."
 - **NDJSON corrupt lines:** Warn but continue — partial results are better than none. The corrupt lines are logged so the user knows which targets to re-audit.
 - **Merge conflict detected by pre-agent gate:** Stop immediately with the conflicting files listed.
-- **Tests fail after forge phase:** Stop immediately. Print the failing phase's commits so the user can revert.
+- **Tests fail after forge/grind phase:** Auto-spawn a regression-fix agent. If the fix agent resolves the failures, continue the pipeline. If it cannot, stop and print the failing commits so the user can revert.
+- **Parity audit fails on drift introduced by this run:** Stop before CLOSE. Retry with `/titan-run --start-from parity` after fixing or reverting.
 - **Validation failure (any V-check marked FAILED):** Stop with details. Warn-level V-checks are logged but don't stop the pipeline.
 
 ---
@@ -616,7 +1072,7 @@ If the agent created PRs, print the PR URLs.
 
 - **You are the orchestrator, not the executor.** Never run codegraph commands, edit source files, or make commits yourself. Only spawn sub-agents and read state files. Exceptions (pure validation/snapshot, no code changes): the post-forge test run (V13), NDJSON integrity checks, the V3 baseline snapshot check (`codegraph snapshot list`), and the pre-forge architectural snapshot capture (Step 3.5a) are run directly by the orchestrator.
 - **Run the Pre-Agent Gate (G1-G4) before EVERY sub-agent.** No exceptions.
-- **One sub-agent at a time.** Phases are sequential — recon before gauntlet, gauntlet before sync, sync before forge.
+- **One sub-agent at a time.** Phases are sequential — recon before gauntlet, gauntlet before sync, sync before forge, forge before grind, grind before parity (when the repo provides one), parity before close.
 - **Fresh context per sub-agent.** This is the whole point — each sub-agent gets a clean context window.
 - **Read AND validate state files after every sub-agent.** Trust the on-disk state, not the sub-agent's text output — but verify the state is structurally sound.
 - **Back up state before every sub-agent.** The `.bak` file is your safety net against mid-write crashes.
@@ -627,4 +1083,8 @@ If the agent created PRs, print the PR URLs.
 
 ## Self-Improvement
 
-This skill lives at `.claude/skills/titan-run/SKILL.md`. Edit if loop logic needs adjustment, error handling needs improvement, or new phases are added to the pipeline.
+This skill lives at `.claude/skills/titan-run/SKILL.md`. It improves itself automatically via Step 6 (RETROSPECTIVE) at the end of every run.
+
+For manual edits: use the Edit tool for targeted changes. Never rewrite sections unrelated to the fix. Commit skill changes separately from pipeline artifacts (`generated/titan/`, `.codegraph/titan/`) — they must not share a commit.
+
+When adding new phases: update `meta.phases` at the top, add the phase to the timestamp list in Step 0.3, add a V-check for the phase's key artifact, and add the phase to Step 0.5's pre-validation table.

--- a/docs/examples/claude-code-skills/titan-sync/SKILL.md
+++ b/docs/examples/claude-code-skills/titan-sync/SKILL.md
@@ -15,32 +15,55 @@ Your goal: analyze GAUNTLET results to find overlapping problems, identify share
 
 ---
 
-## Step 0 — Pre-flight
+## Step 0 — Pre-flight: find or join the Titan worktree
 
-1. **Worktree check:**
+1. **Locate the Titan session.** Prior phases (RECON, GAUNTLET) may have run in a different worktree or branch. Search for it:
+
+   ```bash
+   git worktree list
+   ```
+
+   For each worktree, check if it contains Titan artifacts:
+   ```bash
+   ls <worktree-path>/.codegraph/titan/titan-state.json 2>/dev/null
+   ```
+
+   Also check branches:
+   ```bash
+   git branch -a --list '*titan*'
+   ```
+
+   **Decision logic:**
+   - **Found exactly one worktree with `titan-state.json` and `currentPhase` is `"gauntlet"`:** GAUNTLET completed — this is the right session. Merge its branch into your worktree.
+   - **Found a worktree but `currentPhase` is not `"gauntlet"`:** Suspicious — could be mid-phase or a different run. If `currentPhase` is `"recon"`, GAUNTLET hasn't run yet. If `"sync"` or later, someone else may be ahead. Ask the user: "Found Titan state at `<path>` with phase `<phase>`. Is this the session to continue?"
+   - **Found multiple worktrees with `titan-state.json`:** List them with `currentPhase` and `lastUpdated`. Ask the user which to continue.
+   - **Found a branch (not worktree) with titan artifacts:** Merge it: `git merge <titan-branch> --no-edit`
+   - **Found nothing:** Stop: "No Titan artifacts found. Run `/titan-recon` then `/titan-gauntlet` first."
+
+2. **Ensure worktree isolation:**
    ```bash
    git rev-parse --show-toplevel && git worktree list
    ```
    If not in a worktree, stop: "Run `/worktree` first."
 
-2. **Sync with main:**
+3. **Sync with main:**
    ```bash
    git fetch origin main && git merge origin/main --no-edit
    ```
    If there are merge conflicts, stop: "Merge conflict detected. Resolve conflicts and re-run `/titan-sync`."
 
-3. **Load artifacts.** Read:
+4. **Load artifacts.** Read:
    - `.codegraph/titan/titan-state.json` — state, domains, batches, file audits
    - `.codegraph/titan/GLOBAL_ARCH.md` — architecture, dependency flow, shared types
    - `.codegraph/titan/gauntlet.ndjson` — per-target audit details
    - `.codegraph/titan/gauntlet-summary.json` — aggregated results
 
-4. **Validate state.** If `titan-state.json` fails to parse, stop: "State file corrupted. Run `/titan-reset`."
+5. **Validate state.** If `titan-state.json` fails to parse, stop: "State file corrupted. Run `/titan-reset`."
 
-5. **Check GAUNTLET completeness.** If `gauntlet-summary.json` has `"complete": false`:
+6. **Check GAUNTLET completeness.** If `gauntlet-summary.json` has `"complete": false`:
    > "GAUNTLET incomplete (<N>/<M> batches). SYNC will plan based on known failures only. Run `/titan-gauntlet` first for a complete plan."
 
-6. **Extract.** From artifacts, collect:
+7. **Extract.** From artifacts, collect:
    - All FAIL and DECOMPOSE targets with violations and files
    - Common violation patterns by pillar
    - Community assignments
@@ -49,7 +72,47 @@ Your goal: analyze GAUNTLET results to find overlapping problems, identify share
 
 ---
 
-## Step 1 — Find dependency clusters among failing targets
+## Step 1 — Drift detection: has main moved since GAUNTLET?
+
+The codebase may have changed between GAUNTLET and now. Detect this before planning on stale audit data.
+
+1. **Compare main SHA:**
+   ```bash
+   git rev-parse origin/main
+   ```
+   Compare against `titan-state.json → mainSHA`. If identical, skip to Step 2.
+
+2. **If main has advanced**, find what changed:
+   ```bash
+   git diff --name-only <mainSHA>..origin/main
+   ```
+
+3. **Cross-reference with GAUNTLET results.** Check which changed files overlap with:
+   - Files that were audited (`gauntlet.ndjson → file` field)
+   - FAIL/DECOMPOSE targets (the ones SYNC plans around)
+   - Dead symbols targeted for removal
+
+4. **Classify staleness:**
+
+   | Level | Condition | Action |
+   |-------|-----------|--------|
+   | **none** | main unchanged | Continue normally |
+   | **low** | Changed files don't overlap with any audited targets | Continue — note drift |
+   | **moderate** | Some FAIL/DECOMPOSE targets are in changed files (<30% affected) | Continue but **flag affected targets** — their audit results may be outdated. Mark clusters containing them as `"needs-verification"` |
+   | **high** | >30% of FAIL targets affected OR shared dependencies changed | **Warn user:** "Main has changed significantly since GAUNTLET. Audit results for N targets may be stale. Recommend `/titan-gauntlet` re-run for affected targets before planning." |
+   | **critical** | New files added to src/ that would be in priority queue, or deleted files that were FAIL targets | **Stop:** "Codebase structure changed. Run `/titan-recon` to rebuild baseline, then `/titan-gauntlet`." |
+
+5. **Append drift report** to `.codegraph/titan/drift-report.json` (the file is a JSON array — read existing entries, push the new entry, write back; same schema as GAUNTLET, with `"detectedBy": "sync"`).
+
+6. **Update state:** Set `titan-state.json → mainSHA` to current `origin/main`.
+
+7. **If `moderate`:** Proceed but annotate affected clusters in `sync.json` with `"driftWarning": true`. The execution order should prioritize non-stale targets and defer stale ones pending re-audit.
+
+8. **If re-running SYNC** and a previous `drift-report.json` exists with `reassessmentScope.targets`, re-read GAUNTLET results only for those targets and rebuild affected clusters.
+
+---
+
+## Step 2 — Find dependency clusters among failing targets
 
 For FAIL/DECOMPOSE targets that share a file or community, check connections:
 
@@ -67,7 +130,7 @@ Filter to cycles including at least one FAIL/DECOMPOSE target.
 
 ---
 
-## Step 2 — Identify shared dependencies and ownership
+## Step 3 — Identify shared dependencies and ownership
 
 For each cluster, find what they share:
 
@@ -98,7 +161,7 @@ Avoid re-auditing or conflicting with in-progress work.
 
 ---
 
-## Step 3 — Detect extraction candidates
+## Step 4 — Detect extraction candidates
 
 For DECOMPOSE targets:
 
@@ -114,7 +177,7 @@ Look for:
 
 ---
 
-## Step 4 — Plan shared abstractions
+## Step 5 — Plan shared abstractions
 
 Identify what to build BEFORE individual fixes:
 
@@ -130,7 +193,7 @@ codegraph fn-impact <shared-dep> -T --json
 
 ---
 
-## Step 5 — Build execution order with logical commits
+## Step 6 — Build execution order with logical commits
 
 ### Phases (in order)
 
@@ -160,7 +223,7 @@ codegraph fn-impact <shared-dep> -T --json
 
 ---
 
-## Step 6 — Write the SYNC artifact
+## Step 7 — Write the SYNC artifact
 
 Write `.codegraph/titan/sync.json`:
 
@@ -208,7 +271,7 @@ Update `titan-state.json`: set `currentPhase` to `"sync"`.
 
 ---
 
-## Step 7 — Report to user
+## Step 8 — Report to user
 
 Print:
 - Dependency clusters found (count)
@@ -220,6 +283,25 @@ Print:
 
 ---
 
+## Issue Tracking
+
+Throughout this phase, if you encounter any of the following, append a JSON line to `.codegraph/titan/issues.ndjson`:
+
+- **Codegraph bugs:** incorrect path queries, wrong cycle detection, relationship errors
+- **Tooling issues:** artifact parsing failures, state inconsistencies
+- **Process suggestions:** better clustering strategies, execution order improvements
+- **Codebase observations:** cross-cutting concerns not captured by GAUNTLET
+
+Format (one JSON object per line, append-only):
+
+```json
+{"phase": "sync", "timestamp": "<ISO 8601>", "severity": "bug|limitation|suggestion", "category": "codegraph|tooling|process|codebase", "description": "<what happened>", "context": "<command, cluster, or artifact involved>"}
+```
+
+Log issues as they happen — don't batch them. The `/titan-close` phase compiles these into the final report.
+
+---
+
 ## Rules
 
 - **Read artifacts, don't re-scan.** Codegraph commands only for targeted relationship queries.
@@ -228,6 +310,7 @@ Print:
 - **Logical commits matter.** Never mix concerns.
 - If GAUNTLET found zero failures, produce minimal plan (dead code + warnings only).
 - Keep `codegraph path` queries targeted — same file or community only.
+- If any command fails or produces unexpected output, **log it to `issues.ndjson`** before continuing.
 
 ## Self-Improvement
 

--- a/docs/use-cases/titan-paradigm.md
+++ b/docs/use-cases/titan-paradigm.md
@@ -261,7 +261,7 @@ Several planned features would make codegraph even more powerful for the Titan P
 
 ## Claude Code Skills — Ready-Made Titan Pipeline
 
-We've built five Claude Code skills that implement the full Titan Paradigm using codegraph. Each phase writes structured JSON artifacts to `.codegraph/titan/` that the next phase reads — this keeps context usage minimal even on large codebases.
+We've built Claude Code skills that implement the full Titan Paradigm using codegraph. Each phase writes structured JSON artifacts to `.codegraph/titan/` that the next phase reads — this keeps context usage minimal even on large codebases.
 
 ```
 /titan-run (orchestrator — runs everything below end-to-end via sub-agents)
@@ -272,9 +272,13 @@ We've built five Claude Code skills that implement the full Titan Paradigm using
       │
       ├─→ /titan-sync → sync.json (execution plan with logical commits)
       │
-      └─→ /titan-forge → code changes + commits (loops phases)
-              │
-              └─→ /titan-gate (validates each commit)
+      ├─→ /titan-forge → code changes + commits (loops phases)
+      │       │
+      │       └─→ /titan-gate (validates each commit)
+      │
+      ├─→ /titan-grind → adopts dead helpers from forge (Phase 4.5)
+      │
+      └─→ /titan-close → PRs + titan-report.md
 
 /titan-reset (escape hatch: clean up all artifacts and snapshots)
 ```
@@ -287,6 +291,8 @@ We've built five Claude Code skills that implement the full Titan Paradigm using
 | `/titan-sync` | GLOBAL SYNC | Finds dependency clusters among failures using `codegraph path` + `owners` + `branch-compare`. Plans shared abstractions, produces ordered execution plan with logical commit grouping |
 | `/titan-forge` | FORGE | Executes the sync plan — makes code changes, validates with `/titan-gate`, commits, advances state. One phase per invocation, resumable |
 | `/titan-gate` | STATE MACHINE | Validates staged changes: `codegraph check --staged --cycles --blast-radius 30 --boundaries` + project lint/build/test. Auto-rollback with snapshot restore on failure. Append-only audit trail |
+| `/titan-grind` | GRIND | Finds dead symbols left behind by forge, wires them into consumers or replaces duplicated inline patterns with them, gates on dead-symbol delta (Phase 4.5) |
+| `/titan-close` | CLOSE | Splits the branch's commits into focused PRs, compiles the cross-phase issue tracker (optionally opening GitHub issues), generates a final report with before/after metrics (Phase 5) |
 | `/titan-reset` | ESCAPE HATCH | Restores baseline snapshot, deletes all Titan artifacts and snapshots, rebuilds graph clean |
 
 ### Context window management
@@ -305,6 +311,7 @@ Codegraph snapshots provide instant graph database backup/restore at each stage:
 |----------|-----------|------------|-----------|
 | `titan-baseline` | RECON | GATE (on failure) | GATE (on final success) or RESET |
 | `titan-batch-N` | GAUNTLET (per batch) | GATE (on failure) | GAUNTLET (next batch replaces it) or RESET |
+| `titan-grind-baseline` | GRIND (per target) | GRIND (on failure) | GRIND (on success) or RESET |
 
 See [Claude Code Skills Example](../examples/claude-code-skills/) for installation and usage.
 

--- a/tests/unit/docs-skills-mirror-sync.test.ts
+++ b/tests/unit/docs-skills-mirror-sync.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Regression test for issue #2009: `docs/examples/claude-code-skills/<skill>/SKILL.md`
+ * files are meant to be exact, install-ready copies of their `.claude/skills/<skill>/SKILL.md`
+ * sources (the README's own install instructions do `cp -r .../titan-*
+ * .claude/skills/`), but nothing enforced that and several drifted out of
+ * sync between when #1879 fixed one gap and when #2009 found five more.
+ *
+ * Compares file content directly rather than re-deriving any drift logic —
+ * a byte-for-byte mismatch is exactly the bug this test exists to catch.
+ */
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = path.join(import.meta.dirname, '../..');
+const MIRROR_DIR = path.join(REPO_ROOT, 'docs/examples/claude-code-skills');
+const SOURCE_DIR = path.join(REPO_ROOT, '.claude/skills');
+
+/** Every skill mirrored under docs/examples/claude-code-skills/ (subdirectories only, skips README.md). */
+function mirroredSkillNames(): string[] {
+  return readdirSync(MIRROR_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name);
+}
+
+describe('docs/examples/claude-code-skills mirrors match .claude/skills sources (#2009)', () => {
+  const skills = mirroredSkillNames();
+
+  it('finds a non-trivial number of mirrored skills (discovery sanity check)', () => {
+    expect(skills.length).toBeGreaterThan(5);
+  });
+
+  for (const skill of skills) {
+    it(`${skill}/SKILL.md mirror is byte-identical to its .claude/skills source`, () => {
+      const sourcePath = path.join(SOURCE_DIR, skill, 'SKILL.md');
+      const mirrorPath = path.join(MIRROR_DIR, skill, 'SKILL.md');
+      const source = readFileSync(sourcePath, 'utf-8');
+      const mirror = readFileSync(mirrorPath, 'utf-8');
+      expect(mirror).toBe(source);
+    });
+  }
+});

--- a/tests/unit/docs-skills-mirror-sync.test.ts
+++ b/tests/unit/docs-skills-mirror-sync.test.ts
@@ -5,6 +5,12 @@
  * .claude/skills/`), but nothing enforced that and several drifted out of
  * sync between when #1879 fixed one gap and when #2009 found five more.
  *
+ * Discovers the expected skill set from `.claude/skills/` (the source of
+ * truth), not from the mirror directory — discovering from the mirror side
+ * would silently pass if a new titan-* skill were added to `.claude/skills/`
+ * without ever getting a mirror at all, since there'd be nothing on the
+ * mirror side to iterate (Greptile review on PR #2218).
+ *
  * Compares file content directly rather than re-deriving any drift logic —
  * a byte-for-byte mismatch is exactly the bug this test exists to catch.
  */
@@ -16,22 +22,27 @@ const REPO_ROOT = path.join(import.meta.dirname, '../..');
 const MIRROR_DIR = path.join(REPO_ROOT, 'docs/examples/claude-code-skills');
 const SOURCE_DIR = path.join(REPO_ROOT, '.claude/skills');
 
-/** Every skill mirrored under docs/examples/claude-code-skills/ (subdirectories only, skips README.md). */
-function mirroredSkillNames(): string[] {
-  return readdirSync(MIRROR_DIR, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory())
+/**
+ * Every `titan-*` skill in `.claude/skills/` — the README's own install
+ * instructions (`cp -r .../titan-* .claude/skills/`) establish this prefix
+ * as exactly the set meant to be publicly mirrored; other skills (fixer,
+ * sweep, dogfood, etc.) are internal-only and intentionally have no mirror.
+ */
+function titanSourceSkillNames(): string[] {
+  return readdirSync(SOURCE_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name.startsWith('titan-'))
     .map((entry) => entry.name);
 }
 
 describe('docs/examples/claude-code-skills mirrors match .claude/skills sources (#2009)', () => {
-  const skills = mirroredSkillNames();
+  const skills = titanSourceSkillNames();
 
-  it('finds a non-trivial number of mirrored skills (discovery sanity check)', () => {
+  it('finds a non-trivial number of titan-* source skills (discovery sanity check)', () => {
     expect(skills.length).toBeGreaterThan(5);
   });
 
   for (const skill of skills) {
-    it(`${skill}/SKILL.md mirror is byte-identical to its .claude/skills source`, () => {
+    it(`${skill}/SKILL.md has a mirror that is byte-identical to its .claude/skills source`, () => {
       const sourcePath = path.join(SOURCE_DIR, skill, 'SKILL.md');
       const mirrorPath = path.join(MIRROR_DIR, skill, 'SKILL.md');
       const source = readFileSync(sourcePath, 'utf-8');


### PR DESCRIPTION
## Summary

`docs/examples/claude-code-skills/<skill>/SKILL.md` files are meant to be exact, install-ready copies of their `.claude/skills/<skill>/SKILL.md` sources (the README's own install instructions `cp` them directly), but nothing enforced that. Beyond the three mirrors named in the issue (`titan-close`, `titan-reset`, `titan-run`), diffing found `titan-recon`, `titan-gauntlet`, `titan-sync`, `titan-forge`, and `titan-grind` had also drifted since #1879 fixed one gap — re-synced all of them (verified each diff was purely additive/stale content in the mirror, never unique content the source lacked, before overwriting).

## Changes

- Re-syncs all 8 diverged `docs/examples/claude-code-skills/<skill>/SKILL.md` mirrors to match their `.claude/skills/` sources exactly.
- Adds the missing GRIND and CLOSE phases to `docs/use-cases/titan-paradigm.md`'s pipeline diagram, skills table, and snapshot lifecycle table (`titan-grind-baseline` snapshot) — the doc previously described only a 5-phase pipeline, invisible to both phases entirely.
- Corrects the README's stale artifact count (said "6 files", the table already listed 10 and was itself missing two real artifacts — `grind-targets.ndjson` and `issues.ndjson`, produced by GRIND and read by CLOSE — now 11 files in `.codegraph/titan/` plus the report committed separately to `generated/titan/`).
- Adds a regression test (`docs-skills-mirror-sync.test.ts`) that fails when any mirror diverges from its source, per the issue's own suggested fix — this is the actual root-cause fix; the manual sync above only clears today's drift, this prevents the next one.

## Test plan
- [x] `npx vitest run tests/unit/docs-skills-mirror-sync.test.ts` — 10/10 pass
- [x] `npm test` — full suite, 262 files / 4284 tests pass
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean

Closes #2009