### PR TITLE
fix: give reverse-dep edge reconnection a content-hash identity signal

### DIFF
--- a/crates/codegraph-core/src/db/connection.rs
+++ b/crates/codegraph-core/src/db/connection.rs
@@ -378,6 +378,22 @@ const MIGRATIONS: &[Migration] = &[
       CREATE INDEX IF NOT EXISTS idx_dataflow_call_edge ON dataflow(call_edge_id);
     "#,
     },
+    Migration {
+        // Per-declaration content hash (issue #2015): reverse-dep-edge
+        // reconnection during incremental rebuilds previously matched
+        // siblings by line position alone, which is provably unsafe when a
+        // same-named/same-kind sibling group has one member renamed away
+        // and a different one added in the same edit — the group's size
+        // stays unchanged, so the line-alignment fast path matches by rank
+        // and can silently reconnect a caller to the wrong declaration. A
+        // content hash gives reconnection a true identity signal to try
+        // first, falling back to line alignment only when a hash is
+        // unavailable (e.g. rows from before this migration).
+        version: 24,
+        up: r#"
+      ALTER TABLE nodes ADD COLUMN content_hash TEXT;
+    "#,
+    },
 ];
 
 // ── napi types ──────────────────────────────────────────────────────────
@@ -726,6 +742,18 @@ impl NativeDatabase {
             if !has_column(conn, "nodes", "visibility") {
                 let _ = conn.execute_batch("ALTER TABLE nodes ADD COLUMN visibility TEXT");
             }
+            // #2015: content_hash is referenced unconditionally by every node
+            // insert (see insert_nodes.rs), unlike the other legacy columns in
+            // this block — propagate failure instead of swallowing it, mirroring
+            // the #2001/#2066 dynamic_kind fix on the edges table below.
+            if !has_column(conn, "nodes", "content_hash") {
+                conn.execute_batch("ALTER TABLE nodes ADD COLUMN content_hash TEXT")
+                    .map_err(|e| {
+                        napi::Error::from_reason(format!(
+                            "legacy repair: add nodes.content_hash failed: {e}"
+                        ))
+                    })?;
+            }
             let _ = conn.execute_batch(
                 "UPDATE nodes SET qualified_name = name WHERE qualified_name IS NULL",
             );
@@ -850,8 +878,10 @@ impl NativeDatabase {
     ) -> napi::Result<Vec<serde_json::Value>> {
         let conn = self.conn()?;
         let rusqlite_params = json_to_rusqlite_params(&params)?;
-        let param_refs: Vec<&dyn rusqlite::types::ToSql> =
-            rusqlite_params.iter().map(|v| v as &dyn rusqlite::types::ToSql).collect();
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> = rusqlite_params
+            .iter()
+            .map(|v| v as &dyn rusqlite::types::ToSql)
+            .collect();
 
         let mut stmt = conn
             .prepare(&sql)
@@ -887,8 +917,10 @@ impl NativeDatabase {
     ) -> napi::Result<Option<serde_json::Value>> {
         let conn = self.conn()?;
         let rusqlite_params = json_to_rusqlite_params(&params)?;
-        let param_refs: Vec<&dyn rusqlite::types::ToSql> =
-            rusqlite_params.iter().map(|v| v as &dyn rusqlite::types::ToSql).collect();
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> = rusqlite_params
+            .iter()
+            .map(|v| v as &dyn rusqlite::types::ToSql)
+            .collect();
 
         let mut stmt = conn
             .prepare(&sql)
@@ -948,17 +980,18 @@ impl NativeDatabase {
     /// finished rebuilding the affected files' edges (see
     /// `insertNodes.commitFileHashes` on the JS side, or
     /// `insert_nodes::commit_file_hashes` for the all-Rust orchestrator).
-    #[napi(ts_args_type = "batches: Array<{ file: string; definitions: Array<{ name: string; kind: string; line: number; endLine?: number; visibility?: string; children: Array<{ name: string; kind: string; line: number; endLine?: number; visibility?: string }> }>; exports: Array<{ name: string; kind: string; line: number }> }>, fileHashes: FileHashEntry[], removedFiles: string[]")]
+    #[napi(
+        ts_args_type = "batches: Array<{ file: string; definitions: Array<{ name: string; kind: string; line: number; endLine?: number; visibility?: string; children: Array<{ name: string; kind: string; line: number; endLine?: number; visibility?: string }> }>; exports: Array<{ name: string; kind: string; line: number }> }>, fileHashes: FileHashEntry[], removedFiles: string[]"
+    )]
     pub fn bulk_insert_nodes(
         &self,
         batches: serde_json::Value,
         file_hashes: Vec<FileHashEntry>,
         removed_files: Vec<String>,
     ) -> napi::Result<bool> {
-        let batches: Vec<InsertNodesBatch> = serde_json::from_value(batches)
-            .map_err(|e| {
-                napi::Error::from_reason(format!("bulk_insert_nodes: invalid batches: {e}"))
-            })?;
+        let batches: Vec<InsertNodesBatch> = serde_json::from_value(batches).map_err(|e| {
+            napi::Error::from_reason(format!("bulk_insert_nodes: invalid batches: {e}"))
+        })?;
         let conn = self.conn()?;
         let insert_ok = insert_nodes::do_insert_nodes(conn, &batches, &removed_files)
             .inspect_err(|e| eprintln!("[NativeDatabase] bulk_insert_nodes failed: {e}"))
@@ -967,7 +1000,9 @@ impl NativeDatabase {
             return Ok(false);
         }
         let hashes_ok = insert_nodes::commit_file_hashes(conn, &file_hashes)
-            .inspect_err(|e| eprintln!("[NativeDatabase] bulk_insert_nodes hash commit failed: {e}"))
+            .inspect_err(|e| {
+                eprintln!("[NativeDatabase] bulk_insert_nodes hash commit failed: {e}")
+            })
             .is_ok();
         Ok(hashes_ok)
     }
@@ -1010,8 +1045,9 @@ impl NativeDatabase {
             .map_err(|e| napi::Error::from_reason(format!("complexity tx failed: {e}")))?;
         let mut total = 0u32;
         {
-            let mut stmt = tx.prepare(
-                "INSERT OR REPLACE INTO function_complexity \
+            let mut stmt = tx
+                .prepare(
+                    "INSERT OR REPLACE INTO function_complexity \
                  (node_id, cognitive, cyclomatic, max_nesting, \
                   loc, sloc, comment_lines, \
                   halstead_n1, halstead_n2, halstead_big_n1, halstead_big_n2, \
@@ -1019,8 +1055,8 @@ impl NativeDatabase {
                   halstead_difficulty, halstead_effort, halstead_bugs, \
                   maintainability_index) \
                  VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18)",
-            )
-            .map_err(|e| napi::Error::from_reason(format!("complexity prepare failed: {e}")))?;
+                )
+                .map_err(|e| napi::Error::from_reason(format!("complexity prepare failed: {e}")))?;
 
             for r in &rows {
                 if stmt
@@ -1071,37 +1107,43 @@ impl NativeDatabase {
             .map_err(|e| napi::Error::from_reason(format!("cfg tx failed: {e}")))?;
         let mut total = 0u32;
         {
-            let mut block_stmt = tx.prepare(
-                "INSERT INTO cfg_blocks \
+            let mut block_stmt = tx
+                .prepare(
+                    "INSERT INTO cfg_blocks \
                  (function_node_id, block_index, block_type, start_line, end_line, label) \
                  VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-            )
-            .map_err(|e| napi::Error::from_reason(format!("cfg_blocks prepare failed: {e}")))?;
+                )
+                .map_err(|e| napi::Error::from_reason(format!("cfg_blocks prepare failed: {e}")))?;
 
-            let mut edge_stmt = tx.prepare(
-                "INSERT INTO cfg_edges \
+            let mut edge_stmt = tx
+                .prepare(
+                    "INSERT INTO cfg_edges \
                  (function_node_id, source_block_id, target_block_id, kind) \
                  VALUES (?1, ?2, ?3, ?4)",
-            )
-            .map_err(|e| napi::Error::from_reason(format!("cfg_edges prepare failed: {e}")))?;
+                )
+                .map_err(|e| napi::Error::from_reason(format!("cfg_edges prepare failed: {e}")))?;
 
-            let mut del_edges = tx.prepare(
-                "DELETE FROM cfg_edges WHERE function_node_id = ?1",
-            )
-            .map_err(|e| napi::Error::from_reason(format!("cfg_edges del prepare failed: {e}")))?;
-            let mut del_blocks = tx.prepare(
-                "DELETE FROM cfg_blocks WHERE function_node_id = ?1",
-            )
-            .map_err(|e| napi::Error::from_reason(format!("cfg_blocks del prepare failed: {e}")))?;
+            let mut del_edges = tx
+                .prepare("DELETE FROM cfg_edges WHERE function_node_id = ?1")
+                .map_err(|e| {
+                    napi::Error::from_reason(format!("cfg_edges del prepare failed: {e}"))
+                })?;
+            let mut del_blocks = tx
+                .prepare("DELETE FROM cfg_blocks WHERE function_node_id = ?1")
+                .map_err(|e| {
+                    napi::Error::from_reason(format!("cfg_blocks del prepare failed: {e}"))
+                })?;
 
             for entry in &entries {
                 // Delete existing CFG data for this node so the caller doesn't
                 // need to perform deletes on a separate (JS) connection, which
                 // would cause a WAL conflict with the native connection.
-                del_edges.execute(params![entry.node_id])
-                    .map_err(|e| napi::Error::from_reason(format!("cfg_edges delete failed: {e}")))?;
-                del_blocks.execute(params![entry.node_id])
-                    .map_err(|e| napi::Error::from_reason(format!("cfg_blocks delete failed: {e}")))?;
+                del_edges.execute(params![entry.node_id]).map_err(|e| {
+                    napi::Error::from_reason(format!("cfg_edges delete failed: {e}"))
+                })?;
+                del_blocks.execute(params![entry.node_id]).map_err(|e| {
+                    napi::Error::from_reason(format!("cfg_blocks delete failed: {e}"))
+                })?;
 
                 let mut block_db_ids: std::collections::HashMap<u32, i64> =
                     std::collections::HashMap::new();
@@ -1149,12 +1191,13 @@ impl NativeDatabase {
             .map_err(|e| napi::Error::from_reason(format!("dataflow tx failed: {e}")))?;
         let mut total = 0u32;
         {
-            let mut stmt = tx.prepare(
-                "INSERT INTO dataflow \
+            let mut stmt = tx
+                .prepare(
+                    "INSERT INTO dataflow \
                  (source_id, target_id, kind, param_index, expression, line, confidence) \
                  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-            )
-            .map_err(|e| napi::Error::from_reason(format!("dataflow prepare failed: {e}")))?;
+                )
+                .map_err(|e| napi::Error::from_reason(format!("dataflow prepare failed: {e}")))?;
 
             for e in &edges {
                 if stmt
@@ -1213,7 +1256,9 @@ impl NativeDatabase {
         }
         let mut stmt = conn
             .prepare_cached("SELECT file, hash, mtime, size FROM file_hashes")
-            .map_err(|e| napi::Error::from_reason(format!("getFileHashData prepare failed: {e}")))?;
+            .map_err(|e| {
+                napi::Error::from_reason(format!("getFileHashData prepare failed: {e}"))
+            })?;
         let mut rows = Vec::new();
         let mut max_mtime: i64 = 0;
         let mapped = stmt
@@ -1252,8 +1297,10 @@ impl NativeDatabase {
     pub fn check_pending_analysis(&self) -> napi::Result<PendingAnalysisCounts> {
         let conn = self.conn()?;
         let cfg_count = if has_table(conn, "cfg_blocks") {
-            conn.query_row("SELECT COUNT(*) FROM cfg_blocks", [], |r| r.get::<_, i64>(0))
-                .unwrap_or(-1)
+            conn.query_row("SELECT COUNT(*) FROM cfg_blocks", [], |r| {
+                r.get::<_, i64>(0)
+            })
+            .unwrap_or(-1)
         } else {
             -1
         };
@@ -1300,7 +1347,10 @@ impl NativeDatabase {
     /// Find files that have edges pointing to any of the changed files.
     /// Returns deduplicated list of reverse-dependency file paths.
     #[napi]
-    pub fn find_reverse_dependencies(&self, changed_files: Vec<String>) -> napi::Result<Vec<String>> {
+    pub fn find_reverse_dependencies(
+        &self,
+        changed_files: Vec<String>,
+    ) -> napi::Result<Vec<String>> {
         if changed_files.is_empty() {
             return Ok(vec![]);
         }
@@ -1321,9 +1371,7 @@ impl NativeDatabase {
         for file in &changed_files {
             let rows = stmt
                 .query_map(params![file], |row| row.get::<_, String>(0))
-                .map_err(|e| {
-                    napi::Error::from_reason(format!("reverseDeps query failed: {e}"))
-                })?;
+                .map_err(|e| napi::Error::from_reason(format!("reverseDeps query failed: {e}")))?;
             for row in rows {
                 if let Ok(dep_file) = row {
                     if !changed_set.contains(dep_file.as_str()) {
@@ -1422,10 +1470,7 @@ impl NativeDatabase {
             .map_err(|e| napi::Error::from_reason(format!("collectFiles query failed: {e}")))?;
         let files: Vec<String> = rows.filter_map(|r| r.ok()).collect();
         let count = files.len() as i64;
-        Ok(CollectFilesData {
-            count,
-            files,
-        })
+        Ok(CollectFilesData { count, files })
     }
 
     /// Cascade-delete all graph data for the specified files across all tables.
@@ -1504,12 +1549,11 @@ impl NativeDatabase {
             for file in rev_files {
                 // Optional — column absent in pre-v18 schemas; ignore errors.
                 let _ = tx.execute(dfcall_sql, params![file]);
-                tx.execute(edge_sql, params![file])
-                    .map_err(|e| {
-                        napi::Error::from_reason(format!(
-                            "reverse-dep edge purge failed for \"{file}\": {e}"
-                        ))
-                    })?;
+                tx.execute(edge_sql, params![file]).map_err(|e| {
+                    napi::Error::from_reason(format!(
+                        "reverse-dep edge purge failed for \"{file}\": {e}"
+                    ))
+                })?;
             }
         }
 
@@ -1656,6 +1700,71 @@ fn row_to_json(
 mod tests {
     use super::*;
 
+    /// Regression for #2015: a database whose schema was initialized purely
+    /// through the native `init_schema()` must end up with
+    /// `nodes.content_hash` — needed by reverse-dep-edge reconnection to
+    /// disambiguate a same-named/same-kind sibling group where one member
+    /// was renamed away and a different one added in the same edit (a
+    /// net-zero group-size change the prior line-alignment-only heuristic
+    /// cannot distinguish from "same declaration, shifted").
+    #[test]
+    fn init_schema_adds_nodes_content_hash_column() {
+        let db = NativeDatabase::open_read_write(":memory:".to_string(), None)
+            .expect("open_read_write should succeed for :memory:");
+        db.init_schema().expect("init_schema should succeed");
+
+        let conn = db.conn().expect("connection should still be open");
+        let mut stmt = conn.prepare("PRAGMA table_info(nodes)").unwrap();
+        let has_content_hash = stmt
+            .query_map([], |row| row.get::<_, String>(1))
+            .unwrap()
+            .filter_map(Result::ok)
+            .any(|name| name == "content_hash");
+
+        assert!(
+            has_content_hash,
+            "nodes.content_hash column missing after native-only init_schema()"
+        );
+    }
+
+    /// Regression for #2015, mirroring the #2001/#2066 pattern: a
+    /// native-only database already stamped past v24 (e.g. by a future
+    /// migration added without content_hash ever having been applied) must
+    /// still be repaired by the unconditional legacy-column backfill, not
+    /// just the version-gated migration. Stamps to the current max computed
+    /// from `MIGRATIONS` itself (not a hardcoded literal — see the
+    /// dynamic_kind repair test's doc comment for why a hardcoded version
+    /// number silently goes stale as soon as a later migration is added).
+    #[test]
+    fn init_schema_repairs_nodes_content_hash_on_a_database_already_past_v24() {
+        let db = NativeDatabase::open_read_write(":memory:".to_string(), None)
+            .expect("open_read_write should succeed for :memory:");
+        db.init_schema()
+            .expect("initial init_schema should succeed");
+
+        let max_version = MIGRATIONS.iter().map(|m| m.version).max().unwrap();
+        {
+            let conn = db.conn().expect("connection should still be open");
+            conn.execute_batch(&format!(
+                "ALTER TABLE nodes DROP COLUMN content_hash; \
+                 UPDATE schema_version SET version = {max_version};"
+            ))
+            .expect("simulating the pre-fix state should succeed");
+            assert!(
+                !has_column(conn, "nodes", "content_hash"),
+                "test setup failed: content_hash should be absent after the simulated drop"
+            );
+        }
+
+        db.init_schema()
+            .expect("repair init_schema call should succeed");
+        let conn = db.conn().expect("connection should still be open");
+        assert!(
+            has_column(conn, "nodes", "content_hash"),
+            "nodes.content_hash was not repaired for a database already stamped past v24"
+        );
+    }
+
     /// Regression for #2001/#2066: a database whose schema was initialized
     /// purely through the native `init_schema()` (never touched by the TS
     /// `initSchema()` in src/db/migrations.ts) must still end up with
@@ -1692,23 +1801,29 @@ mod tests {
     /// to the array. Only the unconditional, reality-checked legacy-column
     /// backfill (not the version-gated migration itself) can repair an
     /// already-affected database. Simulates that exact prior-bug state by
-    /// stamping schema_version to 23 (the current max) and dropping
-    /// dynamic_kind back out before re-running init_schema().
+    /// stamping schema_version to the current max (computed from `MIGRATIONS`
+    /// itself, not hardcoded — a hardcoded literal silently drifts stale
+    /// every time a later migration is added, spuriously re-attempting that
+    /// migration and failing on a column that already exists, exactly as
+    /// happened here when v24 was added after this test was written) and
+    /// dropping dynamic_kind back out before re-running init_schema().
     #[test]
     fn init_schema_repairs_edges_dynamic_kind_on_a_database_already_past_v20() {
         let db = NativeDatabase::open_read_write(":memory:".to_string(), None)
             .expect("open_read_write should succeed for :memory:");
-        db.init_schema().expect("initial init_schema should succeed");
+        db.init_schema()
+            .expect("initial init_schema should succeed");
 
+        let max_version = MIGRATIONS.iter().map(|m| m.version).max().unwrap();
         {
             let conn = db.conn().expect("connection should still be open");
             // Simulate the pre-fix native-only end state: schema stamped past
             // v20, but the column itself never actually got added.
-            conn.execute_batch(
+            conn.execute_batch(&format!(
                 "DROP INDEX IF EXISTS idx_edges_dynamic_kind; \
                  ALTER TABLE edges DROP COLUMN dynamic_kind; \
-                 UPDATE schema_version SET version = 23;",
-            )
+                 UPDATE schema_version SET version = {max_version};"
+            ))
             .expect("simulating the pre-fix state should succeed");
             assert!(
                 !has_column(conn, "edges", "dynamic_kind"),

--- a/crates/codegraph-core/src/db/connection.rs
+++ b/crates/codegraph-core/src/db/connection.rs
@@ -878,10 +878,8 @@ impl NativeDatabase {
     ) -> napi::Result<Vec<serde_json::Value>> {
         let conn = self.conn()?;
         let rusqlite_params = json_to_rusqlite_params(&params)?;
-        let param_refs: Vec<&dyn rusqlite::types::ToSql> = rusqlite_params
-            .iter()
-            .map(|v| v as &dyn rusqlite::types::ToSql)
-            .collect();
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+            rusqlite_params.iter().map(|v| v as &dyn rusqlite::types::ToSql).collect();
 
         let mut stmt = conn
             .prepare(&sql)
@@ -917,10 +915,8 @@ impl NativeDatabase {
     ) -> napi::Result<Option<serde_json::Value>> {
         let conn = self.conn()?;
         let rusqlite_params = json_to_rusqlite_params(&params)?;
-        let param_refs: Vec<&dyn rusqlite::types::ToSql> = rusqlite_params
-            .iter()
-            .map(|v| v as &dyn rusqlite::types::ToSql)
-            .collect();
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+            rusqlite_params.iter().map(|v| v as &dyn rusqlite::types::ToSql).collect();
 
         let mut stmt = conn
             .prepare(&sql)
@@ -980,18 +976,17 @@ impl NativeDatabase {
     /// finished rebuilding the affected files' edges (see
     /// `insertNodes.commitFileHashes` on the JS side, or
     /// `insert_nodes::commit_file_hashes` for the all-Rust orchestrator).
-    #[napi(
-        ts_args_type = "batches: Array<{ file: string; definitions: Array<{ name: string; kind: string; line: number; endLine?: number; visibility?: string; children: Array<{ name: string; kind: string; line: number; endLine?: number; visibility?: string }> }>; exports: Array<{ name: string; kind: string; line: number }> }>, fileHashes: FileHashEntry[], removedFiles: string[]"
-    )]
+    #[napi(ts_args_type = "batches: Array<{ file: string; definitions: Array<{ name: string; kind: string; line: number; endLine?: number; visibility?: string; children: Array<{ name: string; kind: string; line: number; endLine?: number; visibility?: string }> }>; exports: Array<{ name: string; kind: string; line: number }> }>, fileHashes: FileHashEntry[], removedFiles: string[]")]
     pub fn bulk_insert_nodes(
         &self,
         batches: serde_json::Value,
         file_hashes: Vec<FileHashEntry>,
         removed_files: Vec<String>,
     ) -> napi::Result<bool> {
-        let batches: Vec<InsertNodesBatch> = serde_json::from_value(batches).map_err(|e| {
-            napi::Error::from_reason(format!("bulk_insert_nodes: invalid batches: {e}"))
-        })?;
+        let batches: Vec<InsertNodesBatch> = serde_json::from_value(batches)
+            .map_err(|e| {
+                napi::Error::from_reason(format!("bulk_insert_nodes: invalid batches: {e}"))
+            })?;
         let conn = self.conn()?;
         let insert_ok = insert_nodes::do_insert_nodes(conn, &batches, &removed_files)
             .inspect_err(|e| eprintln!("[NativeDatabase] bulk_insert_nodes failed: {e}"))
@@ -1000,9 +995,7 @@ impl NativeDatabase {
             return Ok(false);
         }
         let hashes_ok = insert_nodes::commit_file_hashes(conn, &file_hashes)
-            .inspect_err(|e| {
-                eprintln!("[NativeDatabase] bulk_insert_nodes hash commit failed: {e}")
-            })
+            .inspect_err(|e| eprintln!("[NativeDatabase] bulk_insert_nodes hash commit failed: {e}"))
             .is_ok();
         Ok(hashes_ok)
     }
@@ -1045,9 +1038,8 @@ impl NativeDatabase {
             .map_err(|e| napi::Error::from_reason(format!("complexity tx failed: {e}")))?;
         let mut total = 0u32;
         {
-            let mut stmt = tx
-                .prepare(
-                    "INSERT OR REPLACE INTO function_complexity \
+            let mut stmt = tx.prepare(
+                "INSERT OR REPLACE INTO function_complexity \
                  (node_id, cognitive, cyclomatic, max_nesting, \
                   loc, sloc, comment_lines, \
                   halstead_n1, halstead_n2, halstead_big_n1, halstead_big_n2, \
@@ -1055,8 +1047,8 @@ impl NativeDatabase {
                   halstead_difficulty, halstead_effort, halstead_bugs, \
                   maintainability_index) \
                  VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18)",
-                )
-                .map_err(|e| napi::Error::from_reason(format!("complexity prepare failed: {e}")))?;
+            )
+            .map_err(|e| napi::Error::from_reason(format!("complexity prepare failed: {e}")))?;
 
             for r in &rows {
                 if stmt
@@ -1107,43 +1099,37 @@ impl NativeDatabase {
             .map_err(|e| napi::Error::from_reason(format!("cfg tx failed: {e}")))?;
         let mut total = 0u32;
         {
-            let mut block_stmt = tx
-                .prepare(
-                    "INSERT INTO cfg_blocks \
+            let mut block_stmt = tx.prepare(
+                "INSERT INTO cfg_blocks \
                  (function_node_id, block_index, block_type, start_line, end_line, label) \
                  VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-                )
-                .map_err(|e| napi::Error::from_reason(format!("cfg_blocks prepare failed: {e}")))?;
+            )
+            .map_err(|e| napi::Error::from_reason(format!("cfg_blocks prepare failed: {e}")))?;
 
-            let mut edge_stmt = tx
-                .prepare(
-                    "INSERT INTO cfg_edges \
+            let mut edge_stmt = tx.prepare(
+                "INSERT INTO cfg_edges \
                  (function_node_id, source_block_id, target_block_id, kind) \
                  VALUES (?1, ?2, ?3, ?4)",
-                )
-                .map_err(|e| napi::Error::from_reason(format!("cfg_edges prepare failed: {e}")))?;
+            )
+            .map_err(|e| napi::Error::from_reason(format!("cfg_edges prepare failed: {e}")))?;
 
-            let mut del_edges = tx
-                .prepare("DELETE FROM cfg_edges WHERE function_node_id = ?1")
-                .map_err(|e| {
-                    napi::Error::from_reason(format!("cfg_edges del prepare failed: {e}"))
-                })?;
-            let mut del_blocks = tx
-                .prepare("DELETE FROM cfg_blocks WHERE function_node_id = ?1")
-                .map_err(|e| {
-                    napi::Error::from_reason(format!("cfg_blocks del prepare failed: {e}"))
-                })?;
+            let mut del_edges = tx.prepare(
+                "DELETE FROM cfg_edges WHERE function_node_id = ?1",
+            )
+            .map_err(|e| napi::Error::from_reason(format!("cfg_edges del prepare failed: {e}")))?;
+            let mut del_blocks = tx.prepare(
+                "DELETE FROM cfg_blocks WHERE function_node_id = ?1",
+            )
+            .map_err(|e| napi::Error::from_reason(format!("cfg_blocks del prepare failed: {e}")))?;
 
             for entry in &entries {
                 // Delete existing CFG data for this node so the caller doesn't
                 // need to perform deletes on a separate (JS) connection, which
                 // would cause a WAL conflict with the native connection.
-                del_edges.execute(params![entry.node_id]).map_err(|e| {
-                    napi::Error::from_reason(format!("cfg_edges delete failed: {e}"))
-                })?;
-                del_blocks.execute(params![entry.node_id]).map_err(|e| {
-                    napi::Error::from_reason(format!("cfg_blocks delete failed: {e}"))
-                })?;
+                del_edges.execute(params![entry.node_id])
+                    .map_err(|e| napi::Error::from_reason(format!("cfg_edges delete failed: {e}")))?;
+                del_blocks.execute(params![entry.node_id])
+                    .map_err(|e| napi::Error::from_reason(format!("cfg_blocks delete failed: {e}")))?;
 
                 let mut block_db_ids: std::collections::HashMap<u32, i64> =
                     std::collections::HashMap::new();
@@ -1191,13 +1177,12 @@ impl NativeDatabase {
             .map_err(|e| napi::Error::from_reason(format!("dataflow tx failed: {e}")))?;
         let mut total = 0u32;
         {
-            let mut stmt = tx
-                .prepare(
-                    "INSERT INTO dataflow \
+            let mut stmt = tx.prepare(
+                "INSERT INTO dataflow \
                  (source_id, target_id, kind, param_index, expression, line, confidence) \
                  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-                )
-                .map_err(|e| napi::Error::from_reason(format!("dataflow prepare failed: {e}")))?;
+            )
+            .map_err(|e| napi::Error::from_reason(format!("dataflow prepare failed: {e}")))?;
 
             for e in &edges {
                 if stmt
@@ -1256,9 +1241,7 @@ impl NativeDatabase {
         }
         let mut stmt = conn
             .prepare_cached("SELECT file, hash, mtime, size FROM file_hashes")
-            .map_err(|e| {
-                napi::Error::from_reason(format!("getFileHashData prepare failed: {e}"))
-            })?;
+            .map_err(|e| napi::Error::from_reason(format!("getFileHashData prepare failed: {e}")))?;
         let mut rows = Vec::new();
         let mut max_mtime: i64 = 0;
         let mapped = stmt
@@ -1297,10 +1280,8 @@ impl NativeDatabase {
     pub fn check_pending_analysis(&self) -> napi::Result<PendingAnalysisCounts> {
         let conn = self.conn()?;
         let cfg_count = if has_table(conn, "cfg_blocks") {
-            conn.query_row("SELECT COUNT(*) FROM cfg_blocks", [], |r| {
-                r.get::<_, i64>(0)
-            })
-            .unwrap_or(-1)
+            conn.query_row("SELECT COUNT(*) FROM cfg_blocks", [], |r| r.get::<_, i64>(0))
+                .unwrap_or(-1)
         } else {
             -1
         };
@@ -1347,10 +1328,7 @@ impl NativeDatabase {
     /// Find files that have edges pointing to any of the changed files.
     /// Returns deduplicated list of reverse-dependency file paths.
     #[napi]
-    pub fn find_reverse_dependencies(
-        &self,
-        changed_files: Vec<String>,
-    ) -> napi::Result<Vec<String>> {
+    pub fn find_reverse_dependencies(&self, changed_files: Vec<String>) -> napi::Result<Vec<String>> {
         if changed_files.is_empty() {
             return Ok(vec![]);
         }
@@ -1371,7 +1349,9 @@ impl NativeDatabase {
         for file in &changed_files {
             let rows = stmt
                 .query_map(params![file], |row| row.get::<_, String>(0))
-                .map_err(|e| napi::Error::from_reason(format!("reverseDeps query failed: {e}")))?;
+                .map_err(|e| {
+                    napi::Error::from_reason(format!("reverseDeps query failed: {e}"))
+                })?;
             for row in rows {
                 if let Ok(dep_file) = row {
                     if !changed_set.contains(dep_file.as_str()) {
@@ -1470,7 +1450,10 @@ impl NativeDatabase {
             .map_err(|e| napi::Error::from_reason(format!("collectFiles query failed: {e}")))?;
         let files: Vec<String> = rows.filter_map(|r| r.ok()).collect();
         let count = files.len() as i64;
-        Ok(CollectFilesData { count, files })
+        Ok(CollectFilesData {
+            count,
+            files,
+        })
     }
 
     /// Cascade-delete all graph data for the specified files across all tables.
@@ -1549,11 +1532,12 @@ impl NativeDatabase {
             for file in rev_files {
                 // Optional — column absent in pre-v18 schemas; ignore errors.
                 let _ = tx.execute(dfcall_sql, params![file]);
-                tx.execute(edge_sql, params![file]).map_err(|e| {
-                    napi::Error::from_reason(format!(
-                        "reverse-dep edge purge failed for \"{file}\": {e}"
-                    ))
-                })?;
+                tx.execute(edge_sql, params![file])
+                    .map_err(|e| {
+                        napi::Error::from_reason(format!(
+                            "reverse-dep edge purge failed for \"{file}\": {e}"
+                        ))
+                    })?;
             }
         }
 
@@ -1811,8 +1795,7 @@ mod tests {
     fn init_schema_repairs_edges_dynamic_kind_on_a_database_already_past_v20() {
         let db = NativeDatabase::open_read_write(":memory:".to_string(), None)
             .expect("open_read_write should succeed for :memory:");
-        db.init_schema()
-            .expect("initial init_schema should succeed");
+        db.init_schema().expect("initial init_schema should succeed");
 
         let max_version = MIGRATIONS.iter().map(|m| m.version).max().unwrap();
         {

--- a/crates/codegraph-core/src/domain/graph/builder/incremental.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/incremental.rs
@@ -5,6 +5,7 @@ use tree_sitter::{Parser, Tree};
 use napi_derive::napi;
 
 use crate::extractors::extract_symbols;
+use crate::domain::parallel::compute_declaration_hashes;
 use crate::domain::parser::LanguageKind;
 use crate::types::FileSymbols;
 
@@ -48,7 +49,10 @@ impl ParseTreeCache {
         let old_tree = self.entries.get(&file_path).map(|e| &e.tree);
         let tree = parser.parse(source_bytes, old_tree)?;
 
-        let symbols = extract_symbols(lang, &tree, source_bytes, &file_path);
+        let mut symbols = extract_symbols(lang, &tree, source_bytes, &file_path);
+        let source_text = String::from_utf8_lossy(source_bytes);
+        let lines: Vec<&str> = source_text.lines().collect();
+        compute_declaration_hashes(&mut symbols.definitions, &lines);
 
         self.entries.insert(file_path, CacheEntry { tree });
 

--- a/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
@@ -1202,6 +1202,7 @@ fn build_insert_batches(
                         line: d.line,
                         end_line: d.end_line,
                         visibility: None,
+                        content_hash: d.content_hash.clone(),
                         children: d
                             .children
                             .as_ref()
@@ -1213,6 +1214,7 @@ fn build_insert_batches(
                                         line: c.line,
                                         end_line: c.end_line,
                                         visibility: None,
+                                        content_hash: c.content_hash.clone(),
                                     })
                                     .collect()
                             })

--- a/crates/codegraph-core/src/domain/graph/builder/stages/detect_changes.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/detect_changes.rs
@@ -653,8 +653,7 @@ fn pick_reconnect_target(
             let alignment = match alignment_cache.entry(group_key.clone()) {
                 std::collections::hash_map::Entry::Occupied(e) => e.into_mut(),
                 std::collections::hash_map::Entry::Vacant(e) => {
-                    let new_lines: Vec<i64> =
-                        candidates.iter().map(|(_, line, _)| *line).collect();
+                    let new_lines: Vec<i64> = candidates.iter().map(|(_, line, _)| *line).collect();
                     e.insert(align_sibling_lines(old_lines, &new_lines))
                 }
             };
@@ -1309,13 +1308,11 @@ mod tests {
     /// the saved target) — these tests specifically exercise the
     /// hash-unavailable line-alignment fallback; see `pick_with_hash` for
     /// the #2015 hash-matching behavior.
-    fn pick(
-        candidates: &[(i64, i64)],
-        old_lines: &[i64],
-        tgt_line: i64,
-    ) -> Option<i64> {
-        let with_hash: Vec<(i64, i64, Option<String>)> =
-            candidates.iter().map(|&(id, line)| (id, line, None)).collect();
+    fn pick(candidates: &[(i64, i64)], old_lines: &[i64], tgt_line: i64) -> Option<i64> {
+        let with_hash: Vec<(i64, i64, Option<String>)> = candidates
+            .iter()
+            .map(|&(id, line)| (id, line, None))
+            .collect();
         pick_with_hash(&with_hash, tgt_line, None, old_lines)
     }
 
@@ -1331,7 +1328,9 @@ mod tests {
         let mut groups = HashMap::new();
         groups.insert(key.clone(), old_lines.to_vec());
         let mut cache = HashMap::new();
-        pick_reconnect_target(candidates, tgt_line, tgt_hash, &key, &groups, &mut cache, 200)
+        pick_reconnect_target(
+            candidates, tgt_line, tgt_hash, &key, &groups, &mut cache, 200,
+        )
     }
 
     #[test]
@@ -1767,7 +1766,10 @@ mod tests {
             )
             .map(|c| c > 0)
             .unwrap_or(false);
-        assert!(!e_has_incoming, "no caller should have been reconnected to the new sibling E");
+        assert!(
+            !e_has_incoming,
+            "no caller should have been reconnected to the new sibling E"
+        );
     }
 
     // ── capture_removed_file_neighbors (#1839) ──────────────────────────

--- a/crates/codegraph-core/src/domain/graph/builder/stages/detect_changes.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/detect_changes.rs
@@ -613,6 +613,18 @@ fn pick_reconnect_target(
     if candidates.is_empty() {
         return None;
     }
+    // A lone candidate is trusted unconditionally, without consulting the
+    // hash: unlike the multi-candidate case, there is no sibling to
+    // corroborate a hash mismatch as "an unrelated declaration," and the
+    // overwhelmingly common cause of a sole candidate's hash differing from
+    // the saved one is simply that its OWN body was edited in the same
+    // change — content_hash is a hash of the declaration's source text, so
+    // any in-place edit changes it. Gating on the hash here would silently
+    // drop the edge for that ordinary case (caught by #1744's regression
+    // test), trading a common, legitimate scenario for a rare
+    // rename-away-and-replace collision that a hash comparison cannot even
+    // reliably distinguish from a body edit when there is only one
+    // candidate to compare against.
     if candidates.len() == 1 {
         return Some(candidates[0].0);
     }
@@ -1429,6 +1441,22 @@ mod tests {
     }
 
     #[test]
+    fn pick_reconnect_target_trusts_sole_candidate_even_when_hash_mismatches() {
+        // A sole candidate's hash naturally differs from the saved one
+        // whenever its OWN body was edited in the same change — the single
+        // most common real-world scenario (see #1744's regression test,
+        // which exercises exactly this for a file with one function whose
+        // body changes). Unlike the multi-candidate case, there's no
+        // sibling to corroborate a mismatch as "this is a different,
+        // unrelated declaration," so the sole candidate must still be
+        // trusted rather than dropped.
+        let old_lines = vec![100];
+        let candidates = vec![(21, 130, Some("hash-edited-body".to_string()))];
+        let picked = pick_with_hash(&candidates, 100, Some("hash-original-body"), &old_lines);
+        assert_eq!(picked, Some(21));
+    }
+
+    #[test]
     fn pick_reconnect_target_falls_back_to_line_alignment_when_no_candidate_has_a_hash() {
         // Candidates carry no hash at all (e.g. a pre-migration DB, or a
         // declaration whose end_line was unavailable) — must behave
@@ -1770,6 +1798,54 @@ mod tests {
             !e_has_incoming,
             "no caller should have been reconnected to the new sibling E"
         );
+    }
+
+    #[test]
+    fn reconnect_reconnects_sole_candidate_whose_own_body_was_edited() {
+        // The end-to-end counterpart of #1744's regression test: a file with
+        // exactly one (name, kind) declaration whose body is edited in place
+        // (its content_hash necessarily changes) must still have its
+        // reverse-dep edge reconnected to it, not dropped. A hash mismatch
+        // is not evidence of "unrelated declaration" when there is no
+        // sibling to corroborate it — it's simply what an ordinary edit
+        // looks like.
+        let conn = test_conn();
+        let file = "src/utils/callee.ts";
+
+        let old_target = insert_node_with_hash(&conn, "callee", "function", file, 1, "hash-v1");
+        let caller = insert_node(&conn, "caller", "function", "src/features/use.ts", 1);
+        conn.execute(
+            "INSERT INTO edges (source_id, target_id, kind, confidence, dynamic) VALUES (?1, ?2, 'calls', 0.9, 0)",
+            rusqlite::params![caller, old_target],
+        )
+        .unwrap();
+
+        let (saved, sibling_groups) = save_reverse_dep_edges(&conn, &[file.to_string()]);
+        assert_eq!(saved.len(), 1);
+
+        conn.execute(
+            "DELETE FROM edges WHERE target_id IN (SELECT id FROM nodes WHERE file = ?1)",
+            [file],
+        )
+        .unwrap();
+        conn.execute("DELETE FROM nodes WHERE file = ?1", [file])
+            .unwrap();
+
+        // Same function, same name/kind/file, edited body -> different hash.
+        let new_target = insert_node_with_hash(&conn, "callee", "function", file, 1, "hash-v2");
+
+        let (reconnected, dropped) =
+            reconnect_reverse_dep_edges(&conn, &saved, &sibling_groups, 200);
+        assert_eq!((reconnected, dropped), (1, 0));
+
+        let target_of: Option<i64> = conn
+            .query_row(
+                "SELECT target_id FROM edges WHERE source_id = ?1",
+                [caller],
+                |row| row.get(0),
+            )
+            .ok();
+        assert_eq!(target_of, Some(new_target));
     }
 
     // ── capture_removed_file_neighbors (#1839) ──────────────────────────

--- a/crates/codegraph-core/src/domain/graph/builder/stages/detect_changes.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/detect_changes.rs
@@ -369,6 +369,14 @@ pub struct SavedReverseDepEdge {
     pub edge_kind: String,
     pub confidence: f64,
     pub dynamic: i64,
+    /// The target declaration's `content_hash` at save time, or `None` when
+    /// unavailable (rows from before the content_hash migration). Lets
+    /// `pick_reconnect_target` try an exact-hash match before falling back
+    /// to line-position alignment — a true identity signal that line
+    /// position alone cannot provide when a sibling group's size stays
+    /// unchanged because one member was renamed away and a different one
+    /// added in the same edit (issue #2015).
+    pub tgt_hash: Option<String>,
 }
 
 /// Key identifying a same-(name, kind) sibling group within one file.
@@ -436,7 +444,7 @@ pub fn save_reverse_dep_edges(
 
     let mut stmt = match conn.prepare(
         "SELECT e.source_id, n_tgt.name, n_tgt.kind, n_tgt.file, n_tgt.line, \
-                e.kind, e.confidence, e.dynamic, n_src.file \
+                e.kind, e.confidence, e.dynamic, n_tgt.content_hash, n_src.file \
          FROM edges e \
          JOIN nodes n_src ON e.source_id = n_src.id \
          JOIN nodes n_tgt ON e.target_id = n_tgt.id \
@@ -461,7 +469,8 @@ pub fn save_reverse_dep_edges(
                 row.get::<_, String>(5)?,
                 row.get::<_, f64>(6)?,
                 row.get::<_, i64>(7)?,
-                row.get::<_, String>(8)?,
+                row.get::<_, Option<String>>(8)?,
+                row.get::<_, String>(9)?,
             ))
         }) {
             Ok(r) => r,
@@ -470,7 +479,7 @@ pub fn save_reverse_dep_edges(
         for row in rows.flatten() {
             // Skip edges whose source is itself being purged — buildEdges will
             // re-emit them with correct new IDs.
-            if changed_set.contains(row.8.as_str()) {
+            if changed_set.contains(row.9.as_str()) {
                 continue;
             }
             let group_key: SiblingGroupKey = (row.1.clone(), row.2.clone(), row.3.clone());
@@ -489,6 +498,7 @@ pub fn save_reverse_dep_edges(
                 edge_kind: row.5,
                 confidence: row.6,
                 dynamic: row.7,
+                tgt_hash: row.8,
             });
         }
     }
@@ -572,16 +582,29 @@ fn align_sibling_lines(old_lines: &[i64], new_lines: &[i64]) -> HashMap<i64, i64
 /// candidates.
 ///
 /// A single candidate is an unambiguous match. With several candidates (e.g.
-/// multiple object-literal `close() {}` methods in one file), the saved
-/// sibling-group snapshot from before purge is aligned against the current
-/// candidate lines (see `align_sibling_lines`) to find which new line the
-/// saved target's old line maps to — correct even when the whole group
-/// shifted and its size changed in the same edit. Falls back to
-/// nearest-line only when no sibling-group snapshot is available, or the
-/// group is too large to align cheaply.
+/// multiple object-literal `close() {}` methods in one file), an exact
+/// `content_hash` match is tried first (see the `tgt_hash` param doc) since
+/// it's a true identity signal, not just position — falling back to the
+/// saved sibling-group snapshot from before purge, aligned against the
+/// current candidate lines (see `align_sibling_lines`) to find which new
+/// line the saved target's old line maps to. That line-position fallback is
+/// correct even when the whole group shifted and its size changed in the
+/// same edit, EXCEPT the one compound case a hash catches and line position
+/// provably cannot: a same-named/same-kind sibling both removed (renamed
+/// away) and a different one added in the same edit, leaving the group's
+/// size unchanged (issue #2015). Falls back to nearest-line only when no
+/// sibling-group snapshot is available, or the group is too large to align
+/// cheaply.
 fn pick_reconnect_target(
-    candidates: &[(i64, i64)],
+    candidates: &[(i64, i64, Option<String>)],
     tgt_line: i64,
+    // The saved edge's target declaration's `content_hash` at save time, or
+    // `None` when unavailable (pre-migration rows). Only trusted when
+    // exactly one candidate in this group shares it — if two or more
+    // candidates have byte-identical bodies (rare but possible), the hash
+    // can't disambiguate between them, so this falls through to line
+    // alignment instead of guessing.
+    tgt_hash: Option<&str>,
     group_key: &SiblingGroupKey,
     saved_sibling_groups: &HashMap<SiblingGroupKey, Vec<i64>>,
     alignment_cache: &mut HashMap<SiblingGroupKey, HashMap<i64, i64>>,
@@ -594,6 +617,34 @@ fn pick_reconnect_target(
         return Some(candidates[0].0);
     }
 
+    if let Some(hash) = tgt_hash {
+        // Only trust a hash-based verdict when there's actual hash data
+        // among this group's candidates to compare against — if none carry
+        // a hash (e.g. their end_line was unavailable to compute one),
+        // fall through to line alignment entirely rather than treating a
+        // vacuous "0 matches" as proof the target is gone.
+        let has_any_hash_data = candidates.iter().any(|(_, _, h)| h.is_some());
+        if has_any_hash_data {
+            let matches: Vec<i64> = candidates
+                .iter()
+                .filter(|(_, _, h)| h.as_deref() == Some(hash))
+                .map(|(id, _, _)| *id)
+                .collect();
+            match matches.len() {
+                1 => return Some(matches[0]),
+                // Zero matches means the exact body no longer exists among
+                // any current candidate — a stronger, more direct identity
+                // signal than line position, so this is a confident drop,
+                // not a cue to fall through and guess by rank/line (the
+                // exact silent-miswire #2015 describes). More than one
+                // match is a rare byte-identical duplicate — genuinely
+                // ambiguous, so THAT case still falls through.
+                0 => return None,
+                _ => {}
+            }
+        }
+    }
+
     if let Some(old_lines) = saved_sibling_groups.get(group_key) {
         if !old_lines.is_empty()
             && old_lines.len() <= max_align_group_size
@@ -602,15 +653,16 @@ fn pick_reconnect_target(
             let alignment = match alignment_cache.entry(group_key.clone()) {
                 std::collections::hash_map::Entry::Occupied(e) => e.into_mut(),
                 std::collections::hash_map::Entry::Vacant(e) => {
-                    let new_lines: Vec<i64> = candidates.iter().map(|(_, line)| *line).collect();
+                    let new_lines: Vec<i64> =
+                        candidates.iter().map(|(_, line, _)| *line).collect();
                     e.insert(align_sibling_lines(old_lines, &new_lines))
                 }
             };
             return match alignment.get(&tgt_line) {
                 Some(new_line) => candidates
                     .iter()
-                    .find(|(_, line)| line == new_line)
-                    .map(|(id, _)| *id),
+                    .find(|(_, line, _)| line == new_line)
+                    .map(|(id, _, _)| *id),
                 // tgt_line's sibling was legitimately removed in this edit —
                 // the alignment already accounted for the size change, so
                 // falling through to nearest-line here would silently
@@ -626,8 +678,8 @@ fn pick_reconnect_target(
     // alignment size cap — fall back to nearest-line.
     candidates
         .iter()
-        .min_by_key(|(_, line)| (line - tgt_line).abs())
-        .map(|(id, _)| *id)
+        .min_by_key(|(_, line, _)| (line - tgt_line).abs())
+        .map(|(id, _, _)| *id)
 }
 
 /// Reconnect saved reverse-dep edges to the new target node IDs.
@@ -658,7 +710,7 @@ pub fn reconnect_reverse_dep_edges(
     let mut dropped = 0usize;
     {
         let mut candidates_stmt = match tx.prepare(
-            "SELECT id, line FROM nodes WHERE name = ?1 AND kind = ?2 AND file = ?3 ORDER BY line",
+            "SELECT id, line, content_hash FROM nodes WHERE name = ?1 AND kind = ?2 AND file = ?3 ORDER BY line",
         ) {
             Ok(s) => s,
             Err(_) => return (0, 0),
@@ -674,7 +726,8 @@ pub fn reconnect_reverse_dep_edges(
         // Cache candidate lists per (name, kind, file) group — many saved
         // edges often share the same target (e.g. several callers of the
         // same function), so this avoids re-querying per edge.
-        let mut candidates_cache: HashMap<SiblingGroupKey, Vec<(i64, i64)>> = HashMap::new();
+        let mut candidates_cache: HashMap<SiblingGroupKey, Vec<(i64, i64, Option<String>)>> =
+            HashMap::new();
         // Cache the (potentially expensive) alignment result per group too —
         // shared across every saved edge targeting the same sibling group.
         let mut alignment_cache: HashMap<SiblingGroupKey, HashMap<i64, i64>> = HashMap::new();
@@ -684,7 +737,7 @@ pub fn reconnect_reverse_dep_edges(
             let candidates = match candidates_cache.entry(key.clone()) {
                 std::collections::hash_map::Entry::Occupied(e) => e.into_mut(),
                 std::collections::hash_map::Entry::Vacant(e) => {
-                    let mut rows: Vec<(i64, i64)> = Vec::new();
+                    let mut rows: Vec<(i64, i64, Option<String>)> = Vec::new();
                     if let Ok(mut rows_iter) = candidates_stmt
                         .query(rusqlite::params![&s.tgt_name, &s.tgt_kind, &s.tgt_file])
                     {
@@ -692,7 +745,8 @@ pub fn reconnect_reverse_dep_edges(
                             if let (Ok(id), Ok(line)) =
                                 (row.get::<_, i64>(0), row.get::<_, i64>(1))
                             {
-                                rows.push((id, line));
+                                let hash = row.get::<_, Option<String>>(2).unwrap_or(None);
+                                rows.push((id, line, hash));
                             }
                         }
                     }
@@ -703,6 +757,7 @@ pub fn reconnect_reverse_dep_edges(
             match pick_reconnect_target(
                 candidates,
                 s.tgt_line,
+                s.tgt_hash.as_deref(),
                 &key,
                 saved_sibling_groups,
                 &mut alignment_cache,
@@ -1250,17 +1305,33 @@ mod tests {
     /// Convenience wrapper mirroring the pre-#1865 `pick_reconnect_target`
     /// call shape: builds the single-group map + a fresh alignment cache
     /// internally so each test case reads as a plain (candidates, old_lines,
-    /// tgt_line) -> Option<id> call.
+    /// tgt_line) -> Option<id> call. No hash (`None` for every candidate and
+    /// the saved target) — these tests specifically exercise the
+    /// hash-unavailable line-alignment fallback; see `pick_with_hash` for
+    /// the #2015 hash-matching behavior.
     fn pick(
         candidates: &[(i64, i64)],
         old_lines: &[i64],
         tgt_line: i64,
     ) -> Option<i64> {
+        let with_hash: Vec<(i64, i64, Option<String>)> =
+            candidates.iter().map(|&(id, line)| (id, line, None)).collect();
+        pick_with_hash(&with_hash, tgt_line, None, old_lines)
+    }
+
+    /// Like `pick`, but candidates and the saved target each carry a
+    /// `content_hash` (issue #2015).
+    fn pick_with_hash(
+        candidates: &[(i64, i64, Option<String>)],
+        tgt_line: i64,
+        tgt_hash: Option<&str>,
+        old_lines: &[i64],
+    ) -> Option<i64> {
         let key: SiblingGroupKey = ("x".to_string(), "method".to_string(), "f.ts".to_string());
         let mut groups = HashMap::new();
         groups.insert(key.clone(), old_lines.to_vec());
         let mut cache = HashMap::new();
-        pick_reconnect_target(candidates, tgt_line, &key, &groups, &mut cache, 200)
+        pick_reconnect_target(candidates, tgt_line, tgt_hash, &key, &groups, &mut cache, 200)
     }
 
     #[test]
@@ -1318,6 +1389,77 @@ mod tests {
         assert_eq!(pick(&candidates, &old_lines, 400), Some(40));
     }
 
+    // ── Content-hash identity signal (#2015) ────────────────────────────
+
+    #[test]
+    fn pick_reconnect_target_uses_exact_hash_match_over_rank() {
+        // Sibling count unchanged (4 -> 4) — the rank-based fast path would
+        // pair old rank 2 (line 200) to new rank 2 (id 21, line 260), but
+        // the saved hash actually belongs to id 41 (the survivor now at
+        // rank 4) — a case where the group merely reordered relative to
+        // rank, and the hash must win over the position-based guess.
+        let old_lines = vec![100, 200, 300, 400];
+        let candidates = vec![
+            (11, 160, Some("hash-a".to_string())),
+            (21, 260, Some("hash-new".to_string())),
+            (31, 360, Some("hash-c".to_string())),
+            (41, 460, Some("hash-b".to_string())), // the true rank-2 survivor, moved to rank 4
+        ];
+        let picked = pick_with_hash(&candidates, 200, Some("hash-b"), &old_lines);
+        assert_eq!(picked, Some(41));
+    }
+
+    #[test]
+    fn pick_reconnect_target_drops_when_hash_matches_nothing_even_with_unchanged_count() {
+        // The exact compound case #2015 describes: a same-named/same-kind
+        // sibling is renamed away AND a different one is added in the same
+        // edit, so the group's size stays unchanged (4 -> 4) and the
+        // rank-based fast path would silently reattach to the new,
+        // unrelated sibling occupying the old rank. The saved hash for the
+        // renamed-away sibling matches none of the current candidates —
+        // this must drop the edge, not fall through to rank/line alignment.
+        let old_lines = vec![100, 200, 300, 400];
+        let candidates = vec![
+            (11, 160, Some("hash-a".to_string())),
+            (21, 260, Some("hash-new".to_string())), // new sibling, occupies old rank 2
+            (31, 360, Some("hash-c".to_string())),
+            (41, 460, Some("hash-d".to_string())),
+        ];
+        let picked = pick_with_hash(&candidates, 200, Some("hash-b-renamed-away"), &old_lines);
+        assert_eq!(picked, None);
+    }
+
+    #[test]
+    fn pick_reconnect_target_falls_back_to_line_alignment_when_no_candidate_has_a_hash() {
+        // Candidates carry no hash at all (e.g. a pre-migration DB, or a
+        // declaration whose end_line was unavailable) — must behave
+        // exactly like the hash-less `pick()` tests above, not treat the
+        // absence of any hash data as a confident drop.
+        let old_lines = vec![433, 461, 500, 580];
+        let candidates = vec![
+            (10, 178, None),
+            (20, 461, None),
+            (30, 580, None),
+            (40, 660, None),
+        ];
+        let picked = pick_with_hash(&candidates, 500, Some("some-hash"), &old_lines);
+        assert_eq!(picked, Some(30));
+    }
+
+    #[test]
+    fn pick_reconnect_target_falls_back_to_line_alignment_on_ambiguous_duplicate_hash() {
+        // Two candidates share the same (rare, byte-identical) body text —
+        // the hash can't disambiguate between them, so this must fall
+        // through to line alignment rather than picking either arbitrarily.
+        let old_lines = vec![100, 200];
+        let candidates = vec![
+            (11, 150, Some("dup".to_string())),
+            (21, 250, Some("dup".to_string())),
+        ];
+        let picked = pick_with_hash(&candidates, 100, Some("dup"), &old_lines);
+        assert_eq!(picked, Some(11)); // rank-based: old rank 1 -> new rank 1
+    }
+
     #[test]
     fn align_sibling_lines_forces_exact_pairing_when_counts_match() {
         let old_lines = vec![433, 461, 500, 580];
@@ -1347,6 +1489,7 @@ mod tests {
                 kind TEXT NOT NULL,
                 file TEXT NOT NULL,
                 line INTEGER,
+                content_hash TEXT,
                 UNIQUE(name, kind, file, line)
             );
             CREATE TABLE edges (
@@ -1366,6 +1509,22 @@ mod tests {
         conn.execute(
             "INSERT INTO nodes (name, kind, file, line) VALUES (?1, ?2, ?3, ?4)",
             rusqlite::params![name, kind, file, line],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    fn insert_node_with_hash(
+        conn: &Connection,
+        name: &str,
+        kind: &str,
+        file: &str,
+        line: i64,
+        content_hash: &str,
+    ) -> i64 {
+        conn.execute(
+            "INSERT INTO nodes (name, kind, file, line, content_hash) VALUES (?1, ?2, ?3, ?4, ?5)",
+            rusqlite::params![name, kind, file, line, content_hash],
         )
         .unwrap();
         conn.last_insert_rowid()
@@ -1522,6 +1681,93 @@ mod tests {
         assert_eq!(target_of(caller_b), None);
         assert_eq!(target_of(caller_c), Some(c_new));
         assert_eq!(target_of(caller_d), Some(d_new));
+    }
+
+    #[test]
+    fn reconnect_drops_edge_on_compound_rename_and_add_leaving_group_size_unchanged() {
+        // The exact compound case #2015 describes: B's close is renamed
+        // away AND a new sibling E's close is inserted in the same edit, at
+        // a line position that happens to land it at the same rank B used
+        // to hold — so the sibling count for (close, method) stays 4 -> 4.
+        // Without a content-hash identity signal, the rank-based fast path
+        // (old_lines.len() == new_lines.len()) would silently reconnect B's
+        // caller to E instead of dropping the edge.
+        let conn = test_conn();
+        let file = "src/db/connection.ts";
+
+        let a_old = insert_node_with_hash(&conn, "close", "method", file, 433, "hash-a");
+        let b_old = insert_node_with_hash(&conn, "close", "method", file, 461, "hash-b");
+        let c_old = insert_node_with_hash(&conn, "close", "method", file, 500, "hash-c");
+        let d_old = insert_node_with_hash(&conn, "close", "method", file, 580, "hash-d");
+
+        let caller_a = insert_node(&conn, "useA", "function", "src/features/a.ts", 10);
+        let caller_b = insert_node(&conn, "useB", "function", "src/features/b.ts", 10);
+        let caller_c = insert_node(&conn, "useC", "function", "src/features/c.ts", 10);
+        let caller_d = insert_node(&conn, "useD", "function", "src/features/d.ts", 10);
+        for (caller, target) in [
+            (caller_a, a_old),
+            (caller_b, b_old),
+            (caller_c, c_old),
+            (caller_d, d_old),
+        ] {
+            conn.execute(
+                "INSERT INTO edges (source_id, target_id, kind, confidence, dynamic) VALUES (?1, ?2, 'calls', 0.9, 0)",
+                rusqlite::params![caller, target],
+            )
+            .unwrap();
+        }
+
+        let (saved, sibling_groups) = save_reverse_dep_edges(&conn, &[file.to_string()]);
+        assert_eq!(saved.len(), 4);
+
+        conn.execute(
+            "DELETE FROM edges WHERE target_id IN (SELECT id FROM nodes WHERE file = ?1)",
+            [file],
+        )
+        .unwrap();
+        conn.execute("DELETE FROM nodes WHERE file = ?1", [file])
+            .unwrap();
+
+        // Re-insert: A/C/D's close bodies are byte-identical (same hash),
+        // just shifted +147 by unrelated code above them. B's close was
+        // renamed to shutdown (gone). A brand-new sibling E's close is
+        // inserted between A's and C's new lines — landing at the same
+        // rank (2 of 4) B used to hold, so the group's size never changes.
+        let a_new = insert_node_with_hash(&conn, "close", "method", file, 433 + 147, "hash-a");
+        insert_node(&conn, "shutdown", "method", file, 461 + 147); // was B's close
+        let e_new = insert_node_with_hash(&conn, "close", "method", file, 610, "hash-e"); // new sibling, rank 2
+        let c_new = insert_node_with_hash(&conn, "close", "method", file, 500 + 147, "hash-c");
+        let d_new = insert_node_with_hash(&conn, "close", "method", file, 580 + 147, "hash-d");
+
+        let (reconnected, dropped) =
+            reconnect_reverse_dep_edges(&conn, &saved, &sibling_groups, 200);
+        // A, C, D reconnect correctly via hash; B's edge is dropped — NOT
+        // silently reattached to E despite occupying B's old rank.
+        assert_eq!((reconnected, dropped), (3, 1));
+
+        let target_of = |caller: i64| -> Option<i64> {
+            conn.query_row(
+                "SELECT target_id FROM edges WHERE source_id = ?1",
+                [caller],
+                |row| row.get(0),
+            )
+            .ok()
+        };
+        assert_eq!(target_of(caller_a), Some(a_new));
+        assert_eq!(target_of(caller_b), None);
+        assert_eq!(target_of(caller_c), Some(c_new));
+        assert_eq!(target_of(caller_d), Some(d_new));
+        // Nothing at all reconnects to E — it's a genuinely new sibling.
+        let _ = e_new;
+        let e_has_incoming: bool = conn
+            .query_row(
+                "SELECT COUNT(*) FROM edges WHERE target_id = ?1",
+                [e_new],
+                |row| row.get::<_, i64>(0),
+            )
+            .map(|c| c > 0)
+            .unwrap_or(false);
+        assert!(!e_has_incoming, "no caller should have been reconnected to the new sibling E");
     }
 
     // ── capture_removed_file_neighbors (#1839) ──────────────────────────

--- a/crates/codegraph-core/src/domain/graph/builder/stages/import_edges.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/import_edges.rs
@@ -770,6 +770,7 @@ mod tests {
                     cfg: None,
                     children: None,
                     bodyless: None,
+                    content_hash: None,
                 })
                 .collect(),
             imports,

--- a/crates/codegraph-core/src/domain/graph/builder/stages/insert_nodes.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/insert_nodes.rs
@@ -25,6 +25,8 @@ pub struct InsertNodesChild {
     pub end_line: Option<u32>,
     #[serde(default)]
     pub visibility: Option<String>,
+    #[serde(default, rename = "contentHash")]
+    pub content_hash: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -36,6 +38,8 @@ pub struct InsertNodesDefinition {
     pub end_line: Option<u32>,
     #[serde(default)]
     pub visibility: Option<String>,
+    #[serde(default, rename = "contentHash")]
+    pub content_hash: Option<String>,
     #[serde(default)]
     pub children: Vec<InsertNodesChild>,
 }
@@ -142,8 +146,8 @@ fn insert_file_nodes(
 ) -> rusqlite::Result<()> {
     let mut stmt = tx.prepare_cached(
         "INSERT OR IGNORE INTO nodes \
-         (name, kind, file, line, end_line, parent_id, qualified_name, scope, visibility) \
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+         (name, kind, file, line, end_line, parent_id, qualified_name, scope, visibility, content_hash) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
     )?;
 
     for batch in batches {
@@ -157,6 +161,7 @@ fn insert_file_nodes(
             None::<i64>,
             None::<&str>,
             None::<&str>,
+            None::<&str>,
             None::<&str>
         ])?;
 
@@ -166,6 +171,7 @@ fn insert_file_nodes(
             // .as_deref() converts Option<String> → Option<&str> so rusqlite
             // serialises None as SQL NULL unambiguously (#709).
             let vis = def.visibility.as_deref();
+            let content_hash = def.content_hash.as_deref();
             stmt.execute(params![
                 &def.name,
                 &def.kind,
@@ -175,7 +181,8 @@ fn insert_file_nodes(
                 None::<i64>,
                 &def.name,
                 scope,
-                vis
+                vis,
+                content_hash
             ])?;
         }
 
@@ -189,6 +196,7 @@ fn insert_file_nodes(
                 None::<u32>,
                 None::<i64>,
                 &exp.name,
+                None::<&str>,
                 None::<&str>,
                 None::<&str>
             ])?;
@@ -226,8 +234,8 @@ fn insert_symbol_nodes(
             tx.prepare_cached("SELECT id, name, kind, line FROM nodes WHERE file = ?1")?;
         let mut child_stmt = tx.prepare_cached(
             "INSERT OR IGNORE INTO nodes \
-             (name, kind, file, line, end_line, parent_id, qualified_name, scope, visibility) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+             (name, kind, file, line, end_line, parent_id, qualified_name, scope, visibility, content_hash) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
         )?;
 
         for batch in batches {
@@ -251,6 +259,7 @@ fn insert_symbol_nodes(
                 for child in &def.children {
                     let qname = format!("{}.{}", def.name, child.name);
                     let child_vis = child.visibility.as_deref();
+                    let child_content_hash = child.content_hash.as_deref();
                     child_stmt.execute(params![
                         &child.name,
                         &child.kind,
@@ -260,7 +269,8 @@ fn insert_symbol_nodes(
                         def_id,
                         &qname,
                         &def.name,
-                        child_vis
+                        child_vis,
+                        child_content_hash
                     ])?;
                 }
             }

--- a/crates/codegraph-core/src/domain/parallel.rs
+++ b/crates/codegraph-core/src/domain/parallel.rs
@@ -1,11 +1,51 @@
 use rayon::prelude::*;
+use sha2::{Digest, Sha256};
 use std::fs;
 use tree_sitter::Parser;
 
 use crate::ast_analysis::dataflow::extract_dataflow;
 use crate::extractors::extract_symbols_with_opts;
 use crate::domain::parser::LanguageKind;
-use crate::types::FileSymbols;
+use crate::types::{Definition, FileSymbols};
+
+/// SHA-256 hash of a declaration's own source text (1-based, inclusive
+/// `start_line..=end_line`), or `None` when `end_line` is unavailable — a
+/// declaration with no reliable body range has nothing meaningful to hash.
+/// Gives reverse-dep-edge reconnection during incremental rebuilds a true
+/// identity signal beyond line position (issue #2015).
+fn compute_declaration_hash(lines: &[&str], start_line: u32, end_line: Option<u32>) -> Option<String> {
+    let end_line = end_line?;
+    if start_line == 0 || end_line < start_line {
+        return None;
+    }
+    let start_idx = (start_line - 1) as usize;
+    let end_idx = (end_line - 1) as usize;
+    if start_idx >= lines.len() {
+        return None;
+    }
+    let end_idx = end_idx.min(lines.len().saturating_sub(1));
+    let body = lines[start_idx..=end_idx].join("\n");
+    let mut hasher = Sha256::new();
+    hasher.update(body.as_bytes());
+    Some(format!("{:x}", hasher.finalize()))
+}
+
+/// Recursively populates `content_hash` on every definition (and nested
+/// child) in `symbols`, using the already-in-scope raw `source` before it's
+/// discarded — computed once, centrally, here rather than per-extractor,
+/// since every extractor already populates `line`/`end_line` uniformly.
+/// `pub(crate)`: also used by `ParseTreeCache::parse_file`
+/// (`domain/graph/builder/incremental.rs`), the primary incremental-rebuild
+/// parse path, which calls `extract_symbols` directly rather than through
+/// this module's own `parse_file`/`parse_files_parallel*`.
+pub(crate) fn compute_declaration_hashes(definitions: &mut [Definition], lines: &[&str]) {
+    for def in definitions.iter_mut() {
+        def.content_hash = compute_declaration_hash(lines, def.line, def.end_line);
+        if let Some(children) = def.children.as_mut() {
+            compute_declaration_hashes(children, lines);
+        }
+    }
+}
 
 /// Parse multiple files in parallel using rayon.
 /// Each thread creates its own Parser (cheap; Language objects are Send+Sync).
@@ -37,6 +77,9 @@ pub fn parse_files_parallel(
                 symbols.dataflow = extract_dataflow(&tree, &source, lang.lang_id_str());
             }
             symbols.line_count = Some(line_count);
+            let source_text = String::from_utf8_lossy(&source);
+            let lines: Vec<&str> = source_text.lines().collect();
+            compute_declaration_hashes(&mut symbols.definitions, &lines);
             Some(symbols)
         })
         .collect()
@@ -66,6 +109,9 @@ pub fn parse_files_parallel_full(
             // Always extract dataflow
             symbols.dataflow = extract_dataflow(&tree, &source, lang.lang_id_str());
             symbols.line_count = Some(line_count);
+            let source_text = String::from_utf8_lossy(&source);
+            let lines: Vec<&str> = source_text.lines().collect();
+            compute_declaration_hashes(&mut symbols.definitions, &lines);
             Some(symbols)
         })
         .collect()
@@ -94,5 +140,68 @@ pub fn parse_file(
         symbols.dataflow = extract_dataflow(&tree, source_bytes, lang.lang_id_str());
     }
     symbols.line_count = Some(line_count);
+    let lines: Vec<&str> = source.lines().collect();
+    compute_declaration_hashes(&mut symbols.definitions, &lines);
     Some(symbols)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn def(name: &str, line: u32, end_line: Option<u32>) -> Definition {
+        Definition {
+            name: name.to_string(),
+            kind: "function".to_string(),
+            line,
+            end_line,
+            decorators: None,
+            complexity: None,
+            cfg: None,
+            children: None,
+            bodyless: None,
+            content_hash: None,
+        }
+    }
+
+    #[test]
+    fn compute_declaration_hash_is_deterministic_for_identical_content() {
+        let lines = vec!["fn a() {", "  1", "}", "fn a() {", "  1", "}"];
+        let hash_a = compute_declaration_hash(&lines, 1, Some(3));
+        let hash_b = compute_declaration_hash(&lines, 4, Some(6));
+        assert!(hash_a.is_some());
+        assert_eq!(hash_a, hash_b, "identical body text must hash identically");
+    }
+
+    #[test]
+    fn compute_declaration_hash_differs_for_different_content() {
+        let lines = vec!["fn a() {", "  1", "}", "fn b() {", "  2", "}"];
+        let hash_a = compute_declaration_hash(&lines, 1, Some(3));
+        let hash_b = compute_declaration_hash(&lines, 4, Some(6));
+        assert_ne!(hash_a, hash_b, "different body text must hash differently");
+    }
+
+    #[test]
+    fn compute_declaration_hash_returns_none_without_end_line() {
+        let lines = vec!["fn a() {", "  1", "}"];
+        assert_eq!(compute_declaration_hash(&lines, 1, None), None);
+    }
+
+    #[test]
+    fn compute_declaration_hash_returns_none_for_out_of_range_start() {
+        let lines = vec!["fn a() {", "  1", "}"];
+        assert_eq!(compute_declaration_hash(&lines, 99, Some(100)), None);
+    }
+
+    #[test]
+    fn compute_declaration_hashes_recurses_into_children() {
+        let lines = vec!["fn a() {", "  1", "}"];
+        let mut defs = vec![Definition {
+            children: Some(vec![def("child", 1, Some(3))]),
+            ..def("parent", 1, Some(3))
+        }];
+        compute_declaration_hashes(&mut defs, &lines);
+        assert!(defs[0].content_hash.is_some());
+        assert!(defs[0].children.as_ref().unwrap()[0].content_hash.is_some());
+    }
 }

--- a/crates/codegraph-core/src/extractors/bash.rs
+++ b/crates/codegraph-core/src/extractors/bash.rs
@@ -1,9 +1,9 @@
-use tree_sitter::{Node, Tree};
+use super::helpers::*;
+use super::SymbolExtractor;
 use crate::ast_analysis::cfg::build_function_cfg;
 use crate::ast_analysis::complexity::compute_all_metrics;
 use crate::types::*;
-use super::helpers::*;
-use super::SymbolExtractor;
+use tree_sitter::{Node, Tree};
 
 pub struct BashExtractor;
 
@@ -11,7 +11,12 @@ impl SymbolExtractor for BashExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_bash_node);
-        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &BASH_AST_CONFIG);
+        walk_ast_nodes_with_config(
+            &tree.root_node(),
+            source,
+            &mut symbols.ast_nodes,
+            &BASH_AST_CONFIG,
+        );
         symbols
     }
 }
@@ -31,6 +36,7 @@ fn match_bash_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth
                     cfg: build_function_cfg(node, "bash", source),
                     children: None,
                     bodyless: None,
+                    content_hash: None,
                 });
             }
         }
@@ -44,13 +50,18 @@ fn match_bash_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth
                         // Get the first argument after the command name
                         for i in 0..node.child_count() {
                             if let Some(child) = node.child(i) {
-                                if child.kind() == "word" || child.kind() == "string" || child.kind() == "raw_string" {
+                                if child.kind() == "word"
+                                    || child.kind() == "string"
+                                    || child.kind() == "raw_string"
+                                {
                                     let path = node_text(&child, source)
                                         .trim_matches(|c| c == '"' || c == '\'')
                                         .to_string();
                                     if !path.is_empty() {
-                                        let last = path.split('/').last().unwrap_or(&path).to_string();
-                                        let mut imp = Import::new(path, vec![last], start_line(node));
+                                        let last =
+                                            path.split('/').last().unwrap_or(&path).to_string();
+                                        let mut imp =
+                                            Import::new(path, vec![last], start_line(node));
                                         imp.bash_source = Some(true);
                                         symbols.imports.push(imp);
                                     }

--- a/crates/codegraph-core/src/extractors/bash.rs
+++ b/crates/codegraph-core/src/extractors/bash.rs
@@ -1,9 +1,9 @@
-use super::helpers::*;
-use super::SymbolExtractor;
+use tree_sitter::{Node, Tree};
 use crate::ast_analysis::cfg::build_function_cfg;
 use crate::ast_analysis::complexity::compute_all_metrics;
 use crate::types::*;
-use tree_sitter::{Node, Tree};
+use super::helpers::*;
+use super::SymbolExtractor;
 
 pub struct BashExtractor;
 
@@ -11,12 +11,7 @@ impl SymbolExtractor for BashExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_bash_node);
-        walk_ast_nodes_with_config(
-            &tree.root_node(),
-            source,
-            &mut symbols.ast_nodes,
-            &BASH_AST_CONFIG,
-        );
+        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &BASH_AST_CONFIG);
         symbols
     }
 }
@@ -50,18 +45,13 @@ fn match_bash_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth
                         // Get the first argument after the command name
                         for i in 0..node.child_count() {
                             if let Some(child) = node.child(i) {
-                                if child.kind() == "word"
-                                    || child.kind() == "string"
-                                    || child.kind() == "raw_string"
-                                {
+                                if child.kind() == "word" || child.kind() == "string" || child.kind() == "raw_string" {
                                     let path = node_text(&child, source)
                                         .trim_matches(|c| c == '"' || c == '\'')
                                         .to_string();
                                     if !path.is_empty() {
-                                        let last =
-                                            path.split('/').last().unwrap_or(&path).to_string();
-                                        let mut imp =
-                                            Import::new(path, vec![last], start_line(node));
+                                        let last = path.split('/').last().unwrap_or(&path).to_string();
+                                        let mut imp = Import::new(path, vec![last], start_line(node));
                                         imp.bash_source = Some(true);
                                         symbols.imports.push(imp);
                                     }

--- a/crates/codegraph-core/src/extractors/c.rs
+++ b/crates/codegraph-core/src/extractors/c.rs
@@ -1,9 +1,9 @@
-use tree_sitter::{Node, Tree};
+use super::helpers::*;
+use super::SymbolExtractor;
 use crate::ast_analysis::cfg::build_function_cfg;
 use crate::ast_analysis::complexity::compute_all_metrics;
 use crate::types::*;
-use super::helpers::*;
-use super::SymbolExtractor;
+use tree_sitter::{Node, Tree};
 
 pub struct CExtractor;
 
@@ -11,7 +11,12 @@ impl SymbolExtractor for CExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_c_node);
-        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &C_AST_CONFIG);
+        walk_ast_nodes_with_config(
+            &tree.root_node(),
+            source,
+            &mut symbols.ast_nodes,
+            &C_AST_CONFIG,
+        );
         walk_tree(&tree.root_node(), source, &mut symbols, match_c_type_map);
         dedup_type_map(&mut symbols.type_map);
         symbols
@@ -194,6 +199,7 @@ fn match_c_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: u
                     cfg: build_function_cfg(node, "c", source),
                     children: opt_children(children),
                     bodyless: None,
+                    content_hash: None,
                 });
             }
         }
@@ -201,7 +207,8 @@ fn match_c_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: u
         "struct_specifier" => {
             if let Some(name_node) = node.child_by_field_name("name") {
                 let struct_name = node_text(&name_node, source).to_string();
-                let children = node.child_by_field_name("body")
+                let children = node
+                    .child_by_field_name("body")
                     .map(|body| extract_c_fields(&body, source))
                     .unwrap_or_default();
                 symbols.definitions.push(Definition {
@@ -214,13 +221,15 @@ fn match_c_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: u
                     cfg: None,
                     children: opt_children(children),
                     bodyless: None,
+                    content_hash: None,
                 });
             }
         }
 
         "union_specifier" => {
             if let Some(name_node) = node.child_by_field_name("name") {
-                let children = node.child_by_field_name("body")
+                let children = node
+                    .child_by_field_name("body")
                     .map(|body| extract_c_fields(&body, source))
                     .unwrap_or_default();
                 symbols.definitions.push(Definition {
@@ -233,6 +242,7 @@ fn match_c_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: u
                     cfg: None,
                     children: opt_children(children),
                     bodyless: None,
+                    content_hash: None,
                 });
             }
         }
@@ -250,6 +260,7 @@ fn match_c_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: u
                     cfg: None,
                     children: opt_children(children),
                     bodyless: None,
+                    content_hash: None,
                 });
             }
         }
@@ -279,6 +290,7 @@ fn match_c_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: u
                     cfg: None,
                     children: None,
                     bodyless: None,
+                    content_hash: None,
                 });
             }
         }
@@ -290,7 +302,8 @@ fn match_c_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: u
                 if !path.is_empty() {
                     let last = path.split('/').last().unwrap_or(path);
                     let name = last.strip_suffix(".h").unwrap_or(last);
-                    let mut imp = Import::new(path.to_string(), vec![name.to_string()], start_line(node));
+                    let mut imp =
+                        Import::new(path.to_string(), vec![name.to_string()], start_line(node));
                     imp.c_include = Some(true);
                     symbols.imports.push(imp);
                 }
@@ -313,8 +326,8 @@ fn match_c_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: u
                         let name = named_child_text(&fn_node, "field", source)
                             .map(|s| s.to_string())
                             .unwrap_or_else(|| node_text(&fn_node, source).to_string());
-                        let receiver = named_child_text(&fn_node, "argument", source)
-                            .map(|s| s.to_string());
+                        let receiver =
+                            named_child_text(&fn_node, "argument", source).map(|s| s.to_string());
                         symbols.calls.push(Call {
                             name,
                             line: start_line(node),

--- a/crates/codegraph-core/src/extractors/c.rs
+++ b/crates/codegraph-core/src/extractors/c.rs
@@ -1,9 +1,9 @@
-use super::helpers::*;
-use super::SymbolExtractor;
+use tree_sitter::{Node, Tree};
 use crate::ast_analysis::cfg::build_function_cfg;
 use crate::ast_analysis::complexity::compute_all_metrics;
 use crate::types::*;
-use tree_sitter::{Node, Tree};
+use super::helpers::*;
+use super::SymbolExtractor;
 
 pub struct CExtractor;
 
@@ -11,12 +11,7 @@ impl SymbolExtractor for CExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_c_node);
-        walk_ast_nodes_with_config(
-            &tree.root_node(),
-            source,
-            &mut symbols.ast_nodes,
-            &C_AST_CONFIG,
-        );
+        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &C_AST_CONFIG);
         walk_tree(&tree.root_node(), source, &mut symbols, match_c_type_map);
         dedup_type_map(&mut symbols.type_map);
         symbols
@@ -207,8 +202,7 @@ fn match_c_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: u
         "struct_specifier" => {
             if let Some(name_node) = node.child_by_field_name("name") {
                 let struct_name = node_text(&name_node, source).to_string();
-                let children = node
-                    .child_by_field_name("body")
+                let children = node.child_by_field_name("body")
                     .map(|body| extract_c_fields(&body, source))
                     .unwrap_or_default();
                 symbols.definitions.push(Definition {
@@ -228,8 +222,7 @@ fn match_c_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: u
 
         "union_specifier" => {
             if let Some(name_node) = node.child_by_field_name("name") {
-                let children = node
-                    .child_by_field_name("body")
+                let children = node.child_by_field_name("body")
                     .map(|body| extract_c_fields(&body, source))
                     .unwrap_or_default();
                 symbols.definitions.push(Definition {
@@ -302,8 +295,7 @@ fn match_c_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: u
                 if !path.is_empty() {
                     let last = path.split('/').last().unwrap_or(path);
                     let name = last.strip_suffix(".h").unwrap_or(last);
-                    let mut imp =
-                        Import::new(path.to_string(), vec![name.to_string()], start_line(node));
+                    let mut imp = Import::new(path.to_string(), vec![name.to_string()], start_line(node));
                     imp.c_include = Some(true);
                     symbols.imports.push(imp);
                 }
@@ -326,8 +318,8 @@ fn match_c_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: u
                         let name = named_child_text(&fn_node, "field", source)
                             .map(|s| s.to_string())
                             .unwrap_or_else(|| node_text(&fn_node, source).to_string());
-                        let receiver =
-                            named_child_text(&fn_node, "argument", source).map(|s| s.to_string());
+                        let receiver = named_child_text(&fn_node, "argument", source)
+                            .map(|s| s.to_string());
                         symbols.calls.push(Call {
                             name,
                             line: start_line(node),

--- a/crates/codegraph-core/src/extractors/clojure.rs
+++ b/crates/codegraph-core/src/extractors/clojure.rs
@@ -225,11 +225,9 @@ fn extract_ns_requires(require_form: &Node, source: &[u8], symbols: &mut FileSym
             if let Some(sym) = find_first_symbol(&child) {
                 let text = node_text(&sym, source);
                 let last = text.rsplit('.').next().unwrap_or(text).to_string();
-                symbols.imports.push(Import::new(
-                    text.to_string(),
-                    vec![last],
-                    start_line(&child),
-                ));
+                symbols
+                    .imports
+                    .push(Import::new(text.to_string(), vec![last], start_line(&child)));
             }
         }
 
@@ -239,11 +237,9 @@ fn extract_ns_requires(require_form: &Node, source: &[u8], symbols: &mut FileSym
             let text = node_text(&child, source);
             if !text.starts_with(':') {
                 let last = text.rsplit('.').next().unwrap_or(text).to_string();
-                symbols.imports.push(Import::new(
-                    text.to_string(),
-                    vec![last],
-                    start_line(&child),
-                ));
+                symbols
+                    .imports
+                    .push(Import::new(text.to_string(), vec![last], start_line(&child)));
             }
         }
     }

--- a/crates/codegraph-core/src/extractors/clojure.rs
+++ b/crates/codegraph-core/src/extractors/clojure.rs
@@ -191,6 +191,7 @@ fn handle_ns_form(node: &Node, source: &[u8], symbols: &mut FileSymbols) -> Opti
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 
     // Scan for nested `(:require ...)`, `(:import ...)`, `(:use ...)` forms.
@@ -224,9 +225,11 @@ fn extract_ns_requires(require_form: &Node, source: &[u8], symbols: &mut FileSym
             if let Some(sym) = find_first_symbol(&child) {
                 let text = node_text(&sym, source);
                 let last = text.rsplit('.').next().unwrap_or(text).to_string();
-                symbols
-                    .imports
-                    .push(Import::new(text.to_string(), vec![last], start_line(&child)));
+                symbols.imports.push(Import::new(
+                    text.to_string(),
+                    vec![last],
+                    start_line(&child),
+                ));
             }
         }
 
@@ -236,9 +239,11 @@ fn extract_ns_requires(require_form: &Node, source: &[u8], symbols: &mut FileSym
             let text = node_text(&child, source);
             if !text.starts_with(':') {
                 let last = text.rsplit('.').next().unwrap_or(text).to_string();
-                symbols
-                    .imports
-                    .push(Import::new(text.to_string(), vec![last], start_line(&child)));
+                symbols.imports.push(Import::new(
+                    text.to_string(),
+                    vec![last],
+                    start_line(&child),
+                ));
             }
         }
     }
@@ -271,6 +276,7 @@ fn handle_def_form(
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -305,6 +311,7 @@ fn handle_defn_form(
         cfg: build_function_cfg(node, "clojure", source),
         children: opt_children(params),
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -355,6 +362,7 @@ fn handle_defprotocol(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -373,6 +381,7 @@ fn handle_defrecord(node: &Node, source: &[u8], symbols: &mut FileSymbols, kind:
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 

--- a/crates/codegraph-core/src/extractors/cpp.rs
+++ b/crates/codegraph-core/src/extractors/cpp.rs
@@ -1,9 +1,9 @@
-use super::helpers::*;
-use super::SymbolExtractor;
+use tree_sitter::{Node, Tree};
 use crate::ast_analysis::cfg::build_function_cfg;
 use crate::ast_analysis::complexity::compute_all_metrics;
 use crate::types::*;
-use tree_sitter::{Node, Tree};
+use super::helpers::*;
+use super::SymbolExtractor;
 
 pub struct CppExtractor;
 
@@ -11,12 +11,7 @@ impl SymbolExtractor for CppExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_cpp_node);
-        walk_ast_nodes_with_config(
-            &tree.root_node(),
-            source,
-            &mut symbols.ast_nodes,
-            &CPP_AST_CONFIG,
-        );
+        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &CPP_AST_CONFIG);
         walk_tree(&tree.root_node(), source, &mut symbols, match_cpp_type_map);
         dedup_type_map(&mut symbols.type_map);
         symbols
@@ -35,11 +30,8 @@ fn unwrap_cpp_declarator(node: &Node, source: &[u8]) -> String {
     let mut current = *node;
     loop {
         match current.kind() {
-            "pointer_declarator"
-            | "reference_declarator"
-            | "array_declarator"
-            | "parenthesized_declarator"
-            | "function_declarator" => {
+            "pointer_declarator" | "reference_declarator" | "array_declarator"
+            | "parenthesized_declarator" | "function_declarator" => {
                 // tree-sitter-cpp's `reference_declarator` rule does not expose a
                 // `declarator` field, so `child_by_field_name` returns None and
                 // the full node text (`& name`) leaks out. Fall back to scanning
@@ -115,9 +107,7 @@ fn extract_cpp_parameters(node: &Node, source: &[u8]) -> Vec<Definition> {
         if let Some(param_list) = func_decl.child_by_field_name("parameters") {
             for i in 0..param_list.child_count() {
                 if let Some(child) = param_list.child(i) {
-                    if child.kind() == "parameter_declaration"
-                        || child.kind() == "optional_parameter_declaration"
-                    {
+                    if child.kind() == "parameter_declaration" || child.kind() == "optional_parameter_declaration" {
                         if let Some(decl) = child.child_by_field_name("declarator") {
                             let name = unwrap_cpp_declarator(&decl, source);
                             if !name.is_empty() {
@@ -169,21 +159,14 @@ fn extract_cpp_enum_constants(node: &Node, source: &[u8]) -> Vec<Definition> {
     constants
 }
 
-fn extract_cpp_base_classes(
-    node: &Node,
-    source: &[u8],
-    class_name: &str,
-    symbols: &mut FileSymbols,
-) {
+fn extract_cpp_base_classes(node: &Node, source: &[u8], class_name: &str, symbols: &mut FileSymbols) {
     for i in 0..node.child_count() {
         if let Some(child) = node.child(i) {
             if child.kind() == "base_class_clause" {
                 for j in 0..child.child_count() {
                     if let Some(base) = child.child(j) {
                         match base.kind() {
-                            "type_identifier"
-                            | "qualified_identifier"
-                            | "scoped_type_identifier" => {
+                            "type_identifier" | "qualified_identifier" | "scoped_type_identifier" => {
                                 symbols.classes.push(ClassRelation {
                                     name: class_name.to_string(),
                                     extends: Some(node_text(&base, source).to_string()),
@@ -204,17 +187,12 @@ fn extract_cpp_base_classes(
 
 fn handle_cpp_function_definition(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     if let Some(name) = extract_cpp_function_name(node, source) {
-        let parent_class =
-            find_enclosing_type_name(node, &["class_specifier", "struct_specifier"], source);
+        let parent_class = find_enclosing_type_name(node, &["class_specifier", "struct_specifier"], source);
         let full_name = match &parent_class {
             Some(cls) => format!("{}.{}", cls, name),
             None => name,
         };
-        let kind = if parent_class.is_some() {
-            "method"
-        } else {
-            "function"
-        };
+        let kind = if parent_class.is_some() { "method" } else { "function" };
         let children = extract_cpp_parameters(node, source);
         symbols.definitions.push(Definition {
             name: full_name,
@@ -234,8 +212,7 @@ fn handle_cpp_function_definition(node: &Node, source: &[u8], symbols: &mut File
 fn handle_cpp_class_specifier(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     if let Some(name_node) = node.child_by_field_name("name") {
         let class_name = node_text(&name_node, source).to_string();
-        let children = node
-            .child_by_field_name("body")
+        let children = node.child_by_field_name("body")
             .map(|body| extract_cpp_fields(&body, source))
             .unwrap_or_default();
         symbols.definitions.push(Definition {
@@ -257,8 +234,7 @@ fn handle_cpp_class_specifier(node: &Node, source: &[u8], symbols: &mut FileSymb
 fn handle_cpp_struct_specifier(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     if let Some(name_node) = node.child_by_field_name("name") {
         let struct_name = node_text(&name_node, source).to_string();
-        let children = node
-            .child_by_field_name("body")
+        let children = node.child_by_field_name("body")
             .map(|body| extract_cpp_fields(&body, source))
             .unwrap_or_default();
         symbols.definitions.push(Definition {
@@ -347,19 +323,12 @@ fn handle_cpp_preproc_include(node: &Node, source: &[u8], symbols: &mut FileSymb
         let path = raw.trim_matches(|c| c == '"' || c == '<' || c == '>');
         if !path.is_empty() {
             let last = path.split('/').last().unwrap_or(path);
-            let name = last
-                .strip_suffix(".h")
+            let name = last.strip_suffix(".h")
                 .or_else(|| last.strip_suffix(".hpp"))
                 .unwrap_or(last);
-            push_import(
-                symbols,
-                node,
-                path.to_string(),
-                vec![name.to_string()],
-                |imp| {
-                    imp.c_include = Some(true);
-                },
-            );
+            push_import(symbols, node, path.to_string(), vec![name.to_string()], |imp| {
+                imp.c_include = Some(true);
+            });
         }
     }
 }
@@ -374,8 +343,8 @@ fn handle_cpp_call_expression(node: &Node, source: &[u8], symbols: &mut FileSymb
                 let name = named_child_text(&fn_node, "field", source)
                     .map(|s| s.to_string())
                     .unwrap_or_else(|| node_text(&fn_node, source).to_string());
-                let receiver =
-                    named_child_text(&fn_node, "argument", source).map(|s| s.to_string());
+                let receiver = named_child_text(&fn_node, "argument", source)
+                    .map(|s| s.to_string());
                 push_call(symbols, node, name, receiver, None);
             }
             _ => {
@@ -456,11 +425,7 @@ mod tests {
         // field, so the unwrap helper has to scan children for the underlying
         // identifier — otherwise the parameter name comes back as `& action`.
         let s = parse_cpp("void log_action(const std::string& action) {}");
-        let func = s
-            .definitions
-            .iter()
-            .find(|d| d.name == "log_action")
-            .unwrap();
+        let func = s.definitions.iter().find(|d| d.name == "log_action").unwrap();
         let params = func.children.as_ref().expect("function has children");
         assert_eq!(params.len(), 1);
         assert_eq!(params[0].name, "action");

--- a/crates/codegraph-core/src/extractors/cpp.rs
+++ b/crates/codegraph-core/src/extractors/cpp.rs
@@ -1,9 +1,9 @@
-use tree_sitter::{Node, Tree};
+use super::helpers::*;
+use super::SymbolExtractor;
 use crate::ast_analysis::cfg::build_function_cfg;
 use crate::ast_analysis::complexity::compute_all_metrics;
 use crate::types::*;
-use super::helpers::*;
-use super::SymbolExtractor;
+use tree_sitter::{Node, Tree};
 
 pub struct CppExtractor;
 
@@ -11,7 +11,12 @@ impl SymbolExtractor for CppExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_cpp_node);
-        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &CPP_AST_CONFIG);
+        walk_ast_nodes_with_config(
+            &tree.root_node(),
+            source,
+            &mut symbols.ast_nodes,
+            &CPP_AST_CONFIG,
+        );
         walk_tree(&tree.root_node(), source, &mut symbols, match_cpp_type_map);
         dedup_type_map(&mut symbols.type_map);
         symbols
@@ -30,8 +35,11 @@ fn unwrap_cpp_declarator(node: &Node, source: &[u8]) -> String {
     let mut current = *node;
     loop {
         match current.kind() {
-            "pointer_declarator" | "reference_declarator" | "array_declarator"
-            | "parenthesized_declarator" | "function_declarator" => {
+            "pointer_declarator"
+            | "reference_declarator"
+            | "array_declarator"
+            | "parenthesized_declarator"
+            | "function_declarator" => {
                 // tree-sitter-cpp's `reference_declarator` rule does not expose a
                 // `declarator` field, so `child_by_field_name` returns None and
                 // the full node text (`& name`) leaks out. Fall back to scanning
@@ -107,7 +115,9 @@ fn extract_cpp_parameters(node: &Node, source: &[u8]) -> Vec<Definition> {
         if let Some(param_list) = func_decl.child_by_field_name("parameters") {
             for i in 0..param_list.child_count() {
                 if let Some(child) = param_list.child(i) {
-                    if child.kind() == "parameter_declaration" || child.kind() == "optional_parameter_declaration" {
+                    if child.kind() == "parameter_declaration"
+                        || child.kind() == "optional_parameter_declaration"
+                    {
                         if let Some(decl) = child.child_by_field_name("declarator") {
                             let name = unwrap_cpp_declarator(&decl, source);
                             if !name.is_empty() {
@@ -159,14 +169,21 @@ fn extract_cpp_enum_constants(node: &Node, source: &[u8]) -> Vec<Definition> {
     constants
 }
 
-fn extract_cpp_base_classes(node: &Node, source: &[u8], class_name: &str, symbols: &mut FileSymbols) {
+fn extract_cpp_base_classes(
+    node: &Node,
+    source: &[u8],
+    class_name: &str,
+    symbols: &mut FileSymbols,
+) {
     for i in 0..node.child_count() {
         if let Some(child) = node.child(i) {
             if child.kind() == "base_class_clause" {
                 for j in 0..child.child_count() {
                     if let Some(base) = child.child(j) {
                         match base.kind() {
-                            "type_identifier" | "qualified_identifier" | "scoped_type_identifier" => {
+                            "type_identifier"
+                            | "qualified_identifier"
+                            | "scoped_type_identifier" => {
                                 symbols.classes.push(ClassRelation {
                                     name: class_name.to_string(),
                                     extends: Some(node_text(&base, source).to_string()),
@@ -187,12 +204,17 @@ fn extract_cpp_base_classes(node: &Node, source: &[u8], class_name: &str, symbol
 
 fn handle_cpp_function_definition(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     if let Some(name) = extract_cpp_function_name(node, source) {
-        let parent_class = find_enclosing_type_name(node, &["class_specifier", "struct_specifier"], source);
+        let parent_class =
+            find_enclosing_type_name(node, &["class_specifier", "struct_specifier"], source);
         let full_name = match &parent_class {
             Some(cls) => format!("{}.{}", cls, name),
             None => name,
         };
-        let kind = if parent_class.is_some() { "method" } else { "function" };
+        let kind = if parent_class.is_some() {
+            "method"
+        } else {
+            "function"
+        };
         let children = extract_cpp_parameters(node, source);
         symbols.definitions.push(Definition {
             name: full_name,
@@ -204,6 +226,7 @@ fn handle_cpp_function_definition(node: &Node, source: &[u8], symbols: &mut File
             cfg: build_function_cfg(node, "cpp", source),
             children: opt_children(children),
             bodyless: None,
+            content_hash: None,
         });
     }
 }
@@ -211,7 +234,8 @@ fn handle_cpp_function_definition(node: &Node, source: &[u8], symbols: &mut File
 fn handle_cpp_class_specifier(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     if let Some(name_node) = node.child_by_field_name("name") {
         let class_name = node_text(&name_node, source).to_string();
-        let children = node.child_by_field_name("body")
+        let children = node
+            .child_by_field_name("body")
             .map(|body| extract_cpp_fields(&body, source))
             .unwrap_or_default();
         symbols.definitions.push(Definition {
@@ -224,6 +248,7 @@ fn handle_cpp_class_specifier(node: &Node, source: &[u8], symbols: &mut FileSymb
             cfg: None,
             children: opt_children(children),
             bodyless: None,
+            content_hash: None,
         });
         extract_cpp_base_classes(node, source, &class_name, symbols);
     }
@@ -232,7 +257,8 @@ fn handle_cpp_class_specifier(node: &Node, source: &[u8], symbols: &mut FileSymb
 fn handle_cpp_struct_specifier(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     if let Some(name_node) = node.child_by_field_name("name") {
         let struct_name = node_text(&name_node, source).to_string();
-        let children = node.child_by_field_name("body")
+        let children = node
+            .child_by_field_name("body")
             .map(|body| extract_cpp_fields(&body, source))
             .unwrap_or_default();
         symbols.definitions.push(Definition {
@@ -245,6 +271,7 @@ fn handle_cpp_struct_specifier(node: &Node, source: &[u8], symbols: &mut FileSym
             cfg: None,
             children: opt_children(children),
             bodyless: None,
+            content_hash: None,
         });
         extract_cpp_base_classes(node, source, &struct_name, symbols);
     }
@@ -263,6 +290,7 @@ fn handle_cpp_enum_specifier(node: &Node, source: &[u8], symbols: &mut FileSymbo
             cfg: None,
             children: opt_children(children),
             bodyless: None,
+            content_hash: None,
         });
     }
 }
@@ -279,6 +307,7 @@ fn handle_cpp_namespace_definition(node: &Node, source: &[u8], symbols: &mut Fil
             cfg: None,
             children: None,
             bodyless: None,
+            content_hash: None,
         });
     }
 }
@@ -307,6 +336,7 @@ fn handle_cpp_type_definition(node: &Node, source: &[u8], symbols: &mut FileSymb
             cfg: None,
             children: None,
             bodyless: None,
+            content_hash: None,
         });
     }
 }
@@ -317,12 +347,19 @@ fn handle_cpp_preproc_include(node: &Node, source: &[u8], symbols: &mut FileSymb
         let path = raw.trim_matches(|c| c == '"' || c == '<' || c == '>');
         if !path.is_empty() {
             let last = path.split('/').last().unwrap_or(path);
-            let name = last.strip_suffix(".h")
+            let name = last
+                .strip_suffix(".h")
                 .or_else(|| last.strip_suffix(".hpp"))
                 .unwrap_or(last);
-            push_import(symbols, node, path.to_string(), vec![name.to_string()], |imp| {
-                imp.c_include = Some(true);
-            });
+            push_import(
+                symbols,
+                node,
+                path.to_string(),
+                vec![name.to_string()],
+                |imp| {
+                    imp.c_include = Some(true);
+                },
+            );
         }
     }
 }
@@ -337,8 +374,8 @@ fn handle_cpp_call_expression(node: &Node, source: &[u8], symbols: &mut FileSymb
                 let name = named_child_text(&fn_node, "field", source)
                     .map(|s| s.to_string())
                     .unwrap_or_else(|| node_text(&fn_node, source).to_string());
-                let receiver = named_child_text(&fn_node, "argument", source)
-                    .map(|s| s.to_string());
+                let receiver =
+                    named_child_text(&fn_node, "argument", source).map(|s| s.to_string());
                 push_call(symbols, node, name, receiver, None);
             }
             _ => {
@@ -419,7 +456,11 @@ mod tests {
         // field, so the unwrap helper has to scan children for the underlying
         // identifier — otherwise the parameter name comes back as `& action`.
         let s = parse_cpp("void log_action(const std::string& action) {}");
-        let func = s.definitions.iter().find(|d| d.name == "log_action").unwrap();
+        let func = s
+            .definitions
+            .iter()
+            .find(|d| d.name == "log_action")
+            .unwrap();
         let params = func.children.as_ref().expect("function has children");
         assert_eq!(params.len(), 1);
         assert_eq!(params[0].name, "action");

--- a/crates/codegraph-core/src/extractors/csharp.rs
+++ b/crates/codegraph-core/src/extractors/csharp.rs
@@ -13,16 +13,29 @@ impl SymbolExtractor for CSharpExtractor {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_csharp_node);
         reclassify_csharp_implements(&mut symbols);
-        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &CSHARP_AST_CONFIG);
-        walk_tree(&tree.root_node(), source, &mut symbols, match_csharp_type_map);
+        walk_ast_nodes_with_config(
+            &tree.root_node(),
+            source,
+            &mut symbols.ast_nodes,
+            &CSHARP_AST_CONFIG,
+        );
+        walk_tree(
+            &tree.root_node(),
+            source,
+            &mut symbols,
+            match_csharp_type_map,
+        );
         dedup_type_map(&mut symbols.type_map);
         symbols
     }
 }
 
 const CSHARP_TYPE_KINDS: &[&str] = &[
-    "class_declaration", "struct_declaration", "interface_declaration",
-    "enum_declaration", "record_declaration",
+    "class_declaration",
+    "struct_declaration",
+    "interface_declaration",
+    "enum_declaration",
+    "record_declaration",
 ];
 
 fn find_csharp_parent_type(node: &Node, source: &[u8]) -> Option<String> {
@@ -49,7 +62,9 @@ fn match_csharp_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
 // ── Per-node-kind handlers for walk_node_depth ───────────────────────────────
 
 fn handle_class_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else { return };
+    let Some(name_node) = node.child_by_field_name("name") else {
+        return;
+    };
     let class_name = node_text(&name_node, source).to_string();
     let children = extract_csharp_class_fields(node, source);
     symbols.definitions.push(Definition {
@@ -62,12 +77,15 @@ fn handle_class_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: opt_children(children),
         bodyless: None,
+        content_hash: None,
     });
     extract_csharp_base_types(node, &class_name, source, symbols);
 }
 
 fn handle_struct_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else { return };
+    let Some(name_node) = node.child_by_field_name("name") else {
+        return;
+    };
     let name = node_text(&name_node, source).to_string();
     symbols.definitions.push(Definition {
         name: name.clone(),
@@ -79,12 +97,15 @@ fn handle_struct_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
     extract_csharp_base_types(node, &name, source, symbols);
 }
 
 fn handle_record_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else { return };
+    let Some(name_node) = node.child_by_field_name("name") else {
+        return;
+    };
     let name = node_text(&name_node, source).to_string();
     symbols.definitions.push(Definition {
         name: name.clone(),
@@ -96,12 +117,15 @@ fn handle_record_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
     extract_csharp_base_types(node, &name, source, symbols);
 }
 
 fn handle_interface_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else { return };
+    let Some(name_node) = node.child_by_field_name("name") else {
+        return;
+    };
     let iface_name = node_text(&name_node, source).to_string();
     symbols.definitions.push(Definition {
         name: iface_name.clone(),
@@ -113,11 +137,14 @@ fn handle_interface_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
     if let Some(body) = node.child_by_field_name("body") {
         for i in 0..body.child_count() {
             let Some(child) = body.child(i) else { continue };
-            if child.kind() != "method_declaration" { continue; }
+            if child.kind() != "method_declaration" {
+                continue;
+            }
             if let Some(meth_name) = child.child_by_field_name("name") {
                 // Interface method declarations have no body — skip CFG and complexity
                 // to mirror the WASM extractor and avoid producing meaningless metrics
@@ -132,6 +159,7 @@ fn handle_interface_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
                     cfg: None,
                     children: None,
                     bodyless: Some(child.child_by_field_name("body").is_none()),
+                    content_hash: None,
                 });
             }
         }
@@ -152,12 +180,15 @@ fn handle_enum_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             cfg: None,
             children: opt_children(children),
             bodyless: None,
+            content_hash: None,
         });
     }
 }
 
 fn handle_method_or_ctor(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else { return };
+    let Some(name_node) = node.child_by_field_name("name") else {
+        return;
+    };
     let parent_type = find_csharp_parent_type(node, source);
     let name = node_text(&name_node, source);
     let full_name = match &parent_type {
@@ -175,6 +206,7 @@ fn handle_method_or_ctor(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
         cfg: build_function_cfg(node, "csharp", source),
         children: opt_children(children),
         bodyless: Some(node.child_by_field_name("body").is_none()),
+        content_hash: None,
     });
 }
 
@@ -184,7 +216,9 @@ fn handle_method_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     // spurious `contains` edges to parameters of body-less declarations.
     if let Some(parent) = node.parent() {
         if let Some(grand) = parent.parent() {
-            if grand.kind() == "interface_declaration" { return; }
+            if grand.kind() == "interface_declaration" {
+                return;
+            }
         }
     }
     handle_method_or_ctor(node, source, symbols);
@@ -195,7 +229,9 @@ fn handle_constructor_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols
 }
 
 fn handle_property_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else { return };
+    let Some(name_node) = node.child_by_field_name("name") else {
+        return;
+    };
     let parent_type = find_csharp_parent_type(node, source);
     let name = node_text(&name_node, source);
     let full_name = match &parent_type {
@@ -212,6 +248,7 @@ fn handle_property_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -231,12 +268,15 @@ fn handle_using_directive(node: &Node, source: &[u8], symbols: &mut FileSymbols)
 
 /// Get the first string-literal argument text from a C# invocation node.
 fn get_cs_first_string_arg(node: &Node, source: &[u8]) -> Option<String> {
-    let args = node.child_by_field_name("argument_list")
+    let args = node
+        .child_by_field_name("argument_list")
         .or_else(|| find_child(node, "argument_list"))?;
     for i in 0..args.child_count() {
         let Some(child) = args.child(i) else { continue };
         let t = child.kind();
-        if matches!(t, "(" | ")" | ",") { continue; }
+        if matches!(t, "(" | ")" | ",") {
+            continue;
+        }
         // argument node may wrap the literal
         let target = if t == "argument" {
             child.child(0).unwrap_or(child)
@@ -254,7 +294,9 @@ fn get_cs_first_string_arg(node: &Node, source: &[u8]) -> Option<String> {
 }
 
 fn handle_invocation_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let fn_node = node.child_by_field_name("function").or_else(|| node.child(0));
+    let fn_node = node
+        .child_by_field_name("function")
+        .or_else(|| node.child(0));
     let Some(fn_node) = fn_node else { return };
     let call_line = start_line(node);
     match fn_node.kind() {
@@ -266,10 +308,11 @@ fn handle_invocation_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols)
             });
         }
         "member_access_expression" => {
-            let Some(name) = fn_node.child_by_field_name("name") else { return };
+            let Some(name) = fn_node.child_by_field_name("name") else {
+                return;
+            };
             let method_name = node_text(&name, source);
-            let receiver = named_child_text(&fn_node, "expression", source)
-                .map(|s| s.to_string());
+            let receiver = named_child_text(&fn_node, "expression", source).map(|s| s.to_string());
 
             // method.Invoke(target, args) — runtime reflection; target unknown
             if method_name == "Invoke" {
@@ -285,7 +328,10 @@ fn handle_invocation_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols)
             }
 
             // type.GetMethod("name") / GetRuntimeMethod / GetDeclaredMethod — resolvable if literal
-            if matches!(method_name, "GetMethod" | "GetRuntimeMethod" | "GetDeclaredMethod") {
+            if matches!(
+                method_name,
+                "GetMethod" | "GetRuntimeMethod" | "GetDeclaredMethod"
+            ) {
                 let literal = get_cs_first_string_arg(node, source);
                 if let Some(lit) = literal {
                     symbols.calls.push(Call {
@@ -318,7 +364,9 @@ fn handle_invocation_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols)
             });
         }
         "generic_name" | "member_binding_expression" => {
-            let name = fn_node.child_by_field_name("name").or_else(|| fn_node.child(0));
+            let name = fn_node
+                .child_by_field_name("name")
+                .or_else(|| fn_node.child(0));
             if let Some(name) = name {
                 symbols.calls.push(Call {
                     name: node_text(&name, source).to_string(),
@@ -332,9 +380,13 @@ fn handle_invocation_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols)
 }
 
 fn handle_object_creation(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(type_node) = node.child_by_field_name("type") else { return };
+    let Some(type_node) = node.child_by_field_name("type") else {
+        return;
+    };
     let type_name = if type_node.kind() == "generic_name" {
-        type_node.child_by_field_name("name").or_else(|| type_node.child(0))
+        type_node
+            .child_by_field_name("name")
+            .or_else(|| type_node.child(0))
             .map(|n| node_text(&n, source).to_string())
     } else {
         Some(node_text(&type_node, source).to_string())
@@ -354,7 +406,8 @@ fn handle_object_creation(node: &Node, source: &[u8], symbols: &mut FileSymbols)
 
 fn extract_csharp_parameters(node: &Node, source: &[u8]) -> Vec<Definition> {
     let mut params = Vec::new();
-    let params_node = node.child_by_field_name("parameters")
+    let params_node = node
+        .child_by_field_name("parameters")
         .or_else(|| find_child(node, "parameter_list"));
     if let Some(params_node) = params_node {
         for i in 0..params_node.child_count() {
@@ -376,7 +429,8 @@ fn extract_csharp_parameters(node: &Node, source: &[u8]) -> Vec<Definition> {
 
 fn extract_csharp_class_fields(node: &Node, source: &[u8]) -> Vec<Definition> {
     let mut fields = Vec::new();
-    let body = node.child_by_field_name("body")
+    let body = node
+        .child_by_field_name("body")
         .or_else(|| find_child(node, "declaration_list"));
     let Some(body) = body else { return fields };
     for i in 0..body.child_count() {
@@ -391,11 +445,18 @@ fn extract_csharp_class_fields(node: &Node, source: &[u8]) -> Vec<Definition> {
 fn collect_field_declarator_names(field: &Node, source: &[u8], fields: &mut Vec<Definition>) {
     for j in 0..field.child_count() {
         let Some(decl) = field.child(j) else { continue };
-        if decl.kind() != "variable_declaration" { continue; }
+        if decl.kind() != "variable_declaration" {
+            continue;
+        }
         for k in 0..decl.child_count() {
-            let Some(declarator) = decl.child(k) else { continue };
-            if declarator.kind() != "variable_declarator" { continue; }
-            let name_node = declarator.child_by_field_name("name")
+            let Some(declarator) = decl.child(k) else {
+                continue;
+            };
+            if declarator.kind() != "variable_declarator" {
+                continue;
+            }
+            let name_node = declarator
+                .child_by_field_name("name")
                 .or_else(|| declarator.child(0));
             let Some(name_node) = name_node else { continue };
             if name_node.kind() == "identifier" {
@@ -411,14 +472,15 @@ fn collect_field_declarator_names(field: &Node, source: &[u8], fields: &mut Vec<
 
 fn extract_csharp_enum_members(node: &Node, source: &[u8]) -> Vec<Definition> {
     let mut members = Vec::new();
-    let body = node.child_by_field_name("body")
+    let body = node
+        .child_by_field_name("body")
         .or_else(|| find_child(node, "enum_member_declaration_list"));
     if let Some(body) = body {
         for i in 0..body.child_count() {
             if let Some(child) = body.child(i) {
                 if child.kind() == "enum_member_declaration" {
-                    if let Some(name_node) = child.child_by_field_name("name")
-                        .or_else(|| child.child(0))
+                    if let Some(name_node) =
+                        child.child_by_field_name("name").or_else(|| child.child(0))
                     {
                         if name_node.kind() == "identifier" {
                             members.push(child_def(
@@ -491,9 +553,7 @@ fn extract_csharp_base_types(
                     });
                 }
                 "generic_name" => {
-                    let name = child
-                        .child_by_field_name("name")
-                        .or_else(|| child.child(0));
+                    let name = child.child_by_field_name("name").or_else(|| child.child(0));
                     if let Some(name) = name {
                         symbols.classes.push(ClassRelation {
                             name: class_name.to_string(),
@@ -516,9 +576,9 @@ fn extract_csharp_type_name<'a>(type_node: &Node<'a>, source: &'a [u8]) -> Optio
         "identifier" | "qualified_name" => Some(node_text(type_node, source)),
         "predefined_type" => None, // skip int, string, etc.
         "generic_name" => type_node.child(0).map(|n| node_text(&n, source)),
-        "nullable_type" => {
-            type_node.child(0).and_then(|inner| extract_csharp_type_name(&inner, source))
-        }
+        "nullable_type" => type_node
+            .child(0)
+            .and_then(|inner| extract_csharp_type_name(&inner, source)),
         _ => None,
     }
 }
@@ -533,14 +593,25 @@ fn handle_csharp_var_decl_type_map(node: &Node, source: &[u8], symbols: &mut Fil
     if type_node.kind() == "implicit_type" {
         // var x = new Foo() — infer type from object_creation_expression initializer
         for i in 0..node.child_count() {
-            let Some(declarator) = node.child(i) else { continue };
-            if declarator.kind() != "variable_declarator" { continue; }
-            let name_node = declarator.child_by_field_name("name")
+            let Some(declarator) = node.child(i) else {
+                continue;
+            };
+            if declarator.kind() != "variable_declarator" {
+                continue;
+            }
+            let name_node = declarator
+                .child_by_field_name("name")
                 .or_else(|| declarator.child(0));
             let Some(name_node) = name_node else { continue };
-            if name_node.kind() != "identifier" { continue; }
-            let Some(obj_creation) = find_child(&declarator, "object_creation_expression") else { continue };
-            let Some(ctor_type_node) = obj_creation.child_by_field_name("type") else { continue };
+            if name_node.kind() != "identifier" {
+                continue;
+            }
+            let Some(obj_creation) = find_child(&declarator, "object_creation_expression") else {
+                continue;
+            };
+            let Some(ctor_type_node) = obj_creation.child_by_field_name("type") else {
+                continue;
+            };
             if let Some(ctor_type) = extract_csharp_type_name(&ctor_type_node, source) {
                 symbols.type_map.push(TypeMapEntry {
                     name: node_text(&name_node, source).to_string(),
@@ -554,7 +625,9 @@ fn handle_csharp_var_decl_type_map(node: &Node, source: &[u8], symbols: &mut Fil
         if let Some(type_name) = extract_csharp_type_name(&type_node, source) {
             for i in 0..node.child_count() {
                 let Some(child) = node.child(i) else { continue };
-                if child.kind() != "variable_declarator" { continue; }
+                if child.kind() != "variable_declarator" {
+                    continue;
+                }
                 let name_node = child.child_by_field_name("name").or_else(|| child.child(0));
                 if let Some(name_node) = name_node {
                     if name_node.kind() == "identifier" {
@@ -572,9 +645,15 @@ fn handle_csharp_var_decl_type_map(node: &Node, source: &[u8], symbols: &mut Fil
 
 /// Handle `parameter` nodes: emit a type_map entry for typed method/constructor parameters.
 fn handle_csharp_param_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(type_node) = node.child_by_field_name("type") else { return };
-    let Some(type_name) = extract_csharp_type_name(&type_node, source) else { return };
-    let Some(name_node) = node.child_by_field_name("name") else { return };
+    let Some(type_node) = node.child_by_field_name("type") else {
+        return;
+    };
+    let Some(type_name) = extract_csharp_type_name(&type_node, source) else {
+        return;
+    };
+    let Some(name_node) = node.child_by_field_name("name") else {
+        return;
+    };
     symbols.type_map.push(TypeMapEntry {
         name: node_text(&name_node, source).to_string(),
         type_name: type_name.to_string(),

--- a/crates/codegraph-core/src/extractors/csharp.rs
+++ b/crates/codegraph-core/src/extractors/csharp.rs
@@ -13,29 +13,16 @@ impl SymbolExtractor for CSharpExtractor {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_csharp_node);
         reclassify_csharp_implements(&mut symbols);
-        walk_ast_nodes_with_config(
-            &tree.root_node(),
-            source,
-            &mut symbols.ast_nodes,
-            &CSHARP_AST_CONFIG,
-        );
-        walk_tree(
-            &tree.root_node(),
-            source,
-            &mut symbols,
-            match_csharp_type_map,
-        );
+        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &CSHARP_AST_CONFIG);
+        walk_tree(&tree.root_node(), source, &mut symbols, match_csharp_type_map);
         dedup_type_map(&mut symbols.type_map);
         symbols
     }
 }
 
 const CSHARP_TYPE_KINDS: &[&str] = &[
-    "class_declaration",
-    "struct_declaration",
-    "interface_declaration",
-    "enum_declaration",
-    "record_declaration",
+    "class_declaration", "struct_declaration", "interface_declaration",
+    "enum_declaration", "record_declaration",
 ];
 
 fn find_csharp_parent_type(node: &Node, source: &[u8]) -> Option<String> {
@@ -62,9 +49,7 @@ fn match_csharp_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
 // ── Per-node-kind handlers for walk_node_depth ───────────────────────────────
 
 fn handle_class_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else {
-        return;
-    };
+    let Some(name_node) = node.child_by_field_name("name") else { return };
     let class_name = node_text(&name_node, source).to_string();
     let children = extract_csharp_class_fields(node, source);
     symbols.definitions.push(Definition {
@@ -83,9 +68,7 @@ fn handle_class_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 }
 
 fn handle_struct_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else {
-        return;
-    };
+    let Some(name_node) = node.child_by_field_name("name") else { return };
     let name = node_text(&name_node, source).to_string();
     symbols.definitions.push(Definition {
         name: name.clone(),
@@ -103,9 +86,7 @@ fn handle_struct_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 }
 
 fn handle_record_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else {
-        return;
-    };
+    let Some(name_node) = node.child_by_field_name("name") else { return };
     let name = node_text(&name_node, source).to_string();
     symbols.definitions.push(Definition {
         name: name.clone(),
@@ -123,9 +104,7 @@ fn handle_record_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 }
 
 fn handle_interface_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else {
-        return;
-    };
+    let Some(name_node) = node.child_by_field_name("name") else { return };
     let iface_name = node_text(&name_node, source).to_string();
     symbols.definitions.push(Definition {
         name: iface_name.clone(),
@@ -142,9 +121,7 @@ fn handle_interface_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
     if let Some(body) = node.child_by_field_name("body") {
         for i in 0..body.child_count() {
             let Some(child) = body.child(i) else { continue };
-            if child.kind() != "method_declaration" {
-                continue;
-            }
+            if child.kind() != "method_declaration" { continue; }
             if let Some(meth_name) = child.child_by_field_name("name") {
                 // Interface method declarations have no body — skip CFG and complexity
                 // to mirror the WASM extractor and avoid producing meaningless metrics
@@ -186,9 +163,7 @@ fn handle_enum_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 }
 
 fn handle_method_or_ctor(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else {
-        return;
-    };
+    let Some(name_node) = node.child_by_field_name("name") else { return };
     let parent_type = find_csharp_parent_type(node, source);
     let name = node_text(&name_node, source);
     let full_name = match &parent_type {
@@ -216,9 +191,7 @@ fn handle_method_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     // spurious `contains` edges to parameters of body-less declarations.
     if let Some(parent) = node.parent() {
         if let Some(grand) = parent.parent() {
-            if grand.kind() == "interface_declaration" {
-                return;
-            }
+            if grand.kind() == "interface_declaration" { return; }
         }
     }
     handle_method_or_ctor(node, source, symbols);
@@ -229,9 +202,7 @@ fn handle_constructor_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols
 }
 
 fn handle_property_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else {
-        return;
-    };
+    let Some(name_node) = node.child_by_field_name("name") else { return };
     let parent_type = find_csharp_parent_type(node, source);
     let name = node_text(&name_node, source);
     let full_name = match &parent_type {
@@ -268,15 +239,12 @@ fn handle_using_directive(node: &Node, source: &[u8], symbols: &mut FileSymbols)
 
 /// Get the first string-literal argument text from a C# invocation node.
 fn get_cs_first_string_arg(node: &Node, source: &[u8]) -> Option<String> {
-    let args = node
-        .child_by_field_name("argument_list")
+    let args = node.child_by_field_name("argument_list")
         .or_else(|| find_child(node, "argument_list"))?;
     for i in 0..args.child_count() {
         let Some(child) = args.child(i) else { continue };
         let t = child.kind();
-        if matches!(t, "(" | ")" | ",") {
-            continue;
-        }
+        if matches!(t, "(" | ")" | ",") { continue; }
         // argument node may wrap the literal
         let target = if t == "argument" {
             child.child(0).unwrap_or(child)
@@ -294,9 +262,7 @@ fn get_cs_first_string_arg(node: &Node, source: &[u8]) -> Option<String> {
 }
 
 fn handle_invocation_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let fn_node = node
-        .child_by_field_name("function")
-        .or_else(|| node.child(0));
+    let fn_node = node.child_by_field_name("function").or_else(|| node.child(0));
     let Some(fn_node) = fn_node else { return };
     let call_line = start_line(node);
     match fn_node.kind() {
@@ -308,11 +274,10 @@ fn handle_invocation_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols)
             });
         }
         "member_access_expression" => {
-            let Some(name) = fn_node.child_by_field_name("name") else {
-                return;
-            };
+            let Some(name) = fn_node.child_by_field_name("name") else { return };
             let method_name = node_text(&name, source);
-            let receiver = named_child_text(&fn_node, "expression", source).map(|s| s.to_string());
+            let receiver = named_child_text(&fn_node, "expression", source)
+                .map(|s| s.to_string());
 
             // method.Invoke(target, args) — runtime reflection; target unknown
             if method_name == "Invoke" {
@@ -328,10 +293,7 @@ fn handle_invocation_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols)
             }
 
             // type.GetMethod("name") / GetRuntimeMethod / GetDeclaredMethod — resolvable if literal
-            if matches!(
-                method_name,
-                "GetMethod" | "GetRuntimeMethod" | "GetDeclaredMethod"
-            ) {
+            if matches!(method_name, "GetMethod" | "GetRuntimeMethod" | "GetDeclaredMethod") {
                 let literal = get_cs_first_string_arg(node, source);
                 if let Some(lit) = literal {
                     symbols.calls.push(Call {
@@ -364,9 +326,7 @@ fn handle_invocation_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols)
             });
         }
         "generic_name" | "member_binding_expression" => {
-            let name = fn_node
-                .child_by_field_name("name")
-                .or_else(|| fn_node.child(0));
+            let name = fn_node.child_by_field_name("name").or_else(|| fn_node.child(0));
             if let Some(name) = name {
                 symbols.calls.push(Call {
                     name: node_text(&name, source).to_string(),
@@ -380,13 +340,9 @@ fn handle_invocation_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols)
 }
 
 fn handle_object_creation(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(type_node) = node.child_by_field_name("type") else {
-        return;
-    };
+    let Some(type_node) = node.child_by_field_name("type") else { return };
     let type_name = if type_node.kind() == "generic_name" {
-        type_node
-            .child_by_field_name("name")
-            .or_else(|| type_node.child(0))
+        type_node.child_by_field_name("name").or_else(|| type_node.child(0))
             .map(|n| node_text(&n, source).to_string())
     } else {
         Some(node_text(&type_node, source).to_string())
@@ -406,8 +362,7 @@ fn handle_object_creation(node: &Node, source: &[u8], symbols: &mut FileSymbols)
 
 fn extract_csharp_parameters(node: &Node, source: &[u8]) -> Vec<Definition> {
     let mut params = Vec::new();
-    let params_node = node
-        .child_by_field_name("parameters")
+    let params_node = node.child_by_field_name("parameters")
         .or_else(|| find_child(node, "parameter_list"));
     if let Some(params_node) = params_node {
         for i in 0..params_node.child_count() {
@@ -429,8 +384,7 @@ fn extract_csharp_parameters(node: &Node, source: &[u8]) -> Vec<Definition> {
 
 fn extract_csharp_class_fields(node: &Node, source: &[u8]) -> Vec<Definition> {
     let mut fields = Vec::new();
-    let body = node
-        .child_by_field_name("body")
+    let body = node.child_by_field_name("body")
         .or_else(|| find_child(node, "declaration_list"));
     let Some(body) = body else { return fields };
     for i in 0..body.child_count() {
@@ -445,18 +399,11 @@ fn extract_csharp_class_fields(node: &Node, source: &[u8]) -> Vec<Definition> {
 fn collect_field_declarator_names(field: &Node, source: &[u8], fields: &mut Vec<Definition>) {
     for j in 0..field.child_count() {
         let Some(decl) = field.child(j) else { continue };
-        if decl.kind() != "variable_declaration" {
-            continue;
-        }
+        if decl.kind() != "variable_declaration" { continue; }
         for k in 0..decl.child_count() {
-            let Some(declarator) = decl.child(k) else {
-                continue;
-            };
-            if declarator.kind() != "variable_declarator" {
-                continue;
-            }
-            let name_node = declarator
-                .child_by_field_name("name")
+            let Some(declarator) = decl.child(k) else { continue };
+            if declarator.kind() != "variable_declarator" { continue; }
+            let name_node = declarator.child_by_field_name("name")
                 .or_else(|| declarator.child(0));
             let Some(name_node) = name_node else { continue };
             if name_node.kind() == "identifier" {
@@ -472,15 +419,14 @@ fn collect_field_declarator_names(field: &Node, source: &[u8], fields: &mut Vec<
 
 fn extract_csharp_enum_members(node: &Node, source: &[u8]) -> Vec<Definition> {
     let mut members = Vec::new();
-    let body = node
-        .child_by_field_name("body")
+    let body = node.child_by_field_name("body")
         .or_else(|| find_child(node, "enum_member_declaration_list"));
     if let Some(body) = body {
         for i in 0..body.child_count() {
             if let Some(child) = body.child(i) {
                 if child.kind() == "enum_member_declaration" {
-                    if let Some(name_node) =
-                        child.child_by_field_name("name").or_else(|| child.child(0))
+                    if let Some(name_node) = child.child_by_field_name("name")
+                        .or_else(|| child.child(0))
                     {
                         if name_node.kind() == "identifier" {
                             members.push(child_def(
@@ -553,7 +499,9 @@ fn extract_csharp_base_types(
                     });
                 }
                 "generic_name" => {
-                    let name = child.child_by_field_name("name").or_else(|| child.child(0));
+                    let name = child
+                        .child_by_field_name("name")
+                        .or_else(|| child.child(0));
                     if let Some(name) = name {
                         symbols.classes.push(ClassRelation {
                             name: class_name.to_string(),
@@ -576,9 +524,9 @@ fn extract_csharp_type_name<'a>(type_node: &Node<'a>, source: &'a [u8]) -> Optio
         "identifier" | "qualified_name" => Some(node_text(type_node, source)),
         "predefined_type" => None, // skip int, string, etc.
         "generic_name" => type_node.child(0).map(|n| node_text(&n, source)),
-        "nullable_type" => type_node
-            .child(0)
-            .and_then(|inner| extract_csharp_type_name(&inner, source)),
+        "nullable_type" => {
+            type_node.child(0).and_then(|inner| extract_csharp_type_name(&inner, source))
+        }
         _ => None,
     }
 }
@@ -593,25 +541,14 @@ fn handle_csharp_var_decl_type_map(node: &Node, source: &[u8], symbols: &mut Fil
     if type_node.kind() == "implicit_type" {
         // var x = new Foo() — infer type from object_creation_expression initializer
         for i in 0..node.child_count() {
-            let Some(declarator) = node.child(i) else {
-                continue;
-            };
-            if declarator.kind() != "variable_declarator" {
-                continue;
-            }
-            let name_node = declarator
-                .child_by_field_name("name")
+            let Some(declarator) = node.child(i) else { continue };
+            if declarator.kind() != "variable_declarator" { continue; }
+            let name_node = declarator.child_by_field_name("name")
                 .or_else(|| declarator.child(0));
             let Some(name_node) = name_node else { continue };
-            if name_node.kind() != "identifier" {
-                continue;
-            }
-            let Some(obj_creation) = find_child(&declarator, "object_creation_expression") else {
-                continue;
-            };
-            let Some(ctor_type_node) = obj_creation.child_by_field_name("type") else {
-                continue;
-            };
+            if name_node.kind() != "identifier" { continue; }
+            let Some(obj_creation) = find_child(&declarator, "object_creation_expression") else { continue };
+            let Some(ctor_type_node) = obj_creation.child_by_field_name("type") else { continue };
             if let Some(ctor_type) = extract_csharp_type_name(&ctor_type_node, source) {
                 symbols.type_map.push(TypeMapEntry {
                     name: node_text(&name_node, source).to_string(),
@@ -625,9 +562,7 @@ fn handle_csharp_var_decl_type_map(node: &Node, source: &[u8], symbols: &mut Fil
         if let Some(type_name) = extract_csharp_type_name(&type_node, source) {
             for i in 0..node.child_count() {
                 let Some(child) = node.child(i) else { continue };
-                if child.kind() != "variable_declarator" {
-                    continue;
-                }
+                if child.kind() != "variable_declarator" { continue; }
                 let name_node = child.child_by_field_name("name").or_else(|| child.child(0));
                 if let Some(name_node) = name_node {
                     if name_node.kind() == "identifier" {
@@ -645,15 +580,9 @@ fn handle_csharp_var_decl_type_map(node: &Node, source: &[u8], symbols: &mut Fil
 
 /// Handle `parameter` nodes: emit a type_map entry for typed method/constructor parameters.
 fn handle_csharp_param_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(type_node) = node.child_by_field_name("type") else {
-        return;
-    };
-    let Some(type_name) = extract_csharp_type_name(&type_node, source) else {
-        return;
-    };
-    let Some(name_node) = node.child_by_field_name("name") else {
-        return;
-    };
+    let Some(type_node) = node.child_by_field_name("type") else { return };
+    let Some(type_name) = extract_csharp_type_name(&type_node, source) else { return };
+    let Some(name_node) = node.child_by_field_name("name") else { return };
     symbols.type_map.push(TypeMapEntry {
         name: node_text(&name_node, source).to_string(),
         type_name: type_name.to_string(),

--- a/crates/codegraph-core/src/extractors/cuda.rs
+++ b/crates/codegraph-core/src/extractors/cuda.rs
@@ -185,9 +185,7 @@ fn extract_cuda_fields(body: &Node, source: &[u8]) -> Vec<Definition> {
                     // is a `function_declarator` is a method signature in a
                     // header, not a data field. Mirrors the WASM
                     // `isCudaMethodDeclarator` guard so both engines agree.
-                    if is_cuda_method_declarator(&decl) {
-                        continue;
-                    }
+                    if is_cuda_method_declarator(&decl) { continue; }
                     let name = extract_cuda_field_name(&decl, source);
                     if !name.is_empty() {
                         fields.push(child_def(name, "property", start_line(&child)));
@@ -498,15 +496,9 @@ fn handle_cuda_preproc_include(node: &Node, source: &[u8], symbols: &mut FileSym
                 .or_else(|| last.strip_suffix(".hpp"))
                 .or_else(|| last.strip_suffix(".h"))
                 .unwrap_or(last);
-            push_import(
-                symbols,
-                node,
-                path.to_string(),
-                vec![name.to_string()],
-                |imp| {
-                    imp.c_include = Some(true);
-                },
-            );
+            push_import(symbols, node, path.to_string(), vec![name.to_string()], |imp| {
+                imp.c_include = Some(true);
+            });
         }
     }
 }
@@ -629,7 +621,9 @@ mod tests {
 
     #[test]
     fn populates_type_map_from_declarations() {
-        let s = parse_cuda("void run() { DeviceBuffer buf; buf.copy(src, n); }");
+        let s = parse_cuda(
+            "void run() { DeviceBuffer buf; buf.copy(src, n); }",
+        );
         // `DeviceBuffer buf;` should be recorded so receiver-typed call
         // resolution can map `buf.copy` to `DeviceBuffer.copy`.
         let entry = s
@@ -659,8 +653,9 @@ mod tests {
 
     #[test]
     fn extracts_method_call_with_receiver() {
-        let s =
-            parse_cuda("void run() { UserService svc; svc.createUser(\"1\", \"a\", \"a@b\"); }");
+        let s = parse_cuda(
+            "void run() { UserService svc; svc.createUser(\"1\", \"a\", \"a@b\"); }",
+        );
         let call = s
             .calls
             .iter()
@@ -684,10 +679,7 @@ mod tests {
     #[test]
     fn extracts_typedef_alias() {
         let s = parse_cuda("typedef unsigned int uint32_t;");
-        assert!(s
-            .definitions
-            .iter()
-            .any(|d| d.name == "uint32_t" && d.kind == "type"));
+        assert!(s.definitions.iter().any(|d| d.name == "uint32_t" && d.kind == "type"));
     }
 
     #[test]
@@ -728,10 +720,7 @@ mod tests {
         let children = cls.children.as_ref().expect("class has children");
         let names: Vec<&str> = children.iter().map(|c| c.name.as_str()).collect();
         // Function-pointer/reference fields preserved with bare identifier names.
-        assert!(
-            names.contains(&"callback"),
-            "callback field kept: {names:?}"
-        );
+        assert!(names.contains(&"callback"), "callback field kept: {names:?}");
         assert!(names.contains(&"arr_cb"), "arr_cb field kept: {names:?}");
         assert!(names.contains(&"ref_cb"), "ref_cb field kept: {names:?}");
         assert!(names.contains(&"counter"), "counter field kept: {names:?}");

--- a/crates/codegraph-core/src/extractors/cuda.rs
+++ b/crates/codegraph-core/src/extractors/cuda.rs
@@ -185,7 +185,9 @@ fn extract_cuda_fields(body: &Node, source: &[u8]) -> Vec<Definition> {
                     // is a `function_declarator` is a method signature in a
                     // header, not a data field. Mirrors the WASM
                     // `isCudaMethodDeclarator` guard so both engines agree.
-                    if is_cuda_method_declarator(&decl) { continue; }
+                    if is_cuda_method_declarator(&decl) {
+                        continue;
+                    }
                     let name = extract_cuda_field_name(&decl, source);
                     if !name.is_empty() {
                         fields.push(child_def(name, "property", start_line(&child)));
@@ -363,6 +365,7 @@ fn handle_cuda_function_definition(node: &Node, source: &[u8], symbols: &mut Fil
             cfg: build_function_cfg(node, "cpp", source),
             children: opt_children(children),
             bodyless: None,
+            content_hash: None,
         });
     }
 }
@@ -384,6 +387,7 @@ fn handle_cuda_class_specifier(node: &Node, source: &[u8], symbols: &mut FileSym
             cfg: None,
             children: opt_children(children),
             bodyless: None,
+            content_hash: None,
         });
         extract_cuda_base_classes(node, source, &class_name, symbols);
     }
@@ -406,6 +410,7 @@ fn handle_cuda_struct_specifier(node: &Node, source: &[u8], symbols: &mut FileSy
             cfg: None,
             children: opt_children(children),
             bodyless: None,
+            content_hash: None,
         });
     }
 }
@@ -423,6 +428,7 @@ fn handle_cuda_enum_specifier(node: &Node, source: &[u8], symbols: &mut FileSymb
             cfg: None,
             children: opt_children(children),
             bodyless: None,
+            content_hash: None,
         });
     }
 }
@@ -439,6 +445,7 @@ fn handle_cuda_namespace_definition(node: &Node, source: &[u8], symbols: &mut Fi
             cfg: None,
             children: None,
             bodyless: None,
+            content_hash: None,
         });
     }
 }
@@ -470,6 +477,7 @@ fn handle_cuda_type_definition(node: &Node, source: &[u8], symbols: &mut FileSym
             cfg: None,
             children: None,
             bodyless: None,
+            content_hash: None,
         });
     }
 }
@@ -490,9 +498,15 @@ fn handle_cuda_preproc_include(node: &Node, source: &[u8], symbols: &mut FileSym
                 .or_else(|| last.strip_suffix(".hpp"))
                 .or_else(|| last.strip_suffix(".h"))
                 .unwrap_or(last);
-            push_import(symbols, node, path.to_string(), vec![name.to_string()], |imp| {
-                imp.c_include = Some(true);
-            });
+            push_import(
+                symbols,
+                node,
+                path.to_string(),
+                vec![name.to_string()],
+                |imp| {
+                    imp.c_include = Some(true);
+                },
+            );
         }
     }
 }
@@ -615,9 +629,7 @@ mod tests {
 
     #[test]
     fn populates_type_map_from_declarations() {
-        let s = parse_cuda(
-            "void run() { DeviceBuffer buf; buf.copy(src, n); }",
-        );
+        let s = parse_cuda("void run() { DeviceBuffer buf; buf.copy(src, n); }");
         // `DeviceBuffer buf;` should be recorded so receiver-typed call
         // resolution can map `buf.copy` to `DeviceBuffer.copy`.
         let entry = s
@@ -647,9 +659,8 @@ mod tests {
 
     #[test]
     fn extracts_method_call_with_receiver() {
-        let s = parse_cuda(
-            "void run() { UserService svc; svc.createUser(\"1\", \"a\", \"a@b\"); }",
-        );
+        let s =
+            parse_cuda("void run() { UserService svc; svc.createUser(\"1\", \"a\", \"a@b\"); }");
         let call = s
             .calls
             .iter()
@@ -673,7 +684,10 @@ mod tests {
     #[test]
     fn extracts_typedef_alias() {
         let s = parse_cuda("typedef unsigned int uint32_t;");
-        assert!(s.definitions.iter().any(|d| d.name == "uint32_t" && d.kind == "type"));
+        assert!(s
+            .definitions
+            .iter()
+            .any(|d| d.name == "uint32_t" && d.kind == "type"));
     }
 
     #[test]
@@ -714,7 +728,10 @@ mod tests {
         let children = cls.children.as_ref().expect("class has children");
         let names: Vec<&str> = children.iter().map(|c| c.name.as_str()).collect();
         // Function-pointer/reference fields preserved with bare identifier names.
-        assert!(names.contains(&"callback"), "callback field kept: {names:?}");
+        assert!(
+            names.contains(&"callback"),
+            "callback field kept: {names:?}"
+        );
         assert!(names.contains(&"arr_cb"), "arr_cb field kept: {names:?}");
         assert!(names.contains(&"ref_cb"), "ref_cb field kept: {names:?}");
         assert!(names.contains(&"counter"), "counter field kept: {names:?}");

--- a/crates/codegraph-core/src/extractors/dart.rs
+++ b/crates/codegraph-core/src/extractors/dart.rs
@@ -1,9 +1,9 @@
-use super::helpers::*;
-use super::SymbolExtractor;
+use tree_sitter::{Node, Tree};
 use crate::ast_analysis::cfg::build_function_cfg;
 use crate::ast_analysis::complexity::compute_all_metrics;
 use crate::types::*;
-use tree_sitter::{Node, Tree};
+use super::helpers::*;
+use super::SymbolExtractor;
 
 pub struct DartExtractor;
 
@@ -11,12 +11,7 @@ impl SymbolExtractor for DartExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_dart_node);
-        walk_ast_nodes_with_config(
-            &tree.root_node(),
-            source,
-            &mut symbols.ast_nodes,
-            &DART_AST_CONFIG,
-        );
+        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &DART_AST_CONFIG);
         symbols
     }
 }
@@ -36,9 +31,7 @@ fn match_dart_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth
             }
         }
         "library_import" => handle_dart_import(node, source, symbols),
-        "constructor_invocation" | "new_expression" => {
-            handle_dart_constructor_call(node, source, symbols)
-        }
+        "constructor_invocation" | "new_expression" => handle_dart_constructor_call(node, source, symbols),
         "type_alias" => handle_dart_type_alias(node, source, symbols),
         "selector" => handle_dart_selector(node, source, symbols),
         _ => {}
@@ -53,10 +46,7 @@ fn handle_dart_class(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     let class_name = node_text(&name_node, source).to_string();
 
     // Extract methods
-    if let Some(body) = node
-        .child_by_field_name("body")
-        .or_else(|| find_child(node, "class_body"))
-    {
+    if let Some(body) = node.child_by_field_name("body").or_else(|| find_child(node, "class_body")) {
         extract_dart_class_methods(&body, &class_name, source, symbols);
     }
 
@@ -79,8 +69,7 @@ fn handle_dart_class(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                 let type_name = if child.kind() == "type_identifier" {
                     Some(child)
                 } else {
-                    find_child(&child, "type_identifier")
-                        .or_else(|| find_child(&child, "identifier"))
+                    find_child(&child, "type_identifier").or_else(|| find_child(&child, "identifier"))
                 };
                 if let Some(tn) = type_name {
                     symbols.classes.push(ClassRelation {
@@ -108,12 +97,7 @@ fn handle_dart_class(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     });
 }
 
-fn extract_dart_class_methods(
-    body: &Node,
-    class_name: &str,
-    source: &[u8],
-    symbols: &mut FileSymbols,
-) {
+fn extract_dart_class_methods(body: &Node, class_name: &str, source: &[u8], symbols: &mut FileSymbols) {
     for i in 0..body.child_count() {
         if let Some(member) = body.child(i) {
             // Resolve the signature node from the various wrapper layers that
@@ -141,8 +125,7 @@ fn extract_dart_class_methods(
                     match method_decl {
                         Some(md) => {
                             // method_declaration has field "signature" → method_signature
-                            match md
-                                .child_by_field_name("signature")
+                            match md.child_by_field_name("signature")
                                 .or_else(|| find_dart_signature_child(&md))
                             {
                                 Some(s) => s,
@@ -196,10 +179,7 @@ fn extract_dart_fn_name(node: &Node, source: &[u8]) -> Option<String> {
     for i in 0..node.child_count() {
         if let Some(child) = node.child(i) {
             match child.kind() {
-                "function_signature"
-                | "getter_signature"
-                | "setter_signature"
-                | "constructor_signature" => {
+                "function_signature" | "getter_signature" | "setter_signature" | "constructor_signature" => {
                     if let Some(name) = child.child_by_field_name("name") {
                         return Some(node_text(&name, source).to_string());
                     }
@@ -297,13 +277,16 @@ fn handle_dart_import(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         None => return,
     };
 
-    let uri = find_child(&spec, "configurable_uri").or_else(|| find_child(&spec, "uri"));
+    let uri = find_child(&spec, "configurable_uri")
+        .or_else(|| find_child(&spec, "uri"));
     if let Some(uri) = uri {
         let raw = node_text(&uri, source);
         let source_path = raw.trim_matches(|c| c == '\'' || c == '"').to_string();
-        symbols
-            .imports
-            .push(Import::new(source_path, vec![], start_line(node)));
+        symbols.imports.push(Import::new(
+            source_path,
+            vec![],
+            start_line(node),
+        ));
     }
 }
 
@@ -318,11 +301,9 @@ fn handle_dart_constructor_call(node: &Node, source: &[u8], symbols: &mut FileSy
     let name_node = find_child(node, "type_identifier")
         .or_else(|| find_child(node, "identifier"))
         .or_else(|| {
-            node.child_by_field_name("type")
-                .or_else(|| find_child(node, "type"))
-                .and_then(|t| {
-                    find_child(&t, "type_identifier").or_else(|| find_child(&t, "identifier"))
-                })
+            node.child_by_field_name("type").or_else(|| find_child(node, "type")).and_then(|t| {
+                find_child(&t, "type_identifier").or_else(|| find_child(&t, "identifier"))
+            })
         });
     if let Some(name) = name_node {
         symbols.calls.push(Call {
@@ -336,7 +317,8 @@ fn handle_dart_constructor_call(node: &Node, source: &[u8], symbols: &mut FileSy
 }
 
 fn handle_dart_type_alias(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let name_node = find_child(node, "type_identifier").or_else(|| find_child(node, "identifier"));
+    let name_node = find_child(node, "type_identifier")
+        .or_else(|| find_child(node, "identifier"));
     if let Some(name) = name_node {
         symbols.definitions.push(Definition {
             name: node_text(&name, source).to_string(),
@@ -397,11 +379,12 @@ fn is_inside_class(node: &Node) -> bool {
         match parent.kind() {
             // Accept both 0.0.4 (`class_definition`) and 0.2 (`class_declaration`)
             // node names to guard function_signature extraction from top-level scope.
-            "class_body" | "class_definition" | "class_declaration" | "enum_body"
-            | "mixin_declaration" => return true,
+            "class_body" | "class_definition" | "class_declaration"
+            | "enum_body" | "mixin_declaration" => return true,
             _ => {}
         }
         current = parent.parent();
     }
     false
 }
+

--- a/crates/codegraph-core/src/extractors/dart.rs
+++ b/crates/codegraph-core/src/extractors/dart.rs
@@ -1,9 +1,9 @@
-use tree_sitter::{Node, Tree};
+use super::helpers::*;
+use super::SymbolExtractor;
 use crate::ast_analysis::cfg::build_function_cfg;
 use crate::ast_analysis::complexity::compute_all_metrics;
 use crate::types::*;
-use super::helpers::*;
-use super::SymbolExtractor;
+use tree_sitter::{Node, Tree};
 
 pub struct DartExtractor;
 
@@ -11,7 +11,12 @@ impl SymbolExtractor for DartExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_dart_node);
-        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &DART_AST_CONFIG);
+        walk_ast_nodes_with_config(
+            &tree.root_node(),
+            source,
+            &mut symbols.ast_nodes,
+            &DART_AST_CONFIG,
+        );
         symbols
     }
 }
@@ -31,7 +36,9 @@ fn match_dart_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth
             }
         }
         "library_import" => handle_dart_import(node, source, symbols),
-        "constructor_invocation" | "new_expression" => handle_dart_constructor_call(node, source, symbols),
+        "constructor_invocation" | "new_expression" => {
+            handle_dart_constructor_call(node, source, symbols)
+        }
         "type_alias" => handle_dart_type_alias(node, source, symbols),
         "selector" => handle_dart_selector(node, source, symbols),
         _ => {}
@@ -46,7 +53,10 @@ fn handle_dart_class(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     let class_name = node_text(&name_node, source).to_string();
 
     // Extract methods
-    if let Some(body) = node.child_by_field_name("body").or_else(|| find_child(node, "class_body")) {
+    if let Some(body) = node
+        .child_by_field_name("body")
+        .or_else(|| find_child(node, "class_body"))
+    {
         extract_dart_class_methods(&body, &class_name, source, symbols);
     }
 
@@ -69,7 +79,8 @@ fn handle_dart_class(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                 let type_name = if child.kind() == "type_identifier" {
                     Some(child)
                 } else {
-                    find_child(&child, "type_identifier").or_else(|| find_child(&child, "identifier"))
+                    find_child(&child, "type_identifier")
+                        .or_else(|| find_child(&child, "identifier"))
                 };
                 if let Some(tn) = type_name {
                     symbols.classes.push(ClassRelation {
@@ -93,10 +104,16 @@ fn handle_dart_class(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
-fn extract_dart_class_methods(body: &Node, class_name: &str, source: &[u8], symbols: &mut FileSymbols) {
+fn extract_dart_class_methods(
+    body: &Node,
+    class_name: &str,
+    source: &[u8],
+    symbols: &mut FileSymbols,
+) {
     for i in 0..body.child_count() {
         if let Some(member) = body.child(i) {
             // Resolve the signature node from the various wrapper layers that
@@ -124,7 +141,8 @@ fn extract_dart_class_methods(body: &Node, class_name: &str, source: &[u8], symb
                     match method_decl {
                         Some(md) => {
                             // method_declaration has field "signature" → method_signature
-                            match md.child_by_field_name("signature")
+                            match md
+                                .child_by_field_name("signature")
                                 .or_else(|| find_dart_signature_child(&md))
                             {
                                 Some(s) => s,
@@ -150,6 +168,7 @@ fn extract_dart_class_methods(body: &Node, class_name: &str, source: &[u8], symb
                             cfg: build_function_cfg(&sig, "dart", source),
                             children: None,
                             bodyless: None,
+                            content_hash: None,
                         });
                     }
                 }
@@ -177,7 +196,10 @@ fn extract_dart_fn_name(node: &Node, source: &[u8]) -> Option<String> {
     for i in 0..node.child_count() {
         if let Some(child) = node.child(i) {
             match child.kind() {
-                "function_signature" | "getter_signature" | "setter_signature" | "constructor_signature" => {
+                "function_signature"
+                | "getter_signature"
+                | "setter_signature"
+                | "constructor_signature" => {
                     if let Some(name) = child.child_by_field_name("name") {
                         return Some(node_text(&name, source).to_string());
                     }
@@ -205,6 +227,7 @@ fn handle_dart_enum(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -224,6 +247,7 @@ fn handle_dart_mixin(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -243,6 +267,7 @@ fn handle_dart_extension(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -262,6 +287,7 @@ fn handle_dart_function_sig(node: &Node, source: &[u8], symbols: &mut FileSymbol
         cfg: build_function_cfg(node, "dart", source),
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -271,16 +297,13 @@ fn handle_dart_import(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         None => return,
     };
 
-    let uri = find_child(&spec, "configurable_uri")
-        .or_else(|| find_child(&spec, "uri"));
+    let uri = find_child(&spec, "configurable_uri").or_else(|| find_child(&spec, "uri"));
     if let Some(uri) = uri {
         let raw = node_text(&uri, source);
         let source_path = raw.trim_matches(|c| c == '\'' || c == '"').to_string();
-        symbols.imports.push(Import::new(
-            source_path,
-            vec![],
-            start_line(node),
-        ));
+        symbols
+            .imports
+            .push(Import::new(source_path, vec![], start_line(node)));
     }
 }
 
@@ -295,9 +318,11 @@ fn handle_dart_constructor_call(node: &Node, source: &[u8], symbols: &mut FileSy
     let name_node = find_child(node, "type_identifier")
         .or_else(|| find_child(node, "identifier"))
         .or_else(|| {
-            node.child_by_field_name("type").or_else(|| find_child(node, "type")).and_then(|t| {
-                find_child(&t, "type_identifier").or_else(|| find_child(&t, "identifier"))
-            })
+            node.child_by_field_name("type")
+                .or_else(|| find_child(node, "type"))
+                .and_then(|t| {
+                    find_child(&t, "type_identifier").or_else(|| find_child(&t, "identifier"))
+                })
         });
     if let Some(name) = name_node {
         symbols.calls.push(Call {
@@ -311,8 +336,7 @@ fn handle_dart_constructor_call(node: &Node, source: &[u8], symbols: &mut FileSy
 }
 
 fn handle_dart_type_alias(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let name_node = find_child(node, "type_identifier")
-        .or_else(|| find_child(node, "identifier"));
+    let name_node = find_child(node, "type_identifier").or_else(|| find_child(node, "identifier"));
     if let Some(name) = name_node {
         symbols.definitions.push(Definition {
             name: node_text(&name, source).to_string(),
@@ -324,6 +348,7 @@ fn handle_dart_type_alias(node: &Node, source: &[u8], symbols: &mut FileSymbols)
             cfg: None,
             children: None,
             bodyless: None,
+            content_hash: None,
         });
     }
 }
@@ -372,12 +397,11 @@ fn is_inside_class(node: &Node) -> bool {
         match parent.kind() {
             // Accept both 0.0.4 (`class_definition`) and 0.2 (`class_declaration`)
             // node names to guard function_signature extraction from top-level scope.
-            "class_body" | "class_definition" | "class_declaration"
-            | "enum_body" | "mixin_declaration" => return true,
+            "class_body" | "class_definition" | "class_declaration" | "enum_body"
+            | "mixin_declaration" => return true,
             _ => {}
         }
         current = parent.parent();
     }
     false
 }
-

--- a/crates/codegraph-core/src/extractors/elixir.rs
+++ b/crates/codegraph-core/src/extractors/elixir.rs
@@ -1,9 +1,9 @@
-use tree_sitter::{Node, Tree};
+use super::helpers::*;
+use super::SymbolExtractor;
 use crate::ast_analysis::cfg::build_function_cfg;
 use crate::ast_analysis::complexity::compute_all_metrics;
 use crate::types::*;
-use super::helpers::*;
-use super::SymbolExtractor;
+use tree_sitter::{Node, Tree};
 
 pub struct ElixirExtractor;
 
@@ -11,7 +11,12 @@ impl SymbolExtractor for ElixirExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_elixir_node);
-        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &ELIXIR_AST_CONFIG);
+        walk_ast_nodes_with_config(
+            &tree.root_node(),
+            source,
+            &mut symbols.ast_nodes,
+            &ELIXIR_AST_CONFIG,
+        );
         symbols
     }
 }
@@ -33,7 +38,9 @@ fn match_elixir_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
             "def" | "defp" => handle_def_function(node, source, symbols, keyword),
             "defprotocol" => handle_defprotocol(node, source, symbols),
             "defimpl" => handle_defimpl(node, source, symbols),
-            "import" | "use" | "require" | "alias" => handle_elixir_import(node, source, symbols, keyword),
+            "import" | "use" | "require" | "alias" => {
+                handle_elixir_import(node, source, symbols, keyword)
+            }
             "apply" => handle_elixir_apply(node, source, symbols),
             _ => {
                 symbols.calls.push(Call {
@@ -74,6 +81,7 @@ fn handle_defmodule(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: opt_children(children),
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -89,7 +97,10 @@ fn collect_module_children(node: &Node, source: &[u8]) -> Vec<Definition> {
             Some(c) if c.kind() == "call" => c,
             _ => continue,
         };
-        let target = match child.child_by_field_name("target").or_else(|| child.child(0)) {
+        let target = match child
+            .child_by_field_name("target")
+            .or_else(|| child.child(0))
+        {
             Some(t) if t.kind() == "identifier" => t,
             _ => continue,
         };
@@ -144,6 +155,7 @@ fn handle_def_function(node: &Node, source: &[u8], symbols: &mut FileSymbols, _k
         cfg: build_function_cfg(node, "elixir", source),
         children: opt_children(params),
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -151,10 +163,16 @@ fn extract_elixir_params(args: &Node, source: &[u8]) -> Vec<Definition> {
     let mut params = Vec::new();
     for i in 0..args.child_count() {
         let Some(child) = args.child(i) else { continue };
-        if child.kind() != "call" { continue; }
-        let Some(inner_args) = find_child(&child, "arguments") else { continue };
+        if child.kind() != "call" {
+            continue;
+        }
+        let Some(inner_args) = find_child(&child, "arguments") else {
+            continue;
+        };
         for j in 0..inner_args.child_count() {
-            let Some(param) = inner_args.child(j) else { continue };
+            let Some(param) = inner_args.child(j) else {
+                continue;
+            };
             collect_elixir_param_identifiers(&param, source, &mut params);
         }
     }
@@ -229,7 +247,9 @@ fn push_elixir_sequence_items<'a>(node: &Node<'a>, stack: &mut Vec<Node<'a>>) {
     for i in (0..count).rev() {
         let Some(c) = node.child(i) else { continue };
         let k = c.kind();
-        if PUNCTUATION_TOKENS.contains(&k) { continue; }
+        if PUNCTUATION_TOKENS.contains(&k) {
+            continue;
+        }
         stack.push(c);
     }
 }
@@ -244,17 +264,29 @@ fn push_elixir_map_values<'a>(node: &Node<'a>, stack: &mut Vec<Node<'a>>) {
     // Collect values in source order first, then push in reverse so pop() is l-to-r.
     let mut values: Vec<Node<'a>> = Vec::new();
     for i in 0..node.child_count() {
-        let Some(content) = node.child(i) else { continue };
-        if content.kind() != "map_content" { continue; }
+        let Some(content) = node.child(i) else {
+            continue;
+        };
+        if content.kind() != "map_content" {
+            continue;
+        }
         for j in 0..content.child_count() {
-            let Some(kws) = content.child(j) else { continue };
-            if kws.kind() != "keywords" { continue; }
+            let Some(kws) = content.child(j) else {
+                continue;
+            };
+            if kws.kind() != "keywords" {
+                continue;
+            }
             for k in 0..kws.child_count() {
                 let Some(pair) = kws.child(k) else { continue };
-                if pair.kind() != "pair" { continue; }
+                if pair.kind() != "pair" {
+                    continue;
+                }
                 for p in 0..pair.child_count() {
                     let Some(part) = pair.child(p) else { continue };
-                    if part.kind() == "keyword" { continue; }
+                    if part.kind() == "keyword" {
+                        continue;
+                    }
                     values.push(part);
                 }
             }
@@ -269,7 +301,10 @@ fn extract_elixir_fn_name<'a>(args: &Node<'a>, source: &'a [u8]) -> Option<Strin
     for i in 0..args.child_count() {
         if let Some(child) = args.child(i) {
             if child.kind() == "call" {
-                if let Some(target) = child.child_by_field_name("target").or_else(|| child.child(0)) {
+                if let Some(target) = child
+                    .child_by_field_name("target")
+                    .or_else(|| child.child(0))
+                {
                     if target.kind() == "identifier" {
                         return Some(node_text(&target, source).to_string());
                     }
@@ -298,7 +333,9 @@ fn find_elixir_parent_module<'a>(node: &Node<'a>, source: &[u8]) -> Option<Strin
 
 fn try_extract_defmodule_name(do_block: &Node, source: &[u8]) -> Option<String> {
     let gp = do_block.parent()?;
-    if gp.kind() != "call" { return None; }
+    if gp.kind() != "call" {
+        return None;
+    }
     let target = gp.child_by_field_name("target").or_else(|| gp.child(0))?;
     if target.kind() != "identifier" || node_text(&target, source) != "defmodule" {
         return None;
@@ -328,6 +365,7 @@ fn handle_defprotocol(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -351,6 +389,7 @@ fn handle_defimpl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -392,7 +431,9 @@ fn handle_elixir_apply(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     for i in 0..args.child_count() {
         let Some(child) = args.child(i) else { continue };
         let t = child.kind();
-        if matches!(t, "(" | ")" | ",") { continue; }
+        if matches!(t, "(" | ")" | ",") {
+            continue;
+        }
         if arg_idx == 1 {
             second_arg = Some(child);
             break;

--- a/crates/codegraph-core/src/extractors/elixir.rs
+++ b/crates/codegraph-core/src/extractors/elixir.rs
@@ -1,9 +1,9 @@
-use super::helpers::*;
-use super::SymbolExtractor;
+use tree_sitter::{Node, Tree};
 use crate::ast_analysis::cfg::build_function_cfg;
 use crate::ast_analysis::complexity::compute_all_metrics;
 use crate::types::*;
-use tree_sitter::{Node, Tree};
+use super::helpers::*;
+use super::SymbolExtractor;
 
 pub struct ElixirExtractor;
 
@@ -11,12 +11,7 @@ impl SymbolExtractor for ElixirExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_elixir_node);
-        walk_ast_nodes_with_config(
-            &tree.root_node(),
-            source,
-            &mut symbols.ast_nodes,
-            &ELIXIR_AST_CONFIG,
-        );
+        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &ELIXIR_AST_CONFIG);
         symbols
     }
 }
@@ -38,9 +33,7 @@ fn match_elixir_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
             "def" | "defp" => handle_def_function(node, source, symbols, keyword),
             "defprotocol" => handle_defprotocol(node, source, symbols),
             "defimpl" => handle_defimpl(node, source, symbols),
-            "import" | "use" | "require" | "alias" => {
-                handle_elixir_import(node, source, symbols, keyword)
-            }
+            "import" | "use" | "require" | "alias" => handle_elixir_import(node, source, symbols, keyword),
             "apply" => handle_elixir_apply(node, source, symbols),
             _ => {
                 symbols.calls.push(Call {
@@ -97,10 +90,7 @@ fn collect_module_children(node: &Node, source: &[u8]) -> Vec<Definition> {
             Some(c) if c.kind() == "call" => c,
             _ => continue,
         };
-        let target = match child
-            .child_by_field_name("target")
-            .or_else(|| child.child(0))
-        {
+        let target = match child.child_by_field_name("target").or_else(|| child.child(0)) {
             Some(t) if t.kind() == "identifier" => t,
             _ => continue,
         };
@@ -163,16 +153,10 @@ fn extract_elixir_params(args: &Node, source: &[u8]) -> Vec<Definition> {
     let mut params = Vec::new();
     for i in 0..args.child_count() {
         let Some(child) = args.child(i) else { continue };
-        if child.kind() != "call" {
-            continue;
-        }
-        let Some(inner_args) = find_child(&child, "arguments") else {
-            continue;
-        };
+        if child.kind() != "call" { continue; }
+        let Some(inner_args) = find_child(&child, "arguments") else { continue };
         for j in 0..inner_args.child_count() {
-            let Some(param) = inner_args.child(j) else {
-                continue;
-            };
+            let Some(param) = inner_args.child(j) else { continue };
             collect_elixir_param_identifiers(&param, source, &mut params);
         }
     }
@@ -247,9 +231,7 @@ fn push_elixir_sequence_items<'a>(node: &Node<'a>, stack: &mut Vec<Node<'a>>) {
     for i in (0..count).rev() {
         let Some(c) = node.child(i) else { continue };
         let k = c.kind();
-        if PUNCTUATION_TOKENS.contains(&k) {
-            continue;
-        }
+        if PUNCTUATION_TOKENS.contains(&k) { continue; }
         stack.push(c);
     }
 }
@@ -264,29 +246,17 @@ fn push_elixir_map_values<'a>(node: &Node<'a>, stack: &mut Vec<Node<'a>>) {
     // Collect values in source order first, then push in reverse so pop() is l-to-r.
     let mut values: Vec<Node<'a>> = Vec::new();
     for i in 0..node.child_count() {
-        let Some(content) = node.child(i) else {
-            continue;
-        };
-        if content.kind() != "map_content" {
-            continue;
-        }
+        let Some(content) = node.child(i) else { continue };
+        if content.kind() != "map_content" { continue; }
         for j in 0..content.child_count() {
-            let Some(kws) = content.child(j) else {
-                continue;
-            };
-            if kws.kind() != "keywords" {
-                continue;
-            }
+            let Some(kws) = content.child(j) else { continue };
+            if kws.kind() != "keywords" { continue; }
             for k in 0..kws.child_count() {
                 let Some(pair) = kws.child(k) else { continue };
-                if pair.kind() != "pair" {
-                    continue;
-                }
+                if pair.kind() != "pair" { continue; }
                 for p in 0..pair.child_count() {
                     let Some(part) = pair.child(p) else { continue };
-                    if part.kind() == "keyword" {
-                        continue;
-                    }
+                    if part.kind() == "keyword" { continue; }
                     values.push(part);
                 }
             }
@@ -301,10 +271,7 @@ fn extract_elixir_fn_name<'a>(args: &Node<'a>, source: &'a [u8]) -> Option<Strin
     for i in 0..args.child_count() {
         if let Some(child) = args.child(i) {
             if child.kind() == "call" {
-                if let Some(target) = child
-                    .child_by_field_name("target")
-                    .or_else(|| child.child(0))
-                {
+                if let Some(target) = child.child_by_field_name("target").or_else(|| child.child(0)) {
                     if target.kind() == "identifier" {
                         return Some(node_text(&target, source).to_string());
                     }
@@ -333,9 +300,7 @@ fn find_elixir_parent_module<'a>(node: &Node<'a>, source: &[u8]) -> Option<Strin
 
 fn try_extract_defmodule_name(do_block: &Node, source: &[u8]) -> Option<String> {
     let gp = do_block.parent()?;
-    if gp.kind() != "call" {
-        return None;
-    }
+    if gp.kind() != "call" { return None; }
     let target = gp.child_by_field_name("target").or_else(|| gp.child(0))?;
     if target.kind() != "identifier" || node_text(&target, source) != "defmodule" {
         return None;
@@ -431,9 +396,7 @@ fn handle_elixir_apply(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     for i in 0..args.child_count() {
         let Some(child) = args.child(i) else { continue };
         let t = child.kind();
-        if matches!(t, "(" | ")" | ",") {
-            continue;
-        }
+        if matches!(t, "(" | ")" | ",") { continue; }
         if arg_idx == 1 {
             second_arg = Some(child);
             break;

--- a/crates/codegraph-core/src/extractors/erlang.rs
+++ b/crates/codegraph-core/src/extractors/erlang.rs
@@ -1,7 +1,7 @@
-use tree_sitter::{Node, Tree};
-use crate::types::*;
 use super::helpers::*;
 use super::SymbolExtractor;
+use crate::types::*;
+use tree_sitter::{Node, Tree};
 
 pub struct ErlangExtractor;
 
@@ -9,7 +9,12 @@ impl SymbolExtractor for ErlangExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_erlang_node);
-        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &ERLANG_AST_CONFIG);
+        walk_ast_nodes_with_config(
+            &tree.root_node(),
+            source,
+            &mut symbols.ast_nodes,
+            &ERLANG_AST_CONFIG,
+        );
         symbols
     }
 }
@@ -57,6 +62,7 @@ fn handle_module_attr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -99,6 +105,7 @@ fn handle_record_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: opt_children(children),
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -126,6 +133,7 @@ fn handle_type_alias(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -179,6 +187,7 @@ fn handle_function_clause(node: &Node, source: &[u8], symbols: &mut FileSymbols)
         cfg: None,
         children: opt_children(params),
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -249,6 +258,7 @@ fn handle_define(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -300,11 +310,9 @@ fn handle_import_attr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         names.push(module_text.clone());
     }
 
-    symbols.imports.push(Import::new(
-        module_text,
-        names,
-        start_line(node),
-    ));
+    symbols
+        .imports
+        .push(Import::new(module_text, names, start_line(node)));
 }
 
 fn handle_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
@@ -461,24 +469,24 @@ mod tests {
     #[test]
     fn deduplicates_multi_clause_function() {
         // Multiple clauses for the same function produce one definition only.
-        let s = parse_erlang(
-            "fact(0) -> 1;\nfact(N) when N > 0 -> N * fact(N - 1).\n",
-        );
+        let s = parse_erlang("fact(0) -> 1;\nfact(N) when N > 0 -> N * fact(N - 1).\n");
         let fact_defs: Vec<&Definition> = s
             .definitions
             .iter()
             .filter(|d| d.name == "fact" && d.kind == "function")
             .collect();
-        assert_eq!(fact_defs.len(), 1, "expected single function def for multi-clause");
+        assert_eq!(
+            fact_defs.len(),
+            1,
+            "expected single function def for multi-clause"
+        );
     }
 
     #[test]
     fn keeps_distinct_arities_for_same_name() {
         // Erlang overloads by arity: foo/1 and foo/2 are distinct definitions
         // and must not be collapsed by name-only deduplication.
-        let s = parse_erlang(
-            "foo(X) -> X.\nfoo(X, Y) -> X + Y.\nfoo(X, Y, Z) -> X + Y + Z.\n",
-        );
+        let s = parse_erlang("foo(X) -> X.\nfoo(X, Y) -> X + Y.\nfoo(X, Y, Z) -> X + Y + Z.\n");
         let foo_defs: Vec<&Definition> = s
             .definitions
             .iter()
@@ -496,9 +504,7 @@ mod tests {
     #[test]
     fn counts_complex_pattern_arguments_as_parameters() {
         // Tuple, list and binary pattern arguments must still count toward arity.
-        let s = parse_erlang(
-            "handle({ok, X}, [H | T]) -> {X, H, T}.\n",
-        );
+        let s = parse_erlang("handle({ok, X}, [H | T]) -> {X, H, T}.\n");
         let f = s
             .definitions
             .iter()

--- a/crates/codegraph-core/src/extractors/erlang.rs
+++ b/crates/codegraph-core/src/extractors/erlang.rs
@@ -1,7 +1,7 @@
+use tree_sitter::{Node, Tree};
+use crate::types::*;
 use super::helpers::*;
 use super::SymbolExtractor;
-use crate::types::*;
-use tree_sitter::{Node, Tree};
 
 pub struct ErlangExtractor;
 
@@ -9,12 +9,7 @@ impl SymbolExtractor for ErlangExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_erlang_node);
-        walk_ast_nodes_with_config(
-            &tree.root_node(),
-            source,
-            &mut symbols.ast_nodes,
-            &ERLANG_AST_CONFIG,
-        );
+        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &ERLANG_AST_CONFIG);
         symbols
     }
 }
@@ -310,9 +305,11 @@ fn handle_import_attr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         names.push(module_text.clone());
     }
 
-    symbols
-        .imports
-        .push(Import::new(module_text, names, start_line(node)));
+    symbols.imports.push(Import::new(
+        module_text,
+        names,
+        start_line(node),
+    ));
 }
 
 fn handle_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
@@ -469,24 +466,24 @@ mod tests {
     #[test]
     fn deduplicates_multi_clause_function() {
         // Multiple clauses for the same function produce one definition only.
-        let s = parse_erlang("fact(0) -> 1;\nfact(N) when N > 0 -> N * fact(N - 1).\n");
+        let s = parse_erlang(
+            "fact(0) -> 1;\nfact(N) when N > 0 -> N * fact(N - 1).\n",
+        );
         let fact_defs: Vec<&Definition> = s
             .definitions
             .iter()
             .filter(|d| d.name == "fact" && d.kind == "function")
             .collect();
-        assert_eq!(
-            fact_defs.len(),
-            1,
-            "expected single function def for multi-clause"
-        );
+        assert_eq!(fact_defs.len(), 1, "expected single function def for multi-clause");
     }
 
     #[test]
     fn keeps_distinct_arities_for_same_name() {
         // Erlang overloads by arity: foo/1 and foo/2 are distinct definitions
         // and must not be collapsed by name-only deduplication.
-        let s = parse_erlang("foo(X) -> X.\nfoo(X, Y) -> X + Y.\nfoo(X, Y, Z) -> X + Y + Z.\n");
+        let s = parse_erlang(
+            "foo(X) -> X.\nfoo(X, Y) -> X + Y.\nfoo(X, Y, Z) -> X + Y + Z.\n",
+        );
         let foo_defs: Vec<&Definition> = s
             .definitions
             .iter()
@@ -504,7 +501,9 @@ mod tests {
     #[test]
     fn counts_complex_pattern_arguments_as_parameters() {
         // Tuple, list and binary pattern arguments must still count toward arity.
-        let s = parse_erlang("handle({ok, X}, [H | T]) -> {X, H, T}.\n");
+        let s = parse_erlang(
+            "handle({ok, X}, [H | T]) -> {X, H, T}.\n",
+        );
         let f = s
             .definitions
             .iter()

--- a/crates/codegraph-core/src/extractors/fsharp.rs
+++ b/crates/codegraph-core/src/extractors/fsharp.rs
@@ -1,9 +1,9 @@
-use super::helpers::*;
-use super::SymbolExtractor;
+use tree_sitter::{Node, Tree};
 use crate::ast_analysis::cfg::build_function_cfg;
 use crate::ast_analysis::complexity::compute_all_metrics;
 use crate::types::*;
-use tree_sitter::{Node, Tree};
+use super::helpers::*;
+use super::SymbolExtractor;
 
 pub struct FSharpExtractor;
 
@@ -11,12 +11,7 @@ impl SymbolExtractor for FSharpExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_fsharp_node);
-        walk_ast_nodes_with_config(
-            &tree.root_node(),
-            source,
-            &mut symbols.ast_nodes,
-            &FSHARP_AST_CONFIG,
-        );
+        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &FSHARP_AST_CONFIG);
         symbols
     }
 }
@@ -403,11 +398,7 @@ fn handle_value_definition(node: &Node, source: &[u8], symbols: &mut FileSymbols
         None => return,
     };
 
-    let kind = if has_function_type(node) {
-        "function"
-    } else {
-        "variable"
-    };
+    let kind = if has_function_type(node) { "function" } else { "variable" };
     let module_name = enclosing_module_name(node, source);
     let qualified = match module_name {
         Some(m) => format!("{}.{}", m, name),
@@ -440,9 +431,7 @@ fn has_function_type(node: &Node) -> bool {
     // The grammar wraps every type signature in `curried_spec`. A function type
     // (e.g. `val add : int -> int -> int`) contains one or more `arguments_spec`
     // children; a plain value (e.g. `val pi : float`) wraps a single `simple_type`.
-    let Some(curried) = find_child(node, "curried_spec") else {
-        return false;
-    };
+    let Some(curried) = find_child(node, "curried_spec") else { return false };
     for i in 0..curried.child_count() {
         if let Some(child) = curried.child(i) {
             if child.kind() == "arguments_spec" {
@@ -479,9 +468,7 @@ mod tests {
 
     #[test]
     fn signature_extracts_val_declarations() {
-        let s = parse_signature(
-            "namespace MyApp.Domain\n\nval add : int -> int -> int\nval pi : float\n",
-        );
+        let s = parse_signature("namespace MyApp.Domain\n\nval add : int -> int -> int\nval pi : float\n");
         let add = s
             .definitions
             .iter()
@@ -530,16 +517,12 @@ mod tests {
         // must be qualified with the module path.
         let s = parse_signature("namespace X\n\nmodule Foo =\n  val add : int -> int\n");
         assert!(
-            s.definitions
-                .iter()
-                .any(|d| d.name == "Foo.add" && d.kind == "function"),
+            s.definitions.iter().any(|d| d.name == "Foo.add" && d.kind == "function"),
             "val add nested under `module Foo =` must be indexed as `Foo.add`, got: {:?}",
             s.definitions.iter().map(|d| &d.name).collect::<Vec<_>>(),
         );
         assert!(
-            s.definitions
-                .iter()
-                .any(|d| d.name == "Foo" && d.kind == "module"),
+            s.definitions.iter().any(|d| d.name == "Foo" && d.kind == "module"),
             "module Foo must be indexed as a module definition"
         );
     }
@@ -550,7 +533,9 @@ mod tests {
         // node in the source grammar — NOT a `value_definition` — so our
         // `value_definition`/`val`-first-child handler does not see it.
         // This regression guard makes that empirical fact explicit.
-        let s = parse_source("module M\n\ntype C() =\n    val mutable count: int = 0\n");
+        let s = parse_source(
+            "module M\n\ntype C() =\n    val mutable count: int = 0\n",
+        );
         assert!(
             s.definitions.iter().all(|d| d.name != "count"),
             "val mutable class fields must not be extracted by the signature value_definition handler"

--- a/crates/codegraph-core/src/extractors/fsharp.rs
+++ b/crates/codegraph-core/src/extractors/fsharp.rs
@@ -1,9 +1,9 @@
-use tree_sitter::{Node, Tree};
+use super::helpers::*;
+use super::SymbolExtractor;
 use crate::ast_analysis::cfg::build_function_cfg;
 use crate::ast_analysis::complexity::compute_all_metrics;
 use crate::types::*;
-use super::helpers::*;
-use super::SymbolExtractor;
+use tree_sitter::{Node, Tree};
 
 pub struct FSharpExtractor;
 
@@ -11,7 +11,12 @@ impl SymbolExtractor for FSharpExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_fsharp_node);
-        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &FSHARP_AST_CONFIG);
+        walk_ast_nodes_with_config(
+            &tree.root_node(),
+            source,
+            &mut symbols.ast_nodes,
+            &FSHARP_AST_CONFIG,
+        );
         symbols
     }
 }
@@ -81,6 +86,7 @@ fn handle_named_module(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -112,6 +118,7 @@ fn handle_module_defn(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -160,6 +167,7 @@ fn handle_function_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: build_function_cfg(&end, "fsharp", source),
         children: opt_children(params),
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -230,6 +238,7 @@ fn handle_type_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             cfg: None,
             children: opt_children(children),
             bodyless: None,
+            content_hash: None,
         });
     }
 }
@@ -394,7 +403,11 @@ fn handle_value_definition(node: &Node, source: &[u8], symbols: &mut FileSymbols
         None => return,
     };
 
-    let kind = if has_function_type(node) { "function" } else { "variable" };
+    let kind = if has_function_type(node) {
+        "function"
+    } else {
+        "variable"
+    };
     let module_name = enclosing_module_name(node, source);
     let qualified = match module_name {
         Some(m) => format!("{}.{}", m, name),
@@ -411,6 +424,7 @@ fn handle_value_definition(node: &Node, source: &[u8], symbols: &mut FileSymbols
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -426,7 +440,9 @@ fn has_function_type(node: &Node) -> bool {
     // The grammar wraps every type signature in `curried_spec`. A function type
     // (e.g. `val add : int -> int -> int`) contains one or more `arguments_spec`
     // children; a plain value (e.g. `val pi : float`) wraps a single `simple_type`.
-    let Some(curried) = find_child(node, "curried_spec") else { return false };
+    let Some(curried) = find_child(node, "curried_spec") else {
+        return false;
+    };
     for i in 0..curried.child_count() {
         if let Some(child) = curried.child(i) {
             if child.kind() == "arguments_spec" {
@@ -463,7 +479,9 @@ mod tests {
 
     #[test]
     fn signature_extracts_val_declarations() {
-        let s = parse_signature("namespace MyApp.Domain\n\nval add : int -> int -> int\nval pi : float\n");
+        let s = parse_signature(
+            "namespace MyApp.Domain\n\nval add : int -> int -> int\nval pi : float\n",
+        );
         let add = s
             .definitions
             .iter()
@@ -512,12 +530,16 @@ mod tests {
         // must be qualified with the module path.
         let s = parse_signature("namespace X\n\nmodule Foo =\n  val add : int -> int\n");
         assert!(
-            s.definitions.iter().any(|d| d.name == "Foo.add" && d.kind == "function"),
+            s.definitions
+                .iter()
+                .any(|d| d.name == "Foo.add" && d.kind == "function"),
             "val add nested under `module Foo =` must be indexed as `Foo.add`, got: {:?}",
             s.definitions.iter().map(|d| &d.name).collect::<Vec<_>>(),
         );
         assert!(
-            s.definitions.iter().any(|d| d.name == "Foo" && d.kind == "module"),
+            s.definitions
+                .iter()
+                .any(|d| d.name == "Foo" && d.kind == "module"),
             "module Foo must be indexed as a module definition"
         );
     }
@@ -528,9 +550,7 @@ mod tests {
         // node in the source grammar — NOT a `value_definition` — so our
         // `value_definition`/`val`-first-child handler does not see it.
         // This regression guard makes that empirical fact explicit.
-        let s = parse_source(
-            "module M\n\ntype C() =\n    val mutable count: int = 0\n",
-        );
+        let s = parse_source("module M\n\ntype C() =\n    val mutable count: int = 0\n");
         assert!(
             s.definitions.iter().all(|d| d.name != "count"),
             "val mutable class fields must not be extracted by the signature value_definition handler"

--- a/crates/codegraph-core/src/extractors/gleam.rs
+++ b/crates/codegraph-core/src/extractors/gleam.rs
@@ -1,9 +1,9 @@
-use super::helpers::*;
-use super::SymbolExtractor;
+use tree_sitter::{Node, Tree};
 use crate::ast_analysis::cfg::build_function_cfg;
 use crate::ast_analysis::complexity::compute_all_metrics;
 use crate::types::*;
-use tree_sitter::{Node, Tree};
+use super::helpers::*;
+use super::SymbolExtractor;
 
 pub struct GleamExtractor;
 
@@ -11,12 +11,7 @@ impl SymbolExtractor for GleamExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_gleam_node);
-        walk_ast_nodes_with_config(
-            &tree.root_node(),
-            source,
-            &mut symbols.ast_nodes,
-            &GLEAM_AST_CONFIG,
-        );
+        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &GLEAM_AST_CONFIG);
         symbols
     }
 }
@@ -211,7 +206,9 @@ fn handle_import(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     };
 
     let raw = node_text(&module_node, source);
-    let source_path = raw.trim_matches(|c| c == '\'' || c == '"').to_string();
+    let source_path = raw
+        .trim_matches(|c| c == '\'' || c == '"')
+        .to_string();
     let mut names: Vec<String> = Vec::new();
 
     // Unqualified imports: `import gleam/io.{println, print}`
@@ -370,9 +367,7 @@ mod tests {
         let greet = s.definitions.iter().find(|d| d.name == "greet").unwrap();
         assert_eq!(greet.kind, "function");
         let children = greet.children.as_ref().expect("expected children");
-        assert!(children
-            .iter()
-            .any(|c| c.name == "name" && c.kind == "parameter"));
+        assert!(children.iter().any(|c| c.name == "name" && c.kind == "parameter"));
     }
 
     #[test]
@@ -465,8 +460,7 @@ mod tests {
 
     #[test]
     fn extracts_external_function_with_named_parameters() {
-        let code =
-            "pub external fn parse(input: String, base: Int) -> Int = \"erlang_mod\" \"parse\"\n";
+        let code = "pub external fn parse(input: String, base: Int) -> Int = \"erlang_mod\" \"parse\"\n";
         let s = parse_gleam(code);
         let parse_fn = s
             .definitions
@@ -479,14 +473,8 @@ mod tests {
             .as_ref()
             .expect("expected external function parameters as children");
         let names: Vec<&str> = children.iter().map(|c| c.name.as_str()).collect();
-        assert!(
-            names.contains(&"input"),
-            "missing `input` param, got {names:?}"
-        );
-        assert!(
-            names.contains(&"base"),
-            "missing `base` param, got {names:?}"
-        );
+        assert!(names.contains(&"input"), "missing `input` param, got {names:?}");
+        assert!(names.contains(&"base"), "missing `base` param, got {names:?}");
         assert!(children.iter().all(|c| c.kind == "parameter"));
     }
 

--- a/crates/codegraph-core/src/extractors/gleam.rs
+++ b/crates/codegraph-core/src/extractors/gleam.rs
@@ -1,9 +1,9 @@
-use tree_sitter::{Node, Tree};
+use super::helpers::*;
+use super::SymbolExtractor;
 use crate::ast_analysis::cfg::build_function_cfg;
 use crate::ast_analysis::complexity::compute_all_metrics;
 use crate::types::*;
-use super::helpers::*;
-use super::SymbolExtractor;
+use tree_sitter::{Node, Tree};
 
 pub struct GleamExtractor;
 
@@ -11,7 +11,12 @@ impl SymbolExtractor for GleamExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_gleam_node);
-        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &GLEAM_AST_CONFIG);
+        walk_ast_nodes_with_config(
+            &tree.root_node(),
+            source,
+            &mut symbols.ast_nodes,
+            &GLEAM_AST_CONFIG,
+        );
         symbols
     }
 }
@@ -50,6 +55,7 @@ fn handle_function(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: build_function_cfg(node, "gleam", source),
         children: opt_children(params),
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -74,6 +80,7 @@ fn handle_external_function(node: &Node, source: &[u8], symbols: &mut FileSymbol
         cfg: None,
         children: opt_children(params),
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -142,6 +149,7 @@ fn handle_type_definition(node: &Node, source: &[u8], symbols: &mut FileSymbols)
         cfg: None,
         children: opt_children(children),
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -164,6 +172,7 @@ fn handle_type_alias(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -186,6 +195,7 @@ fn handle_constant(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -201,9 +211,7 @@ fn handle_import(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     };
 
     let raw = node_text(&module_node, source);
-    let source_path = raw
-        .trim_matches(|c| c == '\'' || c == '"')
-        .to_string();
+    let source_path = raw.trim_matches(|c| c == '\'' || c == '"').to_string();
     let mut names: Vec<String> = Vec::new();
 
     // Unqualified imports: `import gleam/io.{println, print}`
@@ -362,7 +370,9 @@ mod tests {
         let greet = s.definitions.iter().find(|d| d.name == "greet").unwrap();
         assert_eq!(greet.kind, "function");
         let children = greet.children.as_ref().expect("expected children");
-        assert!(children.iter().any(|c| c.name == "name" && c.kind == "parameter"));
+        assert!(children
+            .iter()
+            .any(|c| c.name == "name" && c.kind == "parameter"));
     }
 
     #[test]
@@ -455,7 +465,8 @@ mod tests {
 
     #[test]
     fn extracts_external_function_with_named_parameters() {
-        let code = "pub external fn parse(input: String, base: Int) -> Int = \"erlang_mod\" \"parse\"\n";
+        let code =
+            "pub external fn parse(input: String, base: Int) -> Int = \"erlang_mod\" \"parse\"\n";
         let s = parse_gleam(code);
         let parse_fn = s
             .definitions
@@ -468,8 +479,14 @@ mod tests {
             .as_ref()
             .expect("expected external function parameters as children");
         let names: Vec<&str> = children.iter().map(|c| c.name.as_str()).collect();
-        assert!(names.contains(&"input"), "missing `input` param, got {names:?}");
-        assert!(names.contains(&"base"), "missing `base` param, got {names:?}");
+        assert!(
+            names.contains(&"input"),
+            "missing `input` param, got {names:?}"
+        );
+        assert!(
+            names.contains(&"base"),
+            "missing `base` param, got {names:?}"
+        );
         assert!(children.iter().all(|c| c.kind == "parameter"));
     }
 

--- a/crates/codegraph-core/src/extractors/go.rs
+++ b/crates/codegraph-core/src/extractors/go.rs
@@ -11,12 +11,7 @@ impl SymbolExtractor for GoExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_go_node);
-        walk_ast_nodes_with_config(
-            &tree.root_node(),
-            source,
-            &mut symbols.ast_nodes,
-            &GO_AST_CONFIG,
-        );
+        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &GO_AST_CONFIG);
         walk_tree(&tree.root_node(), source, &mut symbols, match_go_type_map);
         dedup_type_map(&mut symbols.type_map);
         symbols
@@ -56,9 +51,7 @@ fn handle_function_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 }
 
 fn handle_method_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else {
-        return;
-    };
+    let Some(name_node) = node.child_by_field_name("name") else { return };
     let receiver_type = extract_go_receiver_type(node, source);
     let name = node_text(&name_node, source);
     let full_name = match &receiver_type {
@@ -86,9 +79,7 @@ fn extract_go_receiver_type(node: &Node, source: &[u8]) -> Option<String> {
         if let Some(param) = receiver.child(i) {
             if let Some(type_node) = param.child_by_field_name("type") {
                 return Some(if type_node.kind() == "pointer_type" {
-                    node_text(&type_node, source)
-                        .trim_start_matches('*')
-                        .to_string()
+                    node_text(&type_node, source).trim_start_matches('*').to_string()
                 } else {
                     node_text(&type_node, source).to_string()
                 });
@@ -101,14 +92,10 @@ fn extract_go_receiver_type(node: &Node, source: &[u8]) -> Option<String> {
 fn handle_type_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     for i in 0..node.child_count() {
         let Some(spec) = node.child(i) else { continue };
-        if spec.kind() != "type_spec" {
-            continue;
-        }
+        if spec.kind() != "type_spec" { continue; }
         let name_node = spec.child_by_field_name("name");
         let type_node = spec.child_by_field_name("type");
-        let (Some(name_node), Some(type_node)) = (name_node, type_node) else {
-            continue;
-        };
+        let (Some(name_node), Some(type_node)) = (name_node, type_node) else { continue };
         let name = node_text(&name_node, source).to_string();
         match type_node.kind() {
             "struct_type" => {
@@ -159,19 +146,10 @@ fn handle_type_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     }
 }
 
-fn extract_go_interface_methods(
-    type_node: &Node,
-    iface_name: &str,
-    source: &[u8],
-    symbols: &mut FileSymbols,
-) {
+fn extract_go_interface_methods(type_node: &Node, iface_name: &str, source: &[u8], symbols: &mut FileSymbols) {
     for j in 0..type_node.child_count() {
-        let Some(member) = type_node.child(j) else {
-            continue;
-        };
-        if member.kind() != "method_elem" {
-            continue;
-        }
+        let Some(member) = type_node.child(j) else { continue };
+        if member.kind() != "method_elem" { continue; }
         if let Some(meth_name) = member.child_by_field_name("name") {
             symbols.definitions.push(Definition {
                 name: format!("{}.{}", iface_name, node_text(&meth_name, source)),
@@ -192,9 +170,7 @@ fn extract_go_interface_methods(
 fn handle_const_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     for i in 0..node.child_count() {
         let Some(spec) = node.child(i) else { continue };
-        if spec.kind() != "const_spec" {
-            continue;
-        }
+        if spec.kind() != "const_spec" { continue; }
         if let Some(name_node) = spec.child_by_field_name("name") {
             symbols.definitions.push(Definition {
                 name: node_text(&name_node, source).to_string(),
@@ -234,9 +210,7 @@ fn handle_import_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 }
 
 fn handle_call_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(fn_node) = node.child_by_field_name("function") else {
-        return;
-    };
+    let Some(fn_node) = node.child_by_field_name("function") else { return };
     match fn_node.kind() {
         "identifier" => {
             symbols.calls.push(Call {
@@ -249,7 +223,8 @@ fn handle_call_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         }
         "selector_expression" => {
             if let Some(field) = fn_node.child_by_field_name("field") {
-                let receiver = named_child_text(&fn_node, "operand", source).map(|s| s.to_string());
+                let receiver = named_child_text(&fn_node, "operand", source)
+                    .map(|s| s.to_string());
                 symbols.calls.push(Call {
                     name: node_text(&field, source).to_string(),
                     line: start_line(node),
@@ -267,8 +242,7 @@ fn handle_call_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 
 fn extract_go_parameters(node: &Node, source: &[u8]) -> Vec<Definition> {
     let mut params = Vec::new();
-    let params_node = node
-        .child_by_field_name("parameters")
+    let params_node = node.child_by_field_name("parameters")
         .or_else(|| find_child(node, "parameter_list"));
     if let Some(params_node) = params_node {
         for i in 0..params_node.child_count() {
@@ -372,12 +346,8 @@ fn match_go_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
 /// Mirrors the JS `inferShortVarType` → `inferCompositeLiteral` / `inferAddressOfComposite`
 /// / `inferFactoryCall` chain in `src/extractors/go.ts`.
 fn infer_short_var_types(node: &Node, source: &[u8], type_map: &mut Vec<TypeMapEntry>) {
-    let Some(left) = node.child_by_field_name("left") else {
-        return;
-    };
-    let Some(right) = node.child_by_field_name("right") else {
-        return;
-    };
+    let Some(left) = node.child_by_field_name("left") else { return };
+    let Some(right) = node.child_by_field_name("right") else { return };
 
     // Collect LHS identifiers (may be an expression_list for multi-assignment).
     let lefts: Vec<Node> = if left.kind() == "expression_list" {
@@ -414,12 +384,8 @@ fn infer_single_short_var(
     source: &[u8],
     type_map: &mut Vec<TypeMapEntry>,
 ) {
-    if infer_composite_literal(var_node, rhs, source, type_map) {
-        return;
-    }
-    if infer_address_of_composite(var_node, rhs, source, type_map) {
-        return;
-    }
+    if infer_composite_literal(var_node, rhs, source, type_map) { return; }
+    if infer_address_of_composite(var_node, rhs, source, type_map) { return; }
     infer_factory_call(var_node, rhs, source, type_map);
 }
 
@@ -430,15 +396,9 @@ fn infer_composite_literal(
     source: &[u8],
     type_map: &mut Vec<TypeMapEntry>,
 ) -> bool {
-    if rhs.kind() != "composite_literal" {
-        return false;
-    }
-    let Some(type_node) = rhs.child_by_field_name("type") else {
-        return false;
-    };
-    let Some(type_name) = extract_go_type_name(&type_node, source) else {
-        return false;
-    };
+    if rhs.kind() != "composite_literal" { return false; }
+    let Some(type_node) = rhs.child_by_field_name("type") else { return false };
+    let Some(type_name) = extract_go_type_name(&type_node, source) else { return false };
     type_map.push(TypeMapEntry {
         name: node_text(var_node, source).to_string(),
         type_name: type_name.to_string(),
@@ -454,30 +414,16 @@ fn infer_address_of_composite(
     source: &[u8],
     type_map: &mut Vec<TypeMapEntry>,
 ) -> bool {
-    if rhs.kind() != "unary_expression" {
-        return false;
-    }
+    if rhs.kind() != "unary_expression" { return false; }
     // Verify the operator is `&` — guards against any other unary operator
     // applied to a composite literal on a raw AST.
-    let Some(op_node) = rhs.child(0) else {
-        return false;
-    };
-    if node_text(&op_node, source) != "&" {
-        return false;
-    }
+    let Some(op_node) = rhs.child(0) else { return false };
+    if node_text(&op_node, source) != "&" { return false; }
     // The operand of `&` is a composite_literal.
-    let Some(operand) = rhs.child_by_field_name("operand") else {
-        return false;
-    };
-    if operand.kind() != "composite_literal" {
-        return false;
-    }
-    let Some(type_node) = operand.child_by_field_name("type") else {
-        return false;
-    };
-    let Some(type_name) = extract_go_type_name(&type_node, source) else {
-        return false;
-    };
+    let Some(operand) = rhs.child_by_field_name("operand") else { return false };
+    if operand.kind() != "composite_literal" { return false; }
+    let Some(type_node) = operand.child_by_field_name("type") else { return false };
+    let Some(type_name) = extract_go_type_name(&type_node, source) else { return false };
     type_map.push(TypeMapEntry {
         name: node_text(var_node, source).to_string(),
         type_name: type_name.to_string(),
@@ -493,26 +439,16 @@ fn infer_factory_call(
     source: &[u8],
     type_map: &mut Vec<TypeMapEntry>,
 ) -> bool {
-    if rhs.kind() != "call_expression" {
-        return false;
-    }
-    let Some(fn_node) = rhs.child_by_field_name("function") else {
-        return false;
-    };
+    if rhs.kind() != "call_expression" { return false; }
+    let Some(fn_node) = rhs.child_by_field_name("function") else { return false };
     match fn_node.kind() {
         "selector_expression" => {
             // pkg.NewFoo(...) — use the field name only.
-            let Some(field) = fn_node.child_by_field_name("field") else {
-                return false;
-            };
+            let Some(field) = fn_node.child_by_field_name("field") else { return false };
             let field_text = node_text(&field, source);
-            if !field_text.starts_with("New") {
-                return false;
-            }
+            if !field_text.starts_with("New") { return false; }
             let type_name = &field_text[3..];
-            if type_name.is_empty() {
-                return false;
-            }
+            if type_name.is_empty() { return false; }
             type_map.push(TypeMapEntry {
                 name: node_text(var_node, source).to_string(),
                 type_name: type_name.to_string(),
@@ -522,13 +458,9 @@ fn infer_factory_call(
         }
         "identifier" => {
             let fn_text = node_text(&fn_node, source);
-            if !fn_text.starts_with("New") {
-                return false;
-            }
+            if !fn_text.starts_with("New") { return false; }
             let type_name = &fn_text[3..];
-            if type_name.is_empty() {
-                return false;
-            }
+            if type_name.is_empty() { return false; }
             type_map.push(TypeMapEntry {
                 name: node_text(var_node, source).to_string(),
                 type_name: type_name.to_string(),
@@ -541,12 +473,8 @@ fn infer_factory_call(
 }
 
 fn collect_go_typed_identifiers(node: &Node, source: &[u8], type_map: &mut Vec<TypeMapEntry>) {
-    let Some(type_node) = node.child_by_field_name("type") else {
-        return;
-    };
-    let Some(type_name) = extract_go_type_name(&type_node, source) else {
-        return;
-    };
+    let Some(type_node) = node.child_by_field_name("type") else { return };
+    let Some(type_name) = extract_go_type_name(&type_node, source) else { return };
     for i in 0..node.child_count() {
         let Some(child) = node.child(i) else { continue };
         if child.kind() == "identifier" {
@@ -589,11 +517,7 @@ mod tests {
         assert!(names.contains(&"Server.Start"));
         // A real receiver method has a body — must not be marked bodyless (#1922:
         // a dotted name alone must never be treated as a signature-only stub).
-        let start = s
-            .definitions
-            .iter()
-            .find(|d| d.name == "Server.Start")
-            .unwrap();
+        let start = s.definitions.iter().find(|d| d.name == "Server.Start").unwrap();
         assert_ne!(start.bodyless, Some(true));
     }
 
@@ -606,11 +530,7 @@ mod tests {
         // An interface method_elem structurally has no body field — must be marked
         // bodyless so the WASM/native "needs complexity" gate correctly skips it
         // instead of forcing an unnecessary fallback (#1922).
-        let read = s
-            .definitions
-            .iter()
-            .find(|d| d.name == "Reader.Read")
-            .unwrap();
+        let read = s.definitions.iter().find(|d| d.name == "Reader.Read").unwrap();
         assert_eq!(read.bodyless, Some(true));
     }
 
@@ -632,11 +552,7 @@ mod tests {
         assert_eq!(methods.len(), 2);
         for m in methods {
             assert_ne!(m.bodyless, Some(true), "{} should not be bodyless", m.name);
-            assert!(
-                m.complexity.is_some(),
-                "{} should have complexity computed",
-                m.name
-            );
+            assert!(m.complexity.is_some(), "{} should have complexity computed", m.name);
         }
     }
 
@@ -675,11 +591,7 @@ mod tests {
     #[test]
     fn extracts_const_declarations() {
         let s = parse_go("package main\nconst MaxRetries = 3");
-        let c = s
-            .definitions
-            .iter()
-            .find(|d| d.name == "MaxRetries")
-            .unwrap();
+        let c = s.definitions.iter().find(|d| d.name == "MaxRetries").unwrap();
         assert_eq!(c.kind, "constant");
     }
 
@@ -688,8 +600,9 @@ mod tests {
     #[test]
     fn infers_factory_call_new_prefix() {
         // svc := NewUserService(repo) → svc : UserService at conf 0.7
-        let s =
-            parse_go("package main\nfunc main() {\n  svc := NewUserService(repo)\n  _ = svc\n}\n");
+        let s = parse_go(
+            "package main\nfunc main() {\n  svc := NewUserService(repo)\n  _ = svc\n}\n",
+        );
         let entry = s.type_map.iter().find(|e| e.name == "svc");
         assert!(entry.is_some(), "expected svc in type_map");
         let entry = entry.unwrap();
@@ -711,12 +624,11 @@ mod tests {
     #[test]
     fn infers_composite_literal() {
         // u := User{Name: "Alice"} → u : User at conf 1.0
-        let s = parse_go("package main\nfunc main() {\n  u := User{Name: \"Alice\"}\n  _ = u\n}\n");
-        let entry = s.type_map.iter().find(|e| e.name == "u");
-        assert!(
-            entry.is_some(),
-            "expected u in type_map for composite literal"
+        let s = parse_go(
+            "package main\nfunc main() {\n  u := User{Name: \"Alice\"}\n  _ = u\n}\n",
         );
+        let entry = s.type_map.iter().find(|e| e.name == "u");
+        assert!(entry.is_some(), "expected u in type_map for composite literal");
         assert_eq!(entry.unwrap().type_name, "User");
         assert!((entry.unwrap().confidence - 1.0).abs() < f64::EPSILON);
     }
@@ -724,19 +636,20 @@ mod tests {
     #[test]
     fn infers_address_of_composite() {
         // u := &User{} → u : User at conf 1.0
-        let s = parse_go("package main\nfunc main() {\n  u := &User{}\n  _ = u\n}\n");
-        let entry = s.type_map.iter().find(|e| e.name == "u");
-        assert!(
-            entry.is_some(),
-            "expected u in type_map for address-of composite literal"
+        let s = parse_go(
+            "package main\nfunc main() {\n  u := &User{}\n  _ = u\n}\n",
         );
+        let entry = s.type_map.iter().find(|e| e.name == "u");
+        assert!(entry.is_some(), "expected u in type_map for address-of composite literal");
         assert_eq!(entry.unwrap().type_name, "User");
     }
 
     #[test]
     fn non_new_prefix_not_inferred() {
         // srv := createServer() — not a New* factory, should not seed typeMap
-        let s = parse_go("package main\nfunc main() {\n  srv := createServer()\n  _ = srv\n}\n");
+        let s = parse_go(
+            "package main\nfunc main() {\n  srv := createServer()\n  _ = srv\n}\n",
+        );
         assert!(
             s.type_map.iter().all(|e| e.name != "srv"),
             "unexpected typeMap entry for non-New factory"

--- a/crates/codegraph-core/src/extractors/go.rs
+++ b/crates/codegraph-core/src/extractors/go.rs
@@ -11,7 +11,12 @@ impl SymbolExtractor for GoExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_go_node);
-        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &GO_AST_CONFIG);
+        walk_ast_nodes_with_config(
+            &tree.root_node(),
+            source,
+            &mut symbols.ast_nodes,
+            &GO_AST_CONFIG,
+        );
         walk_tree(&tree.root_node(), source, &mut symbols, match_go_type_map);
         dedup_type_map(&mut symbols.type_map);
         symbols
@@ -45,12 +50,15 @@ fn handle_function_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             cfg: build_function_cfg(node, "go", source),
             children: opt_children(children),
             bodyless: None,
+            content_hash: None,
         });
     }
 }
 
 fn handle_method_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else { return };
+    let Some(name_node) = node.child_by_field_name("name") else {
+        return;
+    };
     let receiver_type = extract_go_receiver_type(node, source);
     let name = node_text(&name_node, source);
     let full_name = match &receiver_type {
@@ -68,6 +76,7 @@ fn handle_method_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: build_function_cfg(node, "go", source),
         children: opt_children(children),
         bodyless: Some(node.child_by_field_name("body").is_none()),
+        content_hash: None,
     });
 }
 
@@ -77,7 +86,9 @@ fn extract_go_receiver_type(node: &Node, source: &[u8]) -> Option<String> {
         if let Some(param) = receiver.child(i) {
             if let Some(type_node) = param.child_by_field_name("type") {
                 return Some(if type_node.kind() == "pointer_type" {
-                    node_text(&type_node, source).trim_start_matches('*').to_string()
+                    node_text(&type_node, source)
+                        .trim_start_matches('*')
+                        .to_string()
                 } else {
                     node_text(&type_node, source).to_string()
                 });
@@ -90,10 +101,14 @@ fn extract_go_receiver_type(node: &Node, source: &[u8]) -> Option<String> {
 fn handle_type_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     for i in 0..node.child_count() {
         let Some(spec) = node.child(i) else { continue };
-        if spec.kind() != "type_spec" { continue; }
+        if spec.kind() != "type_spec" {
+            continue;
+        }
         let name_node = spec.child_by_field_name("name");
         let type_node = spec.child_by_field_name("type");
-        let (Some(name_node), Some(type_node)) = (name_node, type_node) else { continue };
+        let (Some(name_node), Some(type_node)) = (name_node, type_node) else {
+            continue;
+        };
         let name = node_text(&name_node, source).to_string();
         match type_node.kind() {
             "struct_type" => {
@@ -108,6 +123,7 @@ fn handle_type_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                     cfg: None,
                     children: opt_children(children),
                     bodyless: None,
+                    content_hash: None,
                 });
             }
             "interface_type" => {
@@ -121,6 +137,7 @@ fn handle_type_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                     cfg: None,
                     children: None,
                     bodyless: None,
+                    content_hash: None,
                 });
                 extract_go_interface_methods(&type_node, &name, source, symbols);
             }
@@ -135,16 +152,26 @@ fn handle_type_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                     cfg: None,
                     children: None,
                     bodyless: None,
+                    content_hash: None,
                 });
             }
         }
     }
 }
 
-fn extract_go_interface_methods(type_node: &Node, iface_name: &str, source: &[u8], symbols: &mut FileSymbols) {
+fn extract_go_interface_methods(
+    type_node: &Node,
+    iface_name: &str,
+    source: &[u8],
+    symbols: &mut FileSymbols,
+) {
     for j in 0..type_node.child_count() {
-        let Some(member) = type_node.child(j) else { continue };
-        if member.kind() != "method_elem" { continue; }
+        let Some(member) = type_node.child(j) else {
+            continue;
+        };
+        if member.kind() != "method_elem" {
+            continue;
+        }
         if let Some(meth_name) = member.child_by_field_name("name") {
             symbols.definitions.push(Definition {
                 name: format!("{}.{}", iface_name, node_text(&meth_name, source)),
@@ -156,6 +183,7 @@ fn extract_go_interface_methods(type_node: &Node, iface_name: &str, source: &[u8
                 cfg: None,
                 children: None,
                 bodyless: Some(member.child_by_field_name("body").is_none()),
+                content_hash: None,
             });
         }
     }
@@ -164,7 +192,9 @@ fn extract_go_interface_methods(type_node: &Node, iface_name: &str, source: &[u8
 fn handle_const_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     for i in 0..node.child_count() {
         let Some(spec) = node.child(i) else { continue };
-        if spec.kind() != "const_spec" { continue; }
+        if spec.kind() != "const_spec" {
+            continue;
+        }
         if let Some(name_node) = spec.child_by_field_name("name") {
             symbols.definitions.push(Definition {
                 name: node_text(&name_node, source).to_string(),
@@ -176,6 +206,7 @@ fn handle_const_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                 cfg: None,
                 children: None,
                 bodyless: None,
+                content_hash: None,
             });
         }
     }
@@ -203,7 +234,9 @@ fn handle_import_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 }
 
 fn handle_call_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(fn_node) = node.child_by_field_name("function") else { return };
+    let Some(fn_node) = node.child_by_field_name("function") else {
+        return;
+    };
     match fn_node.kind() {
         "identifier" => {
             symbols.calls.push(Call {
@@ -216,8 +249,7 @@ fn handle_call_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         }
         "selector_expression" => {
             if let Some(field) = fn_node.child_by_field_name("field") {
-                let receiver = named_child_text(&fn_node, "operand", source)
-                    .map(|s| s.to_string());
+                let receiver = named_child_text(&fn_node, "operand", source).map(|s| s.to_string());
                 symbols.calls.push(Call {
                     name: node_text(&field, source).to_string(),
                     line: start_line(node),
@@ -235,7 +267,8 @@ fn handle_call_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 
 fn extract_go_parameters(node: &Node, source: &[u8]) -> Vec<Definition> {
     let mut params = Vec::new();
-    let params_node = node.child_by_field_name("parameters")
+    let params_node = node
+        .child_by_field_name("parameters")
         .or_else(|| find_child(node, "parameter_list"));
     if let Some(params_node) = params_node {
         for i in 0..params_node.child_count() {
@@ -339,8 +372,12 @@ fn match_go_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
 /// Mirrors the JS `inferShortVarType` → `inferCompositeLiteral` / `inferAddressOfComposite`
 /// / `inferFactoryCall` chain in `src/extractors/go.ts`.
 fn infer_short_var_types(node: &Node, source: &[u8], type_map: &mut Vec<TypeMapEntry>) {
-    let Some(left) = node.child_by_field_name("left") else { return };
-    let Some(right) = node.child_by_field_name("right") else { return };
+    let Some(left) = node.child_by_field_name("left") else {
+        return;
+    };
+    let Some(right) = node.child_by_field_name("right") else {
+        return;
+    };
 
     // Collect LHS identifiers (may be an expression_list for multi-assignment).
     let lefts: Vec<Node> = if left.kind() == "expression_list" {
@@ -377,8 +414,12 @@ fn infer_single_short_var(
     source: &[u8],
     type_map: &mut Vec<TypeMapEntry>,
 ) {
-    if infer_composite_literal(var_node, rhs, source, type_map) { return; }
-    if infer_address_of_composite(var_node, rhs, source, type_map) { return; }
+    if infer_composite_literal(var_node, rhs, source, type_map) {
+        return;
+    }
+    if infer_address_of_composite(var_node, rhs, source, type_map) {
+        return;
+    }
     infer_factory_call(var_node, rhs, source, type_map);
 }
 
@@ -389,9 +430,15 @@ fn infer_composite_literal(
     source: &[u8],
     type_map: &mut Vec<TypeMapEntry>,
 ) -> bool {
-    if rhs.kind() != "composite_literal" { return false; }
-    let Some(type_node) = rhs.child_by_field_name("type") else { return false };
-    let Some(type_name) = extract_go_type_name(&type_node, source) else { return false };
+    if rhs.kind() != "composite_literal" {
+        return false;
+    }
+    let Some(type_node) = rhs.child_by_field_name("type") else {
+        return false;
+    };
+    let Some(type_name) = extract_go_type_name(&type_node, source) else {
+        return false;
+    };
     type_map.push(TypeMapEntry {
         name: node_text(var_node, source).to_string(),
         type_name: type_name.to_string(),
@@ -407,16 +454,30 @@ fn infer_address_of_composite(
     source: &[u8],
     type_map: &mut Vec<TypeMapEntry>,
 ) -> bool {
-    if rhs.kind() != "unary_expression" { return false; }
+    if rhs.kind() != "unary_expression" {
+        return false;
+    }
     // Verify the operator is `&` — guards against any other unary operator
     // applied to a composite literal on a raw AST.
-    let Some(op_node) = rhs.child(0) else { return false };
-    if node_text(&op_node, source) != "&" { return false; }
+    let Some(op_node) = rhs.child(0) else {
+        return false;
+    };
+    if node_text(&op_node, source) != "&" {
+        return false;
+    }
     // The operand of `&` is a composite_literal.
-    let Some(operand) = rhs.child_by_field_name("operand") else { return false };
-    if operand.kind() != "composite_literal" { return false; }
-    let Some(type_node) = operand.child_by_field_name("type") else { return false };
-    let Some(type_name) = extract_go_type_name(&type_node, source) else { return false };
+    let Some(operand) = rhs.child_by_field_name("operand") else {
+        return false;
+    };
+    if operand.kind() != "composite_literal" {
+        return false;
+    }
+    let Some(type_node) = operand.child_by_field_name("type") else {
+        return false;
+    };
+    let Some(type_name) = extract_go_type_name(&type_node, source) else {
+        return false;
+    };
     type_map.push(TypeMapEntry {
         name: node_text(var_node, source).to_string(),
         type_name: type_name.to_string(),
@@ -432,16 +493,26 @@ fn infer_factory_call(
     source: &[u8],
     type_map: &mut Vec<TypeMapEntry>,
 ) -> bool {
-    if rhs.kind() != "call_expression" { return false; }
-    let Some(fn_node) = rhs.child_by_field_name("function") else { return false };
+    if rhs.kind() != "call_expression" {
+        return false;
+    }
+    let Some(fn_node) = rhs.child_by_field_name("function") else {
+        return false;
+    };
     match fn_node.kind() {
         "selector_expression" => {
             // pkg.NewFoo(...) — use the field name only.
-            let Some(field) = fn_node.child_by_field_name("field") else { return false };
+            let Some(field) = fn_node.child_by_field_name("field") else {
+                return false;
+            };
             let field_text = node_text(&field, source);
-            if !field_text.starts_with("New") { return false; }
+            if !field_text.starts_with("New") {
+                return false;
+            }
             let type_name = &field_text[3..];
-            if type_name.is_empty() { return false; }
+            if type_name.is_empty() {
+                return false;
+            }
             type_map.push(TypeMapEntry {
                 name: node_text(var_node, source).to_string(),
                 type_name: type_name.to_string(),
@@ -451,9 +522,13 @@ fn infer_factory_call(
         }
         "identifier" => {
             let fn_text = node_text(&fn_node, source);
-            if !fn_text.starts_with("New") { return false; }
+            if !fn_text.starts_with("New") {
+                return false;
+            }
             let type_name = &fn_text[3..];
-            if type_name.is_empty() { return false; }
+            if type_name.is_empty() {
+                return false;
+            }
             type_map.push(TypeMapEntry {
                 name: node_text(var_node, source).to_string(),
                 type_name: type_name.to_string(),
@@ -466,8 +541,12 @@ fn infer_factory_call(
 }
 
 fn collect_go_typed_identifiers(node: &Node, source: &[u8], type_map: &mut Vec<TypeMapEntry>) {
-    let Some(type_node) = node.child_by_field_name("type") else { return };
-    let Some(type_name) = extract_go_type_name(&type_node, source) else { return };
+    let Some(type_node) = node.child_by_field_name("type") else {
+        return;
+    };
+    let Some(type_name) = extract_go_type_name(&type_node, source) else {
+        return;
+    };
     for i in 0..node.child_count() {
         let Some(child) = node.child(i) else { continue };
         if child.kind() == "identifier" {
@@ -510,7 +589,11 @@ mod tests {
         assert!(names.contains(&"Server.Start"));
         // A real receiver method has a body — must not be marked bodyless (#1922:
         // a dotted name alone must never be treated as a signature-only stub).
-        let start = s.definitions.iter().find(|d| d.name == "Server.Start").unwrap();
+        let start = s
+            .definitions
+            .iter()
+            .find(|d| d.name == "Server.Start")
+            .unwrap();
         assert_ne!(start.bodyless, Some(true));
     }
 
@@ -523,7 +606,11 @@ mod tests {
         // An interface method_elem structurally has no body field — must be marked
         // bodyless so the WASM/native "needs complexity" gate correctly skips it
         // instead of forcing an unnecessary fallback (#1922).
-        let read = s.definitions.iter().find(|d| d.name == "Reader.Read").unwrap();
+        let read = s
+            .definitions
+            .iter()
+            .find(|d| d.name == "Reader.Read")
+            .unwrap();
         assert_eq!(read.bodyless, Some(true));
     }
 
@@ -545,7 +632,11 @@ mod tests {
         assert_eq!(methods.len(), 2);
         for m in methods {
             assert_ne!(m.bodyless, Some(true), "{} should not be bodyless", m.name);
-            assert!(m.complexity.is_some(), "{} should have complexity computed", m.name);
+            assert!(
+                m.complexity.is_some(),
+                "{} should have complexity computed",
+                m.name
+            );
         }
     }
 
@@ -584,7 +675,11 @@ mod tests {
     #[test]
     fn extracts_const_declarations() {
         let s = parse_go("package main\nconst MaxRetries = 3");
-        let c = s.definitions.iter().find(|d| d.name == "MaxRetries").unwrap();
+        let c = s
+            .definitions
+            .iter()
+            .find(|d| d.name == "MaxRetries")
+            .unwrap();
         assert_eq!(c.kind, "constant");
     }
 
@@ -593,9 +688,8 @@ mod tests {
     #[test]
     fn infers_factory_call_new_prefix() {
         // svc := NewUserService(repo) → svc : UserService at conf 0.7
-        let s = parse_go(
-            "package main\nfunc main() {\n  svc := NewUserService(repo)\n  _ = svc\n}\n",
-        );
+        let s =
+            parse_go("package main\nfunc main() {\n  svc := NewUserService(repo)\n  _ = svc\n}\n");
         let entry = s.type_map.iter().find(|e| e.name == "svc");
         assert!(entry.is_some(), "expected svc in type_map");
         let entry = entry.unwrap();
@@ -617,11 +711,12 @@ mod tests {
     #[test]
     fn infers_composite_literal() {
         // u := User{Name: "Alice"} → u : User at conf 1.0
-        let s = parse_go(
-            "package main\nfunc main() {\n  u := User{Name: \"Alice\"}\n  _ = u\n}\n",
-        );
+        let s = parse_go("package main\nfunc main() {\n  u := User{Name: \"Alice\"}\n  _ = u\n}\n");
         let entry = s.type_map.iter().find(|e| e.name == "u");
-        assert!(entry.is_some(), "expected u in type_map for composite literal");
+        assert!(
+            entry.is_some(),
+            "expected u in type_map for composite literal"
+        );
         assert_eq!(entry.unwrap().type_name, "User");
         assert!((entry.unwrap().confidence - 1.0).abs() < f64::EPSILON);
     }
@@ -629,20 +724,19 @@ mod tests {
     #[test]
     fn infers_address_of_composite() {
         // u := &User{} → u : User at conf 1.0
-        let s = parse_go(
-            "package main\nfunc main() {\n  u := &User{}\n  _ = u\n}\n",
-        );
+        let s = parse_go("package main\nfunc main() {\n  u := &User{}\n  _ = u\n}\n");
         let entry = s.type_map.iter().find(|e| e.name == "u");
-        assert!(entry.is_some(), "expected u in type_map for address-of composite literal");
+        assert!(
+            entry.is_some(),
+            "expected u in type_map for address-of composite literal"
+        );
         assert_eq!(entry.unwrap().type_name, "User");
     }
 
     #[test]
     fn non_new_prefix_not_inferred() {
         // srv := createServer() — not a New* factory, should not seed typeMap
-        let s = parse_go(
-            "package main\nfunc main() {\n  srv := createServer()\n  _ = srv\n}\n",
-        );
+        let s = parse_go("package main\nfunc main() {\n  srv := createServer()\n  _ = srv\n}\n");
         assert!(
             s.type_map.iter().all(|e| e.name != "srv"),
             "unexpected typeMap entry for non-New factory"

--- a/crates/codegraph-core/src/extractors/groovy.rs
+++ b/crates/codegraph-core/src/extractors/groovy.rs
@@ -34,7 +34,12 @@ impl SymbolExtractor for GroovyExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_groovy_node);
-        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &GROOVY_AST_CONFIG);
+        walk_ast_nodes_with_config(
+            &tree.root_node(),
+            source,
+            &mut symbols.ast_nodes,
+            &GROOVY_AST_CONFIG,
+        );
         symbols
     }
 }
@@ -55,11 +60,17 @@ fn find_groovy_parent_class(node: &Node, source: &[u8]) -> Option<String> {
 fn match_groovy_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: usize) {
     match node.kind() {
         "class_declaration" | "class_definition" => handle_class_decl(node, source, symbols),
-        "interface_declaration" | "interface_definition" => handle_interface_decl(node, source, symbols),
+        "interface_declaration" | "interface_definition" => {
+            handle_interface_decl(node, source, symbols)
+        }
         "enum_declaration" | "enum_definition" => handle_enum_decl(node, source, symbols),
         "method_declaration" | "method_definition" => handle_method_decl(node, source, symbols),
-        "constructor_declaration" | "constructor_definition" => handle_constructor_decl(node, source, symbols),
-        "function_definition" | "function_declaration" => handle_function_decl(node, source, symbols),
+        "constructor_declaration" | "constructor_definition" => {
+            handle_constructor_decl(node, source, symbols)
+        }
+        "function_definition" | "function_declaration" => {
+            handle_function_decl(node, source, symbols)
+        }
         "import_declaration" | "import_statement" => handle_import_decl(node, source, symbols),
         "method_invocation" | "method_call" | "call_expression" | "function_call"
         | "juxt_function_call" => handle_call_expr(node, source, symbols),
@@ -71,7 +82,9 @@ fn match_groovy_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
 // ── Class / interface / enum ────────────────────────────────────────────────
 
 fn handle_class_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else { return };
+    let Some(name_node) = node.child_by_field_name("name") else {
+        return;
+    };
     let class_name = node_text(&name_node, source).to_string();
     let children = extract_class_fields(node, source);
     symbols.definitions.push(Definition {
@@ -84,6 +97,7 @@ fn handle_class_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: opt_children(children),
         bodyless: None,
+        content_hash: None,
     });
 
     // Superclass: `superclass` field wraps a `_type` child (type_identifier /
@@ -91,7 +105,9 @@ fn handle_class_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     // type-like node.
     if let Some(superclass) = node.child_by_field_name("superclass") {
         for i in 0..superclass.child_count() {
-            let Some(child) = superclass.child(i) else { continue };
+            let Some(child) = superclass.child(i) else {
+                continue;
+            };
             match child.kind() {
                 "type_identifier" | "identifier" | "scoped_type_identifier" => {
                     symbols.classes.push(ClassRelation {
@@ -131,7 +147,9 @@ fn collect_interfaces(
     symbols: &mut FileSymbols,
 ) {
     for i in 0..interfaces.child_count() {
-        let Some(child) = interfaces.child(i) else { continue };
+        let Some(child) = interfaces.child(i) else {
+            continue;
+        };
         match child.kind() {
             "type_identifier" | "identifier" | "scoped_type_identifier" => {
                 symbols.classes.push(ClassRelation {
@@ -158,7 +176,9 @@ fn collect_interfaces(
 }
 
 fn handle_interface_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else { return };
+    let Some(name_node) = node.child_by_field_name("name") else {
+        return;
+    };
     let iface_name = node_text(&name_node, source).to_string();
     symbols.definitions.push(Definition {
         name: iface_name.clone(),
@@ -170,6 +190,7 @@ fn handle_interface_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 
     // `interface X extends Y, Z` — tree-sitter-groovy 0.1.x exposes parent
@@ -186,11 +207,15 @@ fn handle_interface_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
 }
 
 fn handle_enum_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else { return };
+    let Some(name_node) = node.child_by_field_name("name") else {
+        return;
+    };
     let enum_name = node_text(&name_node, source).to_string();
 
     let mut members: Vec<Definition> = Vec::new();
-    let body = node.child_by_field_name("body").or_else(|| find_child(node, "enum_body"));
+    let body = node
+        .child_by_field_name("body")
+        .or_else(|| find_child(node, "enum_body"));
     if let Some(body) = body {
         for i in 0..body.child_count() {
             let Some(child) = body.child(i) else { continue };
@@ -215,13 +240,16 @@ fn handle_enum_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: opt_children(members),
         bodyless: None,
+        content_hash: None,
     });
 }
 
 // ── Methods / constructors / functions ─────────────────────────────────────
 
 fn handle_method_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else { return };
+    let Some(name_node) = node.child_by_field_name("name") else {
+        return;
+    };
     let parent_class = find_groovy_parent_class(node, source);
     let name = node_text(&name_node, source);
     let full_name = match &parent_class {
@@ -239,11 +267,14 @@ fn handle_method_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: build_function_cfg(node, "groovy", source),
         children: opt_children(params),
         bodyless: None,
+        content_hash: None,
     });
 }
 
 fn handle_constructor_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else { return };
+    let Some(name_node) = node.child_by_field_name("name") else {
+        return;
+    };
     let parent_class = find_groovy_parent_class(node, source);
     let name = node_text(&name_node, source);
     let full_name = match &parent_class {
@@ -261,12 +292,15 @@ fn handle_constructor_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols
         cfg: build_function_cfg(node, "groovy", source),
         children: opt_children(params),
         bodyless: None,
+        content_hash: None,
     });
 }
 
 /// Top-level `function_definition` (Groovy script closure-bodied function).
 fn handle_function_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else { return };
+    let Some(name_node) = node.child_by_field_name("name") else {
+        return;
+    };
     let params = extract_params(node, source);
     symbols.definitions.push(Definition {
         name: node_text(&name_node, source).to_string(),
@@ -278,6 +312,7 @@ fn handle_function_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: build_function_cfg(node, "groovy", source),
         children: opt_children(params),
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -316,7 +351,8 @@ fn handle_import_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 
 /// Extract first string literal argument from a Groovy call node.
 fn get_first_string_arg_groovy(node: &Node, source: &[u8]) -> Option<String> {
-    let args = node.child_by_field_name("arguments")
+    let args = node
+        .child_by_field_name("arguments")
         .or_else(|| find_child(node, "argument_list"))?;
     for i in 0..args.child_count() {
         let child = args.child(i)?;
@@ -435,9 +471,13 @@ fn handle_call_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 }
 
 fn handle_object_creation(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(type_node) = node.child_by_field_name("type") else { return };
+    let Some(type_node) = node.child_by_field_name("type") else {
+        return;
+    };
     let type_name = if type_node.kind() == "generic_type" {
-        type_node.child(0).map(|n| node_text(&n, source).to_string())
+        type_node
+            .child(0)
+            .map(|n| node_text(&n, source).to_string())
     } else {
         Some(node_text(&type_node, source).to_string())
     };
@@ -459,9 +499,13 @@ fn extract_params(func_node: &Node, source: &[u8]) -> Vec<Definition> {
     let params_node = func_node
         .child_by_field_name("parameters")
         .or_else(|| find_child(func_node, "formal_parameters"));
-    let Some(params_node) = params_node else { return params };
+    let Some(params_node) = params_node else {
+        return params;
+    };
     for i in 0..params_node.child_count() {
-        let Some(child) = params_node.child(i) else { continue };
+        let Some(child) = params_node.child(i) else {
+            continue;
+        };
         if child.kind() == "formal_parameter"
             || child.kind() == "parameter"
             || child.kind() == "spread_parameter"
@@ -490,7 +534,9 @@ fn extract_class_fields(class_node: &Node, source: &[u8]) -> Vec<Definition> {
             continue;
         }
         for j in 0..child.child_count() {
-            let Some(var_decl) = child.child(j) else { continue };
+            let Some(var_decl) = child.child(j) else {
+                continue;
+            };
             if var_decl.kind() == "variable_declarator" {
                 if let Some(name_node) = var_decl.child_by_field_name("name") {
                     fields.push(child_def(
@@ -521,12 +567,20 @@ mod tests {
 
     #[test]
     fn extracts_class_and_methods() {
-        let s = parse_groovy(
-            "class Foo {\n  void bar(String x) { x.length() }\n  int baz() { 1 }\n}",
-        );
-        assert!(s.definitions.iter().any(|d| d.name == "Foo" && d.kind == "class"));
-        assert!(s.definitions.iter().any(|d| d.name == "Foo.bar" && d.kind == "method"));
-        assert!(s.definitions.iter().any(|d| d.name == "Foo.baz" && d.kind == "method"));
+        let s =
+            parse_groovy("class Foo {\n  void bar(String x) { x.length() }\n  int baz() { 1 }\n}");
+        assert!(s
+            .definitions
+            .iter()
+            .any(|d| d.name == "Foo" && d.kind == "class"));
+        assert!(s
+            .definitions
+            .iter()
+            .any(|d| d.name == "Foo.bar" && d.kind == "method"));
+        assert!(s
+            .definitions
+            .iter()
+            .any(|d| d.name == "Foo.baz" && d.kind == "method"));
     }
 
     #[test]
@@ -577,8 +631,15 @@ mod tests {
     #[test]
     fn extracts_interface_and_enum() {
         let s = parse_groovy("interface Worker { void work() }\nenum Color { RED, GREEN }");
-        assert!(s.definitions.iter().any(|d| d.name == "Worker" && d.kind == "interface"));
-        let color = s.definitions.iter().find(|d| d.name == "Color" && d.kind == "enum").unwrap();
+        assert!(s
+            .definitions
+            .iter()
+            .any(|d| d.name == "Worker" && d.kind == "interface"));
+        let color = s
+            .definitions
+            .iter()
+            .find(|d| d.name == "Color" && d.kind == "enum")
+            .unwrap();
         let children = color.children.as_ref().unwrap();
         let names: Vec<&str> = children.iter().map(|c| c.name.as_str()).collect();
         assert!(names.contains(&"RED"));
@@ -595,9 +656,21 @@ mod tests {
             "apply plugin: 'java'\ntask someTask {\n  doLast {\n    println \"hello\"\n  }\n}",
         );
         let names: Vec<&str> = s.calls.iter().map(|c| c.name.as_str()).collect();
-        assert!(names.contains(&"apply"), "missing `apply` juxt call: {:?}", names);
-        assert!(names.contains(&"task"), "missing `task` juxt call: {:?}", names);
-        assert!(names.contains(&"println"), "missing `println` juxt call: {:?}", names);
+        assert!(
+            names.contains(&"apply"),
+            "missing `apply` juxt call: {:?}",
+            names
+        );
+        assert!(
+            names.contains(&"task"),
+            "missing `task` juxt call: {:?}",
+            names
+        );
+        assert!(
+            names.contains(&"println"),
+            "missing `println` juxt call: {:?}",
+            names
+        );
     }
 
     #[test]
@@ -615,14 +688,20 @@ mod tests {
         // via an unnamed `extends_interfaces` child (not a field), distinct
         // from class declarations which use the `interfaces` field.
         let s = parse_groovy("interface Serializable extends Comparable, Cloneable {}");
-        let rels: Vec<_> = s.classes.iter().filter(|c| c.name == "Serializable").collect();
+        let rels: Vec<_> = s
+            .classes
+            .iter()
+            .filter(|c| c.name == "Serializable")
+            .collect();
         assert!(
-            rels.iter().any(|c| c.implements.as_deref() == Some("Comparable")),
+            rels.iter()
+                .any(|c| c.implements.as_deref() == Some("Comparable")),
             "missing implements=Comparable, got: {:?}",
             rels
         );
         assert!(
-            rels.iter().any(|c| c.implements.as_deref() == Some("Cloneable")),
+            rels.iter()
+                .any(|c| c.implements.as_deref() == Some("Cloneable")),
             "missing implements=Cloneable, got: {:?}",
             rels
         );
@@ -635,10 +714,18 @@ mod tests {
         // — `collect_interfaces` re-evaluates `start_line(interfaces)` on every
         // recursive call, and the WASM extractor must match.
         let s = parse_groovy("interface Serializable\n  extends Comparable, Cloneable {}");
-        let rels: Vec<_> = s.classes.iter().filter(|c| c.name == "Serializable").collect();
+        let rels: Vec<_> = s
+            .classes
+            .iter()
+            .filter(|c| c.name == "Serializable")
+            .collect();
         assert!(!rels.is_empty(), "expected at least one ClassRelation");
         for rel in &rels {
-            assert_eq!(rel.line, 2, "line should track the extends clause, got: {:?}", rel);
+            assert_eq!(
+                rel.line, 2,
+                "line should track the extends clause, got: {:?}",
+                rel
+            );
         }
     }
 }

--- a/crates/codegraph-core/src/extractors/groovy.rs
+++ b/crates/codegraph-core/src/extractors/groovy.rs
@@ -34,12 +34,7 @@ impl SymbolExtractor for GroovyExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_groovy_node);
-        walk_ast_nodes_with_config(
-            &tree.root_node(),
-            source,
-            &mut symbols.ast_nodes,
-            &GROOVY_AST_CONFIG,
-        );
+        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &GROOVY_AST_CONFIG);
         symbols
     }
 }
@@ -60,17 +55,11 @@ fn find_groovy_parent_class(node: &Node, source: &[u8]) -> Option<String> {
 fn match_groovy_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: usize) {
     match node.kind() {
         "class_declaration" | "class_definition" => handle_class_decl(node, source, symbols),
-        "interface_declaration" | "interface_definition" => {
-            handle_interface_decl(node, source, symbols)
-        }
+        "interface_declaration" | "interface_definition" => handle_interface_decl(node, source, symbols),
         "enum_declaration" | "enum_definition" => handle_enum_decl(node, source, symbols),
         "method_declaration" | "method_definition" => handle_method_decl(node, source, symbols),
-        "constructor_declaration" | "constructor_definition" => {
-            handle_constructor_decl(node, source, symbols)
-        }
-        "function_definition" | "function_declaration" => {
-            handle_function_decl(node, source, symbols)
-        }
+        "constructor_declaration" | "constructor_definition" => handle_constructor_decl(node, source, symbols),
+        "function_definition" | "function_declaration" => handle_function_decl(node, source, symbols),
         "import_declaration" | "import_statement" => handle_import_decl(node, source, symbols),
         "method_invocation" | "method_call" | "call_expression" | "function_call"
         | "juxt_function_call" => handle_call_expr(node, source, symbols),
@@ -82,9 +71,7 @@ fn match_groovy_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
 // ── Class / interface / enum ────────────────────────────────────────────────
 
 fn handle_class_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else {
-        return;
-    };
+    let Some(name_node) = node.child_by_field_name("name") else { return };
     let class_name = node_text(&name_node, source).to_string();
     let children = extract_class_fields(node, source);
     symbols.definitions.push(Definition {
@@ -105,9 +92,7 @@ fn handle_class_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     // type-like node.
     if let Some(superclass) = node.child_by_field_name("superclass") {
         for i in 0..superclass.child_count() {
-            let Some(child) = superclass.child(i) else {
-                continue;
-            };
+            let Some(child) = superclass.child(i) else { continue };
             match child.kind() {
                 "type_identifier" | "identifier" | "scoped_type_identifier" => {
                     symbols.classes.push(ClassRelation {
@@ -147,9 +132,7 @@ fn collect_interfaces(
     symbols: &mut FileSymbols,
 ) {
     for i in 0..interfaces.child_count() {
-        let Some(child) = interfaces.child(i) else {
-            continue;
-        };
+        let Some(child) = interfaces.child(i) else { continue };
         match child.kind() {
             "type_identifier" | "identifier" | "scoped_type_identifier" => {
                 symbols.classes.push(ClassRelation {
@@ -176,9 +159,7 @@ fn collect_interfaces(
 }
 
 fn handle_interface_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else {
-        return;
-    };
+    let Some(name_node) = node.child_by_field_name("name") else { return };
     let iface_name = node_text(&name_node, source).to_string();
     symbols.definitions.push(Definition {
         name: iface_name.clone(),
@@ -207,15 +188,11 @@ fn handle_interface_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
 }
 
 fn handle_enum_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else {
-        return;
-    };
+    let Some(name_node) = node.child_by_field_name("name") else { return };
     let enum_name = node_text(&name_node, source).to_string();
 
     let mut members: Vec<Definition> = Vec::new();
-    let body = node
-        .child_by_field_name("body")
-        .or_else(|| find_child(node, "enum_body"));
+    let body = node.child_by_field_name("body").or_else(|| find_child(node, "enum_body"));
     if let Some(body) = body {
         for i in 0..body.child_count() {
             let Some(child) = body.child(i) else { continue };
@@ -247,9 +224,7 @@ fn handle_enum_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 // ── Methods / constructors / functions ─────────────────────────────────────
 
 fn handle_method_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else {
-        return;
-    };
+    let Some(name_node) = node.child_by_field_name("name") else { return };
     let parent_class = find_groovy_parent_class(node, source);
     let name = node_text(&name_node, source);
     let full_name = match &parent_class {
@@ -272,9 +247,7 @@ fn handle_method_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 }
 
 fn handle_constructor_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else {
-        return;
-    };
+    let Some(name_node) = node.child_by_field_name("name") else { return };
     let parent_class = find_groovy_parent_class(node, source);
     let name = node_text(&name_node, source);
     let full_name = match &parent_class {
@@ -298,9 +271,7 @@ fn handle_constructor_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols
 
 /// Top-level `function_definition` (Groovy script closure-bodied function).
 fn handle_function_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else {
-        return;
-    };
+    let Some(name_node) = node.child_by_field_name("name") else { return };
     let params = extract_params(node, source);
     symbols.definitions.push(Definition {
         name: node_text(&name_node, source).to_string(),
@@ -351,8 +322,7 @@ fn handle_import_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 
 /// Extract first string literal argument from a Groovy call node.
 fn get_first_string_arg_groovy(node: &Node, source: &[u8]) -> Option<String> {
-    let args = node
-        .child_by_field_name("arguments")
+    let args = node.child_by_field_name("arguments")
         .or_else(|| find_child(node, "argument_list"))?;
     for i in 0..args.child_count() {
         let child = args.child(i)?;
@@ -471,13 +441,9 @@ fn handle_call_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 }
 
 fn handle_object_creation(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(type_node) = node.child_by_field_name("type") else {
-        return;
-    };
+    let Some(type_node) = node.child_by_field_name("type") else { return };
     let type_name = if type_node.kind() == "generic_type" {
-        type_node
-            .child(0)
-            .map(|n| node_text(&n, source).to_string())
+        type_node.child(0).map(|n| node_text(&n, source).to_string())
     } else {
         Some(node_text(&type_node, source).to_string())
     };
@@ -499,13 +465,9 @@ fn extract_params(func_node: &Node, source: &[u8]) -> Vec<Definition> {
     let params_node = func_node
         .child_by_field_name("parameters")
         .or_else(|| find_child(func_node, "formal_parameters"));
-    let Some(params_node) = params_node else {
-        return params;
-    };
+    let Some(params_node) = params_node else { return params };
     for i in 0..params_node.child_count() {
-        let Some(child) = params_node.child(i) else {
-            continue;
-        };
+        let Some(child) = params_node.child(i) else { continue };
         if child.kind() == "formal_parameter"
             || child.kind() == "parameter"
             || child.kind() == "spread_parameter"
@@ -534,9 +496,7 @@ fn extract_class_fields(class_node: &Node, source: &[u8]) -> Vec<Definition> {
             continue;
         }
         for j in 0..child.child_count() {
-            let Some(var_decl) = child.child(j) else {
-                continue;
-            };
+            let Some(var_decl) = child.child(j) else { continue };
             if var_decl.kind() == "variable_declarator" {
                 if let Some(name_node) = var_decl.child_by_field_name("name") {
                     fields.push(child_def(
@@ -567,20 +527,12 @@ mod tests {
 
     #[test]
     fn extracts_class_and_methods() {
-        let s =
-            parse_groovy("class Foo {\n  void bar(String x) { x.length() }\n  int baz() { 1 }\n}");
-        assert!(s
-            .definitions
-            .iter()
-            .any(|d| d.name == "Foo" && d.kind == "class"));
-        assert!(s
-            .definitions
-            .iter()
-            .any(|d| d.name == "Foo.bar" && d.kind == "method"));
-        assert!(s
-            .definitions
-            .iter()
-            .any(|d| d.name == "Foo.baz" && d.kind == "method"));
+        let s = parse_groovy(
+            "class Foo {\n  void bar(String x) { x.length() }\n  int baz() { 1 }\n}",
+        );
+        assert!(s.definitions.iter().any(|d| d.name == "Foo" && d.kind == "class"));
+        assert!(s.definitions.iter().any(|d| d.name == "Foo.bar" && d.kind == "method"));
+        assert!(s.definitions.iter().any(|d| d.name == "Foo.baz" && d.kind == "method"));
     }
 
     #[test]
@@ -631,15 +583,8 @@ mod tests {
     #[test]
     fn extracts_interface_and_enum() {
         let s = parse_groovy("interface Worker { void work() }\nenum Color { RED, GREEN }");
-        assert!(s
-            .definitions
-            .iter()
-            .any(|d| d.name == "Worker" && d.kind == "interface"));
-        let color = s
-            .definitions
-            .iter()
-            .find(|d| d.name == "Color" && d.kind == "enum")
-            .unwrap();
+        assert!(s.definitions.iter().any(|d| d.name == "Worker" && d.kind == "interface"));
+        let color = s.definitions.iter().find(|d| d.name == "Color" && d.kind == "enum").unwrap();
         let children = color.children.as_ref().unwrap();
         let names: Vec<&str> = children.iter().map(|c| c.name.as_str()).collect();
         assert!(names.contains(&"RED"));
@@ -656,21 +601,9 @@ mod tests {
             "apply plugin: 'java'\ntask someTask {\n  doLast {\n    println \"hello\"\n  }\n}",
         );
         let names: Vec<&str> = s.calls.iter().map(|c| c.name.as_str()).collect();
-        assert!(
-            names.contains(&"apply"),
-            "missing `apply` juxt call: {:?}",
-            names
-        );
-        assert!(
-            names.contains(&"task"),
-            "missing `task` juxt call: {:?}",
-            names
-        );
-        assert!(
-            names.contains(&"println"),
-            "missing `println` juxt call: {:?}",
-            names
-        );
+        assert!(names.contains(&"apply"), "missing `apply` juxt call: {:?}", names);
+        assert!(names.contains(&"task"), "missing `task` juxt call: {:?}", names);
+        assert!(names.contains(&"println"), "missing `println` juxt call: {:?}", names);
     }
 
     #[test]
@@ -688,20 +621,14 @@ mod tests {
         // via an unnamed `extends_interfaces` child (not a field), distinct
         // from class declarations which use the `interfaces` field.
         let s = parse_groovy("interface Serializable extends Comparable, Cloneable {}");
-        let rels: Vec<_> = s
-            .classes
-            .iter()
-            .filter(|c| c.name == "Serializable")
-            .collect();
+        let rels: Vec<_> = s.classes.iter().filter(|c| c.name == "Serializable").collect();
         assert!(
-            rels.iter()
-                .any(|c| c.implements.as_deref() == Some("Comparable")),
+            rels.iter().any(|c| c.implements.as_deref() == Some("Comparable")),
             "missing implements=Comparable, got: {:?}",
             rels
         );
         assert!(
-            rels.iter()
-                .any(|c| c.implements.as_deref() == Some("Cloneable")),
+            rels.iter().any(|c| c.implements.as_deref() == Some("Cloneable")),
             "missing implements=Cloneable, got: {:?}",
             rels
         );
@@ -714,18 +641,10 @@ mod tests {
         // — `collect_interfaces` re-evaluates `start_line(interfaces)` on every
         // recursive call, and the WASM extractor must match.
         let s = parse_groovy("interface Serializable\n  extends Comparable, Cloneable {}");
-        let rels: Vec<_> = s
-            .classes
-            .iter()
-            .filter(|c| c.name == "Serializable")
-            .collect();
+        let rels: Vec<_> = s.classes.iter().filter(|c| c.name == "Serializable").collect();
         assert!(!rels.is_empty(), "expected at least one ClassRelation");
         for rel in &rels {
-            assert_eq!(
-                rel.line, 2,
-                "line should track the extends clause, got: {:?}",
-                rel
-            );
+            assert_eq!(rel.line, 2, "line should track the extends clause, got: {:?}", rel);
         }
     }
 }

--- a/crates/codegraph-core/src/extractors/haskell.rs
+++ b/crates/codegraph-core/src/extractors/haskell.rs
@@ -1,9 +1,9 @@
-use super::helpers::*;
-use super::SymbolExtractor;
+use tree_sitter::{Node, Tree};
 use crate::ast_analysis::cfg::build_function_cfg;
 use crate::ast_analysis::complexity::compute_all_metrics;
 use crate::types::*;
-use tree_sitter::{Node, Tree};
+use super::helpers::*;
+use super::SymbolExtractor;
 
 pub struct HaskellExtractor;
 
@@ -11,12 +11,7 @@ impl SymbolExtractor for HaskellExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_haskell_node);
-        walk_ast_nodes_with_config(
-            &tree.root_node(),
-            source,
-            &mut symbols.ast_nodes,
-            &HASKELL_AST_CONFIG,
-        );
+        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &HASKELL_AST_CONFIG);
         symbols
     }
 }
@@ -61,9 +56,7 @@ fn handle_haskell_function(node: &Node, source: &[u8], symbols: &mut FileSymbols
 fn extract_haskell_params(func_node: &Node, source: &[u8]) -> Vec<Definition> {
     let mut params = Vec::new();
     for i in 0..func_node.child_count() {
-        let Some(child) = func_node.child(i) else {
-            continue;
-        };
+        let Some(child) = func_node.child(i) else { continue };
         match child.kind() {
             "patterns" | "parameter" => {
                 for j in 0..child.child_count() {
@@ -297,17 +290,11 @@ fn handle_haskell_import(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
     }
 
     if names.is_empty() {
-        let last = source_name
-            .split('.')
-            .last()
-            .unwrap_or(&source_name)
-            .to_string();
+        let last = source_name.split('.').last().unwrap_or(&source_name).to_string();
         names.push(last);
     }
 
-    symbols
-        .imports
-        .push(Import::new(source_name, names, start_line(node)));
+    symbols.imports.push(Import::new(source_name, names, start_line(node)));
 }
 
 fn handle_haskell_apply(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
@@ -317,11 +304,7 @@ fn handle_haskell_apply(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     };
 
     match func_node.kind() {
-        "variable"
-        | "constructor"
-        | "identifier"
-        | "qualified_variable"
-        | "qualified_constructor" => {
+        "variable" | "constructor" | "identifier" | "qualified_variable" | "qualified_constructor" => {
             symbols.calls.push(Call {
                 name: node_text(&func_node, source).to_string(),
                 line: start_line(node),

--- a/crates/codegraph-core/src/extractors/haskell.rs
+++ b/crates/codegraph-core/src/extractors/haskell.rs
@@ -1,9 +1,9 @@
-use tree_sitter::{Node, Tree};
+use super::helpers::*;
+use super::SymbolExtractor;
 use crate::ast_analysis::cfg::build_function_cfg;
 use crate::ast_analysis::complexity::compute_all_metrics;
 use crate::types::*;
-use super::helpers::*;
-use super::SymbolExtractor;
+use tree_sitter::{Node, Tree};
 
 pub struct HaskellExtractor;
 
@@ -11,7 +11,12 @@ impl SymbolExtractor for HaskellExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_haskell_node);
-        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &HASKELL_AST_CONFIG);
+        walk_ast_nodes_with_config(
+            &tree.root_node(),
+            source,
+            &mut symbols.ast_nodes,
+            &HASKELL_AST_CONFIG,
+        );
         symbols
     }
 }
@@ -49,13 +54,16 @@ fn handle_haskell_function(node: &Node, source: &[u8], symbols: &mut FileSymbols
         cfg: build_function_cfg(node, "haskell", source),
         children: opt_children(params),
         bodyless: None,
+        content_hash: None,
     });
 }
 
 fn extract_haskell_params(func_node: &Node, source: &[u8]) -> Vec<Definition> {
     let mut params = Vec::new();
     for i in 0..func_node.child_count() {
-        let Some(child) = func_node.child(i) else { continue };
+        let Some(child) = func_node.child(i) else {
+            continue;
+        };
         match child.kind() {
             "patterns" | "parameter" => {
                 for j in 0..child.child_count() {
@@ -138,6 +146,7 @@ fn handle_haskell_bind(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -177,6 +186,7 @@ fn handle_haskell_data_type(node: &Node, source: &[u8], symbols: &mut FileSymbol
         cfg: None,
         children: opt_children(children),
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -196,6 +206,7 @@ fn handle_haskell_newtype(node: &Node, source: &[u8], symbols: &mut FileSymbols)
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -215,6 +226,7 @@ fn handle_haskell_type_synonym(node: &Node, source: &[u8], symbols: &mut FileSym
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -234,6 +246,7 @@ fn handle_haskell_class(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -253,6 +266,7 @@ fn handle_haskell_instance(node: &Node, source: &[u8], symbols: &mut FileSymbols
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -283,11 +297,17 @@ fn handle_haskell_import(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
     }
 
     if names.is_empty() {
-        let last = source_name.split('.').last().unwrap_or(&source_name).to_string();
+        let last = source_name
+            .split('.')
+            .last()
+            .unwrap_or(&source_name)
+            .to_string();
         names.push(last);
     }
 
-    symbols.imports.push(Import::new(source_name, names, start_line(node)));
+    symbols
+        .imports
+        .push(Import::new(source_name, names, start_line(node)));
 }
 
 fn handle_haskell_apply(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
@@ -297,7 +317,11 @@ fn handle_haskell_apply(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     };
 
     match func_node.kind() {
-        "variable" | "constructor" | "identifier" | "qualified_variable" | "qualified_constructor" => {
+        "variable"
+        | "constructor"
+        | "identifier"
+        | "qualified_variable"
+        | "qualified_constructor" => {
             symbols.calls.push(Call {
                 name: node_text(&func_node, source).to_string(),
                 line: start_line(node),

--- a/crates/codegraph-core/src/extractors/hcl.rs
+++ b/crates/codegraph-core/src/extractors/hcl.rs
@@ -113,11 +113,7 @@ fn match_hcl_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth:
             if !name.is_empty() {
                 let children = if block_type == "variable" || block_type == "output" {
                     let attrs = extract_block_attributes(node, source);
-                    if attrs.is_empty() {
-                        None
-                    } else {
-                        Some(attrs)
-                    }
+                    if attrs.is_empty() { None } else { Some(attrs) }
                 } else {
                     None
                 };

--- a/crates/codegraph-core/src/extractors/hcl.rs
+++ b/crates/codegraph-core/src/extractors/hcl.rs
@@ -70,6 +70,7 @@ fn extract_block_attributes(node: &Node, source: &[u8]) -> Vec<Definition> {
                 cfg: None,
                 children: None,
                 bodyless: None,
+                content_hash: None,
             });
         }
     }
@@ -112,7 +113,11 @@ fn match_hcl_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth:
             if !name.is_empty() {
                 let children = if block_type == "variable" || block_type == "output" {
                     let attrs = extract_block_attributes(node, source);
-                    if attrs.is_empty() { None } else { Some(attrs) }
+                    if attrs.is_empty() {
+                        None
+                    } else {
+                        Some(attrs)
+                    }
                 } else {
                     None
                 };
@@ -126,6 +131,7 @@ fn match_hcl_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth:
                     cfg: None,
                     children,
                     bodyless: None,
+                    content_hash: None,
                 });
                 if block_type == "module" {
                     extract_module_source(node, source, symbols);

--- a/crates/codegraph-core/src/extractors/helpers.rs
+++ b/crates/codegraph-core/src/extractors/helpers.rs
@@ -26,6 +26,7 @@ pub fn child_def(name: String, kind: &str, line: u32) -> Definition {
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     }
 }
 

--- a/crates/codegraph-core/src/extractors/java.rs
+++ b/crates/codegraph-core/src/extractors/java.rs
@@ -11,12 +11,7 @@ impl SymbolExtractor for JavaExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_java_node);
-        walk_ast_nodes_with_config(
-            &tree.root_node(),
-            source,
-            &mut symbols.ast_nodes,
-            &JAVA_AST_CONFIG,
-        );
+        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &JAVA_AST_CONFIG);
         walk_tree(&tree.root_node(), source, &mut symbols, match_java_type_map);
         dedup_type_map(&mut symbols.type_map);
         symbols
@@ -71,11 +66,7 @@ fn match_java_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, _d
     }
 }
 
-const JAVA_CLASS_KINDS: &[&str] = &[
-    "class_declaration",
-    "enum_declaration",
-    "interface_declaration",
-];
+const JAVA_CLASS_KINDS: &[&str] = &["class_declaration", "enum_declaration", "interface_declaration"];
 
 fn find_java_parent_class(node: &Node, source: &[u8]) -> Option<String> {
     find_enclosing_type_name(node, JAVA_CLASS_KINDS, source)
@@ -98,9 +89,7 @@ fn match_java_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth
 // ── Per-node-kind handlers for walk_node_depth ───────────────────────────────
 
 fn handle_class_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else {
-        return;
-    };
+    let Some(name_node) = node.child_by_field_name("name") else { return };
     let class_name = node_text(&name_node, source).to_string();
     let children = extract_java_class_fields(node, source);
     symbols.definitions.push(Definition {
@@ -127,17 +116,9 @@ fn handle_class_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     }
 }
 
-fn extract_java_superclass(
-    superclass: &Node,
-    class_name: &str,
-    node: &Node,
-    source: &[u8],
-    symbols: &mut FileSymbols,
-) {
+fn extract_java_superclass(superclass: &Node, class_name: &str, node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     for i in 0..superclass.child_count() {
-        let Some(child) = superclass.child(i) else {
-            continue;
-        };
+        let Some(child) = superclass.child(i) else { continue };
         match child.kind() {
             "type_identifier" | "identifier" => {
                 symbols.classes.push(ClassRelation {
@@ -165,9 +146,7 @@ fn extract_java_superclass(
 }
 
 fn handle_interface_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else {
-        return;
-    };
+    let Some(name_node) = node.child_by_field_name("name") else { return };
     let iface_name = node_text(&name_node, source).to_string();
     symbols.definitions.push(Definition {
         name: iface_name.clone(),
@@ -184,9 +163,7 @@ fn handle_interface_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
     if let Some(body) = node.child_by_field_name("body") {
         for i in 0..body.child_count() {
             let Some(child) = body.child(i) else { continue };
-            if child.kind() != "method_declaration" {
-                continue;
-            }
+            if child.kind() != "method_declaration" { continue; }
             if let Some(meth_name) = child.child_by_field_name("name") {
                 symbols.definitions.push(Definition {
                     name: format!("{}.{}", iface_name, node_text(&meth_name, source)),
@@ -232,9 +209,7 @@ fn handle_method_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     // `node.parent?.parent?.type === 'interface_declaration'` guard.
     if let Some(parent) = node.parent() {
         if let Some(grand) = parent.parent() {
-            if grand.kind() == "interface_declaration" {
-                return;
-            }
+            if grand.kind() == "interface_declaration" { return; }
         }
     }
     if let Some(name_node) = node.child_by_field_name("name") {
@@ -312,8 +287,7 @@ fn handle_import_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 
 /// Return the text of the first non-punctuation argument in an argument_list.
 fn get_first_string_arg_java(node: &Node, source: &[u8]) -> Option<String> {
-    let args = node
-        .child_by_field_name("arguments")
+    let args = node.child_by_field_name("arguments")
         .or_else(|| find_child(node, "argument_list"))?;
     for i in 0..args.child_count() {
         let child = args.child(i)?;
@@ -329,9 +303,7 @@ fn get_first_string_arg_java(node: &Node, source: &[u8]) -> Option<String> {
 }
 
 fn handle_method_invocation(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else {
-        return;
-    };
+    let Some(name_node) = node.child_by_field_name("name") else { return };
     let method_name = node_text(&name_node, source);
     let receiver = named_child_text(node, "object", source).map(|s| s.to_string());
     let call_line = start_line(node);
@@ -403,13 +375,9 @@ fn handle_method_invocation(node: &Node, source: &[u8], symbols: &mut FileSymbol
 }
 
 fn handle_object_creation(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(type_node) = node.child_by_field_name("type") else {
-        return;
-    };
+    let Some(type_node) = node.child_by_field_name("type") else { return };
     let type_name = if type_node.kind() == "generic_type" {
-        type_node
-            .child(0)
-            .map(|n| node_text(&n, source).to_string())
+        type_node.child(0).map(|n| node_text(&n, source).to_string())
     } else {
         Some(node_text(&type_node, source).to_string())
     };
@@ -493,9 +461,7 @@ fn extract_java_interfaces(
     symbols: &mut FileSymbols,
 ) {
     for i in 0..interfaces.child_count() {
-        let Some(child) = interfaces.child(i) else {
-            continue;
-        };
+        let Some(child) = interfaces.child(i) else { continue };
         match child.kind() {
             "type_identifier" | "identifier" => {
                 push_implements(symbols, class_name, node_text(&child, source), interfaces);
@@ -513,12 +479,7 @@ fn extract_java_interfaces(
     }
 }
 
-fn push_implements(
-    symbols: &mut FileSymbols,
-    class_name: &str,
-    iface_name: &str,
-    line_node: &Node,
-) {
+fn push_implements(symbols: &mut FileSymbols, class_name: &str, iface_name: &str, line_node: &Node) {
     symbols.classes.push(ClassRelation {
         name: class_name.to_string(),
         extends: None,
@@ -535,9 +496,7 @@ fn collect_type_list_implements(
     line_node: &Node,
 ) {
     for j in 0..type_list.child_count() {
-        let Some(t) = type_list.child(j) else {
-            continue;
-        };
+        let Some(t) = type_list.child(j) else { continue };
         match t.kind() {
             "type_identifier" | "identifier" => {
                 push_implements(symbols, class_name, node_text(&t, source), line_node);
@@ -606,8 +565,7 @@ mod tests {
             .unwrap();
         assert_eq!(abstract_save.bodyless, Some(true));
 
-        let concrete =
-            parse_java("class Repo { boolean save(String id, int value) { return true; } }");
+        let concrete = parse_java("class Repo { boolean save(String id, int value) { return true; } }");
         let concrete_save = concrete
             .definitions
             .iter()

--- a/crates/codegraph-core/src/extractors/java.rs
+++ b/crates/codegraph-core/src/extractors/java.rs
@@ -11,7 +11,12 @@ impl SymbolExtractor for JavaExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_java_node);
-        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &JAVA_AST_CONFIG);
+        walk_ast_nodes_with_config(
+            &tree.root_node(),
+            source,
+            &mut symbols.ast_nodes,
+            &JAVA_AST_CONFIG,
+        );
         walk_tree(&tree.root_node(), source, &mut symbols, match_java_type_map);
         dedup_type_map(&mut symbols.type_map);
         symbols
@@ -66,7 +71,11 @@ fn match_java_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, _d
     }
 }
 
-const JAVA_CLASS_KINDS: &[&str] = &["class_declaration", "enum_declaration", "interface_declaration"];
+const JAVA_CLASS_KINDS: &[&str] = &[
+    "class_declaration",
+    "enum_declaration",
+    "interface_declaration",
+];
 
 fn find_java_parent_class(node: &Node, source: &[u8]) -> Option<String> {
     find_enclosing_type_name(node, JAVA_CLASS_KINDS, source)
@@ -89,7 +98,9 @@ fn match_java_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth
 // ── Per-node-kind handlers for walk_node_depth ───────────────────────────────
 
 fn handle_class_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else { return };
+    let Some(name_node) = node.child_by_field_name("name") else {
+        return;
+    };
     let class_name = node_text(&name_node, source).to_string();
     let children = extract_java_class_fields(node, source);
     symbols.definitions.push(Definition {
@@ -102,6 +113,7 @@ fn handle_class_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: opt_children(children),
         bodyless: None,
+        content_hash: None,
     });
 
     // Superclass
@@ -115,9 +127,17 @@ fn handle_class_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     }
 }
 
-fn extract_java_superclass(superclass: &Node, class_name: &str, node: &Node, source: &[u8], symbols: &mut FileSymbols) {
+fn extract_java_superclass(
+    superclass: &Node,
+    class_name: &str,
+    node: &Node,
+    source: &[u8],
+    symbols: &mut FileSymbols,
+) {
     for i in 0..superclass.child_count() {
-        let Some(child) = superclass.child(i) else { continue };
+        let Some(child) = superclass.child(i) else {
+            continue;
+        };
         match child.kind() {
             "type_identifier" | "identifier" => {
                 symbols.classes.push(ClassRelation {
@@ -145,7 +165,9 @@ fn extract_java_superclass(superclass: &Node, class_name: &str, node: &Node, sou
 }
 
 fn handle_interface_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else { return };
+    let Some(name_node) = node.child_by_field_name("name") else {
+        return;
+    };
     let iface_name = node_text(&name_node, source).to_string();
     symbols.definitions.push(Definition {
         name: iface_name.clone(),
@@ -157,11 +179,14 @@ fn handle_interface_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
     if let Some(body) = node.child_by_field_name("body") {
         for i in 0..body.child_count() {
             let Some(child) = body.child(i) else { continue };
-            if child.kind() != "method_declaration" { continue; }
+            if child.kind() != "method_declaration" {
+                continue;
+            }
             if let Some(meth_name) = child.child_by_field_name("name") {
                 symbols.definitions.push(Definition {
                     name: format!("{}.{}", iface_name, node_text(&meth_name, source)),
@@ -173,6 +198,7 @@ fn handle_interface_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
                     cfg: build_function_cfg(&child, "java", source),
                     children: None,
                     bodyless: Some(child.child_by_field_name("body").is_none()),
+                    content_hash: None,
                 });
             }
         }
@@ -193,6 +219,7 @@ fn handle_enum_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             cfg: None,
             children: opt_children(children),
             bodyless: None,
+            content_hash: None,
         });
     }
 }
@@ -205,7 +232,9 @@ fn handle_method_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     // `node.parent?.parent?.type === 'interface_declaration'` guard.
     if let Some(parent) = node.parent() {
         if let Some(grand) = parent.parent() {
-            if grand.kind() == "interface_declaration" { return; }
+            if grand.kind() == "interface_declaration" {
+                return;
+            }
         }
     }
     if let Some(name_node) = node.child_by_field_name("name") {
@@ -226,6 +255,7 @@ fn handle_method_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             cfg: build_function_cfg(node, "java", source),
             children: opt_children(children),
             bodyless: Some(node.child_by_field_name("body").is_none()),
+            content_hash: None,
         });
     }
 }
@@ -249,6 +279,7 @@ fn handle_constructor_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols
             cfg: build_function_cfg(node, "java", source),
             children: opt_children(children),
             bodyless: None,
+            content_hash: None,
         });
     }
 }
@@ -281,7 +312,8 @@ fn handle_import_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 
 /// Return the text of the first non-punctuation argument in an argument_list.
 fn get_first_string_arg_java(node: &Node, source: &[u8]) -> Option<String> {
-    let args = node.child_by_field_name("arguments")
+    let args = node
+        .child_by_field_name("arguments")
         .or_else(|| find_child(node, "argument_list"))?;
     for i in 0..args.child_count() {
         let child = args.child(i)?;
@@ -297,7 +329,9 @@ fn get_first_string_arg_java(node: &Node, source: &[u8]) -> Option<String> {
 }
 
 fn handle_method_invocation(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else { return };
+    let Some(name_node) = node.child_by_field_name("name") else {
+        return;
+    };
     let method_name = node_text(&name_node, source);
     let receiver = named_child_text(node, "object", source).map(|s| s.to_string());
     let call_line = start_line(node);
@@ -369,9 +403,13 @@ fn handle_method_invocation(node: &Node, source: &[u8], symbols: &mut FileSymbol
 }
 
 fn handle_object_creation(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(type_node) = node.child_by_field_name("type") else { return };
+    let Some(type_node) = node.child_by_field_name("type") else {
+        return;
+    };
     let type_name = if type_node.kind() == "generic_type" {
-        type_node.child(0).map(|n| node_text(&n, source).to_string())
+        type_node
+            .child(0)
+            .map(|n| node_text(&n, source).to_string())
     } else {
         Some(node_text(&type_node, source).to_string())
     };
@@ -455,7 +493,9 @@ fn extract_java_interfaces(
     symbols: &mut FileSymbols,
 ) {
     for i in 0..interfaces.child_count() {
-        let Some(child) = interfaces.child(i) else { continue };
+        let Some(child) = interfaces.child(i) else {
+            continue;
+        };
         match child.kind() {
             "type_identifier" | "identifier" => {
                 push_implements(symbols, class_name, node_text(&child, source), interfaces);
@@ -473,7 +513,12 @@ fn extract_java_interfaces(
     }
 }
 
-fn push_implements(symbols: &mut FileSymbols, class_name: &str, iface_name: &str, line_node: &Node) {
+fn push_implements(
+    symbols: &mut FileSymbols,
+    class_name: &str,
+    iface_name: &str,
+    line_node: &Node,
+) {
     symbols.classes.push(ClassRelation {
         name: class_name.to_string(),
         extends: None,
@@ -490,7 +535,9 @@ fn collect_type_list_implements(
     line_node: &Node,
 ) {
     for j in 0..type_list.child_count() {
-        let Some(t) = type_list.child(j) else { continue };
+        let Some(t) = type_list.child(j) else {
+            continue;
+        };
         match t.kind() {
             "type_identifier" | "identifier" => {
                 push_implements(symbols, class_name, node_text(&t, source), line_node);
@@ -559,7 +606,8 @@ mod tests {
             .unwrap();
         assert_eq!(abstract_save.bodyless, Some(true));
 
-        let concrete = parse_java("class Repo { boolean save(String id, int value) { return true; } }");
+        let concrete =
+            parse_java("class Repo { boolean save(String id, int value) { return true; } }");
         let concrete_save = concrete
             .definitions
             .iter()

--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -10,65 +10,20 @@ use tree_sitter::{Node, Tree};
 /// Mirrors the `BUILTIN_GLOBALS` set in `src/extractors/javascript.ts`
 /// and must be identical to the set tested in `is_js_builtin_global`.
 const JS_BUILTIN_GLOBALS: &[&str] = &[
-    "Math",
-    "JSON",
-    "Promise",
-    "Array",
-    "Object",
-    "Date",
-    "Error",
-    "Symbol",
-    "Map",
-    "Set",
-    "RegExp",
-    "Number",
-    "String",
-    "Boolean",
-    "WeakMap",
-    "WeakSet",
-    "WeakRef",
-    "Proxy",
-    "Reflect",
-    "Intl",
-    "ArrayBuffer",
-    "SharedArrayBuffer",
-    "DataView",
-    "Atomics",
-    "BigInt",
-    "Float32Array",
-    "Float64Array",
-    "Int8Array",
-    "Int16Array",
-    "Int32Array",
-    "Uint8Array",
-    "Uint16Array",
-    "Uint32Array",
-    "Uint8ClampedArray",
-    "URL",
-    "URLSearchParams",
-    "TextEncoder",
-    "TextDecoder",
-    "AbortController",
-    "AbortSignal",
-    "Headers",
-    "Request",
-    "Response",
-    "FormData",
-    "Blob",
-    "File",
-    "ReadableStream",
-    "WritableStream",
+    "Math", "JSON", "Promise", "Array", "Object", "Date", "Error",
+    "Symbol", "Map", "Set", "RegExp", "Number", "String", "Boolean",
+    "WeakMap", "WeakSet", "WeakRef", "Proxy", "Reflect", "Intl",
+    "ArrayBuffer", "SharedArrayBuffer", "DataView", "Atomics", "BigInt",
+    "Float32Array", "Float64Array", "Int8Array", "Int16Array", "Int32Array",
+    "Uint8Array", "Uint16Array", "Uint32Array", "Uint8ClampedArray",
+    "URL", "URLSearchParams", "TextEncoder", "TextDecoder",
+    "AbortController", "AbortSignal", "Headers", "Request", "Response",
+    "FormData", "Blob", "File", "ReadableStream", "WritableStream",
     "TransformStream",
     // Browser/runtime globals — must match is_js_builtin_global below
-    "console",
-    "process",
-    "window",
-    "document",
-    "globalThis",
+    "console", "process", "window", "document", "globalThis",
     // Node.js built-ins
-    "Buffer",
-    "EventEmitter",
-    "Stream",
+    "Buffer", "EventEmitter", "Stream",
 ];
 
 pub struct JsExtractor;
@@ -80,44 +35,19 @@ impl SymbolExtractor for JsExtractor {
         // same-file user-defined higher-order functions can be recognized
         // during the single forward walk below, regardless of declaration order.
         let callback_param_shapes = collect_callback_param_shapes(&tree.root_node(), source);
-        walk_tree(
-            &tree.root_node(),
-            source,
-            &mut symbols,
-            |node, source, symbols, depth| {
-                match_js_node(node, source, symbols, depth, &callback_param_shapes)
-            },
-        );
+        walk_tree(&tree.root_node(), source, &mut symbols, |node, source, symbols, depth| {
+            match_js_node(node, source, symbols, depth, &callback_param_shapes)
+        });
         walk_ast_nodes(&tree.root_node(), source, &mut symbols.ast_nodes);
         walk_tree(&tree.root_node(), source, &mut symbols, match_js_type_map);
-        walk_tree(
-            &tree.root_node(),
-            source,
-            &mut symbols,
-            match_js_return_type_map,
-        );
+        walk_tree(&tree.root_node(), source, &mut symbols, match_js_return_type_map);
         // Pre-ES6 prototype methods: `Foo.prototype.bar = fn` and `Foo.prototype = { bar: fn }`
-        walk_tree(
-            &tree.root_node(),
-            source,
-            &mut symbols,
-            match_js_prototype_methods,
-        );
+        walk_tree(&tree.root_node(), source, &mut symbols, match_js_prototype_methods);
         // call_assignments runs after type_map is populated (needs receiver types)
-        walk_tree(
-            &tree.root_node(),
-            source,
-            &mut symbols,
-            match_js_call_assignments,
-        );
+        walk_tree(&tree.root_node(), source, &mut symbols, match_js_call_assignments);
         // Phase 8.3c–8.3f: points-to bindings (params, this-rebinding, arrays,
         // spread, for-of, object rest/props) for the pts constraint solver.
-        walk_tree(
-            &tree.root_node(),
-            source,
-            &mut symbols,
-            match_js_pts_bindings,
-        );
+        walk_tree(&tree.root_node(), source, &mut symbols, match_js_pts_bindings);
         // Collapse duplicate keys accumulated during the tree walks (O(n)).
         dedup_type_map(&mut symbols.type_map);
         dedup_type_map(&mut symbols.return_type_map);
@@ -134,14 +64,9 @@ impl SymbolExtractor for JsExtractor {
         // via `setTypeMapEntry`, so `.get()` is always already resolved — ordering
         // this walk after dedup keeps both engines reading the same resolved view.
         let local_accessors = collect_local_accessors(&tree.root_node(), source);
-        walk_tree(
-            &tree.root_node(),
-            source,
-            &mut symbols,
-            |node, source, symbols, _depth| {
-                handle_accessor_property_read(node, source, symbols, &local_accessors)
-            },
-        );
+        walk_tree(&tree.root_node(), source, &mut symbols, |node, source, symbols, _depth| {
+            handle_accessor_property_read(node, source, symbols, &local_accessors)
+        });
         symbols
     }
 }
@@ -171,12 +96,12 @@ fn extract_new_expr_type_name<'a>(node: &Node<'a>, source: &'a [u8]) -> Option<&
     if node.kind() != "new_expression" {
         return None;
     }
-    let ctor = node
-        .child_by_field_name("constructor")
-        .or_else(|| node.child(1))?;
+    let ctor = node.child_by_field_name("constructor").or_else(|| node.child(1))?;
     match ctor.kind() {
         "identifier" => Some(node_text(&ctor, source)),
-        "member_expression" => named_child_text(&ctor, "property", source),
+        "member_expression" => {
+            named_child_text(&ctor, "property", source)
+        }
         _ => None,
     }
 }
@@ -192,9 +117,7 @@ fn enclosing_type_map_class<'a>(node: &Node<'a>, source: &'a [u8]) -> Option<&'a
     while let Some(n) = cur {
         match n.kind() {
             "class_declaration" | "abstract_class_declaration" => {
-                return n
-                    .child_by_field_name("name")
-                    .map(|name| node_text(&name, source));
+                return n.child_by_field_name("name").map(|name| node_text(&name, source));
             }
             "class" => return None,
             _ => {}
@@ -215,9 +138,7 @@ fn match_js_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
         "assignment_expression" => handle_assignment_type_map(node, source, symbols),
         // TypeScript class field declarations.
         // Mirrors handleFieldDefTypeMap in src/extractors/javascript.ts.
-        "public_field_definition" | "field_definition" => {
-            handle_field_def_type_map(node, source, symbols)
-        }
+        "public_field_definition" | "field_definition" => handle_field_def_type_map(node, source, symbols),
         _ => {}
     }
 }
@@ -230,12 +151,8 @@ fn match_js_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
 /// - Object.create({ key: fn }) composite pts keys (Phase 8.3e)
 /// - object-literal declarations at non-function scope (Phase 8.3f parity)
 fn handle_var_declarator_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_n) = node.child_by_field_name("name") else {
-        return;
-    };
-    if name_n.kind() != "identifier" {
-        return;
-    }
+    let Some(name_n) = node.child_by_field_name("name") else { return };
+    if name_n.kind() != "identifier" { return; }
     let var_name = node_text(&name_n, source);
     // Type annotation: confidence 0.9
     if let Some(type_anno) = find_child(node, "type_annotation") {
@@ -243,9 +160,7 @@ fn handle_var_declarator_type_map(node: &Node, source: &[u8], symbols: &mut File
             push_type_map_entry(symbols, var_name.to_string(), type_name.to_string());
         }
     }
-    let Some(value_n) = node.child_by_field_name("value") else {
-        return;
-    };
+    let Some(value_n) = node.child_by_field_name("value") else { return };
     // Constructor: confidence 1.0 (overrides annotation in edge builder)
     if value_n.kind() == "new_expression" {
         if let Some(type_name) = extract_new_expr_type_name(&value_n, source) {
@@ -265,20 +180,10 @@ fn handle_var_declarator_type_map(node: &Node, source: &[u8], symbols: &mut File
     // Mirrors WASM handleVarDeclaratorTypeMap (no isConst guard there).
     // For `const`, extract_object_literal_functions already seeds these entries;
     // dedup_type_map collapses any duplicates at equal confidence.
-    if value_n.kind() == "object"
-        && find_parent_of_types(
-            node,
-            &[
-                "function_declaration",
-                "arrow_function",
-                "function_expression",
-                "method_definition",
-                "generator_function_declaration",
-                "generator_function",
-            ],
-        )
-        .is_none()
-    {
+    if value_n.kind() == "object" && find_parent_of_types(node, &[
+        "function_declaration", "arrow_function", "function_expression",
+        "method_definition", "generator_function_declaration", "generator_function",
+    ]).is_none() {
         seed_objlit_type_map_entries(var_name, &value_n, source, symbols);
     }
 }
@@ -287,17 +192,12 @@ fn handle_var_declarator_type_map(node: &Node, source: &[u8], symbols: &mut File
 ///
 /// Seeds a type-map entry when the parameter carries a TypeScript type annotation.
 fn handle_param_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let name_node = node
-        .child_by_field_name("pattern")
+    let name_node = node.child_by_field_name("pattern")
         .or_else(|| node.child_by_field_name("left"))
         .or_else(|| node.child(0));
     let Some(name_node) = name_node else { return };
-    if name_node.kind() != "identifier" {
-        return;
-    };
-    let Some(type_anno) = find_child(node, "type_annotation") else {
-        return;
-    };
+    if name_node.kind() != "identifier" { return };
+    let Some(type_anno) = find_child(node, "type_annotation") else { return };
     if let Some(type_name) = extract_simple_type_name(&type_anno, source) {
         push_type_map_entry(
             symbols,
@@ -317,22 +217,14 @@ fn handle_param_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
 fn handle_assignment_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     let lhs = node.child_by_field_name("left");
     let rhs = node.child_by_field_name("right");
-    let (Some(lhs), Some(rhs)) = (lhs, rhs) else {
-        return;
-    };
-    if lhs.kind() != "member_expression" {
-        return;
-    }
+    let (Some(lhs), Some(rhs)) = (lhs, rhs) else { return };
+    if lhs.kind() != "member_expression" { return; }
     let obj = lhs.child_by_field_name("object");
     let prop = lhs.child_by_field_name("property");
-    let (Some(obj), Some(prop)) = (obj, prop) else {
-        return;
-    };
+    let (Some(obj), Some(prop)) = (obj, prop) else { return };
     // Guard: only static property access, not computed subscripts.
     let prop_kind = prop.kind();
-    if prop_kind != "property_identifier" && prop_kind != "identifier" {
-        return;
-    }
+    if prop_kind != "property_identifier" && prop_kind != "identifier" { return; }
     if obj.kind() == "this" && rhs.kind() == "new_expression" {
         if let Some(ctor_type) = extract_new_expr_type_name(&rhs, source) {
             let key = match enclosing_type_map_class(node, source) {
@@ -369,25 +261,17 @@ fn handle_assignment_type_map(node: &Node, source: &[u8], symbols: &mut FileSymb
 ///
 /// Mirrors `handleFieldDefTypeMap` in `src/extractors/javascript.ts`.
 fn handle_field_def_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let name_node = node
-        .child_by_field_name("name")
+    let name_node = node.child_by_field_name("name")
         .or_else(|| node.child_by_field_name("property"))
         .or_else(|| find_child(node, "property_identifier"));
     let Some(name_node) = name_node else { return };
     let kind = name_node.kind();
-    if kind != "property_identifier"
-        && kind != "identifier"
-        && kind != "private_property_identifier"
-    {
+    if kind != "property_identifier" && kind != "identifier" && kind != "private_property_identifier" {
         return;
     }
     let field_name = node_text(&name_node, source).to_string();
-    let Some(type_anno) = find_child(node, "type_annotation") else {
-        return;
-    };
-    let Some(type_name) = extract_simple_type_name(&type_anno, source) else {
-        return;
-    };
+    let Some(type_anno) = find_child(node, "type_annotation") else { return };
+    let Some(type_name) = extract_simple_type_name(&type_anno, source) else { return };
     match enclosing_type_map_class(node, source) {
         Some(class_name) => {
             // Primary: class-scoped key prevents cross-class collision.
@@ -399,23 +283,13 @@ fn handle_field_def_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbo
             );
             // Fallback bare keys at lower confidence.
             set_type_map_entry(symbols, field_name.clone(), type_name.to_string(), 0.6);
-            set_type_map_entry(
-                symbols,
-                format!("this.{}", field_name),
-                type_name.to_string(),
-                0.6,
-            );
+            set_type_map_entry(symbols, format!("this.{}", field_name), type_name.to_string(), 0.6);
         }
         None => {
             // No enclosing class declaration (e.g. class expression)
             // — use bare keys only at full confidence.
             set_type_map_entry(symbols, field_name.clone(), type_name.to_string(), 0.9);
-            set_type_map_entry(
-                symbols,
-                format!("this.{}", field_name),
-                type_name.to_string(),
-                0.9,
-            );
+            set_type_map_entry(symbols, format!("this.{}", field_name), type_name.to_string(), 0.9);
         }
     }
 }
@@ -452,37 +326,22 @@ fn is_js_builtin_global(name: &str) -> bool {
 /// Seed composite pts keys for `Object.defineProperty(obj, "key", { value: fn })`
 /// and `Object.defineProperties(obj, { "key": { value: fn }, ... })`.
 fn seed_define_property_entries(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(callee) = node.child_by_field_name("function") else {
-        return;
-    };
-    if callee.kind() != "member_expression" {
-        return;
-    }
-    let Some(callee_obj) = callee.child_by_field_name("object") else {
-        return;
-    };
-    if node_text(&callee_obj, source) != "Object" {
-        return;
-    }
-    let Some(callee_prop) = callee.child_by_field_name("property") else {
-        return;
-    };
+    let Some(callee) = node.child_by_field_name("function") else { return };
+    if callee.kind() != "member_expression" { return; }
+    let Some(callee_obj) = callee.child_by_field_name("object") else { return };
+    if node_text(&callee_obj, source) != "Object" { return; }
+    let Some(callee_prop) = callee.child_by_field_name("property") else { return };
     let method = node_text(&callee_prop, source);
-    if method != "defineProperty" && method != "defineProperties" {
-        return;
-    }
+    if method != "defineProperty" && method != "defineProperties" { return; }
 
-    let args_node = node
-        .child_by_field_name("arguments")
+    let args_node = node.child_by_field_name("arguments")
         .or_else(|| find_child(node, "arguments"));
     let Some(args_node) = args_node else { return };
 
     // Collect non-punctuation argument nodes in order
     let mut args: Vec<Node> = Vec::new();
     for i in 0..args_node.child_count() {
-        let Some(child) = args_node.child(i) else {
-            continue;
-        };
+        let Some(child) = args_node.child(i) else { continue };
         if !matches!(child.kind(), "(" | ")" | ",") {
             args.push(child);
         }
@@ -490,16 +349,10 @@ fn seed_define_property_entries(node: &Node, source: &[u8], symbols: &mut FileSy
 
     if method == "defineProperty" {
         // Object.defineProperty(obj, "key", { value: fn }) or { get: getter }
-        if args.len() < 3 {
-            return;
-        }
-        if args[0].kind() != "identifier" {
-            return;
-        }
+        if args.len() < 3 { return; }
+        if args[0].kind() != "identifier" { return; }
         let obj_name = node_text(&args[0], source);
-        let Some(key) = extract_string_fragment(&args[1], source) else {
-            return;
-        };
+        let Some(key) = extract_string_fragment(&args[1], source) else { return };
         // Phase 8.3e: { value: fn } → obj.key pts to fn
         if let Some(target) = find_descriptor_value(&args[2], source) {
             symbols.type_map.push(TypeMapEntry {
@@ -518,48 +371,24 @@ fn seed_define_property_entries(node: &Node, source: &[u8], symbols: &mut FileSy
         }
     } else {
         // Object.defineProperties(obj, { "key": { value: fn }, ... })
-        if args.len() < 2 {
-            return;
-        }
-        if args[0].kind() != "identifier" {
-            return;
-        }
+        if args.len() < 2 { return; }
+        if args[0].kind() != "identifier" { return; }
         let obj_name = node_text(&args[0], source).to_string();
-        if args[1].kind() != "object" {
-            return;
-        }
+        if args[1].kind() != "object" { return; }
         seed_descriptor_object(&obj_name, &args[1], source, symbols);
     }
 }
 
 /// Seed composite pts keys from `const obj = Object.create({ f1, f2 })`.
-fn seed_object_create_entries(
-    var_name: &str,
-    call_node: &Node,
-    source: &[u8],
-    symbols: &mut FileSymbols,
-) {
-    let Some(callee) = call_node.child_by_field_name("function") else {
-        return;
-    };
-    if callee.kind() != "member_expression" {
-        return;
-    }
-    let Some(callee_obj) = callee.child_by_field_name("object") else {
-        return;
-    };
-    if node_text(&callee_obj, source) != "Object" {
-        return;
-    }
-    let Some(callee_prop) = callee.child_by_field_name("property") else {
-        return;
-    };
-    if node_text(&callee_prop, source) != "create" {
-        return;
-    }
+fn seed_object_create_entries(var_name: &str, call_node: &Node, source: &[u8], symbols: &mut FileSymbols) {
+    let Some(callee) = call_node.child_by_field_name("function") else { return };
+    if callee.kind() != "member_expression" { return; }
+    let Some(callee_obj) = callee.child_by_field_name("object") else { return };
+    if node_text(&callee_obj, source) != "Object" { return; }
+    let Some(callee_prop) = callee.child_by_field_name("property") else { return };
+    if node_text(&callee_prop, source) != "create" { return; }
 
-    let args_node = call_node
-        .child_by_field_name("arguments")
+    let args_node = call_node.child_by_field_name("arguments")
         .or_else(|| find_child(call_node, "arguments"));
     let Some(args_node) = args_node else { return };
 
@@ -568,14 +397,10 @@ fn seed_object_create_entries(
         .filter_map(|i| args_node.child(i))
         .find(|n| !matches!(n.kind(), "(" | ")" | ","));
     let Some(proto) = proto else { return };
-    if proto.kind() != "object" {
-        return;
-    };
+    if proto.kind() != "object" { return };
 
     for i in 0..proto.child_count() {
-        let Some(child) = proto.child(i) else {
-            continue;
-        };
+        let Some(child) = proto.child(i) else { continue };
         match child.kind() {
             "shorthand_property_identifier" => {
                 // { f1 } shorthand — property name equals value name
@@ -587,18 +412,10 @@ fn seed_object_create_entries(
                 });
             }
             "pair" => {
-                let Some(key_n) = child.child_by_field_name("key") else {
-                    continue;
-                };
-                let Some(val_n) = child.child_by_field_name("value") else {
-                    continue;
-                };
-                if val_n.kind() != "identifier" {
-                    continue;
-                }
-                let Some(key) = resolve_pair_key_name(&key_n, source) else {
-                    continue;
-                };
+                let Some(key_n) = child.child_by_field_name("key") else { continue };
+                let Some(val_n) = child.child_by_field_name("value") else { continue };
+                if val_n.kind() != "identifier" { continue; }
+                let Some(key) = resolve_pair_key_name(&key_n, source) else { continue };
                 symbols.type_map.push(TypeMapEntry {
                     name: format!("{}.{}", var_name, key),
                     type_name: node_text(&val_n, source).to_string(),
@@ -611,31 +428,14 @@ fn seed_object_create_entries(
 }
 
 /// Iterate over the properties of a `defineProperties` descriptor object and seed the type_map.
-fn seed_descriptor_object(
-    obj_name: &str,
-    obj_node: &Node,
-    source: &[u8],
-    symbols: &mut FileSymbols,
-) {
+fn seed_descriptor_object(obj_name: &str, obj_node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     for i in 0..obj_node.child_count() {
-        let Some(child) = obj_node.child(i) else {
-            continue;
-        };
-        if child.kind() != "pair" {
-            continue;
-        }
-        let Some(key_n) = child.child_by_field_name("key") else {
-            continue;
-        };
-        let Some(val_n) = child.child_by_field_name("value") else {
-            continue;
-        };
-        let Some(key) = resolve_pair_key_name(&key_n, source) else {
-            continue;
-        };
-        let Some(target) = find_descriptor_value(&val_n, source) else {
-            continue;
-        };
+        let Some(child) = obj_node.child(i) else { continue };
+        if child.kind() != "pair" { continue; }
+        let Some(key_n) = child.child_by_field_name("key") else { continue };
+        let Some(val_n) = child.child_by_field_name("value") else { continue };
+        let Some(key) = resolve_pair_key_name(&key_n, source) else { continue };
+        let Some(target) = find_descriptor_value(&val_n, source) else { continue };
         symbols.type_map.push(TypeMapEntry {
             name: format!("{}.{}", obj_name, key),
             type_name: target.to_string(),
@@ -646,31 +446,19 @@ fn seed_descriptor_object(
 
 /// Extract the text of the `string_fragment` child of a string node, i.e. content without quotes.
 fn extract_string_fragment<'a>(node: &Node<'a>, source: &'a [u8]) -> Option<&'a str> {
-    if node.kind() != "string" {
-        return None;
-    }
+    if node.kind() != "string" { return None; }
     find_child(node, "string_fragment").map(|n| node_text(&n, source))
 }
 
 /// Find the `value` identifier in a property descriptor object `{ value: fn }`.
 fn find_descriptor_value<'a>(node: &Node<'a>, source: &'a [u8]) -> Option<&'a str> {
-    if node.kind() != "object" {
-        return None;
-    }
+    if node.kind() != "object" { return None; }
     for i in 0..node.child_count() {
         let Some(child) = node.child(i) else { continue };
-        if child.kind() != "pair" {
-            continue;
-        }
-        let Some(key) = child.child_by_field_name("key") else {
-            continue;
-        };
-        if node_text(&key, source) != "value" {
-            continue;
-        }
-        let Some(val) = child.child_by_field_name("value") else {
-            continue;
-        };
+        if child.kind() != "pair" { continue; }
+        let Some(key) = child.child_by_field_name("key") else { continue };
+        if node_text(&key, source) != "value" { continue; }
+        let Some(val) = child.child_by_field_name("value") else { continue };
         if val.kind() == "identifier" {
             return Some(node_text(&val, source));
         }
@@ -682,25 +470,15 @@ fn find_descriptor_value<'a>(node: &Node<'a>, source: &'a [u8]) -> Option<&'a st
 /// descriptor. `{ get: getter, set: setter }` → ["getter", "setter"].
 /// Returns all accessors so that each one gets a `callerName:this = obj` typeMap entry.
 fn find_descriptor_accessors<'a>(node: &Node<'a>, source: &'a [u8]) -> Vec<&'a str> {
-    if node.kind() != "object" {
-        return Vec::new();
-    }
+    if node.kind() != "object" { return Vec::new(); }
     let mut result = Vec::new();
     for i in 0..node.child_count() {
         let Some(child) = node.child(i) else { continue };
-        if child.kind() != "pair" {
-            continue;
-        }
-        let Some(key) = child.child_by_field_name("key") else {
-            continue;
-        };
+        if child.kind() != "pair" { continue; }
+        let Some(key) = child.child_by_field_name("key") else { continue };
         let key_text = node_text(&key, source);
-        if key_text != "get" && key_text != "set" {
-            continue;
-        }
-        let Some(val) = child.child_by_field_name("value") else {
-            continue;
-        };
+        if key_text != "get" && key_text != "set" { continue; }
+        let Some(val) = child.child_by_field_name("value") else { continue };
         if val.kind() == "identifier" {
             result.push(node_text(&val, source));
         }
@@ -711,15 +489,9 @@ fn find_descriptor_accessors<'a>(node: &Node<'a>, source: &'a [u8]) -> Vec<&'a s
 /// True when `declarator` is the shape `extract_object_literal_functions` qualifies: a plain
 /// identifier name, outside any function scope. Mirrors TS `isEligibleObjectLiteralDeclarator`.
 fn is_eligible_object_literal_declarator(declarator: &Node) -> bool {
-    if declarator.kind() != "variable_declarator" {
-        return false;
-    }
-    let Some(name_n) = declarator.child_by_field_name("name") else {
-        return false;
-    };
-    if name_n.kind() != "identifier" {
-        return false;
-    }
+    if declarator.kind() != "variable_declarator" { return false; }
+    let Some(name_n) = declarator.child_by_field_name("name") else { return false };
+    if name_n.kind() != "identifier" { return false; }
     find_parent_of_types(declarator, &VAR_DECL_FN_SCOPE_TYPES).is_none()
 }
 
@@ -737,18 +509,10 @@ fn is_eligible_object_literal_declarator(declarator: &Node) -> bool {
 /// already produces a *class*-qualified entry (`ClassName.method`, via `find_parent_class`)
 /// rather than a bare one; that entry must be left alone, not duplicated by a spurious bare push.
 fn is_object_literal_declarator_method(method_node: &Node, source: &[u8]) -> bool {
-    let Some(obj) = method_node.parent() else {
-        return false;
-    };
-    if obj.kind() != "object" {
-        return false;
-    }
-    let Some(declarator) = obj.parent() else {
-        return false;
-    };
-    if !is_eligible_object_literal_declarator(&declarator) {
-        return false;
-    }
+    let Some(obj) = method_node.parent() else { return false };
+    if obj.kind() != "object" { return false; }
+    let Some(declarator) = obj.parent() else { return false };
+    if !is_eligible_object_literal_declarator(&declarator) { return false; }
     find_parent_class(method_node, source).is_none()
 }
 
@@ -780,9 +544,7 @@ fn extract_object_literal_functions(
     symbols: &mut FileSymbols,
 ) {
     for i in 0..obj_node.child_count() {
-        let Some(child) = obj_node.child(i) else {
-            continue;
-        };
+        let Some(child) = obj_node.child(i) else { continue };
         match child.kind() {
             "shorthand_property_identifier" => {
                 let prop_name = node_text(&child, source);
@@ -793,18 +555,12 @@ fn extract_object_literal_functions(
                 });
             }
             "pair" => {
-                let Some(key_n) = child.child_by_field_name("key") else {
-                    continue;
-                };
-                let Some(val_n) = child.child_by_field_name("value") else {
-                    continue;
-                };
+                let Some(key_n) = child.child_by_field_name("key") else { continue };
+                let Some(val_n) = child.child_by_field_name("value") else { continue };
                 // Use resolve_pair_key_name to strip brackets from computed string keys
                 // (e.g. ['foo'] → "foo") and skip non-string computed keys ([Symbol.iterator]),
                 // mirroring resolve_method_def_name below.
-                let Some(key) = resolve_pair_key_name(&key_n, source) else {
-                    continue;
-                };
+                let Some(key) = resolve_pair_key_name(&key_n, source) else { continue };
                 let qualified = format!("{}.{}", var_name, key);
                 match val_n.kind() {
                     "arrow_function" | "function_expression" | "function" => {
@@ -843,9 +599,7 @@ fn extract_object_literal_functions(
             "method_definition" => {
                 // Use resolve_method_def_name to strip brackets from computed string keys
                 // (e.g. ['foo'] → "foo") and skip non-string computed keys ([Symbol.iterator]).
-                let Some(method_name) = resolve_method_def_name(&child, source) else {
-                    continue;
-                };
+                let Some(method_name) = resolve_method_def_name(&child, source) else { continue };
                 let qualified = format!("{}.{}", var_name, method_name);
                 // typeMap['obj.baz'] = 'baz' — points to the bare-name definition so
                 // the two-step accessor dispatch resolves via the bare node.
@@ -902,16 +656,9 @@ fn extract_object_literal_functions(
 ///
 /// For `const` declarations this produces the same entries as `extract_object_literal_functions`,
 /// but `dedup_type_map` collapses duplicates at equal confidence.
-fn seed_objlit_type_map_entries(
-    var_name: &str,
-    obj_node: &Node,
-    source: &[u8],
-    symbols: &mut FileSymbols,
-) {
+fn seed_objlit_type_map_entries(var_name: &str, obj_node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     for i in 0..obj_node.child_count() {
-        let Some(child) = obj_node.child(i) else {
-            continue;
-        };
+        let Some(child) = obj_node.child(i) else { continue };
         match child.kind() {
             "shorthand_property_identifier" => {
                 let prop_name = node_text(&child, source);
@@ -922,15 +669,9 @@ fn seed_objlit_type_map_entries(
                 });
             }
             "pair" => {
-                let Some(key_n) = child.child_by_field_name("key") else {
-                    continue;
-                };
-                let Some(val_n) = child.child_by_field_name("value") else {
-                    continue;
-                };
-                let Some(key) = resolve_pair_key_name(&key_n, source) else {
-                    continue;
-                };
+                let Some(key_n) = child.child_by_field_name("key") else { continue };
+                let Some(val_n) = child.child_by_field_name("value") else { continue };
+                let Some(key) = resolve_pair_key_name(&key_n, source) else { continue };
                 let qualified = format!("{}.{}", var_name, key);
                 match val_n.kind() {
                     "arrow_function" | "function_expression" | "function" => {
@@ -963,9 +704,7 @@ fn seed_objlit_type_map_entries(
                 // and qualified definitions inline for all declaration kinds (const/let/var) —
                 // see `handle_var_decl`'s two call sites. Using the bare name here keeps
                 // resolution consistent across all declaration kinds.
-                let Some(method_name) = resolve_method_def_name(&child, source) else {
-                    continue;
-                };
+                let Some(method_name) = resolve_method_def_name(&child, source) else { continue };
                 let qualified = format!("{}.{}", var_name, method_name);
                 symbols.type_map.push(TypeMapEntry {
                     name: qualified,
@@ -985,13 +724,9 @@ fn seed_objlit_type_map_entries(
 fn match_js_return_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: usize) {
     match node.kind() {
         "function_declaration" | "generator_function_declaration" => {
-            let Some(name_n) = node.child_by_field_name("name") else {
-                return;
-            };
+            let Some(name_n) = node.child_by_field_name("name") else { return };
             let fn_name = node_text(&name_n, source);
-            if fn_name == "constructor" {
-                return;
-            }
+            if fn_name == "constructor" { return; }
             // Use the boundary-aware variant: nested function declarations inside
             // method bodies must not inherit the class prefix (matches WASM behaviour).
             let key = match find_parent_class_no_fn_boundary(node, source) {
@@ -1001,13 +736,9 @@ fn match_js_return_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbol
             store_return_type(node, &key, source, symbols);
         }
         "method_definition" => {
-            let Some(name_n) = node.child_by_field_name("name") else {
-                return;
-            };
+            let Some(name_n) = node.child_by_field_name("name") else { return };
             let method_name = node_text(&name_n, source);
-            if method_name == "constructor" {
-                return;
-            }
+            if method_name == "constructor" { return; }
             // method_definition is always a direct child of class_body — plain
             // find_parent_class is correct here.
             let key = match find_parent_class(node, source) {
@@ -1017,21 +748,12 @@ fn match_js_return_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbol
             store_return_type(node, &key, source, symbols);
         }
         "variable_declarator" => {
-            let Some(name_n) = node.child_by_field_name("name") else {
-                return;
-            };
-            if name_n.kind() != "identifier" {
-                return;
-            }
-            let Some(value_n) = node.child_by_field_name("value") else {
-                return;
-            };
+            let Some(name_n) = node.child_by_field_name("name") else { return };
+            if name_n.kind() != "identifier" { return; }
+            let Some(value_n) = node.child_by_field_name("value") else { return };
             // Only arrow_function, function_expression and generator_function match the TS reference;
             // "function" is not a valid tree-sitter value-expression kind here.
-            if !matches!(
-                value_n.kind(),
-                "arrow_function" | "function_expression" | "generator_function"
-            ) {
+            if !matches!(value_n.kind(), "arrow_function" | "function_expression" | "generator_function") {
                 return;
             }
             let var_name = node_text(&name_n, source);
@@ -1069,9 +791,7 @@ fn store_return_type(fn_node: &Node, fn_name: &str, source: &[u8], symbols: &mut
 fn find_return_new_expr_type<'a>(body: &Node<'a>, source: &'a [u8]) -> Option<&'a str> {
     for i in 0..body.child_count() {
         let Some(child) = body.child(i) else { continue };
-        if child.kind() != "return_statement" {
-            continue;
-        }
+        if child.kind() != "return_statement" { continue; }
         for j in 0..child.child_count() {
             let Some(expr) = child.child(j) else { continue };
             if expr.kind() == "new_expression" {
@@ -1085,12 +805,7 @@ fn find_return_new_expr_type<'a>(body: &Node<'a>, source: &'a [u8]) -> Option<&'
 /// Append a `(fn_name → type_name)` entry to `return_type_map`.
 /// Deduplication (highest-confidence-wins) is handled in bulk by
 /// [`dedup_type_map`] at the end of `extract()`.
-fn push_return_type_entry(
-    symbols: &mut FileSymbols,
-    fn_name: &str,
-    type_name: &str,
-    confidence: f64,
-) {
+fn push_return_type_entry(symbols: &mut FileSymbols, fn_name: &str, type_name: &str, confidence: f64) {
     symbols.return_type_map.push(TypeMapEntry {
         name: fn_name.to_string(),
         type_name: type_name.to_string(),
@@ -1108,19 +823,10 @@ fn push_return_type_entry(
 ///   1. `Foo.prototype.bar = function(){}`  → emits `Foo.bar` as a method definition
 ///   2. `Foo.prototype.bar = identifier`    → seeds `typeMap['Foo.bar'] = identifier`
 ///   3. `Foo.prototype = { bar: fn, ... }`  → same rules applied per property
-fn match_js_prototype_methods(
-    node: &Node,
-    source: &[u8],
-    symbols: &mut FileSymbols,
-    _depth: usize,
-) {
-    if node.kind() != "expression_statement" {
-        return;
-    }
+fn match_js_prototype_methods(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: usize) {
+    if node.kind() != "expression_statement" { return; }
     let Some(expr) = node.child(0) else { return };
-    if expr.kind() != "assignment_expression" {
-        return;
-    }
+    if expr.kind() != "assignment_expression" { return; }
     let lhs = expr.child_by_field_name("left");
     let rhs = expr.child_by_field_name("right");
     if let (Some(lhs), Some(rhs)) = (lhs, rhs) {
@@ -1128,21 +834,10 @@ fn match_js_prototype_methods(
     }
 }
 
-fn handle_js_prototype_assignment(
-    lhs: &Node,
-    rhs: &Node,
-    source: &[u8],
-    symbols: &mut FileSymbols,
-) {
-    if lhs.kind() != "member_expression" {
-        return;
-    }
-    let Some(lhs_obj) = lhs.child_by_field_name("object") else {
-        return;
-    };
-    let Some(lhs_prop) = lhs.child_by_field_name("property") else {
-        return;
-    };
+fn handle_js_prototype_assignment(lhs: &Node, rhs: &Node, source: &[u8], symbols: &mut FileSymbols) {
+    if lhs.kind() != "member_expression" { return; }
+    let Some(lhs_obj) = lhs.child_by_field_name("object") else { return };
+    let Some(lhs_prop) = lhs.child_by_field_name("property") else { return };
 
     // Pattern 1: `Foo.prototype.bar = rhs`
     // lhs.object is `Foo.prototype` (member_expression), lhs.property is `bar`
@@ -1215,13 +910,7 @@ fn handle_js_prototype_assignment(
 /// Emit one prototype method definition or typeMap alias for `ClassName.methodName = rhs`.
 ///
 /// Mirrors `emitPrototypeMethod` in `src/extractors/javascript.ts`.
-fn emit_js_prototype_method(
-    class_name: &str,
-    method_name: &str,
-    rhs: &Node,
-    source: &[u8],
-    symbols: &mut FileSymbols,
-) {
+fn emit_js_prototype_method(class_name: &str, method_name: &str, rhs: &Node, source: &[u8], symbols: &mut FileSymbols) {
     let full_name = format!("{}.{}", class_name, method_name);
     match rhs.kind() {
         "function_expression" | "arrow_function" => {
@@ -1252,21 +941,12 @@ fn emit_js_prototype_method(
 /// Iterate over an object literal assigned to `Foo.prototype` and emit definitions/aliases.
 ///
 /// Mirrors `extractPrototypeObjectLiteral` in `src/extractors/javascript.ts`.
-fn extract_js_prototype_object_literal(
-    class_name: &str,
-    obj_node: &Node,
-    source: &[u8],
-    symbols: &mut FileSymbols,
-) {
+fn extract_js_prototype_object_literal(class_name: &str, obj_node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     for i in 0..obj_node.child_count() {
-        let Some(child) = obj_node.child(i) else {
-            continue;
-        };
+        let Some(child) = obj_node.child(i) else { continue };
         match child.kind() {
             "method_definition" => {
-                let Some(method_name) = resolve_method_def_name(&child, source) else {
-                    continue;
-                };
+                let Some(method_name) = resolve_method_def_name(&child, source) else { continue };
                 let children = extract_js_parameters(&child, source);
                 symbols.definitions.push(Definition {
                     name: format!("{}.{}", class_name, method_name),
@@ -1295,19 +975,9 @@ fn extract_js_prototype_object_literal(
                 let key_node = child.child_by_field_name("key");
                 let value_node = child.child_by_field_name("value");
                 if let (Some(key_node), Some(value_node)) = (key_node, value_node) {
-                    let Some(method_name) = resolve_pair_key_name(&key_node, source) else {
-                        continue;
-                    };
-                    if method_name.is_empty() {
-                        continue;
-                    }
-                    emit_js_prototype_method(
-                        class_name,
-                        &method_name,
-                        &value_node,
-                        source,
-                        symbols,
-                    );
+                    let Some(method_name) = resolve_pair_key_name(&key_node, source) else { continue };
+                    if method_name.is_empty() { continue; }
+                    emit_js_prototype_method(class_name, &method_name, &value_node, source, symbols);
                 }
             }
             _ => {}
@@ -1321,26 +991,14 @@ fn extract_js_prototype_object_literal(
 /// `symbols.call_assignments` for cross-file return-type propagation.
 /// Mirrors `recordCallAssignment` in src/extractors/javascript.ts.
 fn match_js_call_assignments(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: usize) {
-    if node.kind() != "variable_declarator" {
-        return;
-    }
-    let Some(name_n) = node.child_by_field_name("name") else {
-        return;
-    };
-    if name_n.kind() != "identifier" {
-        return;
-    }
-    let Some(value_n) = node.child_by_field_name("value") else {
-        return;
-    };
-    if value_n.kind() != "call_expression" {
-        return;
-    }
+    if node.kind() != "variable_declarator" { return; }
+    let Some(name_n) = node.child_by_field_name("name") else { return };
+    if name_n.kind() != "identifier" { return; }
+    let Some(value_n) = node.child_by_field_name("value") else { return };
+    if value_n.kind() != "call_expression" { return; }
 
     let var_name = node_text(&name_n, source).to_string();
-    let Some(fn_node) = value_n.child_by_field_name("function") else {
-        return;
-    };
+    let Some(fn_node) = value_n.child_by_field_name("function") else { return };
 
     match fn_node.kind() {
         "identifier" => {
@@ -1351,18 +1009,10 @@ fn match_js_call_assignments(node: &Node, source: &[u8], symbols: &mut FileSymbo
             });
         }
         "member_expression" => {
-            let Some(obj) = fn_node.child_by_field_name("object") else {
-                return;
-            };
-            let Some(prop) = fn_node.child_by_field_name("property") else {
-                return;
-            };
-            if obj.kind() != "identifier" {
-                return;
-            }
-            let receiver_type = symbols
-                .type_map
-                .iter()
+            let Some(obj) = fn_node.child_by_field_name("object") else { return };
+            let Some(prop) = fn_node.child_by_field_name("property") else { return };
+            if obj.kind() != "identifier" { return; }
+            let receiver_type = symbols.type_map.iter()
                 .find(|e| e.name == node_text(&obj, source))
                 .map(|e| e.type_name.clone());
             symbols.call_assignments.push(NativeCallAssignment {
@@ -1435,9 +1085,7 @@ fn handle_function_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 }
 
 fn handle_class_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else {
-        return;
-    };
+    let Some(name_node) = node.child_by_field_name("name") else { return };
     let class_name = node_text(&name_node, source).to_string();
     let children = extract_js_class_properties(node, source);
     symbols.definitions.push(Definition {
@@ -1486,16 +1134,12 @@ fn resolve_computed_key_name(computed_node: &Node, source: &[u8]) -> Option<Stri
     match inner.kind() {
         "string" => {
             let s = extract_string_fragment(&inner, source).unwrap_or("");
-            if s.is_empty() {
-                return None;
-            }
+            if s.is_empty() { return None; }
             Some(s.to_string())
         }
         "string_fragment" => {
             let s = node_text(&inner, source);
-            if s.is_empty() {
-                return None;
-            }
+            if s.is_empty() { return None; }
             Some(s.to_string())
         }
         _ => None, // non-string computed key — skip
@@ -1596,9 +1240,7 @@ type LocalAccessorRegistry = HashMap<String, LocalAccessorInfo>;
 fn get_method_accessor_kind(meth_node: &Node) -> Option<&'static str> {
     let name_node = meth_node.child_by_field_name("name");
     for i in 0..meth_node.child_count() {
-        let Some(child) = meth_node.child(i) else {
-            continue;
-        };
+        let Some(child) = meth_node.child(i) else { continue };
         if Some(child.id()) == name_node.map(|n| n.id()) {
             break;
         }
@@ -1625,10 +1267,9 @@ fn collect_local_accessors(root: &Node, source: &[u8]) -> LocalAccessorRegistry 
         }
         if node.kind() == "method_definition" {
             if let Some(kind) = get_method_accessor_kind(node) {
-                if let (Some(class_name), Some(prop_name)) = (
-                    find_parent_class(node, source),
-                    resolve_method_def_name(node, source),
-                ) {
+                if let (Some(class_name), Some(prop_name)) =
+                    (find_parent_class(node, source), resolve_method_def_name(node, source))
+                {
                     let key = format!("{}.{}", class_name, prop_name);
                     let entry = registry.entry(key).or_default();
                     if kind == "get" {
@@ -1682,12 +1323,8 @@ fn handle_accessor_property_read(
         }
     }
 
-    let Some(obj) = node.child_by_field_name("object") else {
-        return;
-    };
-    let Some(prop_node) = node.child_by_field_name("property") else {
-        return;
-    };
+    let Some(obj) = node.child_by_field_name("object") else { return };
+    let Some(prop_node) = node.child_by_field_name("property") else { return };
     if prop_node.kind() != "property_identifier" {
         return;
     }
@@ -1709,9 +1346,7 @@ fn handle_accessor_property_read(
     let Some(class_name) = class_name else { return };
 
     let key = format!("{}.{}", class_name, prop_name);
-    let Some(accessor_info) = local_accessors.get(&key) else {
-        return;
-    };
+    let Some(accessor_info) = local_accessors.get(&key) else { return };
     if accessor_info.get && accessor_info.set {
         return;
     }
@@ -1746,9 +1381,7 @@ fn handle_accessor_property_read(
 /// class has multiple `static { }` blocks (each has a distinct start position even
 /// if on the same line).
 fn handle_static_block(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(class_name) = find_parent_class(node, source) else {
-        return;
-    };
+    let Some(class_name) = find_parent_class(node, source) else { return };
     let line = start_line(node);
     let col = node.start_position().column;
     symbols.definitions.push(Definition {
@@ -1770,8 +1403,7 @@ fn handle_static_block(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 /// `handleFieldDef` guard.  The synthetic definition has `kind = "method"` so that the SQL
 /// call-edge filter (`kind IN ('function','method')`) accepts edges rooted here.
 fn handle_field_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let name_node = node
-        .child_by_field_name("name")
+    let name_node = node.child_by_field_name("name")
         .or_else(|| node.child_by_field_name("property"))
         .or_else(|| find_child(node, "property_identifier"));
     let Some(name_node) = name_node else { return };
@@ -1779,31 +1411,19 @@ fn handle_field_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     // Allow property_identifier (regular names), identifier, private_property_identifier (#foo),
     // and string (e.g. `"method" = () => {}`) to match the TypeScript path which only denies
     // computed_property_name.
-    if !matches!(
-        name_node.kind(),
-        "property_identifier" | "identifier" | "private_property_identifier" | "string"
-    ) {
+    if !matches!(name_node.kind(), "property_identifier" | "identifier" | "private_property_identifier" | "string") {
         return;
     }
     // Skip uninitialised fields (`class C { x; }`) — must have a value node.
-    let Some(value_node) = node.child_by_field_name("value") else {
-        return;
-    };
+    let Some(value_node) = node.child_by_field_name("value") else { return };
     // Only emit a callable definition when the initializer is a function/arrow expression.
     // Scalar fields like `static x = 42` should not appear as method-kind nodes.
-    if !matches!(
-        value_node.kind(),
-        "arrow_function" | "function_expression" | "generator_function"
-    ) {
+    if !matches!(value_node.kind(), "arrow_function" | "function_expression" | "generator_function") {
         return;
     }
     let field_name = node_text(&name_node, source);
-    if field_name.is_empty() {
-        return;
-    }
-    let Some(class_name) = find_parent_class(node, source) else {
-        return;
-    };
+    if field_name.is_empty() { return; }
+    let Some(class_name) = find_parent_class(node, source) else { return };
     symbols.definitions.push(Definition {
         name: format!("{}.{}", class_name, field_name),
         kind: "method".to_string(),
@@ -1819,9 +1439,7 @@ fn handle_field_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 }
 
 fn handle_interface_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else {
-        return;
-    };
+    let Some(name_node) = node.child_by_field_name("name") else { return };
     let iface_name = node_text(&name_node, source).to_string();
     symbols.definitions.push(Definition {
         name: iface_name.clone(),
@@ -1884,39 +1502,25 @@ fn handle_enum_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 /// Node types marking a function-body scope; declarations inside these are skipped by
 /// the top-level-constant/destructuring branches below (parity with TS `FUNCTION_SCOPE_TYPES`).
 const VAR_DECL_FN_SCOPE_TYPES: [&str; 6] = [
-    "function_declaration",
-    "arrow_function",
-    "function_expression",
-    "method_definition",
-    "generator_function_declaration",
-    "generator_function",
+    "function_declaration", "arrow_function",
+    "function_expression", "method_definition",
+    "generator_function_declaration", "generator_function",
 ];
 
 fn handle_var_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let is_const = node
-        .child(0)
+    let is_const = node.child(0)
         .map(|c| node_text(&c, source) == "const")
         .unwrap_or(false);
     let in_function_scope = find_parent_of_types(node, &VAR_DECL_FN_SCOPE_TYPES).is_some();
     for i in 0..node.child_count() {
-        let Some(declarator) = node.child(i) else {
-            continue;
-        };
-        if declarator.kind() != "variable_declarator" {
-            continue;
-        }
+        let Some(declarator) = node.child(i) else { continue };
+        if declarator.kind() != "variable_declarator" { continue; }
         let name_n = declarator.child_by_field_name("name");
         let value_n = declarator.child_by_field_name("value");
-        let (Some(name_n), Some(value_n)) = (name_n, value_n) else {
-            continue;
-        };
+        let (Some(name_n), Some(value_n)) = (name_n, value_n) else { continue };
         let vt = value_n.kind();
 
-        if vt == "arrow_function"
-            || vt == "function_expression"
-            || vt == "function"
-            || vt == "generator_function"
-        {
+        if vt == "arrow_function" || vt == "function_expression" || vt == "function" || vt == "generator_function" {
             let children = extract_js_parameters(&value_n, source);
             symbols.definitions.push(Definition {
                 name: node_text(&name_n, source).to_string(),
@@ -1934,36 +1538,30 @@ fn handle_var_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             // Parity with TS query path (extractDestructuredBindingsWalk):
             // skip destructured const bindings inside function scopes so the
             // Rust walk path matches FUNCTION_SCOPE_TYPES behaviour.
-            extract_destructured_bindings(
-                &name_n,
-                source,
-                start_line(node),
-                end_line(node),
-                &mut symbols.definitions,
-            );
+            extract_destructured_bindings(&name_n, source, start_line(node), end_line(node), &mut symbols.definitions);
             // If the RHS is a CJS require() call, also add to imports so the
             // receiver-edge resolver treats the names as import artifacts, not
             // local definitions — mirroring the WASM cjsRequireBindings fix (#1678).
             if value_n.kind() == "call_expression" {
                 if let Some(fn_node) = value_n.child_by_field_name("function") {
                     if node_text(&fn_node, source) == "require" {
-                        let args = value_n
-                            .child_by_field_name("arguments")
+                        let args = value_n.child_by_field_name("arguments")
                             .or_else(|| find_child(&value_n, "arguments"));
                         if let Some(args) = args {
                             if let Some(str_arg) = find_child(&args, "string") {
-                                let mod_path =
-                                    node_text(&str_arg, source).replace(&['\'', '"'][..], "");
+                                let mod_path = node_text(&str_arg, source)
+                                    .replace(&['\'', '"'][..], "");
                                 // CJS require bindings never populate renamed_imports —
                                 // resolve_call_targets deliberately ignores the original
                                 // name for these (empty target_file forces a same-file
                                 // fallback match, matching WASM's importedNamesMap
                                 // exclusion, #1678) — so the rename pairs collected here
                                 // are discarded.
-                                let names =
-                                    collect_object_pattern_names(&name_n, source, &mut Vec::new());
+                                let names = collect_object_pattern_names(&name_n, source, &mut Vec::new());
                                 if !names.is_empty() {
-                                    let mut imp = Import::new(mod_path, names, start_line(node));
+                                    let mut imp = Import::new(
+                                        mod_path, names, start_line(node),
+                                    );
                                     imp.cjs_require = Some(true);
                                     symbols.imports.push(imp);
                                 }
@@ -1999,15 +1597,8 @@ fn handle_var_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         } else if is_const && name_n.kind() == "array_pattern" && !in_function_scope {
             // Array destructuring: `const [x, y] = ...` — one constant Definition per
             // bound identifier (#1901). Scope guard mirrors the object_pattern branch above.
-            extract_array_pattern_bindings(
-                &name_n,
-                source,
-                start_line(node),
-                end_line(node),
-                &mut symbols.definitions,
-            );
-        } else if !is_const
-            && value_n.kind() == "object"
+            extract_array_pattern_bindings(&name_n, source, start_line(node), end_line(node), &mut symbols.definitions);
+        } else if !is_const && value_n.kind() == "object"
             && is_eligible_object_literal_declarator(&declarator)
         {
             // `let`/`var` object literals get no "constant" definition of their own (mirrors
@@ -2129,9 +1720,7 @@ fn extract_dispatch_table_call(
     let table_name = format!("<dt_{}_{}>", line, col);
     let mut idx: u32 = 0;
     for i in 0..obj_node.child_count() {
-        let Some(child) = obj_node.child(i) else {
-            continue;
-        };
+        let Some(child) = obj_node.child(i) else { continue };
         match child.kind() {
             "shorthand_property_identifier" => {
                 let text = node_text(&child, source);
@@ -2181,9 +1770,7 @@ fn handle_call_expr(
     symbols: &mut FileSymbols,
     callback_param_shapes: &CallbackParamShapes,
 ) {
-    let Some(fn_node) = node.child_by_field_name("function") else {
-        return;
-    };
+    let Some(fn_node) = node.child_by_field_name("function") else { return };
     if fn_node.kind() == "import" {
         handle_dynamic_import(node, &fn_node, source, symbols);
         return;
@@ -2220,19 +1807,12 @@ fn handle_call_expr(
     // the values as array-elem bindings under a synthetic `<dt_line_col>` name and
     // emit a `<dt_line_col>[*]` call so the PTS solver can resolve each target.
     if fn_node.kind() == "subscript_expression" {
-        if let Some(call) =
-            extract_dispatch_table_call(&fn_node, node, source, &mut symbols.array_elem_bindings)
-        {
+        if let Some(call) = extract_dispatch_table_call(&fn_node, node, source, &mut symbols.array_elem_bindings) {
             symbols.calls.push(call);
             if let Some(cb_def) = extract_callback_definition(node, source) {
                 symbols.definitions.push(cb_def);
             }
-            extract_callback_reference_calls(
-                node,
-                source,
-                callback_param_shapes,
-                &mut symbols.calls,
-            );
+            extract_callback_reference_calls(node, source, callback_param_shapes, &mut symbols.calls);
             return;
         }
     }
@@ -2246,8 +1826,7 @@ fn handle_call_expr(
 }
 
 fn handle_new_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let ctor = node
-        .child_by_field_name("constructor")
+    let ctor = node.child_by_field_name("constructor")
         .or_else(|| node.child(1));
     let Some(ctor) = ctor else { return };
     match ctor.kind() {
@@ -2311,13 +1890,14 @@ fn handle_decorator(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 }
 
 fn handle_dynamic_import(node: &Node, _fn_node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let args = node
-        .child_by_field_name("arguments")
+    let args = node.child_by_field_name("arguments")
         .or_else(|| find_child(node, "arguments"));
     let Some(args) = args else { return };
-    let str_node = find_child(&args, "string").or_else(|| find_child(&args, "template_string"));
+    let str_node = find_child(&args, "string")
+        .or_else(|| find_child(&args, "template_string"));
     if let Some(str_node) = str_node {
-        let mod_path = node_text(&str_node, source).replace(&['\'', '"', '`'][..], "");
+        let mod_path = node_text(&str_node, source)
+            .replace(&['\'', '"', '`'][..], "");
         let mut renamed_imports = Vec::new();
         let names = extract_dynamic_import_names(node, source, &mut renamed_imports);
         let mut imp = Import::new(mod_path, names, start_line(node));
@@ -2336,15 +1916,12 @@ fn handle_import_stmt(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         .child_by_field_name("source")
         .or_else(|| find_child(node, "string"));
     if let Some(source_node) = source_node {
-        let mod_path = node_text(&source_node, source).replace(&['\'', '"'][..], "");
+        let mod_path = node_text(&source_node, source)
+            .replace(&['\'', '"'][..], "");
         let mut renamed_imports = Vec::new();
         let mut type_only_names = Vec::new();
-        let names = extract_import_names_with_renames(
-            node,
-            source,
-            &mut renamed_imports,
-            &mut type_only_names,
-        );
+        let names =
+            extract_import_names_with_renames(node, source, &mut renamed_imports, &mut type_only_names);
         let mut imp = Import::new(mod_path, names, start_line(node));
         if is_type_only {
             imp.type_only = Some(true);
@@ -2419,26 +1996,14 @@ fn collect_exported_var_declarations(
         .unwrap_or(false);
     let line = start_line(node);
     for i in 0..decl.child_count() {
-        let Some(declarator) = decl.child(i) else {
-            continue;
-        };
-        if declarator.kind() != "variable_declarator" {
-            continue;
-        }
+        let Some(declarator) = decl.child(i) else { continue };
+        if declarator.kind() != "variable_declarator" { continue; }
         let name_n = declarator.child_by_field_name("name");
         let value_n = declarator.child_by_field_name("value");
-        let (Some(name_n), Some(value_n)) = (name_n, value_n) else {
-            continue;
-        };
-        if name_n.kind() != "identifier" {
-            continue;
-        }
+        let (Some(name_n), Some(value_n)) = (name_n, value_n) else { continue };
+        if name_n.kind() != "identifier" { continue; }
         let vt = value_n.kind();
-        if vt == "arrow_function"
-            || vt == "function_expression"
-            || vt == "function"
-            || vt == "generator_function"
-        {
+        if vt == "arrow_function" || vt == "function_expression" || vt == "function" || vt == "generator_function" {
             symbols.exports.push(ExportInfo {
                 name: node_text(&name_n, source).to_string(),
                 kind: "function".to_string(),
@@ -2455,15 +2020,12 @@ fn collect_exported_var_declarations(
 }
 
 fn handle_reexport(node: &Node, source_node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let mod_path = node_text(source_node, source).replace(&['\'', '"'][..], "");
+    let mod_path = node_text(source_node, source)
+        .replace(&['\'', '"'][..], "");
     let mut reexport_renames = Vec::new();
     let mut type_only_names = Vec::new();
-    let reexport_names = extract_import_names_with_renames(
-        node,
-        source,
-        &mut reexport_renames,
-        &mut type_only_names,
-    );
+    let reexport_names =
+        extract_import_names_with_renames(node, source, &mut reexport_renames, &mut type_only_names);
     let text = node_text(node, source);
     let is_wildcard = text.contains("export *") || text.contains("export*");
     let mut imp = Import::new(mod_path, reexport_names.clone(), start_line(node));
@@ -2479,18 +2041,12 @@ fn handle_reexport(node: &Node, source_node: &Node, source: &[u8], symbols: &mut
 
 fn handle_expr_stmt(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     let Some(expr) = node.child(0) else { return };
-    if expr.kind() != "assignment_expression" {
-        return;
-    }
+    if expr.kind() != "assignment_expression" { return; }
     let left = expr.child_by_field_name("left");
     let right = expr.child_by_field_name("right");
-    let (Some(left), Some(right)) = (left, right) else {
-        return;
-    };
+    let (Some(left), Some(right)) = (left, right) else { return };
     let left_text = node_text(&left, source);
-    if !left_text.starts_with("module.exports") && left_text != "exports" {
-        return;
-    }
+    if !left_text.starts_with("module.exports") && left_text != "exports" { return; }
     if right.kind() == "call_expression" {
         handle_require_reexport(&right, node, source, symbols);
     }
@@ -2507,7 +2063,8 @@ fn handle_require_reexport(right: &Node, node: &Node, source: &[u8], symbols: &m
     if let (Some(fn_node), Some(args)) = (fn_node, args) {
         if node_text(&fn_node, source) == "require" {
             if let Some(str_arg) = find_child(&args, "string") {
-                let mod_path = node_text(&str_arg, source).replace(&['\'', '"'][..], "");
+                let mod_path = node_text(&str_arg, source)
+                    .replace(&['\'', '"'][..], "");
                 let mut imp = Import::new(mod_path, vec![], start_line(node));
                 imp.reexport = Some(true);
                 imp.wildcard_reexport = Some(true);
@@ -2517,40 +2074,23 @@ fn handle_require_reexport(right: &Node, node: &Node, source: &[u8], symbols: &m
     }
 }
 
-fn handle_spread_require_reexports(
-    right: &Node,
-    node: &Node,
-    source: &[u8],
-    symbols: &mut FileSymbols,
-) {
+fn handle_spread_require_reexports(right: &Node, node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     for ci in 0..right.child_count() {
-        let Some(child) = right.child(ci) else {
-            continue;
-        };
-        if child.kind() != "spread_element" {
-            continue;
-        }
-        let spread_expr = child
-            .child(1)
+        let Some(child) = right.child(ci) else { continue };
+        if child.kind() != "spread_element" { continue; }
+        let spread_expr = child.child(1)
             .or_else(|| child.child_by_field_name("value"));
-        let Some(spread_expr) = spread_expr else {
-            continue;
-        };
-        if spread_expr.kind() != "call_expression" {
-            continue;
-        }
+        let Some(spread_expr) = spread_expr else { continue };
+        if spread_expr.kind() != "call_expression" { continue; }
         let fn2 = spread_expr.child_by_field_name("function");
         let args2 = spread_expr
             .child_by_field_name("arguments")
             .or_else(|| find_child(&spread_expr, "arguments"));
-        let (Some(fn2), Some(args2)) = (fn2, args2) else {
-            continue;
-        };
-        if node_text(&fn2, source) != "require" {
-            continue;
-        }
+        let (Some(fn2), Some(args2)) = (fn2, args2) else { continue };
+        if node_text(&fn2, source) != "require" { continue; }
         if let Some(str_arg2) = find_child(&args2, "string") {
-            let mod_path2 = node_text(&str_arg2, source).replace(&['\'', '"'][..], "");
+            let mod_path2 = node_text(&str_arg2, source)
+                .replace(&['\'', '"'][..], "");
             let mut imp = Import::new(mod_path2, vec![], start_line(node));
             imp.reexport = Some(true);
             imp.wildcard_reexport = Some(true);
@@ -2657,11 +2197,7 @@ fn walk_ast_nodes_depth(node: &Node, source: &[u8], ast_nodes: &mut Vec<AstNode>
         }
         "regex" => {
             let raw = node_text(node, source);
-            let name = if raw.is_empty() {
-                "?".to_string()
-            } else {
-                raw.to_string()
-            };
+            let name = if raw.is_empty() { "?".to_string() } else { raw.to_string() };
             let text = truncate(raw, TEXT_MAX);
             ast_nodes.push(AstNode {
                 kind: "regex".to_string(),
@@ -2767,8 +2303,7 @@ fn extract_expression_text(node: &Node, source: &[u8]) -> Option<String> {
 
 fn extract_js_parameters(node: &Node, source: &[u8]) -> Vec<Definition> {
     let mut params = Vec::new();
-    let params_node = node
-        .child_by_field_name("parameters")
+    let params_node = node.child_by_field_name("parameters")
         .or_else(|| find_child(node, "formal_parameters"));
     if let Some(params_node) = params_node {
         for i in 0..params_node.child_count() {
@@ -2784,8 +2319,7 @@ fn extract_js_parameters(node: &Node, source: &[u8]) -> Vec<Definition> {
                     "required_parameter" | "optional_parameter" => {
                         // TS parameters: pattern field holds the identifier;
                         // fall back to left field or first child for edge cases
-                        let name_node = child
-                            .child_by_field_name("pattern")
+                        let name_node = child.child_by_field_name("pattern")
                             .or_else(|| child.child_by_field_name("left"))
                             .or_else(|| child.child(0));
                         if let Some(name_node) = name_node {
@@ -2834,22 +2368,19 @@ fn extract_js_parameters(node: &Node, source: &[u8]) -> Vec<Definition> {
 
 fn extract_js_class_properties(node: &Node, source: &[u8]) -> Vec<Definition> {
     let mut props = Vec::new();
-    let body = node
-        .child_by_field_name("body")
+    let body = node.child_by_field_name("body")
         .or_else(|| find_child(node, "class_body"));
     if let Some(body) = body {
         for i in 0..body.child_count() {
             if let Some(child) = body.child(i) {
                 match child.kind() {
                     "field_definition" | "public_field_definition" | "property_definition" => {
-                        let prop = child
-                            .child_by_field_name("property")
+                        let prop = child.child_by_field_name("property")
                             .or_else(|| child.child_by_field_name("name"))
                             .or_else(|| find_child(&child, "property_identifier"));
                         if let Some(prop) = prop {
                             let kind = prop.kind();
-                            if kind == "property_identifier"
-                                || kind == "identifier"
+                            if kind == "property_identifier" || kind == "identifier"
                                 || kind == "private_property_identifier"
                             {
                                 props.push(child_def(
@@ -2870,14 +2401,14 @@ fn extract_js_class_properties(node: &Node, source: &[u8]) -> Vec<Definition> {
 
 fn extract_ts_enum_members(node: &Node, source: &[u8]) -> Vec<Definition> {
     let mut members = Vec::new();
-    let body = node
-        .child_by_field_name("body")
+    let body = node.child_by_field_name("body")
         .or_else(|| find_child(node, "enum_body"));
     if let Some(body) = body {
         for i in 0..body.child_count() {
             if let Some(child) = body.child(i) {
                 if child.kind() == "enum_assignment" || child.kind() == "property_identifier" {
-                    let name = child.child_by_field_name("name").unwrap_or(child);
+                    let name = child.child_by_field_name("name")
+                        .unwrap_or(child);
                     members.push(child_def(
                         node_text(&name, source).to_string(),
                         "constant",
@@ -2987,54 +2518,20 @@ fn extract_implements_depth(node: &Node, source: &[u8], result: &mut Vec<String>
 /// Mirrors `CALLBACK_ACCEPTING_CALLEES` in `src/extractors/javascript.ts`.
 const CALLBACK_ACCEPTING_CALLEES: &[&str] = &[
     // Express / router / middleware
-    "use",
-    "get",
-    "post",
-    "put",
-    "delete",
-    "patch",
-    "options",
-    "head",
-    "all",
+    "use", "get", "post", "put", "delete", "patch", "options", "head", "all",
     // Promises
-    "then",
-    "catch",
-    "finally",
+    "then", "catch", "finally",
     // Array iteration / reduction
-    "map",
-    "filter",
-    "forEach",
-    "find",
-    "findIndex",
-    "findLast",
-    "findLastIndex",
-    "some",
-    "every",
-    "reduce",
-    "reduceRight",
-    "flatMap",
-    "sort",
+    "map", "filter", "forEach", "find", "findIndex", "findLast", "findLastIndex",
+    "some", "every", "reduce", "reduceRight", "flatMap", "sort",
     // Event emitters / DOM
-    "on",
-    "once",
-    "off",
-    "addListener",
-    "removeListener",
-    "addEventListener",
-    "removeEventListener",
-    "subscribe",
-    "unsubscribe",
+    "on", "once", "off", "addListener", "removeListener",
+    "addEventListener", "removeEventListener", "subscribe", "unsubscribe",
     // Scheduling / plain function callbacks
-    "setTimeout",
-    "setInterval",
-    "setImmediate",
-    "queueMicrotask",
-    "requestAnimationFrame",
-    "requestIdleCallback",
-    "nextTick",
+    "setTimeout", "setInterval", "setImmediate", "queueMicrotask",
+    "requestAnimationFrame", "requestIdleCallback", "nextTick",
     // Commander / yargs / hooks
-    "action",
-    "command",
+    "action", "command",
 ];
 
 /// HTTP-verb callees that double as Map/cache/repository method names.
@@ -3228,7 +2725,8 @@ fn collect_function_shaped_type_aliases(root: &Node, source: &[u8]) -> HashMap<S
     // Resolve `type A = B` chains against the direct classifications above.
     for (name, alias_of) in &direct_alias_of {
         if !resolved.contains_key(name) {
-            let shaped = alias_of == "Function" || resolved.get(alias_of).copied().unwrap_or(false);
+            let shaped =
+                alias_of == "Function" || resolved.get(alias_of).copied().unwrap_or(false);
             resolved.insert(name.clone(), shaped);
         }
     }
@@ -3263,9 +2761,7 @@ fn collect_callback_param_shapes(root: &Node, source: &[u8]) -> CallbackParamSha
         let params_node = fn_node
             .child_by_field_name("parameters")
             .or_else(|| find_child(fn_node, "formal_parameters"));
-        let Some(params_node) = params_node else {
-            return indices;
-        };
+        let Some(params_node) = params_node else { return indices };
 
         let mut arg_index: usize = 0;
         for child in iter_children(&params_node, PUNCTUATION_TOKENS) {
@@ -3323,22 +2819,10 @@ fn collect_callback_param_shapes(root: &Node, source: &[u8]) -> CallbackParamSha
         }
         match node.kind() {
             "function_declaration" | "generator_function_declaration" => {
-                record_declaration(
-                    node.child_by_field_name("name"),
-                    node,
-                    source,
-                    alias_shapes,
-                    declarations,
-                );
+                record_declaration(node.child_by_field_name("name"), node, source, alias_shapes, declarations);
             }
             "method_definition" => {
-                record_declaration(
-                    node.child_by_field_name("name"),
-                    node,
-                    source,
-                    alias_shapes,
-                    declarations,
-                );
+                record_declaration(node.child_by_field_name("name"), node, source, alias_shapes, declarations);
             }
             "variable_declarator" => {
                 if let (Some(name_node), Some(value_node)) = (
@@ -3347,17 +2831,9 @@ fn collect_callback_param_shapes(root: &Node, source: &[u8]) -> CallbackParamSha
                 ) {
                     let vt = value_node.kind();
                     if name_node.kind() == "identifier"
-                        && (vt == "arrow_function"
-                            || vt == "function_expression"
-                            || vt == "generator_function")
+                        && (vt == "arrow_function" || vt == "function_expression" || vt == "generator_function")
                     {
-                        record_declaration(
-                            Some(name_node),
-                            &value_node,
-                            source,
-                            alias_shapes,
-                            declarations,
-                        );
+                        record_declaration(Some(name_node), &value_node, source, alias_shapes, declarations);
                     }
                 }
             }
@@ -3374,9 +2850,7 @@ fn collect_callback_param_shapes(root: &Node, source: &[u8]) -> CallbackParamSha
     let mut shapes: CallbackParamShapes = HashMap::new();
     for (name, per_decl_indices) in declarations {
         let mut iter = per_decl_indices.into_iter();
-        let Some(mut intersected) = iter.next() else {
-            continue;
-        };
+        let Some(mut intersected) = iter.next() else { continue };
         for other in iter {
             intersected.retain(|idx| other.contains(idx));
         }
@@ -3411,8 +2885,7 @@ fn extract_callback_reference_calls(
     callback_param_shapes: &CallbackParamShapes,
     calls: &mut Vec<Call>,
 ) {
-    let args = call_node
-        .child_by_field_name("arguments")
+    let args = call_node.child_by_field_name("arguments")
         .or_else(|| find_child(call_node, "arguments"));
     let Some(args) = args else { return };
     let call_line = start_line(call_node);
@@ -3458,9 +2931,7 @@ fn extract_callback_reference_calls(
                 continue;
             }
         } else if !callback_args_allowed
-            && !callee_param_shapes
-                .map(|s| s.contains(&arg_index))
-                .unwrap_or(false)
+            && !callee_param_shapes.map(|s| s.contains(&arg_index)).unwrap_or(false)
         {
             continue;
         }
@@ -3477,8 +2948,7 @@ fn extract_callback_reference_calls(
             }
             "member_expression" => {
                 if let Some(prop) = child.child_by_field_name("property") {
-                    let receiver = child
-                        .child_by_field_name("object")
+                    let receiver = child.child_by_field_name("object")
                         .map(|obj| extract_receiver_name(&obj, source));
                     calls.push(Call {
                         name: node_text(&prop, source).to_string(),
@@ -3516,9 +2986,7 @@ fn extract_callback_reference_calls(
 ///
 /// Mirrors `collectObjectLiteralValueRefCall` in `src/extractors/javascript.ts`.
 fn handle_object_literal_pair_value_ref(node: &Node, source: &[u8], calls: &mut Vec<Call>) {
-    let Some(value_n) = node.child_by_field_name("value") else {
-        return;
-    };
+    let Some(value_n) = node.child_by_field_name("value") else { return };
     if value_n.kind() != "identifier" {
         return;
     }
@@ -3526,9 +2994,7 @@ fn handle_object_literal_pair_value_ref(node: &Node, source: &[u8], calls: &mut 
     if JS_BUILTIN_GLOBALS.contains(&text) {
         return;
     }
-    let key_expr = node
-        .child_by_field_name("key")
-        .and_then(|k| resolve_pair_key_name(&k, source));
+    let key_expr = node.child_by_field_name("key").and_then(|k| resolve_pair_key_name(&k, source));
     calls.push(Call {
         name: text.to_string(),
         line: start_line(&value_n),
@@ -3586,15 +3052,11 @@ fn handle_object_literal_shorthand_value_ref(node: &Node, source: &[u8], calls: 
 ///
 /// Mirrors `collectInstanceofValueRefCall` in `src/extractors/javascript.ts`.
 fn handle_instanceof_value_ref(node: &Node, source: &[u8], calls: &mut Vec<Call>) {
-    let Some(operator_n) = node.child_by_field_name("operator") else {
-        return;
-    };
+    let Some(operator_n) = node.child_by_field_name("operator") else { return };
     if node_text(&operator_n, source) != "instanceof" {
         return;
     }
-    let Some(right_n) = node.child_by_field_name("right") else {
-        return;
-    };
+    let Some(right_n) = node.child_by_field_name("right") else { return };
     if right_n.kind() != "identifier" {
         return;
     }
@@ -3632,9 +3094,7 @@ fn extract_destructured_bindings(
     definitions: &mut Vec<Definition>,
 ) {
     for i in 0..pattern.child_count() {
-        let Some(child) = pattern.child(i) else {
-            continue;
-        };
+        let Some(child) = pattern.child(i) else { continue };
         match child.kind() {
             "shorthand_property_identifier_pattern" | "shorthand_property_identifier" => {
                 definitions.push(Definition {
@@ -3691,9 +3151,7 @@ fn extract_array_pattern_bindings(
     definitions: &mut Vec<Definition>,
 ) {
     for i in 0..pattern.child_count() {
-        let Some(child) = pattern.child(i) else {
-            continue;
-        };
+        let Some(child) = pattern.child(i) else { continue };
         match child.kind() {
             "identifier" => {
                 definitions.push(Definition {
@@ -3737,9 +3195,7 @@ fn extract_array_pattern_bindings(
                 // and recurse into a nested array_pattern instead of silently
                 // dropping it, mirroring extract_js_parameters' own rest_pattern scan.
                 for j in 0..child.child_count() {
-                    let Some(inner) = child.child(j) else {
-                        continue;
-                    };
+                    let Some(inner) = child.child(j) else { continue };
                     match inner.kind() {
                         "identifier" => {
                             definitions.push(Definition {
@@ -3759,13 +3215,7 @@ fn extract_array_pattern_bindings(
                         "array_pattern" => {
                             // [...[a, b]] — recurse so the nested pattern's own
                             // bound identifiers each get their own Definition.
-                            extract_array_pattern_bindings(
-                                &inner,
-                                source,
-                                line,
-                                end_line,
-                                definitions,
-                            );
+                            extract_array_pattern_bindings(&inner, source, line, end_line, definitions);
                             break;
                         }
                         _ => {}
@@ -3809,8 +3259,7 @@ fn extract_receiver_name(obj: &Node, source: &[u8]) -> String {
 /// Mirrors `getFirstCallArg` in src/extractors/javascript.ts, which likewise
 /// only needs node structure (not source text) to locate the argument.
 fn get_first_call_arg<'a>(call_node: &'a Node) -> Option<Node<'a>> {
-    let args = call_node
-        .child_by_field_name("arguments")
+    let args = call_node.child_by_field_name("arguments")
         .or_else(|| find_child(call_node, "arguments"))?;
     for i in 0..args.child_count() {
         let child = args.child(i)?;
@@ -3826,19 +3275,16 @@ fn get_first_call_arg<'a>(call_node: &'a Node) -> Option<Node<'a>> {
 fn extract_reflect_callee_from_arg(first_arg: Option<Node>, call_line: u32, source: &[u8]) -> Call {
     if let Some(arg) = first_arg {
         match arg.kind() {
-            "identifier" => {
-                return Call {
-                    name: node_text(&arg, source).to_string(),
-                    line: call_line,
-                    dynamic: Some(true),
-                    dynamic_kind: Some("reflection".to_string()),
-                    ..Default::default()
-                }
-            }
+            "identifier" => return Call {
+                name: node_text(&arg, source).to_string(),
+                line: call_line,
+                dynamic: Some(true),
+                dynamic_kind: Some("reflection".to_string()),
+                ..Default::default()
+            },
             "member_expression" => {
                 if let Some(inner_prop) = arg.child_by_field_name("property") {
-                    let receiver = arg
-                        .child_by_field_name("object")
+                    let receiver = arg.child_by_field_name("object")
                         .map(|o| extract_receiver_name(&o, source));
                     return Call {
                         name: node_text(&inner_prop, source).to_string(),
@@ -3894,8 +3340,7 @@ fn extract_call_info(fn_node: &Node, call_node: &Node, source: &[u8]) -> Option<
             let prop = prop?;
             let prop_text = node_text(&prop, source);
             let call_line = start_line(call_node);
-            let is_reflect = obj
-                .as_ref()
+            let is_reflect = obj.as_ref()
                 .map(|o| o.kind() == "identifier" && node_text(o, source) == "Reflect")
                 .unwrap_or(false);
 
@@ -3920,8 +3365,7 @@ fn extract_call_info(fn_node: &Node, call_node: &Node, source: &[u8]) -> Option<
 
             // Reflect.get(target, prop) — property access via reflection
             if is_reflect && prop_text == "get" {
-                let args = call_node
-                    .child_by_field_name("arguments")
+                let args = call_node.child_by_field_name("arguments")
                     .or_else(|| find_child(call_node, "arguments"));
                 if let Some(args) = args {
                     let mut first_arg: Option<Node> = None;
@@ -3929,23 +3373,17 @@ fn extract_call_info(fn_node: &Node, call_node: &Node, source: &[u8]) -> Option<
                     let mut arg_idx = 0usize;
                     for i in 0..args.child_count() {
                         let Some(child) = args.child(i) else { continue };
-                        if matches!(child.kind(), "(" | ")" | ",") {
-                            continue;
-                        }
-                        if arg_idx == 0 {
-                            first_arg = Some(child);
-                        } else if arg_idx == 1 {
-                            second_arg = Some(child);
-                            break;
-                        }
+                        if matches!(child.kind(), "(" | ")" | ",") { continue }
+                        if arg_idx == 0 { first_arg = Some(child); }
+                        else if arg_idx == 1 { second_arg = Some(child); break; }
                         arg_idx += 1;
                     }
                     let receiver = first_arg.as_ref().map(|a| extract_receiver_name(a, source));
                     if let Some(prop_arg) = second_arg {
                         match prop_arg.kind() {
                             "string" | "string_fragment" => {
-                                let prop_name =
-                                    node_text(&prop_arg, source).replace(&['\'', '"'][..], "");
+                                let prop_name = node_text(&prop_arg, source)
+                                    .replace(&['\'', '"'][..], "");
                                 if !prop_name.is_empty() {
                                     return Some(Call {
                                         name: prop_name,
@@ -4036,13 +3474,12 @@ fn extract_call_info(fn_node: &Node, call_node: &Node, source: &[u8]) -> Option<
         "subscript_expression" => {
             let index = fn_node.child_by_field_name("index");
             if let Some(index) = index {
-                let receiver = fn_node
-                    .child_by_field_name("object")
+                let receiver = fn_node.child_by_field_name("object")
                     .map(|o| extract_receiver_name(&o, source));
                 match index.kind() {
                     "string" | "template_string" => {
-                        let method_name =
-                            node_text(&index, source).replace(&['\'', '"', '`'][..], "");
+                        let method_name = node_text(&index, source)
+                            .replace(&['\'', '"', '`'][..], "");
                         if !method_name.is_empty() && !method_name.contains('$') {
                             return Some(Call {
                                 name: method_name,
@@ -4112,11 +3549,7 @@ fn find_first_string_arg<'a>(args_node: &Node<'a>, source: &'a [u8]) -> Option<S
     None
 }
 
-fn walk_call_chain<'a>(
-    start_node: &Node<'a>,
-    method_name: &str,
-    source: &[u8],
-) -> Option<Node<'a>> {
+fn walk_call_chain<'a>(start_node: &Node<'a>, method_name: &str, source: &[u8]) -> Option<Node<'a>> {
     let mut current = Some(*start_node);
     while let Some(node) = current {
         if node.kind() == "call_expression" {
@@ -4273,7 +3706,8 @@ fn find_parent_class_no_fn_boundary(node: &Node, source: &[u8]) -> Option<String
             return None;
         }
         if JS_CLASS_KINDS.contains(&kind) {
-            return named_child_text(&parent, "name", source).map(|s| s.to_string());
+            return named_child_text(&parent, "name", source)
+                .map(|s| s.to_string());
         }
         current = parent.parent();
     }
@@ -4344,9 +3778,7 @@ fn collect_object_pattern_names(
 ) -> Vec<String> {
     let mut names = Vec::new();
     for i in 0..pattern.child_count() {
-        let Some(child) = pattern.child(i) else {
-            continue;
-        };
+        let Some(child) = pattern.child(i) else { continue };
         match child.kind() {
             "shorthand_property_identifier_pattern" | "shorthand_property_identifier" => {
                 names.push(node_text(&child, source).to_string());
@@ -4361,8 +3793,9 @@ fn collect_object_pattern_names(
                 let key = child.child_by_field_name("key");
                 let value = child.child_by_field_name("value");
                 let local_node = match value.map(|v| (v.kind(), v)) {
-                    Some(("identifier", v))
-                    | Some(("shorthand_property_identifier_pattern", v)) => Some(v),
+                    Some(("identifier", v)) | Some(("shorthand_property_identifier_pattern", v)) => {
+                        Some(v)
+                    }
                     Some(("assignment_pattern", v)) => {
                         // { imported: local = defaultValue } — the local
                         // binding is the assignment_pattern's left identifier.
@@ -4430,9 +3863,7 @@ fn collect_object_pattern_names(
 fn collect_array_pattern_names(pattern: &Node, source: &[u8]) -> Vec<String> {
     let mut names = Vec::new();
     for i in 0..pattern.child_count() {
-        let Some(child) = pattern.child(i) else {
-            continue;
-        };
+        let Some(child) = pattern.child(i) else { continue };
         match child.kind() {
             "identifier" => {
                 names.push(node_text(&child, source).to_string());
@@ -4700,9 +4131,7 @@ fn enclosing_func_context(node: &Node, source: &[u8]) -> String {
 /// - `this(args)` → `Call { name: "this" }` (this used as a function)
 /// - `fn.call(ctx, ...)` / `fn.apply(ctx, ...)` → ThisCallBinding
 fn collect_this_call_and_bindings(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(fn_node) = node.child_by_field_name("function") else {
-        return;
-    };
+    let Some(fn_node) = node.child_by_field_name("function") else { return };
     if fn_node.kind() == "this" {
         symbols.calls.push(Call {
             name: "this".to_string(),
@@ -4743,10 +4172,7 @@ fn collect_this_call_and_bindings(node: &Node, source: &[u8], symbols: &mut File
         }
         if t == "identifier" {
             let arg_text = node_text(&child, source);
-            if !JS_BUILTIN_GLOBALS.contains(&arg_text)
-                && arg_text != "undefined"
-                && arg_text != "null"
-            {
+            if !JS_BUILTIN_GLOBALS.contains(&arg_text) && arg_text != "undefined" && arg_text != "null" {
                 symbols.this_call_bindings.push(ThisCallBinding {
                     callee: obj_text.to_string(),
                     this_arg: arg_text.to_string(),
@@ -4760,9 +4186,7 @@ fn collect_this_call_and_bindings(node: &Node, source: &[u8], symbols: &mut File
 /// Phase 8.3c: `f(x)` identifier-argument bindings, including inline
 /// `f(...[a, b])` array-literal spread expansion.
 fn collect_param_bindings(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(fn_node) = node.child_by_field_name("function") else {
-        return;
-    };
+    let Some(fn_node) = node.child_by_field_name("function") else { return };
     if fn_node.kind() != "identifier" {
         return;
     }
@@ -4792,13 +4216,9 @@ fn collect_param_bindings(node: &Node, source: &[u8], symbols: &mut FileSymbols)
             }
         } else if ct == "spread_element" {
             // f(...[a, b]) — inline array literal: expand each element as a direct binding.
-            let inner = child.child_by_field_name("argument").or_else(|| {
-                if child.child_count() > 1 {
-                    child.child(1)
-                } else {
-                    None
-                }
-            });
+            let inner = child
+                .child_by_field_name("argument")
+                .or_else(|| if child.child_count() > 1 { child.child(1) } else { None });
             if let Some(inner) = inner {
                 if inner.kind() == "array" {
                     let mut elem_count: u32 = 0;
@@ -4833,9 +4253,7 @@ fn collect_param_bindings(node: &Node, source: &[u8], symbols: &mut FileSymbols)
 
 /// Phase 8.3e: `f(...arr)` spread bindings and `Array.from(src, cb)` callbacks.
 fn collect_spread_and_array_from_bindings(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(fn_node) = node.child_by_field_name("function") else {
-        return;
-    };
+    let Some(fn_node) = node.child_by_field_name("function") else { return };
     let args = node
         .child_by_field_name("arguments")
         .or_else(|| find_child(node, "arguments"));
@@ -4853,13 +4271,9 @@ fn collect_spread_and_array_from_bindings(node: &Node, source: &[u8], symbols: &
                     continue;
                 }
                 if ct == "spread_element" {
-                    let target = child.child_by_field_name("argument").or_else(|| {
-                        if child.child_count() > 1 {
-                            child.child(1)
-                        } else {
-                            None
-                        }
-                    });
+                    let target = child
+                        .child_by_field_name("argument")
+                        .or_else(|| if child.child_count() > 1 { child.child(1) } else { None });
                     if let Some(target) = target {
                         if target.kind() == "identifier" {
                             let target_text = node_text(&target, source);
@@ -4931,9 +4345,7 @@ fn collect_array_elem_bindings(node: &Node, source: &[u8], symbols: &mut FileSym
     let array_name = node_text(&name_n, source);
     let mut idx: u32 = 0;
     for i in 0..value_n.child_count() {
-        let Some(elem) = value_n.child(i) else {
-            continue;
-        };
+        let Some(elem) = value_n.child(i) else { continue };
         let et = elem.kind();
         if et == "," || et == "[" || et == "]" {
             continue;
@@ -5010,16 +4422,12 @@ fn collect_for_of_binding(node: &Node, source: &[u8], symbols: &mut FileSymbols)
     if !is_for_of {
         return;
     }
-    let Some(right) = node.child_by_field_name("right") else {
-        return;
-    };
+    let Some(right) = node.child_by_field_name("right") else { return };
     let right_text = node_text(&right, source);
     if right.kind() != "identifier" || JS_BUILTIN_GLOBALS.contains(&right_text) {
         return;
     }
-    let Some(left) = node.child_by_field_name("left") else {
-        return;
-    };
+    let Some(left) = node.child_by_field_name("left") else { return };
     let mut var_name: Option<&str> = None;
     if left.kind() == "identifier" {
         var_name = Some(node_text(&left, source));
@@ -5082,9 +4490,7 @@ fn collect_object_rest_params(node: &Node, source: &[u8], symbols: &mut FileSymb
             ) {
                 let vt = value_n.kind();
                 if name_n.kind() == "identifier"
-                    && (vt == "arrow_function"
-                        || vt == "function_expression"
-                        || vt == "generator_function")
+                    && (vt == "arrow_function" || vt == "function_expression" || vt == "generator_function")
                 {
                     fn_name = Some(node_text(&name_n, source).to_string());
                     params_node = value_n
@@ -5103,10 +4509,7 @@ fn collect_object_rest_params(node: &Node, source: &[u8], symbols: &mut FileSymb
                     .filter(|p| p.kind() == "class_body")
                     .and_then(|p| p.parent())
                     .filter(|c| c.kind() == "class_declaration" || c.kind() == "class")
-                    .and_then(|c| {
-                        c.child_by_field_name("name")
-                            .map(|n| node_text(&n, source).to_string())
-                    });
+                    .and_then(|c| c.child_by_field_name("name").map(|n| node_text(&n, source).to_string()));
                 fn_name = Some(match current_class {
                     Some(c) => format!("{c}.{method}"),
                     None => method.to_string(),
@@ -5126,10 +4529,7 @@ fn collect_object_rest_params(node: &Node, source: &[u8], symbols: &mut FileSymb
                 node.child_by_field_name("value"),
             ) {
                 let vt = value_n.kind();
-                if vt == "arrow_function"
-                    || vt == "function_expression"
-                    || vt == "generator_function"
-                {
+                if vt == "arrow_function" || vt == "function_expression" || vt == "generator_function" {
                     if let Some(key_name) = resolve_pair_key_name(&key_n, source) {
                         fn_name = Some(key_name);
                         params_node = value_n
@@ -5142,34 +4542,26 @@ fn collect_object_rest_params(node: &Node, source: &[u8], symbols: &mut FileSymb
         _ => {}
     }
 
-    let (Some(fn_name), Some(params_node)) = (fn_name, params_node) else {
-        return;
-    };
+    let (Some(fn_name), Some(params_node)) = (fn_name, params_node) else { return };
     let mut param_idx: u32 = 0;
     for i in 0..params_node.child_count() {
-        let Some(child) = params_node.child(i) else {
-            continue;
-        };
+        let Some(child) = params_node.child(i) else { continue };
         let ct = child.kind();
         if ct == "," || ct == "(" || ct == ")" {
             continue;
         }
         if ct == "object_pattern" {
             for j in 0..child.child_count() {
-                let Some(inner) = child.child(j) else {
-                    continue;
-                };
+                let Some(inner) = child.child(j) else { continue };
                 if inner.kind() == "rest_pattern" || inner.kind() == "rest_element" {
                     let rest_id = inner.child(1).or_else(|| inner.child_by_field_name("name"));
                     if let Some(rest_id) = rest_id {
                         if rest_id.kind() == "identifier" {
-                            symbols
-                                .object_rest_param_bindings
-                                .push(ObjectRestParamBinding {
-                                    callee: fn_name.clone(),
-                                    rest_name: node_text(&rest_id, source).to_string(),
-                                    arg_index: param_idx,
-                                });
+                            symbols.object_rest_param_bindings.push(ObjectRestParamBinding {
+                                callee: fn_name.clone(),
+                                rest_name: node_text(&rest_id, source).to_string(),
+                                arg_index: param_idx,
+                            });
                         }
                     }
                 }
@@ -5193,9 +4585,7 @@ fn collect_object_prop_bindings(node: &Node, source: &[u8], symbols: &mut FileSy
     }
     let object_name = node_text(&name_n, source);
     for i in 0..value_n.child_count() {
-        let Some(child) = value_n.child(i) else {
-            continue;
-        };
+        let Some(child) = value_n.child(i) else { continue };
         if child.kind() == "shorthand_property_identifier" {
             let prop = node_text(&child, source);
             symbols.object_prop_bindings.push(ObjectPropBinding {
@@ -5297,11 +4687,7 @@ mod tests {
                }\n\
              }\n",
         );
-        let iface_save = s
-            .definitions
-            .iter()
-            .find(|d| d.name == "Repo.save")
-            .unwrap();
+        let iface_save = s.definitions.iter().find(|d| d.name == "Repo.save").unwrap();
         assert_eq!(iface_save.bodyless, Some(true));
 
         let class_save = s
@@ -5401,24 +4787,14 @@ mod tests {
     #[test]
     fn skips_commander_named_handler() {
         let s = parse_js("program.command('test').action(handleTest);");
-        let defs: Vec<_> = s
-            .definitions
-            .iter()
-            .filter(|d| d.name.starts_with("command:"))
-            .collect();
-        assert!(
-            defs.is_empty(),
-            "should not extract when handler is a named reference"
-        );
+        let defs: Vec<_> = s.definitions.iter().filter(|d| d.name.starts_with("command:")).collect();
+        assert!(defs.is_empty(), "should not extract when handler is a named reference");
     }
 
     #[test]
     fn extracts_express_get_route() {
         let s = parse_js("app.get('/api/users', (req, res) => { res.json([]); });");
-        let def = s
-            .definitions
-            .iter()
-            .find(|d| d.name == "route:GET /api/users");
+        let def = s.definitions.iter().find(|d| d.name == "route:GET /api/users");
         assert!(def.is_some(), "should extract route:GET /api/users");
         assert_eq!(def.unwrap().kind, "function");
     }
@@ -5426,21 +4802,14 @@ mod tests {
     #[test]
     fn extracts_express_post_route() {
         let s = parse_js("router.post('/api/items', async (req, res) => { save(); });");
-        let def = s
-            .definitions
-            .iter()
-            .find(|d| d.name == "route:POST /api/items");
+        let def = s.definitions.iter().find(|d| d.name == "route:POST /api/items");
         assert!(def.is_some(), "should extract route:POST /api/items");
     }
 
     #[test]
     fn skips_map_get_false_positive() {
         let s = parse_js("myMap.get('someKey');");
-        let defs: Vec<_> = s
-            .definitions
-            .iter()
-            .filter(|d| d.name.starts_with("route:"))
-            .collect();
+        let defs: Vec<_> = s.definitions.iter().filter(|d| d.name.starts_with("route:")).collect();
         assert!(defs.is_empty(), "should not extract Map.get as a route");
     }
 
@@ -5462,15 +4831,8 @@ mod tests {
     #[test]
     fn skips_event_named_handler() {
         let s = parse_js("emitter.on('data', handleData);");
-        let defs: Vec<_> = s
-            .definitions
-            .iter()
-            .filter(|d| d.name.starts_with("event:"))
-            .collect();
-        assert!(
-            defs.is_empty(),
-            "should not extract when handler is a named reference"
-        );
+        let defs: Vec<_> = s.definitions.iter().filter(|d| d.name.starts_with("event:")).collect();
+        assert!(defs.is_empty(), "should not extract when handler is a named reference");
     }
 
     // ── Extended kinds tests ────────────────────────────────────────────────
@@ -5563,9 +4925,7 @@ mod tests {
     fn exports_const_with_call_expression_initializer() {
         let s = parse_js("export const config = loadConfig();");
         assert!(
-            s.exports
-                .iter()
-                .any(|e| e.name == "config" && e.kind == "constant"),
+            s.exports.iter().any(|e| e.name == "config" && e.kind == "constant"),
             "config should be listed as an exported constant; got: {:?}",
             s.exports
         );
@@ -5631,16 +4991,12 @@ mod tests {
         // decoupled fnRefBindings pass).
         let s = parse_js("const alias = handler;");
         assert!(
-            s.definitions
-                .iter()
-                .any(|d| d.name == "alias" && d.kind == "constant"),
+            s.definitions.iter().any(|d| d.name == "alias" && d.kind == "constant"),
             "alias should be extracted as a constant definition; got: {:?}",
             s.definitions
         );
         assert!(
-            s.fn_ref_bindings
-                .iter()
-                .any(|b| b.lhs == "alias" && b.rhs == "handler"),
+            s.fn_ref_bindings.iter().any(|b| b.lhs == "alias" && b.rhs == "handler"),
             "alias -> handler fn_ref_binding should still be recorded; got: {:?}",
             s.fn_ref_bindings
         );
@@ -5681,11 +5037,7 @@ mod tests {
         let new_nodes: Vec<_> = s.ast_nodes.iter().filter(|n| n.kind == "new").collect();
         let throw_nodes: Vec<_> = s.ast_nodes.iter().filter(|n| n.kind == "throw").collect();
         assert_eq!(throw_nodes.len(), 1);
-        assert_eq!(
-            new_nodes.len(),
-            0,
-            "throw new Error should not also emit a new node"
-        );
+        assert_eq!(new_nodes.len(), 0, "throw new Error should not also emit a new node");
     }
 
     #[test]
@@ -5743,11 +5095,7 @@ mod tests {
     #[test]
     fn finds_dynamic_import() {
         let s = parse_js("const mod = import('./foo.js');");
-        let dyn_imports: Vec<_> = s
-            .imports
-            .iter()
-            .filter(|i| i.dynamic_import == Some(true))
-            .collect();
+        let dyn_imports: Vec<_> = s.imports.iter().filter(|i| i.dynamic_import == Some(true)).collect();
         assert_eq!(dyn_imports.len(), 1);
         assert_eq!(dyn_imports[0].source, "./foo.js");
     }
@@ -5755,11 +5103,7 @@ mod tests {
     #[test]
     fn finds_dynamic_import_with_destructuring() {
         let s = parse_js("const { a, b } = await import('./bar.js');");
-        let dyn_imports: Vec<_> = s
-            .imports
-            .iter()
-            .filter(|i| i.dynamic_import == Some(true))
-            .collect();
+        let dyn_imports: Vec<_> = s.imports.iter().filter(|i| i.dynamic_import == Some(true)).collect();
         assert_eq!(dyn_imports.len(), 1);
         assert_eq!(dyn_imports[0].source, "./bar.js");
         assert!(dyn_imports[0].names.contains(&"a".to_string()));
@@ -5775,11 +5119,7 @@ mod tests {
         // local → original mapping so call-edge resolution can still find
         // `buildGraph` in the target file.
         let s = parse_js("const { buildGraph: fromBarrel } = await import('./builder.js');");
-        let dyn_imports: Vec<_> = s
-            .imports
-            .iter()
-            .filter(|i| i.dynamic_import == Some(true))
-            .collect();
+        let dyn_imports: Vec<_> = s.imports.iter().filter(|i| i.dynamic_import == Some(true)).collect();
         assert_eq!(dyn_imports.len(), 1);
         assert_eq!(dyn_imports[0].source, "./builder.js");
         assert!(dyn_imports[0].names.contains(&"fromBarrel".to_string()));
@@ -5799,11 +5139,7 @@ mod tests {
         // verbatim as `imported` would make the resolver look for an export
         // literally named `'foo-bar'`, which never matches (Greptile follow-up).
         let s = parse_js("const { 'foo-bar': local } = await import('./mod.js');");
-        let dyn_imports: Vec<_> = s
-            .imports
-            .iter()
-            .filter(|i| i.dynamic_import == Some(true))
-            .collect();
+        let dyn_imports: Vec<_> = s.imports.iter().filter(|i| i.dynamic_import == Some(true)).collect();
         assert_eq!(dyn_imports.len(), 1);
         assert_eq!(dyn_imports[0].names, vec!["local".to_string()]);
         let renamed = dyn_imports[0]
@@ -5818,11 +5154,7 @@ mod tests {
     #[test]
     fn unwraps_computed_string_literal_destructuring_key() {
         let s = parse_js("const { ['foo-bar']: local } = await import('./mod.js');");
-        let dyn_imports: Vec<_> = s
-            .imports
-            .iter()
-            .filter(|i| i.dynamic_import == Some(true))
-            .collect();
+        let dyn_imports: Vec<_> = s.imports.iter().filter(|i| i.dynamic_import == Some(true)).collect();
         assert_eq!(dyn_imports.len(), 1);
         assert_eq!(dyn_imports[0].names, vec!["local".to_string()]);
         let renamed = dyn_imports[0]
@@ -5839,11 +5171,7 @@ mod tests {
         // `[Symbol()]` has no statically resolvable export name — the local
         // binding must still be tracked, just without a renamed_imports entry.
         let s = parse_js("const { [Symbol()]: local } = await import('./mod.js');");
-        let dyn_imports: Vec<_> = s
-            .imports
-            .iter()
-            .filter(|i| i.dynamic_import == Some(true))
-            .collect();
+        let dyn_imports: Vec<_> = s.imports.iter().filter(|i| i.dynamic_import == Some(true)).collect();
         assert_eq!(dyn_imports.len(), 1);
         assert_eq!(dyn_imports[0].names, vec!["local".to_string()]);
         assert!(dyn_imports[0].renamed_imports.is_none());
@@ -5852,11 +5180,7 @@ mod tests {
     #[test]
     fn finds_dynamic_import_with_mixed_destructuring() {
         let s = parse_js("const { a, buildGraph: fromBarrel, c } = await import('./mod.js');");
-        let dyn_imports: Vec<_> = s
-            .imports
-            .iter()
-            .filter(|i| i.dynamic_import == Some(true))
-            .collect();
+        let dyn_imports: Vec<_> = s.imports.iter().filter(|i| i.dynamic_import == Some(true)).collect();
         assert_eq!(dyn_imports.len(), 1);
         assert_eq!(dyn_imports[0].source, "./mod.js");
         assert!(dyn_imports[0].names.contains(&"a".to_string()));
@@ -5875,11 +5199,7 @@ mod tests {
     #[test]
     fn finds_dynamic_import_with_aliased_default_destructuring() {
         let s = parse_js("const { buildGraph: local = null } = await import('./builder.js');");
-        let dyn_imports: Vec<_> = s
-            .imports
-            .iter()
-            .filter(|i| i.dynamic_import == Some(true))
-            .collect();
+        let dyn_imports: Vec<_> = s.imports.iter().filter(|i| i.dynamic_import == Some(true)).collect();
         assert_eq!(dyn_imports.len(), 1);
         assert!(dyn_imports[0].names.contains(&"local".to_string()));
         assert!(!dyn_imports[0].names.contains(&"buildGraph".to_string()));
@@ -5895,11 +5215,7 @@ mod tests {
     #[test]
     fn finds_dynamic_import_with_nested_object_destructuring() {
         let s = parse_js("const { foo: { nested } } = await import('./mod.js');");
-        let dyn_imports: Vec<_> = s
-            .imports
-            .iter()
-            .filter(|i| i.dynamic_import == Some(true))
-            .collect();
+        let dyn_imports: Vec<_> = s.imports.iter().filter(|i| i.dynamic_import == Some(true)).collect();
         assert_eq!(dyn_imports.len(), 1);
         assert!(dyn_imports[0].names.contains(&"foo".to_string()));
         assert!(!dyn_imports[0].names.contains(&"nested".to_string()));
@@ -5917,11 +5233,7 @@ mod tests {
     #[test]
     fn finds_dynamic_import_with_parenthesized_destructuring() {
         let s = parse_ts("const { a, b } = (await import('./foo.js'));");
-        let dyn_imports: Vec<_> = s
-            .imports
-            .iter()
-            .filter(|i| i.dynamic_import == Some(true))
-            .collect();
+        let dyn_imports: Vec<_> = s.imports.iter().filter(|i| i.dynamic_import == Some(true)).collect();
         assert_eq!(dyn_imports.len(), 1);
         assert!(dyn_imports[0].names.contains(&"a".to_string()));
         assert!(dyn_imports[0].names.contains(&"b".to_string()));
@@ -5930,11 +5242,7 @@ mod tests {
     #[test]
     fn finds_dynamic_import_with_as_cast_destructuring() {
         let s = parse_ts("const { a, b } = await import('./foo.js') as { a: Fn; b: Fn };");
-        let dyn_imports: Vec<_> = s
-            .imports
-            .iter()
-            .filter(|i| i.dynamic_import == Some(true))
-            .collect();
+        let dyn_imports: Vec<_> = s.imports.iter().filter(|i| i.dynamic_import == Some(true)).collect();
         assert_eq!(dyn_imports.len(), 1);
         assert!(dyn_imports[0].names.contains(&"a".to_string()));
         assert!(dyn_imports[0].names.contains(&"b".to_string()));
@@ -5945,11 +5253,7 @@ mod tests {
         // TS 4.9+ `satisfies` is structurally identical to `as` here (Greptile
         // follow-up to #1781) — same walk-up gap would otherwise reproduce.
         let s = parse_ts("const { a, b } = await import('./foo.js') satisfies { a: Fn; b: Fn };");
-        let dyn_imports: Vec<_> = s
-            .imports
-            .iter()
-            .filter(|i| i.dynamic_import == Some(true))
-            .collect();
+        let dyn_imports: Vec<_> = s.imports.iter().filter(|i| i.dynamic_import == Some(true)).collect();
         assert_eq!(dyn_imports.len(), 1);
         assert!(dyn_imports[0].names.contains(&"a".to_string()));
         assert!(dyn_imports[0].names.contains(&"b".to_string()));
@@ -5962,19 +5266,11 @@ mod tests {
         let s = parse_ts(
             "const { buildDataflowVerticesFromMap, buildDataflowEdges } = (await import('../../../../features/dataflow.js')) as { buildDataflowVerticesFromMap: Fn; buildDataflowEdges: Fn };",
         );
-        let dyn_imports: Vec<_> = s
-            .imports
-            .iter()
-            .filter(|i| i.dynamic_import == Some(true))
-            .collect();
+        let dyn_imports: Vec<_> = s.imports.iter().filter(|i| i.dynamic_import == Some(true)).collect();
         assert_eq!(dyn_imports.len(), 1);
         assert_eq!(dyn_imports[0].source, "../../../../features/dataflow.js");
-        assert!(dyn_imports[0]
-            .names
-            .contains(&"buildDataflowVerticesFromMap".to_string()));
-        assert!(dyn_imports[0]
-            .names
-            .contains(&"buildDataflowEdges".to_string()));
+        assert!(dyn_imports[0].names.contains(&"buildDataflowVerticesFromMap".to_string()));
+        assert!(dyn_imports[0].names.contains(&"buildDataflowEdges".to_string()));
     }
 
     // Regression tests for #1920: `extract_rest_identifier` indexed into a
@@ -5985,26 +5281,15 @@ mod tests {
     #[test]
     fn finds_dynamic_import_with_object_rest_destructuring() {
         let s = parse_js("const { a, ...rest } = await import('./mod.js');");
-        let dyn_imports: Vec<_> = s
-            .imports
-            .iter()
-            .filter(|i| i.dynamic_import == Some(true))
-            .collect();
+        let dyn_imports: Vec<_> = s.imports.iter().filter(|i| i.dynamic_import == Some(true)).collect();
         assert_eq!(dyn_imports.len(), 1);
-        assert_eq!(
-            dyn_imports[0].names,
-            vec!["a".to_string(), "rest".to_string()]
-        );
+        assert_eq!(dyn_imports[0].names, vec!["a".to_string(), "rest".to_string()]);
     }
 
     #[test]
     fn finds_dynamic_import_with_shorthand_default_destructuring() {
         let s = parse_js("const { a = 1 } = await import('./mod.js');");
-        let dyn_imports: Vec<_> = s
-            .imports
-            .iter()
-            .filter(|i| i.dynamic_import == Some(true))
-            .collect();
+        let dyn_imports: Vec<_> = s.imports.iter().filter(|i| i.dynamic_import == Some(true)).collect();
         assert_eq!(dyn_imports.len(), 1);
         assert_eq!(dyn_imports[0].names, vec!["a".to_string()]);
     }
@@ -6012,20 +5297,11 @@ mod tests {
     #[test]
     fn finds_dynamic_import_with_mixed_plain_renamed_default_and_rest_destructuring() {
         let s = parse_js("const { a, b: alias, c = 1, ...rest } = await import('./mod.js');");
-        let dyn_imports: Vec<_> = s
-            .imports
-            .iter()
-            .filter(|i| i.dynamic_import == Some(true))
-            .collect();
+        let dyn_imports: Vec<_> = s.imports.iter().filter(|i| i.dynamic_import == Some(true)).collect();
         assert_eq!(dyn_imports.len(), 1);
         assert_eq!(
             dyn_imports[0].names,
-            vec![
-                "a".to_string(),
-                "alias".to_string(),
-                "c".to_string(),
-                "rest".to_string()
-            ]
+            vec!["a".to_string(), "alias".to_string(), "c".to_string(), "rest".to_string()]
         );
         let renamed = dyn_imports[0]
             .renamed_imports
@@ -6039,26 +5315,16 @@ mod tests {
     #[test]
     fn finds_dynamic_import_with_array_rest_destructuring() {
         let s = parse_js("const [a, ...rest] = await import('./mod.js');");
-        let dyn_imports: Vec<_> = s
-            .imports
-            .iter()
-            .filter(|i| i.dynamic_import == Some(true))
-            .collect();
+        let dyn_imports: Vec<_> = s.imports.iter().filter(|i| i.dynamic_import == Some(true)).collect();
         assert_eq!(dyn_imports.len(), 1);
-        assert_eq!(
-            dyn_imports[0].names,
-            vec!["a".to_string(), "rest".to_string()]
-        );
+        assert_eq!(dyn_imports[0].names, vec!["a".to_string(), "rest".to_string()]);
     }
 
     #[test]
     fn extracts_callback_reference_in_router_use() {
         let s = parse_js("router.use(handleToken);");
         let dynamic_calls: Vec<_> = s.calls.iter().filter(|c| c.dynamic == Some(true)).collect();
-        assert!(
-            dynamic_calls.iter().any(|c| c.name == "handleToken"),
-            "should extract handleToken as dynamic call"
-        );
+        assert!(dynamic_calls.iter().any(|c| c.name == "handleToken"), "should extract handleToken as dynamic call");
     }
 
     #[test]
@@ -6221,11 +5487,7 @@ mod tests {
             .map(|c| c.name.as_str())
             .collect();
         for expected in ["isA", "resolveA", "isB", "resolveB"] {
-            assert!(
-                names.contains(&expected),
-                "missing value-ref call for {}",
-                expected
-            );
+            assert!(names.contains(&expected), "missing value-ref call for {}", expected);
         }
     }
 
@@ -6312,28 +5574,19 @@ mod tests {
     #[test]
     fn no_value_ref_call_for_call_expression_value() {
         let s = parse_js("const table = { resolve: someFunction() };");
-        assert!(s
-            .calls
-            .iter()
-            .all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
+        assert!(s.calls.iter().all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
     }
 
     #[test]
     fn no_value_ref_call_for_member_expression_value() {
         let s = parse_js("const table = { resolve: obj.someFunction };");
-        assert!(s
-            .calls
-            .iter()
-            .all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
+        assert!(s.calls.iter().all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
     }
 
     #[test]
     fn no_value_ref_call_for_inline_function_value() {
         let s = parse_js("const table = { resolve: () => {}, other: function () {} };");
-        assert!(s
-            .calls
-            .iter()
-            .all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
+        assert!(s.calls.iter().all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
     }
 
     #[test]
@@ -6341,19 +5594,13 @@ mod tests {
         let s = parse_js(
             "const config = { name: 'literal', count: 42, active: true, empty: null, list: [1, 2] };",
         );
-        assert!(s
-            .calls
-            .iter()
-            .all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
+        assert!(s.calls.iter().all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
     }
 
     #[test]
     fn no_value_ref_call_for_builtin_globals() {
         let s = parse_js("const table = { log: console, Ctor: Object };");
-        assert!(s
-            .calls
-            .iter()
-            .all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
+        assert!(s.calls.iter().all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
     }
 
     // ── #1784: instanceof value-ref extraction ──────────────────────────────
@@ -6386,19 +5633,17 @@ mod tests {
     #[test]
     fn no_value_ref_call_for_instanceof_member_expression_operand() {
         let s = parse_js("const check = (a) => a instanceof ns.SomeClass;");
-        assert!(s
-            .calls
-            .iter()
-            .all(|c| !(c.dynamic_kind.as_deref() == Some("value-ref") && c.name == "SomeClass")));
+        assert!(
+            s.calls
+                .iter()
+                .all(|c| !(c.dynamic_kind.as_deref() == Some("value-ref") && c.name == "SomeClass"))
+        );
     }
 
     #[test]
     fn no_value_ref_call_for_instanceof_call_expression_operand() {
         let s = parse_js("const check = (a) => a instanceof getClass();");
-        assert!(s
-            .calls
-            .iter()
-            .all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
+        assert!(s.calls.iter().all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
     }
 
     #[test]
@@ -6406,38 +5651,25 @@ mod tests {
         let s = parse_js(
             "function isBuiltin(x) { return x instanceof Error || x instanceof Array || x instanceof Map; }",
         );
-        assert!(s
-            .calls
-            .iter()
-            .all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
+        assert!(s.calls.iter().all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
     }
 
     #[test]
     fn no_value_ref_call_for_in_operator() {
         let s = parse_js("const has = (obj) => 'key' in obj;");
-        assert!(s
-            .calls
-            .iter()
-            .all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
+        assert!(s.calls.iter().all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
     }
 
     #[test]
     fn no_value_ref_call_for_other_binary_operators() {
         let s = parse_js("const sum = (a, b) => a + b === Total;");
-        assert!(s
-            .calls
-            .iter()
-            .all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
+        assert!(s.calls.iter().all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
     }
 
     #[test]
     fn no_duplicate_call_for_call_expression_arg() {
         let s = parse_js("router.use(checkPermissions(['admin']));");
-        let cp_calls: Vec<_> = s
-            .calls
-            .iter()
-            .filter(|c| c.name == "checkPermissions")
-            .collect();
+        let cp_calls: Vec<_> = s.calls.iter().filter(|c| c.name == "checkPermissions").collect();
         assert_eq!(cp_calls.len(), 1);
     }
 
@@ -6448,11 +5680,8 @@ mod tests {
         // map, addEventListener, etc.) get member_expression args emitted as
         // dynamic calls. Mirrors WASM test in `tests/parsers/javascript.test.ts`.
         let s = parse_js("store.set(user.id, user);");
-        let dyn_member_calls: Vec<_> = s
-            .calls
-            .iter()
-            .filter(|c| c.dynamic == Some(true) && c.name == "id")
-            .collect();
+        let dyn_member_calls: Vec<_> =
+            s.calls.iter().filter(|c| c.dynamic == Some(true) && c.name == "id").collect();
         assert!(
             dyn_member_calls.is_empty(),
             "store.set non-allowlisted callee must not emit member-expr arg `id` as dynamic call",
@@ -6465,25 +5694,15 @@ mod tests {
         // must still produce dynamic calls with receivers, because `use` and `then`
         // are callback-accepting APIs.
         let use_s = parse_js("app.use(auth.validate);");
-        let use_cb = use_s
-            .calls
-            .iter()
+        let use_cb = use_s.calls.iter()
             .find(|c| c.dynamic == Some(true) && c.name == "validate");
-        assert!(
-            use_cb.is_some(),
-            "app.use must still emit validate as dynamic call"
-        );
+        assert!(use_cb.is_some(), "app.use must still emit validate as dynamic call");
         assert_eq!(use_cb.unwrap().receiver.as_deref(), Some("auth"));
 
         let then_s = parse_js("promise.then(handlers.onSuccess);");
-        let then_cb = then_s
-            .calls
-            .iter()
+        let then_cb = then_s.calls.iter()
             .find(|c| c.dynamic == Some(true) && c.name == "onSuccess");
-        assert!(
-            then_cb.is_some(),
-            "promise.then must still emit onSuccess as dynamic call"
-        );
+        assert!(then_cb.is_some(), "promise.then must still emit onSuccess as dynamic call");
         assert_eq!(then_cb.unwrap().receiver.as_deref(), Some("handlers"));
     }
 
@@ -6494,28 +5713,19 @@ mod tests {
         // must not be emitted as dynamic calls. Same for `repo.put`, `map.delete`.
         let cache_s = parse_js("cache.get(user.id);");
         assert!(
-            !cache_s
-                .calls
-                .iter()
-                .any(|c| c.dynamic == Some(true) && c.name == "id"),
+            !cache_s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "id"),
             "cache.get(user.id) must not emit `id` as dynamic call",
         );
 
         let repo_s = parse_js("repo.put(record.key, value);");
         assert!(
-            !repo_s
-                .calls
-                .iter()
-                .any(|c| c.dynamic == Some(true) && c.name == "key"),
+            !repo_s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "key"),
             "repo.put(record.key) must not emit `key` as dynamic call",
         );
 
         let map_s = parse_js("map.delete(entry.id);");
         assert!(
-            !map_s
-                .calls
-                .iter()
-                .any(|c| c.dynamic == Some(true) && c.name == "id"),
+            !map_s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "id"),
             "map.delete(entry.id) must not emit `id` as dynamic call",
         );
     }
@@ -6525,25 +5735,15 @@ mod tests {
         // Positive regression guard: HTTP-verb calls with a string-literal
         // first arg (Express route signature) must still emit member-expr args.
         let router_s = parse_js("router.get('/users/:id', auth.check);");
-        let router_cb = router_s
-            .calls
-            .iter()
+        let router_cb = router_s.calls.iter()
             .find(|c| c.dynamic == Some(true) && c.name == "check");
-        assert!(
-            router_cb.is_some(),
-            "Express route with string path must emit auth.check"
-        );
+        assert!(router_cb.is_some(), "Express route with string path must emit auth.check");
         assert_eq!(router_cb.unwrap().receiver.as_deref(), Some("auth"));
 
         let template_s = parse_js("app.post(`/api`, handlers.create);");
-        let template_cb = template_s
-            .calls
-            .iter()
+        let template_cb = template_s.calls.iter()
             .find(|c| c.dynamic == Some(true) && c.name == "create");
-        assert!(
-            template_cb.is_some(),
-            "Express route with template string must emit handlers.create"
-        );
+        assert!(template_cb.is_some(), "Express route with template string must emit handlers.create");
         assert_eq!(template_cb.unwrap().receiver.as_deref(), Some("handlers"));
     }
 
@@ -6553,14 +5753,9 @@ mod tests {
         // represent `obj?.on` as a `member_expression` with an `optional_chain`
         // child, so `extract_callee_name` returns `on` and the allowlist gate works.
         let s = parse_js("emitter?.on('tick', handlers.fn);");
-        let cb = s
-            .calls
-            .iter()
+        let cb = s.calls.iter()
             .find(|c| c.dynamic == Some(true) && c.name == "fn");
-        assert!(
-            cb.is_some(),
-            "optional-chain callee must still gate by allowlist"
-        );
+        assert!(cb.is_some(), "optional-chain callee must still gate by allowlist");
         assert_eq!(cb.unwrap().receiver.as_deref(), Some("handlers"));
     }
 
@@ -6599,9 +5794,7 @@ mod tests {
         // "identifier args are always emitted" trade-off existed to preserve.
         let s = parse_js("arr.forEach(myNamedCallback);");
         assert!(
-            s.calls
-                .iter()
-                .any(|c| c.dynamic == Some(true) && c.name == "myNamedCallback"),
+            s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "myNamedCallback"),
             "arr.forEach must still emit myNamedCallback as dynamic call; got: {:?}",
             s.calls,
         );
@@ -6624,9 +5817,7 @@ mod tests {
              }",
         );
         assert!(
-            s.calls
-                .iter()
-                .any(|c| c.dynamic == Some(true) && c.name == "logUser"),
+            s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "logUser"),
             "processEach(users, logUser) must emit logUser as dynamic call; got: {:?}",
             s.calls,
         );
@@ -6644,9 +5835,7 @@ mod tests {
              }",
         );
         assert!(
-            s.calls
-                .iter()
-                .any(|c| c.dynamic == Some(true) && c.name == "logUser"),
+            s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "logUser"),
             "inline arrow-function-type param must recognize logUser; got: {:?}",
             s.calls,
         );
@@ -6662,9 +5851,7 @@ mod tests {
              }",
         );
         assert!(
-            s.calls
-                .iter()
-                .any(|c| c.dynamic == Some(true) && c.name == "handler"),
+            s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "handler"),
             "Function-typed param must recognize handler; got: {:?}",
             s.calls,
         );
@@ -6681,9 +5868,7 @@ mod tests {
              }",
         );
         assert!(
-            !s.calls
-                .iter()
-                .any(|c| c.dynamic == Some(true) && c.name == "communities"),
+            !s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "communities"),
             "non-function-shaped param must not emit communities as dynamic call; got: {:?}",
             s.calls,
         );
@@ -6701,9 +5886,7 @@ mod tests {
                filterThen(users, hasEmail, logUser);
              }",
         );
-        let dynamic_names: Vec<&str> = s
-            .calls
-            .iter()
+        let dynamic_names: Vec<&str> = s.calls.iter()
             .filter(|c| c.dynamic == Some(true))
             .map(|c| c.name.as_str())
             .collect();
@@ -6724,9 +5907,7 @@ mod tests {
              }",
         );
         assert!(
-            s.calls
-                .iter()
-                .any(|c| c.dynamic == Some(true) && c.name == "logUser"),
+            s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "logUser"),
             "one-level alias indirection must still recognize logUser; got: {:?}",
             s.calls,
         );
@@ -6744,9 +5925,7 @@ mod tests {
              }",
         );
         assert!(
-            s.calls
-                .iter()
-                .any(|c| c.dynamic == Some(true) && c.name == "logUser"),
+            s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "logUser"),
             "class-method function-shaped param must recognize logUser; got: {:?}",
             s.calls,
         );
@@ -6764,9 +5943,7 @@ mod tests {
              }",
         );
         assert!(
-            s.calls
-                .iter()
-                .any(|c| c.dynamic == Some(true) && c.name == "logUser"),
+            s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "logUser"),
             "explicit this param must not misalign the callback param index; got: {:?}",
             s.calls,
         );
@@ -6785,9 +5962,7 @@ mod tests {
              }",
         );
         assert!(
-            s.calls
-                .iter()
-                .any(|c| c.dynamic == Some(true) && c.name == "logUser"),
+            s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "logUser"),
             "arrow-function HOF must recognize logUser; got: {:?}",
             s.calls,
         );
@@ -6806,9 +5981,7 @@ mod tests {
              }",
         );
         assert!(
-            s.calls
-                .iter()
-                .any(|c| c.dynamic == Some(true) && c.name == "logUser"),
+            s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "logUser"),
             "function-expression HOF must recognize logUser; got: {:?}",
             s.calls,
         );
@@ -6828,9 +6001,7 @@ mod tests {
              }",
         );
         assert!(
-            !s.calls
-                .iter()
-                .any(|c| c.dynamic == Some(true) && c.name == "users"),
+            !s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "users"),
             "unrelated same-named methods must not merge callback shapes; got: {:?}",
             s.calls,
         );
@@ -6844,9 +6015,7 @@ mod tests {
         // arg must not be emitted as a dynamic call either.
         let s = parse_js("cache.get(someKey);");
         assert!(
-            !s.calls
-                .iter()
-                .any(|c| c.dynamic == Some(true) && c.name == "someKey"),
+            !s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "someKey"),
             "cache.get(someKey) must not emit `someKey` as dynamic call; got: {:?}",
             s.calls,
         );
@@ -6861,16 +6030,12 @@ mod tests {
         // class #1741 fixes for the data argument; only `mapFn` should resolve.
         let s = parse_js("Array.from(arr, mapCallback);");
         assert!(
-            s.calls
-                .iter()
-                .any(|c| c.dynamic == Some(true) && c.name == "mapCallback"),
+            s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "mapCallback"),
             "Array.from(arr, mapCallback) must emit mapCallback as dynamic call; got: {:?}",
             s.calls,
         );
         assert!(
-            !s.calls
-                .iter()
-                .any(|c| c.dynamic == Some(true) && c.name == "arr"),
+            !s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "arr"),
             "Array.from(arr, mapCallback) must not emit `arr` (index 0) as dynamic call; got: {:?}",
             s.calls,
         );
@@ -6881,17 +6046,13 @@ mod tests {
         // `Array.from(arrayLike, mapFn, thisArg)` — thisArg (index 2) is a `this`
         // binding context, not a callback, and must not be emitted either.
         let s = parse_js("Array.from(arr, mapCallback, thisArg);");
-        let dynamic_names: Vec<&str> = s
-            .calls
-            .iter()
+        let dynamic_names: Vec<&str> = s.calls.iter()
             .filter(|c| c.dynamic == Some(true))
             .map(|c| c.name.as_str())
             .collect();
         assert_eq!(
-            dynamic_names,
-            vec!["mapCallback"],
-            "only index-1 mapCallback should be dynamic; got: {:?}",
-            s.calls,
+            dynamic_names, vec!["mapCallback"],
+            "only index-1 mapCallback should be dynamic; got: {:?}", s.calls,
         );
     }
 
@@ -6903,16 +6064,12 @@ mod tests {
         // uniformly.
         let s = parse_js("Uint8Array.from(arr, mapCallback);");
         assert!(
-            s.calls
-                .iter()
-                .any(|c| c.dynamic == Some(true) && c.name == "mapCallback"),
+            s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "mapCallback"),
             "Uint8Array.from(arr, mapCallback) must emit mapCallback; got: {:?}",
             s.calls,
         );
         assert!(
-            !s.calls
-                .iter()
-                .any(|c| c.dynamic == Some(true) && c.name == "arr"),
+            !s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "arr"),
             "Uint8Array.from(arr, mapCallback) must not emit `arr`; got: {:?}",
             s.calls,
         );
@@ -6928,32 +6085,24 @@ mod tests {
         // emitted with its receiver, while one at index 0 is not.
         let s = parse_js("Array.from(arr, obj.mapper);");
         assert!(
-            s.calls.iter().any(|c| c.dynamic == Some(true)
-                && c.name == "mapper"
-                && c.receiver.as_deref() == Some("obj")),
+            s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "mapper" && c.receiver.as_deref() == Some("obj")),
             "Array.from(arr, obj.mapper) must emit mapper with receiver obj; got: {:?}",
             s.calls,
         );
         assert!(
-            !s.calls
-                .iter()
-                .any(|c| c.dynamic == Some(true) && c.name == "arr"),
+            !s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "arr"),
             "Array.from(arr, obj.mapper) must not emit `arr` (index 0); got: {:?}",
             s.calls,
         );
 
         let s2 = parse_js("Array.from(obj.arrayLike, mapCallback);");
         assert!(
-            !s2.calls
-                .iter()
-                .any(|c| c.dynamic == Some(true) && c.name == "arrayLike"),
+            !s2.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "arrayLike"),
             "Array.from(obj.arrayLike, mapCallback) must not emit `arrayLike` (index 0); got: {:?}",
             s2.calls,
         );
         assert!(
-            s2.calls
-                .iter()
-                .any(|c| c.dynamic == Some(true) && c.name == "mapCallback"),
+            s2.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "mapCallback"),
             "Array.from(obj.arrayLike, mapCallback) must emit mapCallback; got: {:?}",
             s2.calls,
         );
@@ -6981,19 +6130,9 @@ mod tests {
         // destructured bindings like `handleToken` still resolve when called.
         let s = parse_js("const { handleToken, checkPermissions } = initAuth(config);");
         let names: Vec<&str> = s.definitions.iter().map(|d| d.name.as_str()).collect();
-        assert!(
-            names.contains(&"handleToken"),
-            "should extract handleToken definition"
-        );
-        assert!(
-            names.contains(&"checkPermissions"),
-            "should extract checkPermissions definition"
-        );
-        let ht = s
-            .definitions
-            .iter()
-            .find(|d| d.name == "handleToken")
-            .unwrap();
+        assert!(names.contains(&"handleToken"), "should extract handleToken definition");
+        assert!(names.contains(&"checkPermissions"), "should extract checkPermissions definition");
+        let ht = s.definitions.iter().find(|d| d.name == "handleToken").unwrap();
         assert_eq!(ht.kind, "constant");
     }
 
@@ -7037,9 +6176,7 @@ mod tests {
         // Parity with TS query path (extractDestructuredBindingsWalk), which
         // skips FUNCTION_SCOPE_TYPES. Function-internal destructured const
         // bindings must not be emitted as definitions in the Rust walk path.
-        let s = parse_js(
-            "function setup() { const { handleToken, checkPermissions } = initAuth(config); }",
-        );
+        let s = parse_js("function setup() { const { handleToken, checkPermissions } = initAuth(config); }");
         assert!(
             !s.definitions.iter().any(|d| d.name == "handleToken"),
             "function-nested destructured binding must not be emitted"
@@ -7060,10 +6197,7 @@ mod tests {
             .expect("should use the local alias");
         // kind is "constant" (#1773) — see comment on extracts_destructured_const_bindings.
         assert_eq!(renamed.kind, "constant");
-        assert!(
-            !s.definitions.iter().any(|d| d.name == "original"),
-            "should not use the original key"
-        );
+        assert!(!s.definitions.iter().any(|d| d.name == "original"), "should not use the original key");
     }
 
     /// Regression test for issue #1271: native engine missing receiver edges.
@@ -7097,10 +6231,7 @@ mod tests {
         assert!(
             compute_call.is_some(),
             "calls should contain 'compute'; got: {:?}",
-            s.calls
-                .iter()
-                .map(|c| (&c.name, &c.receiver))
-                .collect::<Vec<_>>()
+            s.calls.iter().map(|c| (&c.name, &c.receiver)).collect::<Vec<_>>()
         );
         assert_eq!(
             compute_call.unwrap().receiver.as_deref(),
@@ -7134,7 +6265,9 @@ mod tests {
     /// constructor) falls back to the un-scoped `this.prop` key.
     #[test]
     fn this_prop_constructor_assignment_outside_class_uses_this_key() {
-        let s = parse_js("function Service() { this.client = new HttpClient(); }");
+        let s = parse_js(
+            "function Service() { this.client = new HttpClient(); }",
+        );
         let tm = s.type_map.iter().find(|t| t.name == "this.client");
         assert!(
             tm.is_some(),
@@ -7203,9 +6336,7 @@ mod tests {
              const b = Math.bind(null);",
         );
         assert!(
-            s.fn_ref_bindings
-                .iter()
-                .all(|b| b.lhs != "a" && b.lhs != "b"),
+            s.fn_ref_bindings.iter().all(|b| b.lhs != "a" && b.lhs != "b"),
             "method-receiver and builtin binds must not be tracked; got: {:?}",
             s.fn_ref_bindings
         );
@@ -7220,17 +6351,10 @@ mod tests {
              C.prototype.foo = function() { return 1; };",
         );
         let def = s.definitions.iter().find(|d| d.name == "C.foo");
-        assert!(
-            def.is_some(),
-            "C.foo definition missing; got: {:?}",
-            s.definitions.iter().map(|d| &d.name).collect::<Vec<_>>()
-        );
+        assert!(def.is_some(), "C.foo definition missing; got: {:?}", s.definitions.iter().map(|d| &d.name).collect::<Vec<_>>());
         let def = def.unwrap();
         assert_eq!(def.kind, "method");
-        assert!(
-            def.complexity.is_some(),
-            "C.foo should have complexity metrics"
-        );
+        assert!(def.complexity.is_some(), "C.foo should have complexity metrics");
         assert!(def.cfg.is_some(), "C.foo should have a CFG");
     }
 
@@ -7241,17 +6365,10 @@ mod tests {
              C.prototype.foo = () => { return 1; };",
         );
         let def = s.definitions.iter().find(|d| d.name == "C.foo");
-        assert!(
-            def.is_some(),
-            "C.foo definition missing; got: {:?}",
-            s.definitions.iter().map(|d| &d.name).collect::<Vec<_>>()
-        );
+        assert!(def.is_some(), "C.foo definition missing; got: {:?}", s.definitions.iter().map(|d| &d.name).collect::<Vec<_>>());
         let def = def.unwrap();
         assert_eq!(def.kind, "method");
-        assert!(
-            def.complexity.is_some(),
-            "C.foo (arrow) should have complexity metrics"
-        );
+        assert!(def.complexity.is_some(), "C.foo (arrow) should have complexity metrics");
         assert!(def.cfg.is_some(), "C.foo (arrow) should have a CFG");
     }
 
@@ -7263,11 +6380,7 @@ mod tests {
              A.prototype.t = f;",
         );
         let entry = s.type_map.iter().find(|e| e.name == "A.t");
-        assert!(
-            entry.is_some(),
-            "type_map entry A.t missing; got: {:?}",
-            s.type_map.iter().map(|e| &e.name).collect::<Vec<_>>()
-        );
+        assert!(entry.is_some(), "type_map entry A.t missing; got: {:?}", s.type_map.iter().map(|e| &e.name).collect::<Vec<_>>());
         assert_eq!(entry.unwrap().type_name, "f");
     }
 
@@ -7285,18 +6398,12 @@ mod tests {
         assert!(foo.is_some(), "C.foo missing");
         let foo = foo.unwrap();
         assert_eq!(foo.kind, "method");
-        assert!(
-            foo.complexity.is_some(),
-            "C.foo should have complexity metrics"
-        );
+        assert!(foo.complexity.is_some(), "C.foo should have complexity metrics");
         assert!(foo.cfg.is_some(), "C.foo should have a CFG");
         assert!(bar.is_some(), "C.bar missing");
         let bar = bar.unwrap();
         assert_eq!(bar.kind, "method");
-        assert!(
-            bar.complexity.is_some(),
-            "C.bar should have complexity metrics"
-        );
+        assert!(bar.complexity.is_some(), "C.bar should have complexity metrics");
         assert!(bar.cfg.is_some(), "C.bar should have a CFG");
     }
 
@@ -7309,17 +6416,10 @@ mod tests {
              };",
         );
         let def = s.definitions.iter().find(|d| d.name == "C.greet");
-        assert!(
-            def.is_some(),
-            "C.greet definition missing; got: {:?}",
-            s.definitions.iter().map(|d| &d.name).collect::<Vec<_>>()
-        );
+        assert!(def.is_some(), "C.greet definition missing; got: {:?}", s.definitions.iter().map(|d| &d.name).collect::<Vec<_>>());
         let def = def.unwrap();
         assert_eq!(def.kind, "method");
-        assert!(
-            def.complexity.is_some(),
-            "C.greet should have complexity metrics"
-        );
+        assert!(def.complexity.is_some(), "C.greet should have complexity metrics");
         assert!(def.cfg.is_some(), "C.greet should have a CFG");
     }
 
@@ -7331,11 +6431,7 @@ mod tests {
              C.prototype = { helper };",
         );
         let entry = s.type_map.iter().find(|e| e.name == "C.helper");
-        assert!(
-            entry.is_some(),
-            "type_map entry C.helper missing; got: {:?}",
-            s.type_map.iter().map(|e| &e.name).collect::<Vec<_>>()
-        );
+        assert!(entry.is_some(), "type_map entry C.helper missing; got: {:?}", s.type_map.iter().map(|e| &e.name).collect::<Vec<_>>());
         assert_eq!(entry.unwrap().type_name, "helper");
     }
 
@@ -7343,11 +6439,7 @@ mod tests {
     fn prototype_builtin_globals_are_excluded() {
         let s = parse_js("Array.prototype.custom = function() {};");
         let def = s.definitions.iter().find(|d| d.name.contains("Array"));
-        assert!(
-            def.is_none(),
-            "built-in prototype assignment should be ignored; got: {:?}",
-            def
-        );
+        assert!(def.is_none(), "built-in prototype assignment should be ignored; got: {:?}", def);
     }
 
     #[test]
@@ -7356,26 +6448,17 @@ mod tests {
             "function C() {}\n\
              C.prototype.foo = function(x, y) { if (true) { return 1; } return 0; };",
         );
-        let def = s
-            .definitions
-            .iter()
-            .find(|d| d.name == "C.foo")
-            .expect("C.foo missing");
-        assert!(
-            def.complexity.is_some(),
-            "C.foo should have complexity metrics"
-        );
+        let def = s.definitions.iter().find(|d| d.name == "C.foo").expect("C.foo missing");
+        assert!(def.complexity.is_some(), "C.foo should have complexity metrics");
         assert!(def.cfg.is_some(), "C.foo should have CFG data");
         let children = def.children.as_deref().unwrap_or(&[]);
         assert!(
             children.iter().any(|c| c.name == "x"),
-            "C.foo should have parameter 'x'; got: {:?}",
-            children
+            "C.foo should have parameter 'x'; got: {:?}", children
         );
         assert!(
             children.iter().any(|c| c.name == "y"),
-            "C.foo should have parameter 'y'; got: {:?}",
-            children
+            "C.foo should have parameter 'y'; got: {:?}", children
         );
     }
 
@@ -7389,17 +6472,10 @@ mod tests {
              f.g = function() { return 1; };",
         );
         let def = s.definitions.iter().find(|d| d.name == "f.g");
-        assert!(
-            def.is_some(),
-            "f.g definition missing; got: {:?}",
-            s.definitions.iter().map(|d| &d.name).collect::<Vec<_>>()
-        );
+        assert!(def.is_some(), "f.g definition missing; got: {:?}", s.definitions.iter().map(|d| &d.name).collect::<Vec<_>>());
         let def = def.unwrap();
         assert_eq!(def.kind, "method");
-        assert!(
-            def.complexity.is_some(),
-            "f.g should have complexity metrics"
-        );
+        assert!(def.complexity.is_some(), "f.g should have complexity metrics");
         assert!(def.cfg.is_some(), "f.g should have a CFG");
     }
 
@@ -7410,11 +6486,7 @@ mod tests {
              f.g = (x) => x + 1;",
         );
         let def = s.definitions.iter().find(|d| d.name == "f.g");
-        assert!(
-            def.is_some(),
-            "f.g definition missing; got: {:?}",
-            s.definitions.iter().map(|d| &d.name).collect::<Vec<_>>()
-        );
+        assert!(def.is_some(), "f.g definition missing; got: {:?}", s.definitions.iter().map(|d| &d.name).collect::<Vec<_>>());
         assert_eq!(def.unwrap().kind, "method");
     }
 
@@ -7424,21 +6496,15 @@ mod tests {
             "function f() {}\n\
              f.process = function(a, b) { return a + b; };",
         );
-        let def = s
-            .definitions
-            .iter()
-            .find(|d| d.name == "f.process")
-            .expect("f.process missing");
+        let def = s.definitions.iter().find(|d| d.name == "f.process").expect("f.process missing");
         let children = def.children.as_deref().unwrap_or(&[]);
         assert!(
             children.iter().any(|c| c.name == "a"),
-            "f.process should have parameter 'a'; got: {:?}",
-            children
+            "f.process should have parameter 'a'; got: {:?}", children
         );
         assert!(
             children.iter().any(|c| c.name == "b"),
-            "f.process should have parameter 'b'; got: {:?}",
-            children
+            "f.process should have parameter 'b'; got: {:?}", children
         );
     }
 
@@ -7446,11 +6512,7 @@ mod tests {
     fn func_prop_builtin_globals_are_excluded() {
         let s = parse_js("console.log = function() {};");
         let def = s.definitions.iter().find(|d| d.name == "console.log");
-        assert!(
-            def.is_none(),
-            "built-in global func-prop assignment should be ignored; got: {:?}",
-            def
-        );
+        assert!(def.is_none(), "built-in global func-prop assignment should be ignored; got: {:?}", def);
     }
 
     #[test]
@@ -7460,11 +6522,7 @@ mod tests {
         // extractor).
         let s = parse_js("const a = { b: {} };\na.b.c = function() {};");
         let def = s.definitions.iter().find(|d| d.name.ends_with(".c"));
-        assert!(
-            def.is_none(),
-            "nested member receiver should be skipped; got: {:?}",
-            def
-        );
+        assert!(def.is_none(), "nested member receiver should be skipped; got: {:?}", def);
     }
 
     #[test]
@@ -7477,11 +6535,7 @@ mod tests {
              C.prototype = function() {};",
         );
         let def = s.definitions.iter().find(|d| d.name == "C.prototype");
-        assert!(
-            def.is_none(),
-            "C.prototype function assignment should not emit a method; got: {:?}",
-            def
-        );
+        assert!(def.is_none(), "C.prototype function assignment should not emit a method; got: {:?}", def);
     }
 
     #[test]
@@ -7490,26 +6544,17 @@ mod tests {
             "function C() {}\n\
              C.prototype.bar = (a, b) => a > 0 ? a : b;",
         );
-        let def = s
-            .definitions
-            .iter()
-            .find(|d| d.name == "C.bar")
-            .expect("C.bar missing");
-        assert!(
-            def.complexity.is_some(),
-            "C.bar arrow should have complexity metrics"
-        );
+        let def = s.definitions.iter().find(|d| d.name == "C.bar").expect("C.bar missing");
+        assert!(def.complexity.is_some(), "C.bar arrow should have complexity metrics");
         assert!(def.cfg.is_some(), "C.bar arrow should have CFG data");
         let children = def.children.as_deref().unwrap_or(&[]);
         assert!(
             children.iter().any(|c| c.name == "a"),
-            "C.bar should have parameter 'a'; got: {:?}",
-            children
+            "C.bar should have parameter 'a'; got: {:?}", children
         );
         assert!(
             children.iter().any(|c| c.name == "b"),
-            "C.bar should have parameter 'b'; got: {:?}",
-            children
+            "C.bar should have parameter 'b'; got: {:?}", children
         );
     }
 
@@ -7521,21 +6566,13 @@ mod tests {
                greet(name) { if (true) { return 'hi'; } return ''; },\n\
              };",
         );
-        let def = s
-            .definitions
-            .iter()
-            .find(|d| d.name == "C.greet")
-            .expect("C.greet missing");
-        assert!(
-            def.complexity.is_some(),
-            "C.greet should have complexity metrics"
-        );
+        let def = s.definitions.iter().find(|d| d.name == "C.greet").expect("C.greet missing");
+        assert!(def.complexity.is_some(), "C.greet should have complexity metrics");
         assert!(def.cfg.is_some(), "C.greet should have CFG data");
         let children = def.children.as_deref().unwrap_or(&[]);
         assert!(
             children.iter().any(|c| c.name == "name"),
-            "C.greet should have parameter 'name'; got: {:?}",
-            children
+            "C.greet should have parameter 'name'; got: {:?}", children
         );
     }
 
@@ -7547,21 +6584,13 @@ mod tests {
                bar: function(n) { if (true) { return 1; } return 0; },\n\
              };",
         );
-        let def = s
-            .definitions
-            .iter()
-            .find(|d| d.name == "C.bar")
-            .expect("C.bar missing");
-        assert!(
-            def.complexity.is_some(),
-            "C.bar should have complexity metrics"
-        );
+        let def = s.definitions.iter().find(|d| d.name == "C.bar").expect("C.bar missing");
+        assert!(def.complexity.is_some(), "C.bar should have complexity metrics");
         assert!(def.cfg.is_some(), "C.bar should have CFG data");
         let children = def.children.as_deref().unwrap_or(&[]);
         assert!(
             children.iter().any(|c| c.name == "n"),
-            "C.bar should have parameter 'n'; got: {:?}",
-            children
+            "C.bar should have parameter 'n'; got: {:?}", children
         );
     }
 
@@ -7574,11 +6603,7 @@ mod tests {
              Object.defineProperty(obj, \"f\", { value: f1 });",
         );
         let entry = s.type_map.iter().find(|e| e.name == "obj.f");
-        assert!(
-            entry.is_some(),
-            "type_map should contain 'obj.f'; got: {:?}",
-            s.type_map
-        );
+        assert!(entry.is_some(), "type_map should contain 'obj.f'; got: {:?}", s.type_map);
         assert_eq!(entry.unwrap().type_name, "f1");
     }
 
@@ -7596,16 +6621,8 @@ mod tests {
         );
         let e1 = s.type_map.iter().find(|e| e.name == "obj.f1");
         let e2 = s.type_map.iter().find(|e| e.name == "obj.f2");
-        assert!(
-            e1.is_some(),
-            "type_map should contain 'obj.f1'; got: {:?}",
-            s.type_map
-        );
-        assert!(
-            e2.is_some(),
-            "type_map should contain 'obj.f2'; got: {:?}",
-            s.type_map
-        );
+        assert!(e1.is_some(), "type_map should contain 'obj.f1'; got: {:?}", s.type_map);
+        assert!(e2.is_some(), "type_map should contain 'obj.f2'; got: {:?}", s.type_map);
         assert_eq!(e1.unwrap().type_name, "f1");
         assert_eq!(e2.unwrap().type_name, "f2");
     }
@@ -7620,16 +6637,8 @@ mod tests {
         );
         let e1 = s.type_map.iter().find(|e| e.name == "obj.f1");
         let e2 = s.type_map.iter().find(|e| e.name == "obj.f2");
-        assert!(
-            e1.is_some(),
-            "type_map should contain 'obj.f1'; got: {:?}",
-            s.type_map
-        );
-        assert!(
-            e2.is_some(),
-            "type_map should contain 'obj.f2'; got: {:?}",
-            s.type_map
-        );
+        assert!(e1.is_some(), "type_map should contain 'obj.f1'; got: {:?}", s.type_map);
+        assert!(e2.is_some(), "type_map should contain 'obj.f2'; got: {:?}", s.type_map);
         assert_eq!(e1.unwrap().type_name, "f1");
         assert_eq!(e2.unwrap().type_name, "f2");
     }
@@ -7649,53 +6658,23 @@ mod tests {
              };",
         );
         let names: Vec<_> = s.definitions.iter().map(|d| (&d.name, &d.kind)).collect();
-        let f_bare_pos = s
-            .definitions
-            .iter()
-            .position(|d| d.name == "f" && d.kind == "method");
-        let g_bare_pos = s
-            .definitions
-            .iter()
-            .position(|d| d.name == "g" && d.kind == "method");
-        let f_qual_pos = s
-            .definitions
-            .iter()
-            .position(|d| d.name == "o1.f" && d.kind == "function");
-        let g_qual_pos = s
-            .definitions
-            .iter()
-            .position(|d| d.name == "o1.g" && d.kind == "function");
-        assert!(
-            f_bare_pos.is_some(),
-            "bare f(method) missing; got: {:?}",
-            names
-        );
-        assert!(
-            g_bare_pos.is_some(),
-            "bare g(method) missing; got: {:?}",
-            names
-        );
-        assert!(
-            f_qual_pos.is_some(),
-            "qualified o1.f(function) missing; got: {:?}",
-            names
-        );
-        assert!(
-            g_qual_pos.is_some(),
-            "qualified o1.g(function) missing; got: {:?}",
-            names
-        );
+        let f_bare_pos = s.definitions.iter().position(|d| d.name == "f" && d.kind == "method");
+        let g_bare_pos = s.definitions.iter().position(|d| d.name == "g" && d.kind == "method");
+        let f_qual_pos = s.definitions.iter().position(|d| d.name == "o1.f" && d.kind == "function");
+        let g_qual_pos = s.definitions.iter().position(|d| d.name == "o1.g" && d.kind == "function");
+        assert!(f_bare_pos.is_some(), "bare f(method) missing; got: {:?}", names);
+        assert!(g_bare_pos.is_some(), "bare g(method) missing; got: {:?}", names);
+        assert!(f_qual_pos.is_some(), "qualified o1.f(function) missing; got: {:?}", names);
+        assert!(g_qual_pos.is_some(), "qualified o1.g(function) missing; got: {:?}", names);
         assert!(
             f_bare_pos.unwrap() < f_qual_pos.unwrap(),
             "f(method) at {} must precede o1.f(function) at {} — equal-span tie-break",
-            f_bare_pos.unwrap(),
-            f_qual_pos.unwrap()
+            f_bare_pos.unwrap(), f_qual_pos.unwrap()
         );
         assert!(
             g_bare_pos.unwrap() < g_qual_pos.unwrap(),
             "g(method) at {} must precede o1.g(function) at {}",
-            g_bare_pos.unwrap(),
-            g_qual_pos.unwrap()
+            g_bare_pos.unwrap(), g_qual_pos.unwrap()
         );
         // typeMap entry must point to bare name for two-step accessor dispatch.
         let tm_f = s.type_map.iter().find(|e| e.name == "o1.f");
@@ -7717,16 +6696,8 @@ mod tests {
              obj.bar();",
         );
         let names: Vec<_> = s.definitions.iter().map(|d| d.name.as_str()).collect();
-        assert!(
-            names.contains(&"obj.foo"),
-            "expected 'obj.foo'; got: {:?}",
-            names
-        );
-        assert!(
-            names.contains(&"obj.bar"),
-            "expected 'obj.bar'; got: {:?}",
-            names
-        );
+        assert!(names.contains(&"obj.foo"), "expected 'obj.foo'; got: {:?}", names);
+        assert!(names.contains(&"obj.bar"), "expected 'obj.bar'; got: {:?}", names);
         assert!(
             !names.iter().any(|n| n.contains('[')),
             "no definition name should retain the bracketed/quoted form; got: {:?}",
@@ -7751,11 +6722,7 @@ mod tests {
             "non-string computed key must not produce a definition; got: {:?}",
             names
         );
-        assert!(
-            names.contains(&"obj.bar"),
-            "expected 'obj.bar'; got: {:?}",
-            names
-        );
+        assert!(names.contains(&"obj.bar"), "expected 'obj.bar'; got: {:?}", names);
     }
 
     /// Issue #1944: a plain quoted (non-computed) method key (`'foo'() {}`, kind `"string"`,
@@ -7766,11 +6733,7 @@ mod tests {
     fn quoted_plain_method_key_resolves_to_plain_name() {
         let s = parse_js("class A {\n  'foo'() { return 1; }\n}");
         let names: Vec<_> = s.definitions.iter().map(|d| d.name.as_str()).collect();
-        assert!(
-            names.contains(&"A.foo"),
-            "expected 'A.foo'; got: {:?}",
-            names
-        );
+        assert!(names.contains(&"A.foo"), "expected 'A.foo'; got: {:?}", names);
         assert!(
             !names.iter().any(|n| n.contains('\'')),
             "no definition name should retain the quoted form; got: {:?}",
@@ -7783,11 +6746,7 @@ mod tests {
     fn quoted_plain_object_literal_method_key_resolves_to_plain_name() {
         let s = parse_js("const obj = { 'quoted'() { return 1; } };");
         let names: Vec<_> = s.definitions.iter().map(|d| d.name.as_str()).collect();
-        assert!(
-            names.contains(&"obj.quoted"),
-            "expected 'obj.quoted'; got: {:?}",
-            names
-        );
+        assert!(names.contains(&"obj.quoted"), "expected 'obj.quoted'; got: {:?}", names);
         assert!(
             !names.iter().any(|n| n.contains('\'')),
             "no definition name should retain the quoted form; got: {:?}",
@@ -7804,21 +6763,9 @@ mod tests {
              var obj3 = { ['computedVar']: () => {} };",
         );
         let names: Vec<_> = s.definitions.iter().map(|d| d.name.as_str()).collect();
-        assert!(
-            names.contains(&"obj2.computedLet"),
-            "expected 'obj2.computedLet'; got: {:?}",
-            names
-        );
-        assert!(
-            names.contains(&"obj2.plain"),
-            "expected 'obj2.plain'; got: {:?}",
-            names
-        );
-        assert!(
-            names.contains(&"obj3.computedVar"),
-            "expected 'obj3.computedVar'; got: {:?}",
-            names
-        );
+        assert!(names.contains(&"obj2.computedLet"), "expected 'obj2.computedLet'; got: {:?}", names);
+        assert!(names.contains(&"obj2.plain"), "expected 'obj2.plain'; got: {:?}", names);
+        assert!(names.contains(&"obj3.computedVar"), "expected 'obj3.computedVar'; got: {:?}", names);
     }
 
     /// Issue #1884: `seed_object_create_entries`'s pair arm must unwrap a computed
@@ -7831,11 +6778,7 @@ mod tests {
              const obj = Object.create({ ['foo']: fn });",
         );
         let entry = s.type_map.iter().find(|e| e.name == "obj.foo");
-        assert!(
-            entry.is_some(),
-            "type_map should contain 'obj.foo'; got: {:?}",
-            s.type_map
-        );
+        assert!(entry.is_some(), "type_map should contain 'obj.foo'; got: {:?}", s.type_map);
         assert_eq!(entry.unwrap().type_name, "fn");
     }
 
@@ -7849,11 +6792,7 @@ mod tests {
              Object.defineProperties(obj, { ['foo']: { value: f1 } });",
         );
         let entry = s.type_map.iter().find(|e| e.name == "obj.foo");
-        assert!(
-            entry.is_some(),
-            "type_map should contain 'obj.foo'; got: {:?}",
-            s.type_map
-        );
+        assert!(entry.is_some(), "type_map should contain 'obj.foo'; got: {:?}", s.type_map);
         assert_eq!(entry.unwrap().type_name, "f1");
     }
 
@@ -7868,8 +6807,7 @@ mod tests {
         );
         assert!(
             !s.type_map.iter().any(|e| e.name.contains("Symbol")),
-            "non-string computed key must not produce a type_map entry; got: {:?}",
-            s.type_map
+            "non-string computed key must not produce a type_map entry; got: {:?}", s.type_map
         );
     }
 
@@ -7882,11 +6820,7 @@ mod tests {
              var routes = { ['get']: handler };",
         );
         let entry = s.type_map.iter().find(|e| e.name == "routes.get");
-        assert!(
-            entry.is_some(),
-            "type_map should contain 'routes.get'; got: {:?}",
-            s.type_map
-        );
+        assert!(entry.is_some(), "type_map should contain 'routes.get'; got: {:?}", s.type_map);
         assert_eq!(entry.unwrap().type_name, "handler");
     }
 
@@ -7900,11 +6834,7 @@ mod tests {
              C.prototype = { ['run']: helper };",
         );
         let entry = s.type_map.iter().find(|e| e.name == "C.run");
-        assert!(
-            entry.is_some(),
-            "type_map should contain 'C.run'; got: {:?}",
-            s.type_map
-        );
+        assert!(entry.is_some(), "type_map should contain 'C.run'; got: {:?}", s.type_map);
         assert_eq!(entry.unwrap().type_name, "helper");
     }
 
@@ -7917,11 +6847,7 @@ mod tests {
              C.prototype = { ['foo']: function() { return 1; } };",
         );
         let names: Vec<_> = s.definitions.iter().map(|d| d.name.as_str()).collect();
-        assert!(
-            names.contains(&"C.foo"),
-            "expected 'C.foo'; got: {:?}",
-            names
-        );
+        assert!(names.contains(&"C.foo"), "expected 'C.foo'; got: {:?}", names);
     }
 
     /// Issue #1884: `collect_object_rest_params`'s pair arm previously skipped ALL computed
@@ -7936,15 +6862,8 @@ mod tests {
                }\n\
              };",
         );
-        let b = s
-            .object_rest_param_bindings
-            .iter()
-            .find(|b| b.callee == "process");
-        assert!(
-            b.is_some(),
-            "object_rest_param_bindings missing; got: {:?}",
-            s.object_rest_param_bindings
-        );
+        let b = s.object_rest_param_bindings.iter().find(|b| b.callee == "process");
+        assert!(b.is_some(), "object_rest_param_bindings missing; got: {:?}", s.object_rest_param_bindings);
         let b = b.unwrap();
         assert_eq!(b.rest_name, "rest");
         assert_eq!(b.arg_index, 0);
@@ -7962,11 +6881,8 @@ mod tests {
              };",
         );
         assert!(
-            !s.object_rest_param_bindings
-                .iter()
-                .any(|b| b.rest_name == "rest"),
-            "non-string computed key must not produce a binding; got: {:?}",
-            s.object_rest_param_bindings
+            !s.object_rest_param_bindings.iter().any(|b| b.rest_name == "rest"),
+            "non-string computed key must not produce a binding; got: {:?}", s.object_rest_param_bindings
         );
     }
 
@@ -7981,33 +6897,14 @@ mod tests {
              obj.f();",
         );
         let tm = s_let_method.type_map.iter().find(|e| e.name == "obj.f");
-        assert!(
-            tm.is_some(),
-            "let obj method: typeMap 'obj.f' missing; got: {:?}",
-            s_let_method
-                .type_map
-                .iter()
-                .map(|e| &e.name)
-                .collect::<Vec<_>>()
-        );
-        assert_eq!(
-            tm.unwrap().type_name,
-            "f",
-            "typeMap 'obj.f' must point at bare name 'f', not the qualified key"
-        );
-        let call = s_let_method
-            .calls
-            .iter()
-            .find(|c| c.name == "f" && c.receiver.as_deref() == Some("obj"));
-        assert!(
-            call.is_some(),
+        assert!(tm.is_some(), "let obj method: typeMap 'obj.f' missing; got: {:?}",
+            s_let_method.type_map.iter().map(|e| &e.name).collect::<Vec<_>>());
+        assert_eq!(tm.unwrap().type_name, "f",
+            "typeMap 'obj.f' must point at bare name 'f', not the qualified key");
+        let call = s_let_method.calls.iter().find(|c| c.name == "f" && c.receiver.as_deref() == Some("obj"));
+        assert!(call.is_some(),
             "calls must contain obj.f() with receiver='obj'; got: {:?}",
-            s_let_method
-                .calls
-                .iter()
-                .map(|c| (&c.name, &c.receiver))
-                .collect::<Vec<_>>()
-        );
+            s_let_method.calls.iter().map(|c| (&c.name, &c.receiver)).collect::<Vec<_>>());
 
         // Shorthand property: `var obj = { e4 }` → typeMap['obj.e4'] = 'e4'
         let s_var_shorthand = parse_js(
@@ -8015,15 +6912,8 @@ mod tests {
              var obj = { e4 };",
         );
         let tm2 = s_var_shorthand.type_map.iter().find(|e| e.name == "obj.e4");
-        assert!(
-            tm2.is_some(),
-            "var obj shorthand: typeMap 'obj.e4' missing; got: {:?}",
-            s_var_shorthand
-                .type_map
-                .iter()
-                .map(|e| &e.name)
-                .collect::<Vec<_>>()
-        );
+        assert!(tm2.is_some(), "var obj shorthand: typeMap 'obj.e4' missing; got: {:?}",
+            s_var_shorthand.type_map.iter().map(|e| &e.name).collect::<Vec<_>>());
         assert_eq!(tm2.unwrap().type_name, "e4");
 
         // Pair with identifier value: `var routes = { get: handler }` → typeMap['routes.get'] = 'handler'
@@ -8032,15 +6922,8 @@ mod tests {
              var routes = { get: handler };",
         );
         let tm3 = s_var_pair.type_map.iter().find(|e| e.name == "routes.get");
-        assert!(
-            tm3.is_some(),
-            "var routes pair: typeMap 'routes.get' missing; got: {:?}",
-            s_var_pair
-                .type_map
-                .iter()
-                .map(|e| &e.name)
-                .collect::<Vec<_>>()
-        );
+        assert!(tm3.is_some(), "var routes pair: typeMap 'routes.get' missing; got: {:?}",
+            s_var_pair.type_map.iter().map(|e| &e.name).collect::<Vec<_>>());
         assert_eq!(tm3.unwrap().type_name, "handler");
 
         // Pair with arrow value: `let api = { save: () => {} }` → typeMap['api.save'] = 'api.save'
@@ -8051,39 +6934,19 @@ mod tests {
              api.save();",
         );
         let tm4 = s_let_arrow.type_map.iter().find(|e| e.name == "api.save");
-        assert!(
-            tm4.is_some(),
-            "let api arrow: typeMap 'api.save' missing; got: {:?}",
-            s_let_arrow
-                .type_map
-                .iter()
-                .map(|e| &e.name)
-                .collect::<Vec<_>>()
-        );
+        assert!(tm4.is_some(), "let api arrow: typeMap 'api.save' missing; got: {:?}",
+            s_let_arrow.type_map.iter().map(|e| &e.name).collect::<Vec<_>>());
         assert_eq!(tm4.unwrap().type_name, "api.save",
             "typeMap 'api.save' must point at the qualified name 'api.save' (qualified definition exists)");
         assert!(
             s_let_arrow.definitions.iter().any(|d| d.name == "api.save"),
             "let api arrow: qualified definition 'api.save' missing; got: {:?}",
-            s_let_arrow
-                .definitions
-                .iter()
-                .map(|d| &d.name)
-                .collect::<Vec<_>>()
+            s_let_arrow.definitions.iter().map(|d| &d.name).collect::<Vec<_>>()
         );
-        let call4 = s_let_arrow
-            .calls
-            .iter()
-            .find(|c| c.name == "save" && c.receiver.as_deref() == Some("api"));
-        assert!(
-            call4.is_some(),
+        let call4 = s_let_arrow.calls.iter().find(|c| c.name == "save" && c.receiver.as_deref() == Some("api"));
+        assert!(call4.is_some(),
             "calls must contain api.save() with receiver='api'; got: {:?}",
-            s_let_arrow
-                .calls
-                .iter()
-                .map(|c| (&c.name, &c.receiver))
-                .collect::<Vec<_>>()
-        );
+            s_let_arrow.calls.iter().map(|c| (&c.name, &c.receiver)).collect::<Vec<_>>());
 
         // Scope guard: object literal inside a function body must NOT seed module-level typeMap.
         let s_scoped = parse_js(
@@ -8095,11 +6958,7 @@ mod tests {
         assert!(
             s_scoped.type_map.iter().all(|e| e.name != "local.run"),
             "function-scoped let obj must not pollute typeMap; got: {:?}",
-            s_scoped
-                .type_map
-                .iter()
-                .map(|e| &e.name)
-                .collect::<Vec<_>>()
+            s_scoped.type_map.iter().map(|e| &e.name).collect::<Vec<_>>()
         );
     }
 
@@ -8115,24 +6974,14 @@ mod tests {
              }",
         );
         let tm = s.type_map.iter().find(|e| e.name == "obj.f");
-        assert!(
-            tm.is_some(),
-            "type_map should contain 'obj.f'; got: {:?}",
-            s.type_map
-        );
+        assert!(tm.is_some(), "type_map should contain 'obj.f'; got: {:?}", s.type_map);
         assert_eq!(tm.unwrap().type_name, "f1");
 
-        let call = s
-            .calls
-            .iter()
-            .find(|c| c.name == "f" && c.receiver.as_deref() == Some("obj"));
+        let call = s.calls.iter().find(|c| c.name == "f" && c.receiver.as_deref() == Some("obj"));
         assert!(
             call.is_some(),
             "calls should contain obj.f() with receiver='obj'; got: {:?}",
-            s.calls
-                .iter()
-                .map(|c| (&c.name, &c.receiver))
-                .collect::<Vec<_>>()
+            s.calls.iter().map(|c| (&c.name, &c.receiver)).collect::<Vec<_>>()
         );
     }
 
@@ -8149,11 +6998,7 @@ mod tests {
             .param_bindings
             .iter()
             .find(|b| b.callee == "hof" && b.arg_name == "target");
-        assert!(
-            b.is_some(),
-            "param_bindings should contain hof←target; got: {:?}",
-            s.param_bindings
-        );
+        assert!(b.is_some(), "param_bindings should contain hof←target; got: {:?}", s.param_bindings);
         assert_eq!(b.unwrap().arg_index, 0);
     }
 
@@ -8227,29 +7072,17 @@ mod tests {
              function runCallThis() { return invoker.call(handler, 10); }",
         );
         assert!(
-            s.calls
-                .iter()
-                .any(|c| c.name == "invoker" && c.dynamic == Some(true)),
+            s.calls.iter().any(|c| c.name == "invoker" && c.dynamic == Some(true)),
             "invoker.call() should emit a dynamic call to invoker; got: {:?}",
-            s.calls
-                .iter()
-                .map(|c| (&c.name, c.dynamic))
-                .collect::<Vec<_>>()
+            s.calls.iter().map(|c| (&c.name, c.dynamic)).collect::<Vec<_>>()
         );
         assert!(
             !s.calls.iter().any(|c| c.name == "handler"),
             ".call() args must not become callback-reference calls; got: {:?}",
-            s.calls
-                .iter()
-                .map(|c| (&c.name, c.dynamic))
-                .collect::<Vec<_>>()
+            s.calls.iter().map(|c| (&c.name, c.dynamic)).collect::<Vec<_>>()
         );
         let b = s.this_call_bindings.iter().find(|b| b.callee == "invoker");
-        assert!(
-            b.is_some(),
-            "this_call_bindings should contain invoker→handler; got: {:?}",
-            s.this_call_bindings
-        );
+        assert!(b.is_some(), "this_call_bindings should contain invoker→handler; got: {:?}", s.this_call_bindings);
         assert_eq!(b.unwrap().this_arg, "handler");
     }
 
@@ -8271,10 +7104,7 @@ mod tests {
         assert!(
             !s.calls.iter().any(|c| c.name == "b"),
             "argument `b` of this(b) must not become a callback-reference call; got: {:?}",
-            s.calls
-                .iter()
-                .map(|c| (&c.name, c.dynamic))
-                .collect::<Vec<_>>()
+            s.calls.iter().map(|c| (&c.name, c.dynamic)).collect::<Vec<_>>()
         );
     }
 
@@ -8292,18 +7122,12 @@ mod tests {
         assert!(
             !s.calls.iter().any(|c| c.name == "a"),
             "argument `a` of super(a, b) must not become a callback-reference call; got: {:?}",
-            s.calls
-                .iter()
-                .map(|c| (&c.name, c.dynamic))
-                .collect::<Vec<_>>()
+            s.calls.iter().map(|c| (&c.name, c.dynamic)).collect::<Vec<_>>()
         );
         assert!(
             !s.calls.iter().any(|c| c.name == "b"),
             "argument `b` of super(a, b) must not become a callback-reference call; got: {:?}",
-            s.calls
-                .iter()
-                .map(|c| (&c.name, c.dynamic))
-                .collect::<Vec<_>>()
+            s.calls.iter().map(|c| (&c.name, c.dynamic)).collect::<Vec<_>>()
         );
     }
 
@@ -8326,10 +7150,7 @@ mod tests {
         assert!(
             super_call.is_some(),
             "bare super(...) must be recorded as a constructor call with receiver=super; got: {:?}",
-            s.calls
-                .iter()
-                .map(|c| (&c.name, &c.receiver))
-                .collect::<Vec<_>>()
+            s.calls.iter().map(|c| (&c.name, &c.receiver)).collect::<Vec<_>>()
         );
     }
 
@@ -8346,16 +7167,8 @@ mod tests {
             .filter(|b| b.array_name == "arr")
             .map(|b| (b.index, b.elem_name.as_str()))
             .collect();
-        assert!(
-            got.contains(&(0, "fn1")),
-            "expected (0, fn1); got: {:?}",
-            got
-        );
-        assert!(
-            got.contains(&(1, "fn2")),
-            "expected (1, fn2); got: {:?}",
-            got
-        );
+        assert!(got.contains(&(0, "fn1")), "expected (0, fn1); got: {:?}", got);
+        assert!(got.contains(&(1, "fn2")), "expected (1, fn2); got: {:?}", got);
     }
 
     #[test]
@@ -8366,11 +7179,7 @@ mod tests {
              callAll(...fns);",
         );
         let b = s.spread_arg_bindings.iter().find(|b| b.callee == "callAll");
-        assert!(
-            b.is_some(),
-            "spread_arg_bindings missing; got: {:?}",
-            s.spread_arg_bindings
-        );
+        assert!(b.is_some(), "spread_arg_bindings missing; got: {:?}", s.spread_arg_bindings);
         let b = b.unwrap();
         assert_eq!(b.array_name, "fns");
         assert_eq!(b.start_index, 0);
@@ -8383,11 +7192,7 @@ mod tests {
              const wrapped = new Set(arr);",
         );
         let b = s.fn_ref_bindings.iter().find(|b| b.lhs == "wrapped[*]");
-        assert!(
-            b.is_some(),
-            "Set wrap should bind wrapped[*] ⊇ arr[*]; got: {:?}",
-            s.fn_ref_bindings
-        );
+        assert!(b.is_some(), "Set wrap should bind wrapped[*] ⊇ arr[*]; got: {:?}", s.fn_ref_bindings);
         assert_eq!(b.unwrap().rhs, "arr[*]");
     }
 
@@ -8399,11 +7204,7 @@ mod tests {
              }",
         );
         let b = s.for_of_bindings.iter().find(|b| b.var_name == "h");
-        assert!(
-            b.is_some(),
-            "for_of_bindings missing; got: {:?}",
-            s.for_of_bindings
-        );
+        assert!(b.is_some(), "for_of_bindings missing; got: {:?}", s.for_of_bindings);
         let b = b.unwrap();
         assert_eq!(b.source_name, "handlers");
         assert_eq!(b.enclosing_func, "run");
@@ -8417,11 +7218,7 @@ mod tests {
              }",
         );
         let b = s.for_of_bindings.iter().find(|b| b.var_name == "g");
-        assert!(
-            b.is_some(),
-            "for_of_bindings missing for g; got: {:?}",
-            s.for_of_bindings
-        );
+        assert!(b.is_some(), "for_of_bindings missing for g; got: {:?}", s.for_of_bindings);
         assert_eq!(b.unwrap().enclosing_func, "Runner.runAll");
     }
 
@@ -8429,11 +7226,7 @@ mod tests {
     fn for_of_binding_at_module_level_uses_module_context() {
         let s = parse_js("for (const cb of callbacks) { cb(); }");
         let b = s.for_of_bindings.iter().find(|b| b.var_name == "cb");
-        assert!(
-            b.is_some(),
-            "for_of_bindings missing; got: {:?}",
-            s.for_of_bindings
-        );
+        assert!(b.is_some(), "for_of_bindings missing; got: {:?}", s.for_of_bindings);
         assert_eq!(b.unwrap().enclosing_func, "<module>");
     }
 
@@ -8447,11 +7240,7 @@ mod tests {
             .array_callback_bindings
             .iter()
             .find(|b| b.callee_name == "makeThing");
-        assert!(
-            b.is_some(),
-            "array_callback_bindings missing; got: {:?}",
-            s.array_callback_bindings
-        );
+        assert!(b.is_some(), "array_callback_bindings missing; got: {:?}", s.array_callback_bindings);
         assert_eq!(b.unwrap().source_name, "items");
     }
 
@@ -8462,11 +7251,7 @@ mod tests {
             .object_rest_param_bindings
             .iter()
             .find(|b| b.callee == "f3");
-        assert!(
-            b.is_some(),
-            "object_rest_param_bindings missing; got: {:?}",
-            s.object_rest_param_bindings
-        );
+        assert!(b.is_some(), "object_rest_param_bindings missing; got: {:?}", s.object_rest_param_bindings);
         let b = b.unwrap();
         assert_eq!(b.rest_name, "eerest");
         assert_eq!(b.arg_index, 0);
@@ -8479,15 +7264,8 @@ mod tests {
                handle({ id, ...rest }) { rest.go(); }\n\
              }",
         );
-        let b = s
-            .object_rest_param_bindings
-            .iter()
-            .find(|b| b.rest_name == "rest");
-        assert!(
-            b.is_some(),
-            "object_rest_param_bindings missing; got: {:?}",
-            s.object_rest_param_bindings
-        );
+        let b = s.object_rest_param_bindings.iter().find(|b| b.rest_name == "rest");
+        assert!(b.is_some(), "object_rest_param_bindings missing; got: {:?}", s.object_rest_param_bindings);
         assert_eq!(b.unwrap().callee, "Svc.handle");
     }
 
@@ -8502,22 +7280,14 @@ mod tests {
             .object_prop_bindings
             .iter()
             .find(|b| b.object_name == "obj" && b.prop_name == "e4");
-        assert!(
-            shorthand.is_some(),
-            "shorthand binding missing; got: {:?}",
-            s.object_prop_bindings
-        );
+        assert!(shorthand.is_some(), "shorthand binding missing; got: {:?}", s.object_prop_bindings);
         assert_eq!(shorthand.unwrap().value_name, "e4");
 
         let pair = s
             .object_prop_bindings
             .iter()
             .find(|b| b.object_name == "obj" && b.prop_name == "alias");
-        assert!(
-            pair.is_some(),
-            "pair binding missing; got: {:?}",
-            s.object_prop_bindings
-        );
+        assert!(pair.is_some(), "pair binding missing; got: {:?}", s.object_prop_bindings);
         assert_eq!(pair.unwrap().value_name, "named");
     }
 
@@ -8553,39 +7323,18 @@ mod tests {
              function runDispatch(key) { ({ a: dtFn1, b: dtFn2 })[key](); }",
         );
         // The call name must be <dt_line_col>[*]
-        let dt_call = s
-            .calls
-            .iter()
-            .find(|c| c.name.starts_with("<dt_") && c.name.ends_with(">[*]"));
-        assert!(
-            dt_call.is_some(),
-            "dispatch-table call missing; got: {:?}",
-            s.calls
-        );
+        let dt_call = s.calls.iter().find(|c| c.name.starts_with("<dt_") && c.name.ends_with(">[*]"));
+        assert!(dt_call.is_some(), "dispatch-table call missing; got: {:?}", s.calls);
         let dt_call = dt_call.unwrap();
         assert_eq!(dt_call.dynamic, Some(true));
         assert_eq!(dt_call.dynamic_kind.as_deref(), Some("dispatch-table"));
 
         // The array_elem_bindings must contain dtFn1 and dtFn2 under the same table name
         let table_name = dt_call.name.trim_end_matches("[*]");
-        let elem1 = s
-            .array_elem_bindings
-            .iter()
-            .find(|b| b.array_name == table_name && b.elem_name == "dtFn1");
-        let elem2 = s
-            .array_elem_bindings
-            .iter()
-            .find(|b| b.array_name == table_name && b.elem_name == "dtFn2");
-        assert!(
-            elem1.is_some(),
-            "dtFn1 array_elem_binding missing; got: {:?}",
-            s.array_elem_bindings
-        );
-        assert!(
-            elem2.is_some(),
-            "dtFn2 array_elem_binding missing; got: {:?}",
-            s.array_elem_bindings
-        );
+        let elem1 = s.array_elem_bindings.iter().find(|b| b.array_name == table_name && b.elem_name == "dtFn1");
+        let elem2 = s.array_elem_bindings.iter().find(|b| b.array_name == table_name && b.elem_name == "dtFn2");
+        assert!(elem1.is_some(), "dtFn1 array_elem_binding missing; got: {:?}", s.array_elem_bindings);
+        assert!(elem2.is_some(), "dtFn2 array_elem_binding missing; got: {:?}", s.array_elem_bindings);
         assert_eq!(elem1.unwrap().index, 0);
         assert_eq!(elem2.unwrap().index, 1);
     }
@@ -8597,15 +7346,8 @@ mod tests {
              function fnB() {}\n\
              function run(k) { ({a: fnA, b: fnB})[k](); }",
         );
-        let dt_call = s
-            .calls
-            .iter()
-            .find(|c| c.name.starts_with("<dt_") && c.name.ends_with(">[*]"));
-        assert!(
-            dt_call.is_some(),
-            "dispatch-table call missing for parenthesized object; got: {:?}",
-            s.calls
-        );
+        let dt_call = s.calls.iter().find(|c| c.name.starts_with("<dt_") && c.name.ends_with(">[*]"));
+        assert!(dt_call.is_some(), "dispatch-table call missing for parenthesized object; got: {:?}", s.calls);
     }
 
     // ── ES6 getter/setter same-file property-read call attribution (#1893) ──
@@ -8619,9 +7361,7 @@ mod tests {
              }",
         );
         assert!(
-            s.calls
-                .iter()
-                .any(|c| c.name == "isReady" && c.receiver.as_deref() == Some("this")),
+            s.calls.iter().any(|c| c.name == "isReady" && c.receiver.as_deref() == Some("this")),
             "expected a call to isReady via this; got: {:?}",
             s.calls
         );
@@ -8638,9 +7378,7 @@ mod tests {
              }",
         );
         assert!(
-            s.calls
-                .iter()
-                .any(|c| c.name == "db" && c.receiver.as_deref() == Some("repo")),
+            s.calls.iter().any(|c| c.name == "db" && c.receiver.as_deref() == Some("repo")),
             "expected a call to db via repo; got: {:?}",
             s.calls
         );
@@ -8655,9 +7393,7 @@ mod tests {
              }",
         );
         assert!(
-            s.calls
-                .iter()
-                .any(|c| c.name == "flag" && c.receiver.as_deref() == Some("this")),
+            s.calls.iter().any(|c| c.name == "flag" && c.receiver.as_deref() == Some("this")),
             "expected a call to flag via this; got: {:?}",
             s.calls
         );
@@ -8689,16 +7425,8 @@ mod tests {
                return w.value();\n\
              }",
         );
-        let matches = s
-            .calls
-            .iter()
-            .filter(|c| c.name == "value" && c.receiver.as_deref() == Some("w"))
-            .count();
-        assert_eq!(
-            matches, 1,
-            "expected exactly one call to w.value(); got: {:?}",
-            s.calls
-        );
+        let matches = s.calls.iter().filter(|c| c.name == "value" && c.receiver.as_deref() == Some("w")).count();
+        assert_eq!(matches, 1, "expected exactly one call to w.value(); got: {:?}", s.calls);
     }
 
     #[test]
@@ -8713,9 +7441,7 @@ mod tests {
              }",
         );
         assert!(
-            !s.calls
-                .iter()
-                .any(|c| c.name == "render" && c.receiver.as_deref() == Some("w")),
+            !s.calls.iter().any(|c| c.name == "render" && c.receiver.as_deref() == Some("w")),
             "plain method reference (no accessor) must not produce a call; got: {:?}",
             s.calls
         );
@@ -8730,9 +7456,7 @@ mod tests {
              }",
         );
         assert!(
-            s.calls
-                .iter()
-                .any(|c| c.name == "version" && c.receiver.as_deref() == Some("this")),
+            s.calls.iter().any(|c| c.name == "version" && c.receiver.as_deref() == Some("this")),
             "expected a call to version via this; got: {:?}",
             s.calls
         );

--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -10,20 +10,65 @@ use tree_sitter::{Node, Tree};
 /// Mirrors the `BUILTIN_GLOBALS` set in `src/extractors/javascript.ts`
 /// and must be identical to the set tested in `is_js_builtin_global`.
 const JS_BUILTIN_GLOBALS: &[&str] = &[
-    "Math", "JSON", "Promise", "Array", "Object", "Date", "Error",
-    "Symbol", "Map", "Set", "RegExp", "Number", "String", "Boolean",
-    "WeakMap", "WeakSet", "WeakRef", "Proxy", "Reflect", "Intl",
-    "ArrayBuffer", "SharedArrayBuffer", "DataView", "Atomics", "BigInt",
-    "Float32Array", "Float64Array", "Int8Array", "Int16Array", "Int32Array",
-    "Uint8Array", "Uint16Array", "Uint32Array", "Uint8ClampedArray",
-    "URL", "URLSearchParams", "TextEncoder", "TextDecoder",
-    "AbortController", "AbortSignal", "Headers", "Request", "Response",
-    "FormData", "Blob", "File", "ReadableStream", "WritableStream",
+    "Math",
+    "JSON",
+    "Promise",
+    "Array",
+    "Object",
+    "Date",
+    "Error",
+    "Symbol",
+    "Map",
+    "Set",
+    "RegExp",
+    "Number",
+    "String",
+    "Boolean",
+    "WeakMap",
+    "WeakSet",
+    "WeakRef",
+    "Proxy",
+    "Reflect",
+    "Intl",
+    "ArrayBuffer",
+    "SharedArrayBuffer",
+    "DataView",
+    "Atomics",
+    "BigInt",
+    "Float32Array",
+    "Float64Array",
+    "Int8Array",
+    "Int16Array",
+    "Int32Array",
+    "Uint8Array",
+    "Uint16Array",
+    "Uint32Array",
+    "Uint8ClampedArray",
+    "URL",
+    "URLSearchParams",
+    "TextEncoder",
+    "TextDecoder",
+    "AbortController",
+    "AbortSignal",
+    "Headers",
+    "Request",
+    "Response",
+    "FormData",
+    "Blob",
+    "File",
+    "ReadableStream",
+    "WritableStream",
     "TransformStream",
     // Browser/runtime globals — must match is_js_builtin_global below
-    "console", "process", "window", "document", "globalThis",
+    "console",
+    "process",
+    "window",
+    "document",
+    "globalThis",
     // Node.js built-ins
-    "Buffer", "EventEmitter", "Stream",
+    "Buffer",
+    "EventEmitter",
+    "Stream",
 ];
 
 pub struct JsExtractor;
@@ -35,19 +80,44 @@ impl SymbolExtractor for JsExtractor {
         // same-file user-defined higher-order functions can be recognized
         // during the single forward walk below, regardless of declaration order.
         let callback_param_shapes = collect_callback_param_shapes(&tree.root_node(), source);
-        walk_tree(&tree.root_node(), source, &mut symbols, |node, source, symbols, depth| {
-            match_js_node(node, source, symbols, depth, &callback_param_shapes)
-        });
+        walk_tree(
+            &tree.root_node(),
+            source,
+            &mut symbols,
+            |node, source, symbols, depth| {
+                match_js_node(node, source, symbols, depth, &callback_param_shapes)
+            },
+        );
         walk_ast_nodes(&tree.root_node(), source, &mut symbols.ast_nodes);
         walk_tree(&tree.root_node(), source, &mut symbols, match_js_type_map);
-        walk_tree(&tree.root_node(), source, &mut symbols, match_js_return_type_map);
+        walk_tree(
+            &tree.root_node(),
+            source,
+            &mut symbols,
+            match_js_return_type_map,
+        );
         // Pre-ES6 prototype methods: `Foo.prototype.bar = fn` and `Foo.prototype = { bar: fn }`
-        walk_tree(&tree.root_node(), source, &mut symbols, match_js_prototype_methods);
+        walk_tree(
+            &tree.root_node(),
+            source,
+            &mut symbols,
+            match_js_prototype_methods,
+        );
         // call_assignments runs after type_map is populated (needs receiver types)
-        walk_tree(&tree.root_node(), source, &mut symbols, match_js_call_assignments);
+        walk_tree(
+            &tree.root_node(),
+            source,
+            &mut symbols,
+            match_js_call_assignments,
+        );
         // Phase 8.3c–8.3f: points-to bindings (params, this-rebinding, arrays,
         // spread, for-of, object rest/props) for the pts constraint solver.
-        walk_tree(&tree.root_node(), source, &mut symbols, match_js_pts_bindings);
+        walk_tree(
+            &tree.root_node(),
+            source,
+            &mut symbols,
+            match_js_pts_bindings,
+        );
         // Collapse duplicate keys accumulated during the tree walks (O(n)).
         dedup_type_map(&mut symbols.type_map);
         dedup_type_map(&mut symbols.return_type_map);
@@ -64,9 +134,14 @@ impl SymbolExtractor for JsExtractor {
         // via `setTypeMapEntry`, so `.get()` is always already resolved — ordering
         // this walk after dedup keeps both engines reading the same resolved view.
         let local_accessors = collect_local_accessors(&tree.root_node(), source);
-        walk_tree(&tree.root_node(), source, &mut symbols, |node, source, symbols, _depth| {
-            handle_accessor_property_read(node, source, symbols, &local_accessors)
-        });
+        walk_tree(
+            &tree.root_node(),
+            source,
+            &mut symbols,
+            |node, source, symbols, _depth| {
+                handle_accessor_property_read(node, source, symbols, &local_accessors)
+            },
+        );
         symbols
     }
 }
@@ -96,12 +171,12 @@ fn extract_new_expr_type_name<'a>(node: &Node<'a>, source: &'a [u8]) -> Option<&
     if node.kind() != "new_expression" {
         return None;
     }
-    let ctor = node.child_by_field_name("constructor").or_else(|| node.child(1))?;
+    let ctor = node
+        .child_by_field_name("constructor")
+        .or_else(|| node.child(1))?;
     match ctor.kind() {
         "identifier" => Some(node_text(&ctor, source)),
-        "member_expression" => {
-            named_child_text(&ctor, "property", source)
-        }
+        "member_expression" => named_child_text(&ctor, "property", source),
         _ => None,
     }
 }
@@ -117,7 +192,9 @@ fn enclosing_type_map_class<'a>(node: &Node<'a>, source: &'a [u8]) -> Option<&'a
     while let Some(n) = cur {
         match n.kind() {
             "class_declaration" | "abstract_class_declaration" => {
-                return n.child_by_field_name("name").map(|name| node_text(&name, source));
+                return n
+                    .child_by_field_name("name")
+                    .map(|name| node_text(&name, source));
             }
             "class" => return None,
             _ => {}
@@ -138,7 +215,9 @@ fn match_js_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
         "assignment_expression" => handle_assignment_type_map(node, source, symbols),
         // TypeScript class field declarations.
         // Mirrors handleFieldDefTypeMap in src/extractors/javascript.ts.
-        "public_field_definition" | "field_definition" => handle_field_def_type_map(node, source, symbols),
+        "public_field_definition" | "field_definition" => {
+            handle_field_def_type_map(node, source, symbols)
+        }
         _ => {}
     }
 }
@@ -151,8 +230,12 @@ fn match_js_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
 /// - Object.create({ key: fn }) composite pts keys (Phase 8.3e)
 /// - object-literal declarations at non-function scope (Phase 8.3f parity)
 fn handle_var_declarator_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_n) = node.child_by_field_name("name") else { return };
-    if name_n.kind() != "identifier" { return; }
+    let Some(name_n) = node.child_by_field_name("name") else {
+        return;
+    };
+    if name_n.kind() != "identifier" {
+        return;
+    }
     let var_name = node_text(&name_n, source);
     // Type annotation: confidence 0.9
     if let Some(type_anno) = find_child(node, "type_annotation") {
@@ -160,7 +243,9 @@ fn handle_var_declarator_type_map(node: &Node, source: &[u8], symbols: &mut File
             push_type_map_entry(symbols, var_name.to_string(), type_name.to_string());
         }
     }
-    let Some(value_n) = node.child_by_field_name("value") else { return };
+    let Some(value_n) = node.child_by_field_name("value") else {
+        return;
+    };
     // Constructor: confidence 1.0 (overrides annotation in edge builder)
     if value_n.kind() == "new_expression" {
         if let Some(type_name) = extract_new_expr_type_name(&value_n, source) {
@@ -180,10 +265,20 @@ fn handle_var_declarator_type_map(node: &Node, source: &[u8], symbols: &mut File
     // Mirrors WASM handleVarDeclaratorTypeMap (no isConst guard there).
     // For `const`, extract_object_literal_functions already seeds these entries;
     // dedup_type_map collapses any duplicates at equal confidence.
-    if value_n.kind() == "object" && find_parent_of_types(node, &[
-        "function_declaration", "arrow_function", "function_expression",
-        "method_definition", "generator_function_declaration", "generator_function",
-    ]).is_none() {
+    if value_n.kind() == "object"
+        && find_parent_of_types(
+            node,
+            &[
+                "function_declaration",
+                "arrow_function",
+                "function_expression",
+                "method_definition",
+                "generator_function_declaration",
+                "generator_function",
+            ],
+        )
+        .is_none()
+    {
         seed_objlit_type_map_entries(var_name, &value_n, source, symbols);
     }
 }
@@ -192,12 +287,17 @@ fn handle_var_declarator_type_map(node: &Node, source: &[u8], symbols: &mut File
 ///
 /// Seeds a type-map entry when the parameter carries a TypeScript type annotation.
 fn handle_param_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let name_node = node.child_by_field_name("pattern")
+    let name_node = node
+        .child_by_field_name("pattern")
         .or_else(|| node.child_by_field_name("left"))
         .or_else(|| node.child(0));
     let Some(name_node) = name_node else { return };
-    if name_node.kind() != "identifier" { return };
-    let Some(type_anno) = find_child(node, "type_annotation") else { return };
+    if name_node.kind() != "identifier" {
+        return;
+    };
+    let Some(type_anno) = find_child(node, "type_annotation") else {
+        return;
+    };
     if let Some(type_name) = extract_simple_type_name(&type_anno, source) {
         push_type_map_entry(
             symbols,
@@ -217,14 +317,22 @@ fn handle_param_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
 fn handle_assignment_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     let lhs = node.child_by_field_name("left");
     let rhs = node.child_by_field_name("right");
-    let (Some(lhs), Some(rhs)) = (lhs, rhs) else { return };
-    if lhs.kind() != "member_expression" { return; }
+    let (Some(lhs), Some(rhs)) = (lhs, rhs) else {
+        return;
+    };
+    if lhs.kind() != "member_expression" {
+        return;
+    }
     let obj = lhs.child_by_field_name("object");
     let prop = lhs.child_by_field_name("property");
-    let (Some(obj), Some(prop)) = (obj, prop) else { return };
+    let (Some(obj), Some(prop)) = (obj, prop) else {
+        return;
+    };
     // Guard: only static property access, not computed subscripts.
     let prop_kind = prop.kind();
-    if prop_kind != "property_identifier" && prop_kind != "identifier" { return; }
+    if prop_kind != "property_identifier" && prop_kind != "identifier" {
+        return;
+    }
     if obj.kind() == "this" && rhs.kind() == "new_expression" {
         if let Some(ctor_type) = extract_new_expr_type_name(&rhs, source) {
             let key = match enclosing_type_map_class(node, source) {
@@ -261,17 +369,25 @@ fn handle_assignment_type_map(node: &Node, source: &[u8], symbols: &mut FileSymb
 ///
 /// Mirrors `handleFieldDefTypeMap` in `src/extractors/javascript.ts`.
 fn handle_field_def_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let name_node = node.child_by_field_name("name")
+    let name_node = node
+        .child_by_field_name("name")
         .or_else(|| node.child_by_field_name("property"))
         .or_else(|| find_child(node, "property_identifier"));
     let Some(name_node) = name_node else { return };
     let kind = name_node.kind();
-    if kind != "property_identifier" && kind != "identifier" && kind != "private_property_identifier" {
+    if kind != "property_identifier"
+        && kind != "identifier"
+        && kind != "private_property_identifier"
+    {
         return;
     }
     let field_name = node_text(&name_node, source).to_string();
-    let Some(type_anno) = find_child(node, "type_annotation") else { return };
-    let Some(type_name) = extract_simple_type_name(&type_anno, source) else { return };
+    let Some(type_anno) = find_child(node, "type_annotation") else {
+        return;
+    };
+    let Some(type_name) = extract_simple_type_name(&type_anno, source) else {
+        return;
+    };
     match enclosing_type_map_class(node, source) {
         Some(class_name) => {
             // Primary: class-scoped key prevents cross-class collision.
@@ -283,13 +399,23 @@ fn handle_field_def_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbo
             );
             // Fallback bare keys at lower confidence.
             set_type_map_entry(symbols, field_name.clone(), type_name.to_string(), 0.6);
-            set_type_map_entry(symbols, format!("this.{}", field_name), type_name.to_string(), 0.6);
+            set_type_map_entry(
+                symbols,
+                format!("this.{}", field_name),
+                type_name.to_string(),
+                0.6,
+            );
         }
         None => {
             // No enclosing class declaration (e.g. class expression)
             // — use bare keys only at full confidence.
             set_type_map_entry(symbols, field_name.clone(), type_name.to_string(), 0.9);
-            set_type_map_entry(symbols, format!("this.{}", field_name), type_name.to_string(), 0.9);
+            set_type_map_entry(
+                symbols,
+                format!("this.{}", field_name),
+                type_name.to_string(),
+                0.9,
+            );
         }
     }
 }
@@ -326,22 +452,37 @@ fn is_js_builtin_global(name: &str) -> bool {
 /// Seed composite pts keys for `Object.defineProperty(obj, "key", { value: fn })`
 /// and `Object.defineProperties(obj, { "key": { value: fn }, ... })`.
 fn seed_define_property_entries(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(callee) = node.child_by_field_name("function") else { return };
-    if callee.kind() != "member_expression" { return; }
-    let Some(callee_obj) = callee.child_by_field_name("object") else { return };
-    if node_text(&callee_obj, source) != "Object" { return; }
-    let Some(callee_prop) = callee.child_by_field_name("property") else { return };
+    let Some(callee) = node.child_by_field_name("function") else {
+        return;
+    };
+    if callee.kind() != "member_expression" {
+        return;
+    }
+    let Some(callee_obj) = callee.child_by_field_name("object") else {
+        return;
+    };
+    if node_text(&callee_obj, source) != "Object" {
+        return;
+    }
+    let Some(callee_prop) = callee.child_by_field_name("property") else {
+        return;
+    };
     let method = node_text(&callee_prop, source);
-    if method != "defineProperty" && method != "defineProperties" { return; }
+    if method != "defineProperty" && method != "defineProperties" {
+        return;
+    }
 
-    let args_node = node.child_by_field_name("arguments")
+    let args_node = node
+        .child_by_field_name("arguments")
         .or_else(|| find_child(node, "arguments"));
     let Some(args_node) = args_node else { return };
 
     // Collect non-punctuation argument nodes in order
     let mut args: Vec<Node> = Vec::new();
     for i in 0..args_node.child_count() {
-        let Some(child) = args_node.child(i) else { continue };
+        let Some(child) = args_node.child(i) else {
+            continue;
+        };
         if !matches!(child.kind(), "(" | ")" | ",") {
             args.push(child);
         }
@@ -349,10 +490,16 @@ fn seed_define_property_entries(node: &Node, source: &[u8], symbols: &mut FileSy
 
     if method == "defineProperty" {
         // Object.defineProperty(obj, "key", { value: fn }) or { get: getter }
-        if args.len() < 3 { return; }
-        if args[0].kind() != "identifier" { return; }
+        if args.len() < 3 {
+            return;
+        }
+        if args[0].kind() != "identifier" {
+            return;
+        }
         let obj_name = node_text(&args[0], source);
-        let Some(key) = extract_string_fragment(&args[1], source) else { return };
+        let Some(key) = extract_string_fragment(&args[1], source) else {
+            return;
+        };
         // Phase 8.3e: { value: fn } → obj.key pts to fn
         if let Some(target) = find_descriptor_value(&args[2], source) {
             symbols.type_map.push(TypeMapEntry {
@@ -371,24 +518,48 @@ fn seed_define_property_entries(node: &Node, source: &[u8], symbols: &mut FileSy
         }
     } else {
         // Object.defineProperties(obj, { "key": { value: fn }, ... })
-        if args.len() < 2 { return; }
-        if args[0].kind() != "identifier" { return; }
+        if args.len() < 2 {
+            return;
+        }
+        if args[0].kind() != "identifier" {
+            return;
+        }
         let obj_name = node_text(&args[0], source).to_string();
-        if args[1].kind() != "object" { return; }
+        if args[1].kind() != "object" {
+            return;
+        }
         seed_descriptor_object(&obj_name, &args[1], source, symbols);
     }
 }
 
 /// Seed composite pts keys from `const obj = Object.create({ f1, f2 })`.
-fn seed_object_create_entries(var_name: &str, call_node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(callee) = call_node.child_by_field_name("function") else { return };
-    if callee.kind() != "member_expression" { return; }
-    let Some(callee_obj) = callee.child_by_field_name("object") else { return };
-    if node_text(&callee_obj, source) != "Object" { return; }
-    let Some(callee_prop) = callee.child_by_field_name("property") else { return };
-    if node_text(&callee_prop, source) != "create" { return; }
+fn seed_object_create_entries(
+    var_name: &str,
+    call_node: &Node,
+    source: &[u8],
+    symbols: &mut FileSymbols,
+) {
+    let Some(callee) = call_node.child_by_field_name("function") else {
+        return;
+    };
+    if callee.kind() != "member_expression" {
+        return;
+    }
+    let Some(callee_obj) = callee.child_by_field_name("object") else {
+        return;
+    };
+    if node_text(&callee_obj, source) != "Object" {
+        return;
+    }
+    let Some(callee_prop) = callee.child_by_field_name("property") else {
+        return;
+    };
+    if node_text(&callee_prop, source) != "create" {
+        return;
+    }
 
-    let args_node = call_node.child_by_field_name("arguments")
+    let args_node = call_node
+        .child_by_field_name("arguments")
         .or_else(|| find_child(call_node, "arguments"));
     let Some(args_node) = args_node else { return };
 
@@ -397,10 +568,14 @@ fn seed_object_create_entries(var_name: &str, call_node: &Node, source: &[u8], s
         .filter_map(|i| args_node.child(i))
         .find(|n| !matches!(n.kind(), "(" | ")" | ","));
     let Some(proto) = proto else { return };
-    if proto.kind() != "object" { return };
+    if proto.kind() != "object" {
+        return;
+    };
 
     for i in 0..proto.child_count() {
-        let Some(child) = proto.child(i) else { continue };
+        let Some(child) = proto.child(i) else {
+            continue;
+        };
         match child.kind() {
             "shorthand_property_identifier" => {
                 // { f1 } shorthand — property name equals value name
@@ -412,10 +587,18 @@ fn seed_object_create_entries(var_name: &str, call_node: &Node, source: &[u8], s
                 });
             }
             "pair" => {
-                let Some(key_n) = child.child_by_field_name("key") else { continue };
-                let Some(val_n) = child.child_by_field_name("value") else { continue };
-                if val_n.kind() != "identifier" { continue; }
-                let Some(key) = resolve_pair_key_name(&key_n, source) else { continue };
+                let Some(key_n) = child.child_by_field_name("key") else {
+                    continue;
+                };
+                let Some(val_n) = child.child_by_field_name("value") else {
+                    continue;
+                };
+                if val_n.kind() != "identifier" {
+                    continue;
+                }
+                let Some(key) = resolve_pair_key_name(&key_n, source) else {
+                    continue;
+                };
                 symbols.type_map.push(TypeMapEntry {
                     name: format!("{}.{}", var_name, key),
                     type_name: node_text(&val_n, source).to_string(),
@@ -428,14 +611,31 @@ fn seed_object_create_entries(var_name: &str, call_node: &Node, source: &[u8], s
 }
 
 /// Iterate over the properties of a `defineProperties` descriptor object and seed the type_map.
-fn seed_descriptor_object(obj_name: &str, obj_node: &Node, source: &[u8], symbols: &mut FileSymbols) {
+fn seed_descriptor_object(
+    obj_name: &str,
+    obj_node: &Node,
+    source: &[u8],
+    symbols: &mut FileSymbols,
+) {
     for i in 0..obj_node.child_count() {
-        let Some(child) = obj_node.child(i) else { continue };
-        if child.kind() != "pair" { continue; }
-        let Some(key_n) = child.child_by_field_name("key") else { continue };
-        let Some(val_n) = child.child_by_field_name("value") else { continue };
-        let Some(key) = resolve_pair_key_name(&key_n, source) else { continue };
-        let Some(target) = find_descriptor_value(&val_n, source) else { continue };
+        let Some(child) = obj_node.child(i) else {
+            continue;
+        };
+        if child.kind() != "pair" {
+            continue;
+        }
+        let Some(key_n) = child.child_by_field_name("key") else {
+            continue;
+        };
+        let Some(val_n) = child.child_by_field_name("value") else {
+            continue;
+        };
+        let Some(key) = resolve_pair_key_name(&key_n, source) else {
+            continue;
+        };
+        let Some(target) = find_descriptor_value(&val_n, source) else {
+            continue;
+        };
         symbols.type_map.push(TypeMapEntry {
             name: format!("{}.{}", obj_name, key),
             type_name: target.to_string(),
@@ -446,19 +646,31 @@ fn seed_descriptor_object(obj_name: &str, obj_node: &Node, source: &[u8], symbol
 
 /// Extract the text of the `string_fragment` child of a string node, i.e. content without quotes.
 fn extract_string_fragment<'a>(node: &Node<'a>, source: &'a [u8]) -> Option<&'a str> {
-    if node.kind() != "string" { return None; }
+    if node.kind() != "string" {
+        return None;
+    }
     find_child(node, "string_fragment").map(|n| node_text(&n, source))
 }
 
 /// Find the `value` identifier in a property descriptor object `{ value: fn }`.
 fn find_descriptor_value<'a>(node: &Node<'a>, source: &'a [u8]) -> Option<&'a str> {
-    if node.kind() != "object" { return None; }
+    if node.kind() != "object" {
+        return None;
+    }
     for i in 0..node.child_count() {
         let Some(child) = node.child(i) else { continue };
-        if child.kind() != "pair" { continue; }
-        let Some(key) = child.child_by_field_name("key") else { continue };
-        if node_text(&key, source) != "value" { continue; }
-        let Some(val) = child.child_by_field_name("value") else { continue };
+        if child.kind() != "pair" {
+            continue;
+        }
+        let Some(key) = child.child_by_field_name("key") else {
+            continue;
+        };
+        if node_text(&key, source) != "value" {
+            continue;
+        }
+        let Some(val) = child.child_by_field_name("value") else {
+            continue;
+        };
         if val.kind() == "identifier" {
             return Some(node_text(&val, source));
         }
@@ -470,15 +682,25 @@ fn find_descriptor_value<'a>(node: &Node<'a>, source: &'a [u8]) -> Option<&'a st
 /// descriptor. `{ get: getter, set: setter }` → ["getter", "setter"].
 /// Returns all accessors so that each one gets a `callerName:this = obj` typeMap entry.
 fn find_descriptor_accessors<'a>(node: &Node<'a>, source: &'a [u8]) -> Vec<&'a str> {
-    if node.kind() != "object" { return Vec::new(); }
+    if node.kind() != "object" {
+        return Vec::new();
+    }
     let mut result = Vec::new();
     for i in 0..node.child_count() {
         let Some(child) = node.child(i) else { continue };
-        if child.kind() != "pair" { continue; }
-        let Some(key) = child.child_by_field_name("key") else { continue };
+        if child.kind() != "pair" {
+            continue;
+        }
+        let Some(key) = child.child_by_field_name("key") else {
+            continue;
+        };
         let key_text = node_text(&key, source);
-        if key_text != "get" && key_text != "set" { continue; }
-        let Some(val) = child.child_by_field_name("value") else { continue };
+        if key_text != "get" && key_text != "set" {
+            continue;
+        }
+        let Some(val) = child.child_by_field_name("value") else {
+            continue;
+        };
         if val.kind() == "identifier" {
             result.push(node_text(&val, source));
         }
@@ -489,9 +711,15 @@ fn find_descriptor_accessors<'a>(node: &Node<'a>, source: &'a [u8]) -> Vec<&'a s
 /// True when `declarator` is the shape `extract_object_literal_functions` qualifies: a plain
 /// identifier name, outside any function scope. Mirrors TS `isEligibleObjectLiteralDeclarator`.
 fn is_eligible_object_literal_declarator(declarator: &Node) -> bool {
-    if declarator.kind() != "variable_declarator" { return false; }
-    let Some(name_n) = declarator.child_by_field_name("name") else { return false };
-    if name_n.kind() != "identifier" { return false; }
+    if declarator.kind() != "variable_declarator" {
+        return false;
+    }
+    let Some(name_n) = declarator.child_by_field_name("name") else {
+        return false;
+    };
+    if name_n.kind() != "identifier" {
+        return false;
+    }
     find_parent_of_types(declarator, &VAR_DECL_FN_SCOPE_TYPES).is_none()
 }
 
@@ -509,10 +737,18 @@ fn is_eligible_object_literal_declarator(declarator: &Node) -> bool {
 /// already produces a *class*-qualified entry (`ClassName.method`, via `find_parent_class`)
 /// rather than a bare one; that entry must be left alone, not duplicated by a spurious bare push.
 fn is_object_literal_declarator_method(method_node: &Node, source: &[u8]) -> bool {
-    let Some(obj) = method_node.parent() else { return false };
-    if obj.kind() != "object" { return false; }
-    let Some(declarator) = obj.parent() else { return false };
-    if !is_eligible_object_literal_declarator(&declarator) { return false; }
+    let Some(obj) = method_node.parent() else {
+        return false;
+    };
+    if obj.kind() != "object" {
+        return false;
+    }
+    let Some(declarator) = obj.parent() else {
+        return false;
+    };
+    if !is_eligible_object_literal_declarator(&declarator) {
+        return false;
+    }
     find_parent_class(method_node, source).is_none()
 }
 
@@ -544,7 +780,9 @@ fn extract_object_literal_functions(
     symbols: &mut FileSymbols,
 ) {
     for i in 0..obj_node.child_count() {
-        let Some(child) = obj_node.child(i) else { continue };
+        let Some(child) = obj_node.child(i) else {
+            continue;
+        };
         match child.kind() {
             "shorthand_property_identifier" => {
                 let prop_name = node_text(&child, source);
@@ -555,12 +793,18 @@ fn extract_object_literal_functions(
                 });
             }
             "pair" => {
-                let Some(key_n) = child.child_by_field_name("key") else { continue };
-                let Some(val_n) = child.child_by_field_name("value") else { continue };
+                let Some(key_n) = child.child_by_field_name("key") else {
+                    continue;
+                };
+                let Some(val_n) = child.child_by_field_name("value") else {
+                    continue;
+                };
                 // Use resolve_pair_key_name to strip brackets from computed string keys
                 // (e.g. ['foo'] → "foo") and skip non-string computed keys ([Symbol.iterator]),
                 // mirroring resolve_method_def_name below.
-                let Some(key) = resolve_pair_key_name(&key_n, source) else { continue };
+                let Some(key) = resolve_pair_key_name(&key_n, source) else {
+                    continue;
+                };
                 let qualified = format!("{}.{}", var_name, key);
                 match val_n.kind() {
                     "arrow_function" | "function_expression" | "function" => {
@@ -576,6 +820,7 @@ fn extract_object_literal_functions(
                             cfg: build_function_cfg(&val_n, "javascript", source),
                             children: None,
                             bodyless: None,
+                            content_hash: None,
                         });
                         // Store qualified name as value so resolver looks up the qualified def.
                         symbols.type_map.push(TypeMapEntry {
@@ -598,7 +843,9 @@ fn extract_object_literal_functions(
             "method_definition" => {
                 // Use resolve_method_def_name to strip brackets from computed string keys
                 // (e.g. ['foo'] → "foo") and skip non-string computed keys ([Symbol.iterator]).
-                let Some(method_name) = resolve_method_def_name(&child, source) else { continue };
+                let Some(method_name) = resolve_method_def_name(&child, source) else {
+                    continue;
+                };
                 let qualified = format!("{}.{}", var_name, method_name);
                 // typeMap['obj.baz'] = 'baz' — points to the bare-name definition so
                 // the two-step accessor dispatch resolves via the bare node.
@@ -624,6 +871,7 @@ fn extract_object_literal_functions(
                         cfg: build_function_cfg(&child, "javascript", source),
                         children: opt_children(children),
                         bodyless: None,
+                        content_hash: None,
                     });
                 }
                 let body = child.child_by_field_name("body");
@@ -637,6 +885,7 @@ fn extract_object_literal_functions(
                     cfg: body.and_then(|b| build_function_cfg(&b, "javascript", source)),
                     children: None,
                     bodyless: None,
+                    content_hash: None,
                 });
             }
             _ => {}
@@ -653,9 +902,16 @@ fn extract_object_literal_functions(
 ///
 /// For `const` declarations this produces the same entries as `extract_object_literal_functions`,
 /// but `dedup_type_map` collapses duplicates at equal confidence.
-fn seed_objlit_type_map_entries(var_name: &str, obj_node: &Node, source: &[u8], symbols: &mut FileSymbols) {
+fn seed_objlit_type_map_entries(
+    var_name: &str,
+    obj_node: &Node,
+    source: &[u8],
+    symbols: &mut FileSymbols,
+) {
     for i in 0..obj_node.child_count() {
-        let Some(child) = obj_node.child(i) else { continue };
+        let Some(child) = obj_node.child(i) else {
+            continue;
+        };
         match child.kind() {
             "shorthand_property_identifier" => {
                 let prop_name = node_text(&child, source);
@@ -666,9 +922,15 @@ fn seed_objlit_type_map_entries(var_name: &str, obj_node: &Node, source: &[u8], 
                 });
             }
             "pair" => {
-                let Some(key_n) = child.child_by_field_name("key") else { continue };
-                let Some(val_n) = child.child_by_field_name("value") else { continue };
-                let Some(key) = resolve_pair_key_name(&key_n, source) else { continue };
+                let Some(key_n) = child.child_by_field_name("key") else {
+                    continue;
+                };
+                let Some(val_n) = child.child_by_field_name("value") else {
+                    continue;
+                };
+                let Some(key) = resolve_pair_key_name(&key_n, source) else {
+                    continue;
+                };
                 let qualified = format!("{}.{}", var_name, key);
                 match val_n.kind() {
                     "arrow_function" | "function_expression" | "function" => {
@@ -701,7 +963,9 @@ fn seed_objlit_type_map_entries(var_name: &str, obj_node: &Node, source: &[u8], 
                 // and qualified definitions inline for all declaration kinds (const/let/var) —
                 // see `handle_var_decl`'s two call sites. Using the bare name here keeps
                 // resolution consistent across all declaration kinds.
-                let Some(method_name) = resolve_method_def_name(&child, source) else { continue };
+                let Some(method_name) = resolve_method_def_name(&child, source) else {
+                    continue;
+                };
                 let qualified = format!("{}.{}", var_name, method_name);
                 symbols.type_map.push(TypeMapEntry {
                     name: qualified,
@@ -721,9 +985,13 @@ fn seed_objlit_type_map_entries(var_name: &str, obj_node: &Node, source: &[u8], 
 fn match_js_return_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: usize) {
     match node.kind() {
         "function_declaration" | "generator_function_declaration" => {
-            let Some(name_n) = node.child_by_field_name("name") else { return };
+            let Some(name_n) = node.child_by_field_name("name") else {
+                return;
+            };
             let fn_name = node_text(&name_n, source);
-            if fn_name == "constructor" { return; }
+            if fn_name == "constructor" {
+                return;
+            }
             // Use the boundary-aware variant: nested function declarations inside
             // method bodies must not inherit the class prefix (matches WASM behaviour).
             let key = match find_parent_class_no_fn_boundary(node, source) {
@@ -733,9 +1001,13 @@ fn match_js_return_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbol
             store_return_type(node, &key, source, symbols);
         }
         "method_definition" => {
-            let Some(name_n) = node.child_by_field_name("name") else { return };
+            let Some(name_n) = node.child_by_field_name("name") else {
+                return;
+            };
             let method_name = node_text(&name_n, source);
-            if method_name == "constructor" { return; }
+            if method_name == "constructor" {
+                return;
+            }
             // method_definition is always a direct child of class_body — plain
             // find_parent_class is correct here.
             let key = match find_parent_class(node, source) {
@@ -745,12 +1017,21 @@ fn match_js_return_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbol
             store_return_type(node, &key, source, symbols);
         }
         "variable_declarator" => {
-            let Some(name_n) = node.child_by_field_name("name") else { return };
-            if name_n.kind() != "identifier" { return; }
-            let Some(value_n) = node.child_by_field_name("value") else { return };
+            let Some(name_n) = node.child_by_field_name("name") else {
+                return;
+            };
+            if name_n.kind() != "identifier" {
+                return;
+            }
+            let Some(value_n) = node.child_by_field_name("value") else {
+                return;
+            };
             // Only arrow_function, function_expression and generator_function match the TS reference;
             // "function" is not a valid tree-sitter value-expression kind here.
-            if !matches!(value_n.kind(), "arrow_function" | "function_expression" | "generator_function") {
+            if !matches!(
+                value_n.kind(),
+                "arrow_function" | "function_expression" | "generator_function"
+            ) {
                 return;
             }
             let var_name = node_text(&name_n, source);
@@ -788,7 +1069,9 @@ fn store_return_type(fn_node: &Node, fn_name: &str, source: &[u8], symbols: &mut
 fn find_return_new_expr_type<'a>(body: &Node<'a>, source: &'a [u8]) -> Option<&'a str> {
     for i in 0..body.child_count() {
         let Some(child) = body.child(i) else { continue };
-        if child.kind() != "return_statement" { continue; }
+        if child.kind() != "return_statement" {
+            continue;
+        }
         for j in 0..child.child_count() {
             let Some(expr) = child.child(j) else { continue };
             if expr.kind() == "new_expression" {
@@ -802,7 +1085,12 @@ fn find_return_new_expr_type<'a>(body: &Node<'a>, source: &'a [u8]) -> Option<&'
 /// Append a `(fn_name → type_name)` entry to `return_type_map`.
 /// Deduplication (highest-confidence-wins) is handled in bulk by
 /// [`dedup_type_map`] at the end of `extract()`.
-fn push_return_type_entry(symbols: &mut FileSymbols, fn_name: &str, type_name: &str, confidence: f64) {
+fn push_return_type_entry(
+    symbols: &mut FileSymbols,
+    fn_name: &str,
+    type_name: &str,
+    confidence: f64,
+) {
     symbols.return_type_map.push(TypeMapEntry {
         name: fn_name.to_string(),
         type_name: type_name.to_string(),
@@ -820,10 +1108,19 @@ fn push_return_type_entry(symbols: &mut FileSymbols, fn_name: &str, type_name: &
 ///   1. `Foo.prototype.bar = function(){}`  → emits `Foo.bar` as a method definition
 ///   2. `Foo.prototype.bar = identifier`    → seeds `typeMap['Foo.bar'] = identifier`
 ///   3. `Foo.prototype = { bar: fn, ... }`  → same rules applied per property
-fn match_js_prototype_methods(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: usize) {
-    if node.kind() != "expression_statement" { return; }
+fn match_js_prototype_methods(
+    node: &Node,
+    source: &[u8],
+    symbols: &mut FileSymbols,
+    _depth: usize,
+) {
+    if node.kind() != "expression_statement" {
+        return;
+    }
     let Some(expr) = node.child(0) else { return };
-    if expr.kind() != "assignment_expression" { return; }
+    if expr.kind() != "assignment_expression" {
+        return;
+    }
     let lhs = expr.child_by_field_name("left");
     let rhs = expr.child_by_field_name("right");
     if let (Some(lhs), Some(rhs)) = (lhs, rhs) {
@@ -831,10 +1128,21 @@ fn match_js_prototype_methods(node: &Node, source: &[u8], symbols: &mut FileSymb
     }
 }
 
-fn handle_js_prototype_assignment(lhs: &Node, rhs: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    if lhs.kind() != "member_expression" { return; }
-    let Some(lhs_obj) = lhs.child_by_field_name("object") else { return };
-    let Some(lhs_prop) = lhs.child_by_field_name("property") else { return };
+fn handle_js_prototype_assignment(
+    lhs: &Node,
+    rhs: &Node,
+    source: &[u8],
+    symbols: &mut FileSymbols,
+) {
+    if lhs.kind() != "member_expression" {
+        return;
+    }
+    let Some(lhs_obj) = lhs.child_by_field_name("object") else {
+        return;
+    };
+    let Some(lhs_prop) = lhs.child_by_field_name("property") else {
+        return;
+    };
 
     // Pattern 1: `Foo.prototype.bar = rhs`
     // lhs.object is `Foo.prototype` (member_expression), lhs.property is `bar`
@@ -899,6 +1207,7 @@ fn handle_js_prototype_assignment(lhs: &Node, rhs: &Node, source: &[u8], symbols
             cfg: build_function_cfg(rhs, "javascript", source),
             children: opt_children(children),
             bodyless: None,
+            content_hash: None,
         });
     }
 }
@@ -906,7 +1215,13 @@ fn handle_js_prototype_assignment(lhs: &Node, rhs: &Node, source: &[u8], symbols
 /// Emit one prototype method definition or typeMap alias for `ClassName.methodName = rhs`.
 ///
 /// Mirrors `emitPrototypeMethod` in `src/extractors/javascript.ts`.
-fn emit_js_prototype_method(class_name: &str, method_name: &str, rhs: &Node, source: &[u8], symbols: &mut FileSymbols) {
+fn emit_js_prototype_method(
+    class_name: &str,
+    method_name: &str,
+    rhs: &Node,
+    source: &[u8],
+    symbols: &mut FileSymbols,
+) {
     let full_name = format!("{}.{}", class_name, method_name);
     match rhs.kind() {
         "function_expression" | "arrow_function" => {
@@ -921,6 +1236,7 @@ fn emit_js_prototype_method(class_name: &str, method_name: &str, rhs: &Node, sou
                 cfg: build_function_cfg(rhs, "javascript", source),
                 children: opt_children(children),
                 bodyless: None,
+                content_hash: None,
             });
         }
         "identifier" => {
@@ -936,12 +1252,21 @@ fn emit_js_prototype_method(class_name: &str, method_name: &str, rhs: &Node, sou
 /// Iterate over an object literal assigned to `Foo.prototype` and emit definitions/aliases.
 ///
 /// Mirrors `extractPrototypeObjectLiteral` in `src/extractors/javascript.ts`.
-fn extract_js_prototype_object_literal(class_name: &str, obj_node: &Node, source: &[u8], symbols: &mut FileSymbols) {
+fn extract_js_prototype_object_literal(
+    class_name: &str,
+    obj_node: &Node,
+    source: &[u8],
+    symbols: &mut FileSymbols,
+) {
     for i in 0..obj_node.child_count() {
-        let Some(child) = obj_node.child(i) else { continue };
+        let Some(child) = obj_node.child(i) else {
+            continue;
+        };
         match child.kind() {
             "method_definition" => {
-                let Some(method_name) = resolve_method_def_name(&child, source) else { continue };
+                let Some(method_name) = resolve_method_def_name(&child, source) else {
+                    continue;
+                };
                 let children = extract_js_parameters(&child, source);
                 symbols.definitions.push(Definition {
                     name: format!("{}.{}", class_name, method_name),
@@ -953,6 +1278,7 @@ fn extract_js_prototype_object_literal(class_name: &str, obj_node: &Node, source
                     cfg: build_function_cfg(&child, "javascript", source),
                     children: opt_children(children),
                     bodyless: None,
+                    content_hash: None,
                 });
             }
             "shorthand_property_identifier" => {
@@ -969,9 +1295,19 @@ fn extract_js_prototype_object_literal(class_name: &str, obj_node: &Node, source
                 let key_node = child.child_by_field_name("key");
                 let value_node = child.child_by_field_name("value");
                 if let (Some(key_node), Some(value_node)) = (key_node, value_node) {
-                    let Some(method_name) = resolve_pair_key_name(&key_node, source) else { continue };
-                    if method_name.is_empty() { continue; }
-                    emit_js_prototype_method(class_name, &method_name, &value_node, source, symbols);
+                    let Some(method_name) = resolve_pair_key_name(&key_node, source) else {
+                        continue;
+                    };
+                    if method_name.is_empty() {
+                        continue;
+                    }
+                    emit_js_prototype_method(
+                        class_name,
+                        &method_name,
+                        &value_node,
+                        source,
+                        symbols,
+                    );
                 }
             }
             _ => {}
@@ -985,14 +1321,26 @@ fn extract_js_prototype_object_literal(class_name: &str, obj_node: &Node, source
 /// `symbols.call_assignments` for cross-file return-type propagation.
 /// Mirrors `recordCallAssignment` in src/extractors/javascript.ts.
 fn match_js_call_assignments(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: usize) {
-    if node.kind() != "variable_declarator" { return; }
-    let Some(name_n) = node.child_by_field_name("name") else { return };
-    if name_n.kind() != "identifier" { return; }
-    let Some(value_n) = node.child_by_field_name("value") else { return };
-    if value_n.kind() != "call_expression" { return; }
+    if node.kind() != "variable_declarator" {
+        return;
+    }
+    let Some(name_n) = node.child_by_field_name("name") else {
+        return;
+    };
+    if name_n.kind() != "identifier" {
+        return;
+    }
+    let Some(value_n) = node.child_by_field_name("value") else {
+        return;
+    };
+    if value_n.kind() != "call_expression" {
+        return;
+    }
 
     let var_name = node_text(&name_n, source).to_string();
-    let Some(fn_node) = value_n.child_by_field_name("function") else { return };
+    let Some(fn_node) = value_n.child_by_field_name("function") else {
+        return;
+    };
 
     match fn_node.kind() {
         "identifier" => {
@@ -1003,10 +1351,18 @@ fn match_js_call_assignments(node: &Node, source: &[u8], symbols: &mut FileSymbo
             });
         }
         "member_expression" => {
-            let Some(obj) = fn_node.child_by_field_name("object") else { return };
-            let Some(prop) = fn_node.child_by_field_name("property") else { return };
-            if obj.kind() != "identifier" { return; }
-            let receiver_type = symbols.type_map.iter()
+            let Some(obj) = fn_node.child_by_field_name("object") else {
+                return;
+            };
+            let Some(prop) = fn_node.child_by_field_name("property") else {
+                return;
+            };
+            if obj.kind() != "identifier" {
+                return;
+            }
+            let receiver_type = symbols
+                .type_map
+                .iter()
                 .find(|e| e.name == node_text(&obj, source))
                 .map(|e| e.type_name.clone());
             symbols.call_assignments.push(NativeCallAssignment {
@@ -1073,12 +1429,15 @@ fn handle_function_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             cfg: build_function_cfg(node, "javascript", source),
             children: opt_children(children),
             bodyless: None,
+            content_hash: None,
         });
     }
 }
 
 fn handle_class_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else { return };
+    let Some(name_node) = node.child_by_field_name("name") else {
+        return;
+    };
     let class_name = node_text(&name_node, source).to_string();
     let children = extract_js_class_properties(node, source);
     symbols.definitions.push(Definition {
@@ -1091,6 +1450,7 @@ fn handle_class_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: opt_children(children),
         bodyless: None,
+        content_hash: None,
     });
 
     // Heritage: extends + implements
@@ -1126,12 +1486,16 @@ fn resolve_computed_key_name(computed_node: &Node, source: &[u8]) -> Option<Stri
     match inner.kind() {
         "string" => {
             let s = extract_string_fragment(&inner, source).unwrap_or("");
-            if s.is_empty() { return None; }
+            if s.is_empty() {
+                return None;
+            }
             Some(s.to_string())
         }
         "string_fragment" => {
             let s = node_text(&inner, source);
-            if s.is_empty() { return None; }
+            if s.is_empty() {
+                return None;
+            }
             Some(s.to_string())
         }
         _ => None, // non-string computed key — skip
@@ -1195,6 +1559,7 @@ fn handle_method_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             cfg: build_function_cfg(node, "javascript", source),
             children: opt_children(children),
             bodyless: None,
+            content_hash: None,
         });
     }
 }
@@ -1231,7 +1596,9 @@ type LocalAccessorRegistry = HashMap<String, LocalAccessorInfo>;
 fn get_method_accessor_kind(meth_node: &Node) -> Option<&'static str> {
     let name_node = meth_node.child_by_field_name("name");
     for i in 0..meth_node.child_count() {
-        let Some(child) = meth_node.child(i) else { continue };
+        let Some(child) = meth_node.child(i) else {
+            continue;
+        };
         if Some(child.id()) == name_node.map(|n| n.id()) {
             break;
         }
@@ -1258,9 +1625,10 @@ fn collect_local_accessors(root: &Node, source: &[u8]) -> LocalAccessorRegistry 
         }
         if node.kind() == "method_definition" {
             if let Some(kind) = get_method_accessor_kind(node) {
-                if let (Some(class_name), Some(prop_name)) =
-                    (find_parent_class(node, source), resolve_method_def_name(node, source))
-                {
+                if let (Some(class_name), Some(prop_name)) = (
+                    find_parent_class(node, source),
+                    resolve_method_def_name(node, source),
+                ) {
                     let key = format!("{}.{}", class_name, prop_name);
                     let entry = registry.entry(key).or_default();
                     if kind == "get" {
@@ -1314,8 +1682,12 @@ fn handle_accessor_property_read(
         }
     }
 
-    let Some(obj) = node.child_by_field_name("object") else { return };
-    let Some(prop_node) = node.child_by_field_name("property") else { return };
+    let Some(obj) = node.child_by_field_name("object") else {
+        return;
+    };
+    let Some(prop_node) = node.child_by_field_name("property") else {
+        return;
+    };
     if prop_node.kind() != "property_identifier" {
         return;
     }
@@ -1337,7 +1709,9 @@ fn handle_accessor_property_read(
     let Some(class_name) = class_name else { return };
 
     let key = format!("{}.{}", class_name, prop_name);
-    let Some(accessor_info) = local_accessors.get(&key) else { return };
+    let Some(accessor_info) = local_accessors.get(&key) else {
+        return;
+    };
     if accessor_info.get && accessor_info.set {
         return;
     }
@@ -1372,7 +1746,9 @@ fn handle_accessor_property_read(
 /// class has multiple `static { }` blocks (each has a distinct start position even
 /// if on the same line).
 fn handle_static_block(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(class_name) = find_parent_class(node, source) else { return };
+    let Some(class_name) = find_parent_class(node, source) else {
+        return;
+    };
     let line = start_line(node);
     let col = node.start_position().column;
     symbols.definitions.push(Definition {
@@ -1385,6 +1761,7 @@ fn handle_static_block(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -1393,7 +1770,8 @@ fn handle_static_block(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 /// `handleFieldDef` guard.  The synthetic definition has `kind = "method"` so that the SQL
 /// call-edge filter (`kind IN ('function','method')`) accepts edges rooted here.
 fn handle_field_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let name_node = node.child_by_field_name("name")
+    let name_node = node
+        .child_by_field_name("name")
         .or_else(|| node.child_by_field_name("property"))
         .or_else(|| find_child(node, "property_identifier"));
     let Some(name_node) = name_node else { return };
@@ -1401,19 +1779,31 @@ fn handle_field_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     // Allow property_identifier (regular names), identifier, private_property_identifier (#foo),
     // and string (e.g. `"method" = () => {}`) to match the TypeScript path which only denies
     // computed_property_name.
-    if !matches!(name_node.kind(), "property_identifier" | "identifier" | "private_property_identifier" | "string") {
+    if !matches!(
+        name_node.kind(),
+        "property_identifier" | "identifier" | "private_property_identifier" | "string"
+    ) {
         return;
     }
     // Skip uninitialised fields (`class C { x; }`) — must have a value node.
-    let Some(value_node) = node.child_by_field_name("value") else { return };
+    let Some(value_node) = node.child_by_field_name("value") else {
+        return;
+    };
     // Only emit a callable definition when the initializer is a function/arrow expression.
     // Scalar fields like `static x = 42` should not appear as method-kind nodes.
-    if !matches!(value_node.kind(), "arrow_function" | "function_expression" | "generator_function") {
+    if !matches!(
+        value_node.kind(),
+        "arrow_function" | "function_expression" | "generator_function"
+    ) {
         return;
     }
     let field_name = node_text(&name_node, source);
-    if field_name.is_empty() { return; }
-    let Some(class_name) = find_parent_class(node, source) else { return };
+    if field_name.is_empty() {
+        return;
+    }
+    let Some(class_name) = find_parent_class(node, source) else {
+        return;
+    };
     symbols.definitions.push(Definition {
         name: format!("{}.{}", class_name, field_name),
         kind: "method".to_string(),
@@ -1424,11 +1814,14 @@ fn handle_field_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
 fn handle_interface_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else { return };
+    let Some(name_node) = node.child_by_field_name("name") else {
+        return;
+    };
     let iface_name = node_text(&name_node, source).to_string();
     symbols.definitions.push(Definition {
         name: iface_name.clone(),
@@ -1440,6 +1833,7 @@ fn handle_interface_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
     // Extract interface methods
     let body = node
@@ -1463,6 +1857,7 @@ fn handle_type_alias(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             cfg: None,
             children: None,
             bodyless: None,
+            content_hash: None,
         });
     }
 }
@@ -1481,6 +1876,7 @@ fn handle_enum_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             cfg: None,
             children: opt_children(children),
             bodyless: None,
+            content_hash: None,
         });
     }
 }
@@ -1488,25 +1884,39 @@ fn handle_enum_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 /// Node types marking a function-body scope; declarations inside these are skipped by
 /// the top-level-constant/destructuring branches below (parity with TS `FUNCTION_SCOPE_TYPES`).
 const VAR_DECL_FN_SCOPE_TYPES: [&str; 6] = [
-    "function_declaration", "arrow_function",
-    "function_expression", "method_definition",
-    "generator_function_declaration", "generator_function",
+    "function_declaration",
+    "arrow_function",
+    "function_expression",
+    "method_definition",
+    "generator_function_declaration",
+    "generator_function",
 ];
 
 fn handle_var_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let is_const = node.child(0)
+    let is_const = node
+        .child(0)
         .map(|c| node_text(&c, source) == "const")
         .unwrap_or(false);
     let in_function_scope = find_parent_of_types(node, &VAR_DECL_FN_SCOPE_TYPES).is_some();
     for i in 0..node.child_count() {
-        let Some(declarator) = node.child(i) else { continue };
-        if declarator.kind() != "variable_declarator" { continue; }
+        let Some(declarator) = node.child(i) else {
+            continue;
+        };
+        if declarator.kind() != "variable_declarator" {
+            continue;
+        }
         let name_n = declarator.child_by_field_name("name");
         let value_n = declarator.child_by_field_name("value");
-        let (Some(name_n), Some(value_n)) = (name_n, value_n) else { continue };
+        let (Some(name_n), Some(value_n)) = (name_n, value_n) else {
+            continue;
+        };
         let vt = value_n.kind();
 
-        if vt == "arrow_function" || vt == "function_expression" || vt == "function" || vt == "generator_function" {
+        if vt == "arrow_function"
+            || vt == "function_expression"
+            || vt == "function"
+            || vt == "generator_function"
+        {
             let children = extract_js_parameters(&value_n, source);
             symbols.definitions.push(Definition {
                 name: node_text(&name_n, source).to_string(),
@@ -1518,35 +1928,42 @@ fn handle_var_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                 cfg: build_function_cfg(&value_n, "javascript", source),
                 children: opt_children(children),
                 bodyless: None,
+                content_hash: None,
             });
         } else if is_const && name_n.kind() == "object_pattern" && !in_function_scope {
             // Parity with TS query path (extractDestructuredBindingsWalk):
             // skip destructured const bindings inside function scopes so the
             // Rust walk path matches FUNCTION_SCOPE_TYPES behaviour.
-            extract_destructured_bindings(&name_n, source, start_line(node), end_line(node), &mut symbols.definitions);
+            extract_destructured_bindings(
+                &name_n,
+                source,
+                start_line(node),
+                end_line(node),
+                &mut symbols.definitions,
+            );
             // If the RHS is a CJS require() call, also add to imports so the
             // receiver-edge resolver treats the names as import artifacts, not
             // local definitions — mirroring the WASM cjsRequireBindings fix (#1678).
             if value_n.kind() == "call_expression" {
                 if let Some(fn_node) = value_n.child_by_field_name("function") {
                     if node_text(&fn_node, source) == "require" {
-                        let args = value_n.child_by_field_name("arguments")
+                        let args = value_n
+                            .child_by_field_name("arguments")
                             .or_else(|| find_child(&value_n, "arguments"));
                         if let Some(args) = args {
                             if let Some(str_arg) = find_child(&args, "string") {
-                                let mod_path = node_text(&str_arg, source)
-                                    .replace(&['\'', '"'][..], "");
+                                let mod_path =
+                                    node_text(&str_arg, source).replace(&['\'', '"'][..], "");
                                 // CJS require bindings never populate renamed_imports —
                                 // resolve_call_targets deliberately ignores the original
                                 // name for these (empty target_file forces a same-file
                                 // fallback match, matching WASM's importedNamesMap
                                 // exclusion, #1678) — so the rename pairs collected here
                                 // are discarded.
-                                let names = collect_object_pattern_names(&name_n, source, &mut Vec::new());
+                                let names =
+                                    collect_object_pattern_names(&name_n, source, &mut Vec::new());
                                 if !names.is_empty() {
-                                    let mut imp = Import::new(
-                                        mod_path, names, start_line(node),
-                                    );
+                                    let mut imp = Import::new(mod_path, names, start_line(node));
                                     imp.cjs_require = Some(true);
                                     symbols.imports.push(imp);
                                 }
@@ -1570,6 +1987,7 @@ fn handle_var_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                 cfg: None,
                 children: None,
                 bodyless: None,
+                content_hash: None,
             });
             // Phase 8.3f: extract function/arrow properties from object literals and seed
             // typeMap composite keys so that this.method() inside Object.defineProperty
@@ -1581,8 +1999,15 @@ fn handle_var_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         } else if is_const && name_n.kind() == "array_pattern" && !in_function_scope {
             // Array destructuring: `const [x, y] = ...` — one constant Definition per
             // bound identifier (#1901). Scope guard mirrors the object_pattern branch above.
-            extract_array_pattern_bindings(&name_n, source, start_line(node), end_line(node), &mut symbols.definitions);
-        } else if !is_const && value_n.kind() == "object"
+            extract_array_pattern_bindings(
+                &name_n,
+                source,
+                start_line(node),
+                end_line(node),
+                &mut symbols.definitions,
+            );
+        } else if !is_const
+            && value_n.kind() == "object"
             && is_eligible_object_literal_declarator(&declarator)
         {
             // `let`/`var` object literals get no "constant" definition of their own (mirrors
@@ -1704,7 +2129,9 @@ fn extract_dispatch_table_call(
     let table_name = format!("<dt_{}_{}>", line, col);
     let mut idx: u32 = 0;
     for i in 0..obj_node.child_count() {
-        let Some(child) = obj_node.child(i) else { continue };
+        let Some(child) = obj_node.child(i) else {
+            continue;
+        };
         match child.kind() {
             "shorthand_property_identifier" => {
                 let text = node_text(&child, source);
@@ -1754,7 +2181,9 @@ fn handle_call_expr(
     symbols: &mut FileSymbols,
     callback_param_shapes: &CallbackParamShapes,
 ) {
-    let Some(fn_node) = node.child_by_field_name("function") else { return };
+    let Some(fn_node) = node.child_by_field_name("function") else {
+        return;
+    };
     if fn_node.kind() == "import" {
         handle_dynamic_import(node, &fn_node, source, symbols);
         return;
@@ -1791,12 +2220,19 @@ fn handle_call_expr(
     // the values as array-elem bindings under a synthetic `<dt_line_col>` name and
     // emit a `<dt_line_col>[*]` call so the PTS solver can resolve each target.
     if fn_node.kind() == "subscript_expression" {
-        if let Some(call) = extract_dispatch_table_call(&fn_node, node, source, &mut symbols.array_elem_bindings) {
+        if let Some(call) =
+            extract_dispatch_table_call(&fn_node, node, source, &mut symbols.array_elem_bindings)
+        {
             symbols.calls.push(call);
             if let Some(cb_def) = extract_callback_definition(node, source) {
                 symbols.definitions.push(cb_def);
             }
-            extract_callback_reference_calls(node, source, callback_param_shapes, &mut symbols.calls);
+            extract_callback_reference_calls(
+                node,
+                source,
+                callback_param_shapes,
+                &mut symbols.calls,
+            );
             return;
         }
     }
@@ -1810,7 +2246,8 @@ fn handle_call_expr(
 }
 
 fn handle_new_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let ctor = node.child_by_field_name("constructor")
+    let ctor = node
+        .child_by_field_name("constructor")
         .or_else(|| node.child(1));
     let Some(ctor) = ctor else { return };
     match ctor.kind() {
@@ -1874,14 +2311,13 @@ fn handle_decorator(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 }
 
 fn handle_dynamic_import(node: &Node, _fn_node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let args = node.child_by_field_name("arguments")
+    let args = node
+        .child_by_field_name("arguments")
         .or_else(|| find_child(node, "arguments"));
     let Some(args) = args else { return };
-    let str_node = find_child(&args, "string")
-        .or_else(|| find_child(&args, "template_string"));
+    let str_node = find_child(&args, "string").or_else(|| find_child(&args, "template_string"));
     if let Some(str_node) = str_node {
-        let mod_path = node_text(&str_node, source)
-            .replace(&['\'', '"', '`'][..], "");
+        let mod_path = node_text(&str_node, source).replace(&['\'', '"', '`'][..], "");
         let mut renamed_imports = Vec::new();
         let names = extract_dynamic_import_names(node, source, &mut renamed_imports);
         let mut imp = Import::new(mod_path, names, start_line(node));
@@ -1900,12 +2336,15 @@ fn handle_import_stmt(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         .child_by_field_name("source")
         .or_else(|| find_child(node, "string"));
     if let Some(source_node) = source_node {
-        let mod_path = node_text(&source_node, source)
-            .replace(&['\'', '"'][..], "");
+        let mod_path = node_text(&source_node, source).replace(&['\'', '"'][..], "");
         let mut renamed_imports = Vec::new();
         let mut type_only_names = Vec::new();
-        let names =
-            extract_import_names_with_renames(node, source, &mut renamed_imports, &mut type_only_names);
+        let names = extract_import_names_with_renames(
+            node,
+            source,
+            &mut renamed_imports,
+            &mut type_only_names,
+        );
         let mut imp = Import::new(mod_path, names, start_line(node));
         if is_type_only {
             imp.type_only = Some(true);
@@ -1980,14 +2419,26 @@ fn collect_exported_var_declarations(
         .unwrap_or(false);
     let line = start_line(node);
     for i in 0..decl.child_count() {
-        let Some(declarator) = decl.child(i) else { continue };
-        if declarator.kind() != "variable_declarator" { continue; }
+        let Some(declarator) = decl.child(i) else {
+            continue;
+        };
+        if declarator.kind() != "variable_declarator" {
+            continue;
+        }
         let name_n = declarator.child_by_field_name("name");
         let value_n = declarator.child_by_field_name("value");
-        let (Some(name_n), Some(value_n)) = (name_n, value_n) else { continue };
-        if name_n.kind() != "identifier" { continue; }
+        let (Some(name_n), Some(value_n)) = (name_n, value_n) else {
+            continue;
+        };
+        if name_n.kind() != "identifier" {
+            continue;
+        }
         let vt = value_n.kind();
-        if vt == "arrow_function" || vt == "function_expression" || vt == "function" || vt == "generator_function" {
+        if vt == "arrow_function"
+            || vt == "function_expression"
+            || vt == "function"
+            || vt == "generator_function"
+        {
             symbols.exports.push(ExportInfo {
                 name: node_text(&name_n, source).to_string(),
                 kind: "function".to_string(),
@@ -2004,12 +2455,15 @@ fn collect_exported_var_declarations(
 }
 
 fn handle_reexport(node: &Node, source_node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let mod_path = node_text(source_node, source)
-        .replace(&['\'', '"'][..], "");
+    let mod_path = node_text(source_node, source).replace(&['\'', '"'][..], "");
     let mut reexport_renames = Vec::new();
     let mut type_only_names = Vec::new();
-    let reexport_names =
-        extract_import_names_with_renames(node, source, &mut reexport_renames, &mut type_only_names);
+    let reexport_names = extract_import_names_with_renames(
+        node,
+        source,
+        &mut reexport_renames,
+        &mut type_only_names,
+    );
     let text = node_text(node, source);
     let is_wildcard = text.contains("export *") || text.contains("export*");
     let mut imp = Import::new(mod_path, reexport_names.clone(), start_line(node));
@@ -2025,12 +2479,18 @@ fn handle_reexport(node: &Node, source_node: &Node, source: &[u8], symbols: &mut
 
 fn handle_expr_stmt(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     let Some(expr) = node.child(0) else { return };
-    if expr.kind() != "assignment_expression" { return; }
+    if expr.kind() != "assignment_expression" {
+        return;
+    }
     let left = expr.child_by_field_name("left");
     let right = expr.child_by_field_name("right");
-    let (Some(left), Some(right)) = (left, right) else { return };
+    let (Some(left), Some(right)) = (left, right) else {
+        return;
+    };
     let left_text = node_text(&left, source);
-    if !left_text.starts_with("module.exports") && left_text != "exports" { return; }
+    if !left_text.starts_with("module.exports") && left_text != "exports" {
+        return;
+    }
     if right.kind() == "call_expression" {
         handle_require_reexport(&right, node, source, symbols);
     }
@@ -2047,8 +2507,7 @@ fn handle_require_reexport(right: &Node, node: &Node, source: &[u8], symbols: &m
     if let (Some(fn_node), Some(args)) = (fn_node, args) {
         if node_text(&fn_node, source) == "require" {
             if let Some(str_arg) = find_child(&args, "string") {
-                let mod_path = node_text(&str_arg, source)
-                    .replace(&['\'', '"'][..], "");
+                let mod_path = node_text(&str_arg, source).replace(&['\'', '"'][..], "");
                 let mut imp = Import::new(mod_path, vec![], start_line(node));
                 imp.reexport = Some(true);
                 imp.wildcard_reexport = Some(true);
@@ -2058,23 +2517,40 @@ fn handle_require_reexport(right: &Node, node: &Node, source: &[u8], symbols: &m
     }
 }
 
-fn handle_spread_require_reexports(right: &Node, node: &Node, source: &[u8], symbols: &mut FileSymbols) {
+fn handle_spread_require_reexports(
+    right: &Node,
+    node: &Node,
+    source: &[u8],
+    symbols: &mut FileSymbols,
+) {
     for ci in 0..right.child_count() {
-        let Some(child) = right.child(ci) else { continue };
-        if child.kind() != "spread_element" { continue; }
-        let spread_expr = child.child(1)
+        let Some(child) = right.child(ci) else {
+            continue;
+        };
+        if child.kind() != "spread_element" {
+            continue;
+        }
+        let spread_expr = child
+            .child(1)
             .or_else(|| child.child_by_field_name("value"));
-        let Some(spread_expr) = spread_expr else { continue };
-        if spread_expr.kind() != "call_expression" { continue; }
+        let Some(spread_expr) = spread_expr else {
+            continue;
+        };
+        if spread_expr.kind() != "call_expression" {
+            continue;
+        }
         let fn2 = spread_expr.child_by_field_name("function");
         let args2 = spread_expr
             .child_by_field_name("arguments")
             .or_else(|| find_child(&spread_expr, "arguments"));
-        let (Some(fn2), Some(args2)) = (fn2, args2) else { continue };
-        if node_text(&fn2, source) != "require" { continue; }
+        let (Some(fn2), Some(args2)) = (fn2, args2) else {
+            continue;
+        };
+        if node_text(&fn2, source) != "require" {
+            continue;
+        }
         if let Some(str_arg2) = find_child(&args2, "string") {
-            let mod_path2 = node_text(&str_arg2, source)
-                .replace(&['\'', '"'][..], "");
+            let mod_path2 = node_text(&str_arg2, source).replace(&['\'', '"'][..], "");
             let mut imp = Import::new(mod_path2, vec![], start_line(node));
             imp.reexport = Some(true);
             imp.wildcard_reexport = Some(true);
@@ -2181,7 +2657,11 @@ fn walk_ast_nodes_depth(node: &Node, source: &[u8], ast_nodes: &mut Vec<AstNode>
         }
         "regex" => {
             let raw = node_text(node, source);
-            let name = if raw.is_empty() { "?".to_string() } else { raw.to_string() };
+            let name = if raw.is_empty() {
+                "?".to_string()
+            } else {
+                raw.to_string()
+            };
             let text = truncate(raw, TEXT_MAX);
             ast_nodes.push(AstNode {
                 kind: "regex".to_string(),
@@ -2287,7 +2767,8 @@ fn extract_expression_text(node: &Node, source: &[u8]) -> Option<String> {
 
 fn extract_js_parameters(node: &Node, source: &[u8]) -> Vec<Definition> {
     let mut params = Vec::new();
-    let params_node = node.child_by_field_name("parameters")
+    let params_node = node
+        .child_by_field_name("parameters")
         .or_else(|| find_child(node, "formal_parameters"));
     if let Some(params_node) = params_node {
         for i in 0..params_node.child_count() {
@@ -2303,7 +2784,8 @@ fn extract_js_parameters(node: &Node, source: &[u8]) -> Vec<Definition> {
                     "required_parameter" | "optional_parameter" => {
                         // TS parameters: pattern field holds the identifier;
                         // fall back to left field or first child for edge cases
-                        let name_node = child.child_by_field_name("pattern")
+                        let name_node = child
+                            .child_by_field_name("pattern")
                             .or_else(|| child.child_by_field_name("left"))
                             .or_else(|| child.child(0));
                         if let Some(name_node) = name_node {
@@ -2352,19 +2834,22 @@ fn extract_js_parameters(node: &Node, source: &[u8]) -> Vec<Definition> {
 
 fn extract_js_class_properties(node: &Node, source: &[u8]) -> Vec<Definition> {
     let mut props = Vec::new();
-    let body = node.child_by_field_name("body")
+    let body = node
+        .child_by_field_name("body")
         .or_else(|| find_child(node, "class_body"));
     if let Some(body) = body {
         for i in 0..body.child_count() {
             if let Some(child) = body.child(i) {
                 match child.kind() {
                     "field_definition" | "public_field_definition" | "property_definition" => {
-                        let prop = child.child_by_field_name("property")
+                        let prop = child
+                            .child_by_field_name("property")
                             .or_else(|| child.child_by_field_name("name"))
                             .or_else(|| find_child(&child, "property_identifier"));
                         if let Some(prop) = prop {
                             let kind = prop.kind();
-                            if kind == "property_identifier" || kind == "identifier"
+                            if kind == "property_identifier"
+                                || kind == "identifier"
                                 || kind == "private_property_identifier"
                             {
                                 props.push(child_def(
@@ -2385,14 +2870,14 @@ fn extract_js_class_properties(node: &Node, source: &[u8]) -> Vec<Definition> {
 
 fn extract_ts_enum_members(node: &Node, source: &[u8]) -> Vec<Definition> {
     let mut members = Vec::new();
-    let body = node.child_by_field_name("body")
+    let body = node
+        .child_by_field_name("body")
         .or_else(|| find_child(node, "enum_body"));
     if let Some(body) = body {
         for i in 0..body.child_count() {
             if let Some(child) = body.child(i) {
                 if child.kind() == "enum_assignment" || child.kind() == "property_identifier" {
-                    let name = child.child_by_field_name("name")
-                        .unwrap_or(child);
+                    let name = child.child_by_field_name("name").unwrap_or(child);
                     members.push(child_def(
                         node_text(&name, source).to_string(),
                         "constant",
@@ -2432,6 +2917,7 @@ fn extract_interface_methods(
                         cfg: None,
                         children: None,
                         bodyless: Some(child.child_by_field_name("body").is_none()),
+                        content_hash: None,
                     });
                 }
             }
@@ -2501,20 +2987,54 @@ fn extract_implements_depth(node: &Node, source: &[u8], result: &mut Vec<String>
 /// Mirrors `CALLBACK_ACCEPTING_CALLEES` in `src/extractors/javascript.ts`.
 const CALLBACK_ACCEPTING_CALLEES: &[&str] = &[
     // Express / router / middleware
-    "use", "get", "post", "put", "delete", "patch", "options", "head", "all",
+    "use",
+    "get",
+    "post",
+    "put",
+    "delete",
+    "patch",
+    "options",
+    "head",
+    "all",
     // Promises
-    "then", "catch", "finally",
+    "then",
+    "catch",
+    "finally",
     // Array iteration / reduction
-    "map", "filter", "forEach", "find", "findIndex", "findLast", "findLastIndex",
-    "some", "every", "reduce", "reduceRight", "flatMap", "sort",
+    "map",
+    "filter",
+    "forEach",
+    "find",
+    "findIndex",
+    "findLast",
+    "findLastIndex",
+    "some",
+    "every",
+    "reduce",
+    "reduceRight",
+    "flatMap",
+    "sort",
     // Event emitters / DOM
-    "on", "once", "off", "addListener", "removeListener",
-    "addEventListener", "removeEventListener", "subscribe", "unsubscribe",
+    "on",
+    "once",
+    "off",
+    "addListener",
+    "removeListener",
+    "addEventListener",
+    "removeEventListener",
+    "subscribe",
+    "unsubscribe",
     // Scheduling / plain function callbacks
-    "setTimeout", "setInterval", "setImmediate", "queueMicrotask",
-    "requestAnimationFrame", "requestIdleCallback", "nextTick",
+    "setTimeout",
+    "setInterval",
+    "setImmediate",
+    "queueMicrotask",
+    "requestAnimationFrame",
+    "requestIdleCallback",
+    "nextTick",
     // Commander / yargs / hooks
-    "action", "command",
+    "action",
+    "command",
 ];
 
 /// HTTP-verb callees that double as Map/cache/repository method names.
@@ -2708,8 +3228,7 @@ fn collect_function_shaped_type_aliases(root: &Node, source: &[u8]) -> HashMap<S
     // Resolve `type A = B` chains against the direct classifications above.
     for (name, alias_of) in &direct_alias_of {
         if !resolved.contains_key(name) {
-            let shaped =
-                alias_of == "Function" || resolved.get(alias_of).copied().unwrap_or(false);
+            let shaped = alias_of == "Function" || resolved.get(alias_of).copied().unwrap_or(false);
             resolved.insert(name.clone(), shaped);
         }
     }
@@ -2744,7 +3263,9 @@ fn collect_callback_param_shapes(root: &Node, source: &[u8]) -> CallbackParamSha
         let params_node = fn_node
             .child_by_field_name("parameters")
             .or_else(|| find_child(fn_node, "formal_parameters"));
-        let Some(params_node) = params_node else { return indices };
+        let Some(params_node) = params_node else {
+            return indices;
+        };
 
         let mut arg_index: usize = 0;
         for child in iter_children(&params_node, PUNCTUATION_TOKENS) {
@@ -2802,10 +3323,22 @@ fn collect_callback_param_shapes(root: &Node, source: &[u8]) -> CallbackParamSha
         }
         match node.kind() {
             "function_declaration" | "generator_function_declaration" => {
-                record_declaration(node.child_by_field_name("name"), node, source, alias_shapes, declarations);
+                record_declaration(
+                    node.child_by_field_name("name"),
+                    node,
+                    source,
+                    alias_shapes,
+                    declarations,
+                );
             }
             "method_definition" => {
-                record_declaration(node.child_by_field_name("name"), node, source, alias_shapes, declarations);
+                record_declaration(
+                    node.child_by_field_name("name"),
+                    node,
+                    source,
+                    alias_shapes,
+                    declarations,
+                );
             }
             "variable_declarator" => {
                 if let (Some(name_node), Some(value_node)) = (
@@ -2814,9 +3347,17 @@ fn collect_callback_param_shapes(root: &Node, source: &[u8]) -> CallbackParamSha
                 ) {
                     let vt = value_node.kind();
                     if name_node.kind() == "identifier"
-                        && (vt == "arrow_function" || vt == "function_expression" || vt == "generator_function")
+                        && (vt == "arrow_function"
+                            || vt == "function_expression"
+                            || vt == "generator_function")
                     {
-                        record_declaration(Some(name_node), &value_node, source, alias_shapes, declarations);
+                        record_declaration(
+                            Some(name_node),
+                            &value_node,
+                            source,
+                            alias_shapes,
+                            declarations,
+                        );
                     }
                 }
             }
@@ -2833,7 +3374,9 @@ fn collect_callback_param_shapes(root: &Node, source: &[u8]) -> CallbackParamSha
     let mut shapes: CallbackParamShapes = HashMap::new();
     for (name, per_decl_indices) in declarations {
         let mut iter = per_decl_indices.into_iter();
-        let Some(mut intersected) = iter.next() else { continue };
+        let Some(mut intersected) = iter.next() else {
+            continue;
+        };
         for other in iter {
             intersected.retain(|idx| other.contains(idx));
         }
@@ -2868,7 +3411,8 @@ fn extract_callback_reference_calls(
     callback_param_shapes: &CallbackParamShapes,
     calls: &mut Vec<Call>,
 ) {
-    let args = call_node.child_by_field_name("arguments")
+    let args = call_node
+        .child_by_field_name("arguments")
         .or_else(|| find_child(call_node, "arguments"));
     let Some(args) = args else { return };
     let call_line = start_line(call_node);
@@ -2914,7 +3458,9 @@ fn extract_callback_reference_calls(
                 continue;
             }
         } else if !callback_args_allowed
-            && !callee_param_shapes.map(|s| s.contains(&arg_index)).unwrap_or(false)
+            && !callee_param_shapes
+                .map(|s| s.contains(&arg_index))
+                .unwrap_or(false)
         {
             continue;
         }
@@ -2931,7 +3477,8 @@ fn extract_callback_reference_calls(
             }
             "member_expression" => {
                 if let Some(prop) = child.child_by_field_name("property") {
-                    let receiver = child.child_by_field_name("object")
+                    let receiver = child
+                        .child_by_field_name("object")
                         .map(|obj| extract_receiver_name(&obj, source));
                     calls.push(Call {
                         name: node_text(&prop, source).to_string(),
@@ -2969,7 +3516,9 @@ fn extract_callback_reference_calls(
 ///
 /// Mirrors `collectObjectLiteralValueRefCall` in `src/extractors/javascript.ts`.
 fn handle_object_literal_pair_value_ref(node: &Node, source: &[u8], calls: &mut Vec<Call>) {
-    let Some(value_n) = node.child_by_field_name("value") else { return };
+    let Some(value_n) = node.child_by_field_name("value") else {
+        return;
+    };
     if value_n.kind() != "identifier" {
         return;
     }
@@ -2977,7 +3526,9 @@ fn handle_object_literal_pair_value_ref(node: &Node, source: &[u8], calls: &mut 
     if JS_BUILTIN_GLOBALS.contains(&text) {
         return;
     }
-    let key_expr = node.child_by_field_name("key").and_then(|k| resolve_pair_key_name(&k, source));
+    let key_expr = node
+        .child_by_field_name("key")
+        .and_then(|k| resolve_pair_key_name(&k, source));
     calls.push(Call {
         name: text.to_string(),
         line: start_line(&value_n),
@@ -3035,11 +3586,15 @@ fn handle_object_literal_shorthand_value_ref(node: &Node, source: &[u8], calls: 
 ///
 /// Mirrors `collectInstanceofValueRefCall` in `src/extractors/javascript.ts`.
 fn handle_instanceof_value_ref(node: &Node, source: &[u8], calls: &mut Vec<Call>) {
-    let Some(operator_n) = node.child_by_field_name("operator") else { return };
+    let Some(operator_n) = node.child_by_field_name("operator") else {
+        return;
+    };
     if node_text(&operator_n, source) != "instanceof" {
         return;
     }
-    let Some(right_n) = node.child_by_field_name("right") else { return };
+    let Some(right_n) = node.child_by_field_name("right") else {
+        return;
+    };
     if right_n.kind() != "identifier" {
         return;
     }
@@ -3077,7 +3632,9 @@ fn extract_destructured_bindings(
     definitions: &mut Vec<Definition>,
 ) {
     for i in 0..pattern.child_count() {
-        let Some(child) = pattern.child(i) else { continue };
+        let Some(child) = pattern.child(i) else {
+            continue;
+        };
         match child.kind() {
             "shorthand_property_identifier_pattern" | "shorthand_property_identifier" => {
                 definitions.push(Definition {
@@ -3090,6 +3647,7 @@ fn extract_destructured_bindings(
                     cfg: None,
                     children: None,
                     bodyless: None,
+                    content_hash: None,
                 });
             }
             "pair_pattern" | "pair" => {
@@ -3107,6 +3665,7 @@ fn extract_destructured_bindings(
                             cfg: None,
                             children: None,
                             bodyless: None,
+                            content_hash: None,
                         });
                     }
                 }
@@ -3132,7 +3691,9 @@ fn extract_array_pattern_bindings(
     definitions: &mut Vec<Definition>,
 ) {
     for i in 0..pattern.child_count() {
-        let Some(child) = pattern.child(i) else { continue };
+        let Some(child) = pattern.child(i) else {
+            continue;
+        };
         match child.kind() {
             "identifier" => {
                 definitions.push(Definition {
@@ -3145,6 +3706,7 @@ fn extract_array_pattern_bindings(
                     cfg: None,
                     children: None,
                     bodyless: None,
+                    content_hash: None,
                 });
             }
             "assignment_pattern" => {
@@ -3160,6 +3722,7 @@ fn extract_array_pattern_bindings(
                             cfg: None,
                             children: None,
                             bodyless: None,
+                            content_hash: None,
                         });
                     }
                 }
@@ -3174,7 +3737,9 @@ fn extract_array_pattern_bindings(
                 // and recurse into a nested array_pattern instead of silently
                 // dropping it, mirroring extract_js_parameters' own rest_pattern scan.
                 for j in 0..child.child_count() {
-                    let Some(inner) = child.child(j) else { continue };
+                    let Some(inner) = child.child(j) else {
+                        continue;
+                    };
                     match inner.kind() {
                         "identifier" => {
                             definitions.push(Definition {
@@ -3187,13 +3752,20 @@ fn extract_array_pattern_bindings(
                                 cfg: None,
                                 children: None,
                                 bodyless: None,
+                                content_hash: None,
                             });
                             break;
                         }
                         "array_pattern" => {
                             // [...[a, b]] — recurse so the nested pattern's own
                             // bound identifiers each get their own Definition.
-                            extract_array_pattern_bindings(&inner, source, line, end_line, definitions);
+                            extract_array_pattern_bindings(
+                                &inner,
+                                source,
+                                line,
+                                end_line,
+                                definitions,
+                            );
                             break;
                         }
                         _ => {}
@@ -3237,7 +3809,8 @@ fn extract_receiver_name(obj: &Node, source: &[u8]) -> String {
 /// Mirrors `getFirstCallArg` in src/extractors/javascript.ts, which likewise
 /// only needs node structure (not source text) to locate the argument.
 fn get_first_call_arg<'a>(call_node: &'a Node) -> Option<Node<'a>> {
-    let args = call_node.child_by_field_name("arguments")
+    let args = call_node
+        .child_by_field_name("arguments")
         .or_else(|| find_child(call_node, "arguments"))?;
     for i in 0..args.child_count() {
         let child = args.child(i)?;
@@ -3253,16 +3826,19 @@ fn get_first_call_arg<'a>(call_node: &'a Node) -> Option<Node<'a>> {
 fn extract_reflect_callee_from_arg(first_arg: Option<Node>, call_line: u32, source: &[u8]) -> Call {
     if let Some(arg) = first_arg {
         match arg.kind() {
-            "identifier" => return Call {
-                name: node_text(&arg, source).to_string(),
-                line: call_line,
-                dynamic: Some(true),
-                dynamic_kind: Some("reflection".to_string()),
-                ..Default::default()
-            },
+            "identifier" => {
+                return Call {
+                    name: node_text(&arg, source).to_string(),
+                    line: call_line,
+                    dynamic: Some(true),
+                    dynamic_kind: Some("reflection".to_string()),
+                    ..Default::default()
+                }
+            }
             "member_expression" => {
                 if let Some(inner_prop) = arg.child_by_field_name("property") {
-                    let receiver = arg.child_by_field_name("object")
+                    let receiver = arg
+                        .child_by_field_name("object")
                         .map(|o| extract_receiver_name(&o, source));
                     return Call {
                         name: node_text(&inner_prop, source).to_string(),
@@ -3318,7 +3894,8 @@ fn extract_call_info(fn_node: &Node, call_node: &Node, source: &[u8]) -> Option<
             let prop = prop?;
             let prop_text = node_text(&prop, source);
             let call_line = start_line(call_node);
-            let is_reflect = obj.as_ref()
+            let is_reflect = obj
+                .as_ref()
                 .map(|o| o.kind() == "identifier" && node_text(o, source) == "Reflect")
                 .unwrap_or(false);
 
@@ -3343,7 +3920,8 @@ fn extract_call_info(fn_node: &Node, call_node: &Node, source: &[u8]) -> Option<
 
             // Reflect.get(target, prop) — property access via reflection
             if is_reflect && prop_text == "get" {
-                let args = call_node.child_by_field_name("arguments")
+                let args = call_node
+                    .child_by_field_name("arguments")
                     .or_else(|| find_child(call_node, "arguments"));
                 if let Some(args) = args {
                     let mut first_arg: Option<Node> = None;
@@ -3351,17 +3929,23 @@ fn extract_call_info(fn_node: &Node, call_node: &Node, source: &[u8]) -> Option<
                     let mut arg_idx = 0usize;
                     for i in 0..args.child_count() {
                         let Some(child) = args.child(i) else { continue };
-                        if matches!(child.kind(), "(" | ")" | ",") { continue }
-                        if arg_idx == 0 { first_arg = Some(child); }
-                        else if arg_idx == 1 { second_arg = Some(child); break; }
+                        if matches!(child.kind(), "(" | ")" | ",") {
+                            continue;
+                        }
+                        if arg_idx == 0 {
+                            first_arg = Some(child);
+                        } else if arg_idx == 1 {
+                            second_arg = Some(child);
+                            break;
+                        }
                         arg_idx += 1;
                     }
                     let receiver = first_arg.as_ref().map(|a| extract_receiver_name(a, source));
                     if let Some(prop_arg) = second_arg {
                         match prop_arg.kind() {
                             "string" | "string_fragment" => {
-                                let prop_name = node_text(&prop_arg, source)
-                                    .replace(&['\'', '"'][..], "");
+                                let prop_name =
+                                    node_text(&prop_arg, source).replace(&['\'', '"'][..], "");
                                 if !prop_name.is_empty() {
                                     return Some(Call {
                                         name: prop_name,
@@ -3452,12 +4036,13 @@ fn extract_call_info(fn_node: &Node, call_node: &Node, source: &[u8]) -> Option<
         "subscript_expression" => {
             let index = fn_node.child_by_field_name("index");
             if let Some(index) = index {
-                let receiver = fn_node.child_by_field_name("object")
+                let receiver = fn_node
+                    .child_by_field_name("object")
                     .map(|o| extract_receiver_name(&o, source));
                 match index.kind() {
                     "string" | "template_string" => {
-                        let method_name = node_text(&index, source)
-                            .replace(&['\'', '"', '`'][..], "");
+                        let method_name =
+                            node_text(&index, source).replace(&['\'', '"', '`'][..], "");
                         if !method_name.is_empty() && !method_name.contains('$') {
                             return Some(Call {
                                 name: method_name,
@@ -3527,7 +4112,11 @@ fn find_first_string_arg<'a>(args_node: &Node<'a>, source: &'a [u8]) -> Option<S
     None
 }
 
-fn walk_call_chain<'a>(start_node: &Node<'a>, method_name: &str, source: &[u8]) -> Option<Node<'a>> {
+fn walk_call_chain<'a>(
+    start_node: &Node<'a>,
+    method_name: &str,
+    source: &[u8],
+) -> Option<Node<'a>> {
     let mut current = Some(*start_node);
     while let Some(node) = current {
         if node.kind() == "call_expression" {
@@ -3594,6 +4183,7 @@ fn extract_callback_definition(call_node: &Node, source: &[u8]) -> Option<Defini
             cfg: build_function_cfg(&cb, "javascript", source),
             children: None,
             bodyless: None,
+            content_hash: None,
         });
     }
 
@@ -3614,6 +4204,7 @@ fn extract_callback_definition(call_node: &Node, source: &[u8]) -> Option<Defini
             cfg: build_function_cfg(&cb, "javascript", source),
             children: None,
             bodyless: None,
+            content_hash: None,
         });
     }
 
@@ -3631,6 +4222,7 @@ fn extract_callback_definition(call_node: &Node, source: &[u8]) -> Option<Defini
             cfg: build_function_cfg(&cb, "javascript", source),
             children: None,
             bodyless: None,
+            content_hash: None,
         });
     }
 
@@ -3681,8 +4273,7 @@ fn find_parent_class_no_fn_boundary(node: &Node, source: &[u8]) -> Option<String
             return None;
         }
         if JS_CLASS_KINDS.contains(&kind) {
-            return named_child_text(&parent, "name", source)
-                .map(|s| s.to_string());
+            return named_child_text(&parent, "name", source).map(|s| s.to_string());
         }
         current = parent.parent();
     }
@@ -3753,7 +4344,9 @@ fn collect_object_pattern_names(
 ) -> Vec<String> {
     let mut names = Vec::new();
     for i in 0..pattern.child_count() {
-        let Some(child) = pattern.child(i) else { continue };
+        let Some(child) = pattern.child(i) else {
+            continue;
+        };
         match child.kind() {
             "shorthand_property_identifier_pattern" | "shorthand_property_identifier" => {
                 names.push(node_text(&child, source).to_string());
@@ -3768,9 +4361,8 @@ fn collect_object_pattern_names(
                 let key = child.child_by_field_name("key");
                 let value = child.child_by_field_name("value");
                 let local_node = match value.map(|v| (v.kind(), v)) {
-                    Some(("identifier", v)) | Some(("shorthand_property_identifier_pattern", v)) => {
-                        Some(v)
-                    }
+                    Some(("identifier", v))
+                    | Some(("shorthand_property_identifier_pattern", v)) => Some(v),
                     Some(("assignment_pattern", v)) => {
                         // { imported: local = defaultValue } — the local
                         // binding is the assignment_pattern's left identifier.
@@ -3838,7 +4430,9 @@ fn collect_object_pattern_names(
 fn collect_array_pattern_names(pattern: &Node, source: &[u8]) -> Vec<String> {
     let mut names = Vec::new();
     for i in 0..pattern.child_count() {
-        let Some(child) = pattern.child(i) else { continue };
+        let Some(child) = pattern.child(i) else {
+            continue;
+        };
         match child.kind() {
             "identifier" => {
                 names.push(node_text(&child, source).to_string());
@@ -4106,7 +4700,9 @@ fn enclosing_func_context(node: &Node, source: &[u8]) -> String {
 /// - `this(args)` → `Call { name: "this" }` (this used as a function)
 /// - `fn.call(ctx, ...)` / `fn.apply(ctx, ...)` → ThisCallBinding
 fn collect_this_call_and_bindings(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(fn_node) = node.child_by_field_name("function") else { return };
+    let Some(fn_node) = node.child_by_field_name("function") else {
+        return;
+    };
     if fn_node.kind() == "this" {
         symbols.calls.push(Call {
             name: "this".to_string(),
@@ -4147,7 +4743,10 @@ fn collect_this_call_and_bindings(node: &Node, source: &[u8], symbols: &mut File
         }
         if t == "identifier" {
             let arg_text = node_text(&child, source);
-            if !JS_BUILTIN_GLOBALS.contains(&arg_text) && arg_text != "undefined" && arg_text != "null" {
+            if !JS_BUILTIN_GLOBALS.contains(&arg_text)
+                && arg_text != "undefined"
+                && arg_text != "null"
+            {
                 symbols.this_call_bindings.push(ThisCallBinding {
                     callee: obj_text.to_string(),
                     this_arg: arg_text.to_string(),
@@ -4161,7 +4760,9 @@ fn collect_this_call_and_bindings(node: &Node, source: &[u8], symbols: &mut File
 /// Phase 8.3c: `f(x)` identifier-argument bindings, including inline
 /// `f(...[a, b])` array-literal spread expansion.
 fn collect_param_bindings(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(fn_node) = node.child_by_field_name("function") else { return };
+    let Some(fn_node) = node.child_by_field_name("function") else {
+        return;
+    };
     if fn_node.kind() != "identifier" {
         return;
     }
@@ -4191,9 +4792,13 @@ fn collect_param_bindings(node: &Node, source: &[u8], symbols: &mut FileSymbols)
             }
         } else if ct == "spread_element" {
             // f(...[a, b]) — inline array literal: expand each element as a direct binding.
-            let inner = child
-                .child_by_field_name("argument")
-                .or_else(|| if child.child_count() > 1 { child.child(1) } else { None });
+            let inner = child.child_by_field_name("argument").or_else(|| {
+                if child.child_count() > 1 {
+                    child.child(1)
+                } else {
+                    None
+                }
+            });
             if let Some(inner) = inner {
                 if inner.kind() == "array" {
                     let mut elem_count: u32 = 0;
@@ -4228,7 +4833,9 @@ fn collect_param_bindings(node: &Node, source: &[u8], symbols: &mut FileSymbols)
 
 /// Phase 8.3e: `f(...arr)` spread bindings and `Array.from(src, cb)` callbacks.
 fn collect_spread_and_array_from_bindings(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(fn_node) = node.child_by_field_name("function") else { return };
+    let Some(fn_node) = node.child_by_field_name("function") else {
+        return;
+    };
     let args = node
         .child_by_field_name("arguments")
         .or_else(|| find_child(node, "arguments"));
@@ -4246,9 +4853,13 @@ fn collect_spread_and_array_from_bindings(node: &Node, source: &[u8], symbols: &
                     continue;
                 }
                 if ct == "spread_element" {
-                    let target = child
-                        .child_by_field_name("argument")
-                        .or_else(|| if child.child_count() > 1 { child.child(1) } else { None });
+                    let target = child.child_by_field_name("argument").or_else(|| {
+                        if child.child_count() > 1 {
+                            child.child(1)
+                        } else {
+                            None
+                        }
+                    });
                     if let Some(target) = target {
                         if target.kind() == "identifier" {
                             let target_text = node_text(&target, source);
@@ -4320,7 +4931,9 @@ fn collect_array_elem_bindings(node: &Node, source: &[u8], symbols: &mut FileSym
     let array_name = node_text(&name_n, source);
     let mut idx: u32 = 0;
     for i in 0..value_n.child_count() {
-        let Some(elem) = value_n.child(i) else { continue };
+        let Some(elem) = value_n.child(i) else {
+            continue;
+        };
         let et = elem.kind();
         if et == "," || et == "[" || et == "]" {
             continue;
@@ -4397,12 +5010,16 @@ fn collect_for_of_binding(node: &Node, source: &[u8], symbols: &mut FileSymbols)
     if !is_for_of {
         return;
     }
-    let Some(right) = node.child_by_field_name("right") else { return };
+    let Some(right) = node.child_by_field_name("right") else {
+        return;
+    };
     let right_text = node_text(&right, source);
     if right.kind() != "identifier" || JS_BUILTIN_GLOBALS.contains(&right_text) {
         return;
     }
-    let Some(left) = node.child_by_field_name("left") else { return };
+    let Some(left) = node.child_by_field_name("left") else {
+        return;
+    };
     let mut var_name: Option<&str> = None;
     if left.kind() == "identifier" {
         var_name = Some(node_text(&left, source));
@@ -4465,7 +5082,9 @@ fn collect_object_rest_params(node: &Node, source: &[u8], symbols: &mut FileSymb
             ) {
                 let vt = value_n.kind();
                 if name_n.kind() == "identifier"
-                    && (vt == "arrow_function" || vt == "function_expression" || vt == "generator_function")
+                    && (vt == "arrow_function"
+                        || vt == "function_expression"
+                        || vt == "generator_function")
                 {
                     fn_name = Some(node_text(&name_n, source).to_string());
                     params_node = value_n
@@ -4484,7 +5103,10 @@ fn collect_object_rest_params(node: &Node, source: &[u8], symbols: &mut FileSymb
                     .filter(|p| p.kind() == "class_body")
                     .and_then(|p| p.parent())
                     .filter(|c| c.kind() == "class_declaration" || c.kind() == "class")
-                    .and_then(|c| c.child_by_field_name("name").map(|n| node_text(&n, source).to_string()));
+                    .and_then(|c| {
+                        c.child_by_field_name("name")
+                            .map(|n| node_text(&n, source).to_string())
+                    });
                 fn_name = Some(match current_class {
                     Some(c) => format!("{c}.{method}"),
                     None => method.to_string(),
@@ -4504,7 +5126,10 @@ fn collect_object_rest_params(node: &Node, source: &[u8], symbols: &mut FileSymb
                 node.child_by_field_name("value"),
             ) {
                 let vt = value_n.kind();
-                if vt == "arrow_function" || vt == "function_expression" || vt == "generator_function" {
+                if vt == "arrow_function"
+                    || vt == "function_expression"
+                    || vt == "generator_function"
+                {
                     if let Some(key_name) = resolve_pair_key_name(&key_n, source) {
                         fn_name = Some(key_name);
                         params_node = value_n
@@ -4517,26 +5142,34 @@ fn collect_object_rest_params(node: &Node, source: &[u8], symbols: &mut FileSymb
         _ => {}
     }
 
-    let (Some(fn_name), Some(params_node)) = (fn_name, params_node) else { return };
+    let (Some(fn_name), Some(params_node)) = (fn_name, params_node) else {
+        return;
+    };
     let mut param_idx: u32 = 0;
     for i in 0..params_node.child_count() {
-        let Some(child) = params_node.child(i) else { continue };
+        let Some(child) = params_node.child(i) else {
+            continue;
+        };
         let ct = child.kind();
         if ct == "," || ct == "(" || ct == ")" {
             continue;
         }
         if ct == "object_pattern" {
             for j in 0..child.child_count() {
-                let Some(inner) = child.child(j) else { continue };
+                let Some(inner) = child.child(j) else {
+                    continue;
+                };
                 if inner.kind() == "rest_pattern" || inner.kind() == "rest_element" {
                     let rest_id = inner.child(1).or_else(|| inner.child_by_field_name("name"));
                     if let Some(rest_id) = rest_id {
                         if rest_id.kind() == "identifier" {
-                            symbols.object_rest_param_bindings.push(ObjectRestParamBinding {
-                                callee: fn_name.clone(),
-                                rest_name: node_text(&rest_id, source).to_string(),
-                                arg_index: param_idx,
-                            });
+                            symbols
+                                .object_rest_param_bindings
+                                .push(ObjectRestParamBinding {
+                                    callee: fn_name.clone(),
+                                    rest_name: node_text(&rest_id, source).to_string(),
+                                    arg_index: param_idx,
+                                });
                         }
                     }
                 }
@@ -4560,7 +5193,9 @@ fn collect_object_prop_bindings(node: &Node, source: &[u8], symbols: &mut FileSy
     }
     let object_name = node_text(&name_n, source);
     for i in 0..value_n.child_count() {
-        let Some(child) = value_n.child(i) else { continue };
+        let Some(child) = value_n.child(i) else {
+            continue;
+        };
         if child.kind() == "shorthand_property_identifier" {
             let prop = node_text(&child, source);
             symbols.object_prop_bindings.push(ObjectPropBinding {
@@ -4662,7 +5297,11 @@ mod tests {
                }\n\
              }\n",
         );
-        let iface_save = s.definitions.iter().find(|d| d.name == "Repo.save").unwrap();
+        let iface_save = s
+            .definitions
+            .iter()
+            .find(|d| d.name == "Repo.save")
+            .unwrap();
         assert_eq!(iface_save.bodyless, Some(true));
 
         let class_save = s
@@ -4762,14 +5401,24 @@ mod tests {
     #[test]
     fn skips_commander_named_handler() {
         let s = parse_js("program.command('test').action(handleTest);");
-        let defs: Vec<_> = s.definitions.iter().filter(|d| d.name.starts_with("command:")).collect();
-        assert!(defs.is_empty(), "should not extract when handler is a named reference");
+        let defs: Vec<_> = s
+            .definitions
+            .iter()
+            .filter(|d| d.name.starts_with("command:"))
+            .collect();
+        assert!(
+            defs.is_empty(),
+            "should not extract when handler is a named reference"
+        );
     }
 
     #[test]
     fn extracts_express_get_route() {
         let s = parse_js("app.get('/api/users', (req, res) => { res.json([]); });");
-        let def = s.definitions.iter().find(|d| d.name == "route:GET /api/users");
+        let def = s
+            .definitions
+            .iter()
+            .find(|d| d.name == "route:GET /api/users");
         assert!(def.is_some(), "should extract route:GET /api/users");
         assert_eq!(def.unwrap().kind, "function");
     }
@@ -4777,14 +5426,21 @@ mod tests {
     #[test]
     fn extracts_express_post_route() {
         let s = parse_js("router.post('/api/items', async (req, res) => { save(); });");
-        let def = s.definitions.iter().find(|d| d.name == "route:POST /api/items");
+        let def = s
+            .definitions
+            .iter()
+            .find(|d| d.name == "route:POST /api/items");
         assert!(def.is_some(), "should extract route:POST /api/items");
     }
 
     #[test]
     fn skips_map_get_false_positive() {
         let s = parse_js("myMap.get('someKey');");
-        let defs: Vec<_> = s.definitions.iter().filter(|d| d.name.starts_with("route:")).collect();
+        let defs: Vec<_> = s
+            .definitions
+            .iter()
+            .filter(|d| d.name.starts_with("route:"))
+            .collect();
         assert!(defs.is_empty(), "should not extract Map.get as a route");
     }
 
@@ -4806,8 +5462,15 @@ mod tests {
     #[test]
     fn skips_event_named_handler() {
         let s = parse_js("emitter.on('data', handleData);");
-        let defs: Vec<_> = s.definitions.iter().filter(|d| d.name.starts_with("event:")).collect();
-        assert!(defs.is_empty(), "should not extract when handler is a named reference");
+        let defs: Vec<_> = s
+            .definitions
+            .iter()
+            .filter(|d| d.name.starts_with("event:"))
+            .collect();
+        assert!(
+            defs.is_empty(),
+            "should not extract when handler is a named reference"
+        );
     }
 
     // ── Extended kinds tests ────────────────────────────────────────────────
@@ -4900,7 +5563,9 @@ mod tests {
     fn exports_const_with_call_expression_initializer() {
         let s = parse_js("export const config = loadConfig();");
         assert!(
-            s.exports.iter().any(|e| e.name == "config" && e.kind == "constant"),
+            s.exports
+                .iter()
+                .any(|e| e.name == "config" && e.kind == "constant"),
             "config should be listed as an exported constant; got: {:?}",
             s.exports
         );
@@ -4966,12 +5631,16 @@ mod tests {
         // decoupled fnRefBindings pass).
         let s = parse_js("const alias = handler;");
         assert!(
-            s.definitions.iter().any(|d| d.name == "alias" && d.kind == "constant"),
+            s.definitions
+                .iter()
+                .any(|d| d.name == "alias" && d.kind == "constant"),
             "alias should be extracted as a constant definition; got: {:?}",
             s.definitions
         );
         assert!(
-            s.fn_ref_bindings.iter().any(|b| b.lhs == "alias" && b.rhs == "handler"),
+            s.fn_ref_bindings
+                .iter()
+                .any(|b| b.lhs == "alias" && b.rhs == "handler"),
             "alias -> handler fn_ref_binding should still be recorded; got: {:?}",
             s.fn_ref_bindings
         );
@@ -5012,7 +5681,11 @@ mod tests {
         let new_nodes: Vec<_> = s.ast_nodes.iter().filter(|n| n.kind == "new").collect();
         let throw_nodes: Vec<_> = s.ast_nodes.iter().filter(|n| n.kind == "throw").collect();
         assert_eq!(throw_nodes.len(), 1);
-        assert_eq!(new_nodes.len(), 0, "throw new Error should not also emit a new node");
+        assert_eq!(
+            new_nodes.len(),
+            0,
+            "throw new Error should not also emit a new node"
+        );
     }
 
     #[test]
@@ -5070,7 +5743,11 @@ mod tests {
     #[test]
     fn finds_dynamic_import() {
         let s = parse_js("const mod = import('./foo.js');");
-        let dyn_imports: Vec<_> = s.imports.iter().filter(|i| i.dynamic_import == Some(true)).collect();
+        let dyn_imports: Vec<_> = s
+            .imports
+            .iter()
+            .filter(|i| i.dynamic_import == Some(true))
+            .collect();
         assert_eq!(dyn_imports.len(), 1);
         assert_eq!(dyn_imports[0].source, "./foo.js");
     }
@@ -5078,7 +5755,11 @@ mod tests {
     #[test]
     fn finds_dynamic_import_with_destructuring() {
         let s = parse_js("const { a, b } = await import('./bar.js');");
-        let dyn_imports: Vec<_> = s.imports.iter().filter(|i| i.dynamic_import == Some(true)).collect();
+        let dyn_imports: Vec<_> = s
+            .imports
+            .iter()
+            .filter(|i| i.dynamic_import == Some(true))
+            .collect();
         assert_eq!(dyn_imports.len(), 1);
         assert_eq!(dyn_imports[0].source, "./bar.js");
         assert!(dyn_imports[0].names.contains(&"a".to_string()));
@@ -5094,7 +5775,11 @@ mod tests {
         // local → original mapping so call-edge resolution can still find
         // `buildGraph` in the target file.
         let s = parse_js("const { buildGraph: fromBarrel } = await import('./builder.js');");
-        let dyn_imports: Vec<_> = s.imports.iter().filter(|i| i.dynamic_import == Some(true)).collect();
+        let dyn_imports: Vec<_> = s
+            .imports
+            .iter()
+            .filter(|i| i.dynamic_import == Some(true))
+            .collect();
         assert_eq!(dyn_imports.len(), 1);
         assert_eq!(dyn_imports[0].source, "./builder.js");
         assert!(dyn_imports[0].names.contains(&"fromBarrel".to_string()));
@@ -5114,7 +5799,11 @@ mod tests {
         // verbatim as `imported` would make the resolver look for an export
         // literally named `'foo-bar'`, which never matches (Greptile follow-up).
         let s = parse_js("const { 'foo-bar': local } = await import('./mod.js');");
-        let dyn_imports: Vec<_> = s.imports.iter().filter(|i| i.dynamic_import == Some(true)).collect();
+        let dyn_imports: Vec<_> = s
+            .imports
+            .iter()
+            .filter(|i| i.dynamic_import == Some(true))
+            .collect();
         assert_eq!(dyn_imports.len(), 1);
         assert_eq!(dyn_imports[0].names, vec!["local".to_string()]);
         let renamed = dyn_imports[0]
@@ -5129,7 +5818,11 @@ mod tests {
     #[test]
     fn unwraps_computed_string_literal_destructuring_key() {
         let s = parse_js("const { ['foo-bar']: local } = await import('./mod.js');");
-        let dyn_imports: Vec<_> = s.imports.iter().filter(|i| i.dynamic_import == Some(true)).collect();
+        let dyn_imports: Vec<_> = s
+            .imports
+            .iter()
+            .filter(|i| i.dynamic_import == Some(true))
+            .collect();
         assert_eq!(dyn_imports.len(), 1);
         assert_eq!(dyn_imports[0].names, vec!["local".to_string()]);
         let renamed = dyn_imports[0]
@@ -5146,7 +5839,11 @@ mod tests {
         // `[Symbol()]` has no statically resolvable export name — the local
         // binding must still be tracked, just without a renamed_imports entry.
         let s = parse_js("const { [Symbol()]: local } = await import('./mod.js');");
-        let dyn_imports: Vec<_> = s.imports.iter().filter(|i| i.dynamic_import == Some(true)).collect();
+        let dyn_imports: Vec<_> = s
+            .imports
+            .iter()
+            .filter(|i| i.dynamic_import == Some(true))
+            .collect();
         assert_eq!(dyn_imports.len(), 1);
         assert_eq!(dyn_imports[0].names, vec!["local".to_string()]);
         assert!(dyn_imports[0].renamed_imports.is_none());
@@ -5155,7 +5852,11 @@ mod tests {
     #[test]
     fn finds_dynamic_import_with_mixed_destructuring() {
         let s = parse_js("const { a, buildGraph: fromBarrel, c } = await import('./mod.js');");
-        let dyn_imports: Vec<_> = s.imports.iter().filter(|i| i.dynamic_import == Some(true)).collect();
+        let dyn_imports: Vec<_> = s
+            .imports
+            .iter()
+            .filter(|i| i.dynamic_import == Some(true))
+            .collect();
         assert_eq!(dyn_imports.len(), 1);
         assert_eq!(dyn_imports[0].source, "./mod.js");
         assert!(dyn_imports[0].names.contains(&"a".to_string()));
@@ -5174,7 +5875,11 @@ mod tests {
     #[test]
     fn finds_dynamic_import_with_aliased_default_destructuring() {
         let s = parse_js("const { buildGraph: local = null } = await import('./builder.js');");
-        let dyn_imports: Vec<_> = s.imports.iter().filter(|i| i.dynamic_import == Some(true)).collect();
+        let dyn_imports: Vec<_> = s
+            .imports
+            .iter()
+            .filter(|i| i.dynamic_import == Some(true))
+            .collect();
         assert_eq!(dyn_imports.len(), 1);
         assert!(dyn_imports[0].names.contains(&"local".to_string()));
         assert!(!dyn_imports[0].names.contains(&"buildGraph".to_string()));
@@ -5190,7 +5895,11 @@ mod tests {
     #[test]
     fn finds_dynamic_import_with_nested_object_destructuring() {
         let s = parse_js("const { foo: { nested } } = await import('./mod.js');");
-        let dyn_imports: Vec<_> = s.imports.iter().filter(|i| i.dynamic_import == Some(true)).collect();
+        let dyn_imports: Vec<_> = s
+            .imports
+            .iter()
+            .filter(|i| i.dynamic_import == Some(true))
+            .collect();
         assert_eq!(dyn_imports.len(), 1);
         assert!(dyn_imports[0].names.contains(&"foo".to_string()));
         assert!(!dyn_imports[0].names.contains(&"nested".to_string()));
@@ -5208,7 +5917,11 @@ mod tests {
     #[test]
     fn finds_dynamic_import_with_parenthesized_destructuring() {
         let s = parse_ts("const { a, b } = (await import('./foo.js'));");
-        let dyn_imports: Vec<_> = s.imports.iter().filter(|i| i.dynamic_import == Some(true)).collect();
+        let dyn_imports: Vec<_> = s
+            .imports
+            .iter()
+            .filter(|i| i.dynamic_import == Some(true))
+            .collect();
         assert_eq!(dyn_imports.len(), 1);
         assert!(dyn_imports[0].names.contains(&"a".to_string()));
         assert!(dyn_imports[0].names.contains(&"b".to_string()));
@@ -5217,7 +5930,11 @@ mod tests {
     #[test]
     fn finds_dynamic_import_with_as_cast_destructuring() {
         let s = parse_ts("const { a, b } = await import('./foo.js') as { a: Fn; b: Fn };");
-        let dyn_imports: Vec<_> = s.imports.iter().filter(|i| i.dynamic_import == Some(true)).collect();
+        let dyn_imports: Vec<_> = s
+            .imports
+            .iter()
+            .filter(|i| i.dynamic_import == Some(true))
+            .collect();
         assert_eq!(dyn_imports.len(), 1);
         assert!(dyn_imports[0].names.contains(&"a".to_string()));
         assert!(dyn_imports[0].names.contains(&"b".to_string()));
@@ -5228,7 +5945,11 @@ mod tests {
         // TS 4.9+ `satisfies` is structurally identical to `as` here (Greptile
         // follow-up to #1781) — same walk-up gap would otherwise reproduce.
         let s = parse_ts("const { a, b } = await import('./foo.js') satisfies { a: Fn; b: Fn };");
-        let dyn_imports: Vec<_> = s.imports.iter().filter(|i| i.dynamic_import == Some(true)).collect();
+        let dyn_imports: Vec<_> = s
+            .imports
+            .iter()
+            .filter(|i| i.dynamic_import == Some(true))
+            .collect();
         assert_eq!(dyn_imports.len(), 1);
         assert!(dyn_imports[0].names.contains(&"a".to_string()));
         assert!(dyn_imports[0].names.contains(&"b".to_string()));
@@ -5241,11 +5962,19 @@ mod tests {
         let s = parse_ts(
             "const { buildDataflowVerticesFromMap, buildDataflowEdges } = (await import('../../../../features/dataflow.js')) as { buildDataflowVerticesFromMap: Fn; buildDataflowEdges: Fn };",
         );
-        let dyn_imports: Vec<_> = s.imports.iter().filter(|i| i.dynamic_import == Some(true)).collect();
+        let dyn_imports: Vec<_> = s
+            .imports
+            .iter()
+            .filter(|i| i.dynamic_import == Some(true))
+            .collect();
         assert_eq!(dyn_imports.len(), 1);
         assert_eq!(dyn_imports[0].source, "../../../../features/dataflow.js");
-        assert!(dyn_imports[0].names.contains(&"buildDataflowVerticesFromMap".to_string()));
-        assert!(dyn_imports[0].names.contains(&"buildDataflowEdges".to_string()));
+        assert!(dyn_imports[0]
+            .names
+            .contains(&"buildDataflowVerticesFromMap".to_string()));
+        assert!(dyn_imports[0]
+            .names
+            .contains(&"buildDataflowEdges".to_string()));
     }
 
     // Regression tests for #1920: `extract_rest_identifier` indexed into a
@@ -5256,15 +5985,26 @@ mod tests {
     #[test]
     fn finds_dynamic_import_with_object_rest_destructuring() {
         let s = parse_js("const { a, ...rest } = await import('./mod.js');");
-        let dyn_imports: Vec<_> = s.imports.iter().filter(|i| i.dynamic_import == Some(true)).collect();
+        let dyn_imports: Vec<_> = s
+            .imports
+            .iter()
+            .filter(|i| i.dynamic_import == Some(true))
+            .collect();
         assert_eq!(dyn_imports.len(), 1);
-        assert_eq!(dyn_imports[0].names, vec!["a".to_string(), "rest".to_string()]);
+        assert_eq!(
+            dyn_imports[0].names,
+            vec!["a".to_string(), "rest".to_string()]
+        );
     }
 
     #[test]
     fn finds_dynamic_import_with_shorthand_default_destructuring() {
         let s = parse_js("const { a = 1 } = await import('./mod.js');");
-        let dyn_imports: Vec<_> = s.imports.iter().filter(|i| i.dynamic_import == Some(true)).collect();
+        let dyn_imports: Vec<_> = s
+            .imports
+            .iter()
+            .filter(|i| i.dynamic_import == Some(true))
+            .collect();
         assert_eq!(dyn_imports.len(), 1);
         assert_eq!(dyn_imports[0].names, vec!["a".to_string()]);
     }
@@ -5272,11 +6012,20 @@ mod tests {
     #[test]
     fn finds_dynamic_import_with_mixed_plain_renamed_default_and_rest_destructuring() {
         let s = parse_js("const { a, b: alias, c = 1, ...rest } = await import('./mod.js');");
-        let dyn_imports: Vec<_> = s.imports.iter().filter(|i| i.dynamic_import == Some(true)).collect();
+        let dyn_imports: Vec<_> = s
+            .imports
+            .iter()
+            .filter(|i| i.dynamic_import == Some(true))
+            .collect();
         assert_eq!(dyn_imports.len(), 1);
         assert_eq!(
             dyn_imports[0].names,
-            vec!["a".to_string(), "alias".to_string(), "c".to_string(), "rest".to_string()]
+            vec![
+                "a".to_string(),
+                "alias".to_string(),
+                "c".to_string(),
+                "rest".to_string()
+            ]
         );
         let renamed = dyn_imports[0]
             .renamed_imports
@@ -5290,16 +6039,26 @@ mod tests {
     #[test]
     fn finds_dynamic_import_with_array_rest_destructuring() {
         let s = parse_js("const [a, ...rest] = await import('./mod.js');");
-        let dyn_imports: Vec<_> = s.imports.iter().filter(|i| i.dynamic_import == Some(true)).collect();
+        let dyn_imports: Vec<_> = s
+            .imports
+            .iter()
+            .filter(|i| i.dynamic_import == Some(true))
+            .collect();
         assert_eq!(dyn_imports.len(), 1);
-        assert_eq!(dyn_imports[0].names, vec!["a".to_string(), "rest".to_string()]);
+        assert_eq!(
+            dyn_imports[0].names,
+            vec!["a".to_string(), "rest".to_string()]
+        );
     }
 
     #[test]
     fn extracts_callback_reference_in_router_use() {
         let s = parse_js("router.use(handleToken);");
         let dynamic_calls: Vec<_> = s.calls.iter().filter(|c| c.dynamic == Some(true)).collect();
-        assert!(dynamic_calls.iter().any(|c| c.name == "handleToken"), "should extract handleToken as dynamic call");
+        assert!(
+            dynamic_calls.iter().any(|c| c.name == "handleToken"),
+            "should extract handleToken as dynamic call"
+        );
     }
 
     #[test]
@@ -5462,7 +6221,11 @@ mod tests {
             .map(|c| c.name.as_str())
             .collect();
         for expected in ["isA", "resolveA", "isB", "resolveB"] {
-            assert!(names.contains(&expected), "missing value-ref call for {}", expected);
+            assert!(
+                names.contains(&expected),
+                "missing value-ref call for {}",
+                expected
+            );
         }
     }
 
@@ -5549,19 +6312,28 @@ mod tests {
     #[test]
     fn no_value_ref_call_for_call_expression_value() {
         let s = parse_js("const table = { resolve: someFunction() };");
-        assert!(s.calls.iter().all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
+        assert!(s
+            .calls
+            .iter()
+            .all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
     }
 
     #[test]
     fn no_value_ref_call_for_member_expression_value() {
         let s = parse_js("const table = { resolve: obj.someFunction };");
-        assert!(s.calls.iter().all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
+        assert!(s
+            .calls
+            .iter()
+            .all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
     }
 
     #[test]
     fn no_value_ref_call_for_inline_function_value() {
         let s = parse_js("const table = { resolve: () => {}, other: function () {} };");
-        assert!(s.calls.iter().all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
+        assert!(s
+            .calls
+            .iter()
+            .all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
     }
 
     #[test]
@@ -5569,13 +6341,19 @@ mod tests {
         let s = parse_js(
             "const config = { name: 'literal', count: 42, active: true, empty: null, list: [1, 2] };",
         );
-        assert!(s.calls.iter().all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
+        assert!(s
+            .calls
+            .iter()
+            .all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
     }
 
     #[test]
     fn no_value_ref_call_for_builtin_globals() {
         let s = parse_js("const table = { log: console, Ctor: Object };");
-        assert!(s.calls.iter().all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
+        assert!(s
+            .calls
+            .iter()
+            .all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
     }
 
     // ── #1784: instanceof value-ref extraction ──────────────────────────────
@@ -5608,17 +6386,19 @@ mod tests {
     #[test]
     fn no_value_ref_call_for_instanceof_member_expression_operand() {
         let s = parse_js("const check = (a) => a instanceof ns.SomeClass;");
-        assert!(
-            s.calls
-                .iter()
-                .all(|c| !(c.dynamic_kind.as_deref() == Some("value-ref") && c.name == "SomeClass"))
-        );
+        assert!(s
+            .calls
+            .iter()
+            .all(|c| !(c.dynamic_kind.as_deref() == Some("value-ref") && c.name == "SomeClass")));
     }
 
     #[test]
     fn no_value_ref_call_for_instanceof_call_expression_operand() {
         let s = parse_js("const check = (a) => a instanceof getClass();");
-        assert!(s.calls.iter().all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
+        assert!(s
+            .calls
+            .iter()
+            .all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
     }
 
     #[test]
@@ -5626,25 +6406,38 @@ mod tests {
         let s = parse_js(
             "function isBuiltin(x) { return x instanceof Error || x instanceof Array || x instanceof Map; }",
         );
-        assert!(s.calls.iter().all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
+        assert!(s
+            .calls
+            .iter()
+            .all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
     }
 
     #[test]
     fn no_value_ref_call_for_in_operator() {
         let s = parse_js("const has = (obj) => 'key' in obj;");
-        assert!(s.calls.iter().all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
+        assert!(s
+            .calls
+            .iter()
+            .all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
     }
 
     #[test]
     fn no_value_ref_call_for_other_binary_operators() {
         let s = parse_js("const sum = (a, b) => a + b === Total;");
-        assert!(s.calls.iter().all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
+        assert!(s
+            .calls
+            .iter()
+            .all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
     }
 
     #[test]
     fn no_duplicate_call_for_call_expression_arg() {
         let s = parse_js("router.use(checkPermissions(['admin']));");
-        let cp_calls: Vec<_> = s.calls.iter().filter(|c| c.name == "checkPermissions").collect();
+        let cp_calls: Vec<_> = s
+            .calls
+            .iter()
+            .filter(|c| c.name == "checkPermissions")
+            .collect();
         assert_eq!(cp_calls.len(), 1);
     }
 
@@ -5655,8 +6448,11 @@ mod tests {
         // map, addEventListener, etc.) get member_expression args emitted as
         // dynamic calls. Mirrors WASM test in `tests/parsers/javascript.test.ts`.
         let s = parse_js("store.set(user.id, user);");
-        let dyn_member_calls: Vec<_> =
-            s.calls.iter().filter(|c| c.dynamic == Some(true) && c.name == "id").collect();
+        let dyn_member_calls: Vec<_> = s
+            .calls
+            .iter()
+            .filter(|c| c.dynamic == Some(true) && c.name == "id")
+            .collect();
         assert!(
             dyn_member_calls.is_empty(),
             "store.set non-allowlisted callee must not emit member-expr arg `id` as dynamic call",
@@ -5669,15 +6465,25 @@ mod tests {
         // must still produce dynamic calls with receivers, because `use` and `then`
         // are callback-accepting APIs.
         let use_s = parse_js("app.use(auth.validate);");
-        let use_cb = use_s.calls.iter()
+        let use_cb = use_s
+            .calls
+            .iter()
             .find(|c| c.dynamic == Some(true) && c.name == "validate");
-        assert!(use_cb.is_some(), "app.use must still emit validate as dynamic call");
+        assert!(
+            use_cb.is_some(),
+            "app.use must still emit validate as dynamic call"
+        );
         assert_eq!(use_cb.unwrap().receiver.as_deref(), Some("auth"));
 
         let then_s = parse_js("promise.then(handlers.onSuccess);");
-        let then_cb = then_s.calls.iter()
+        let then_cb = then_s
+            .calls
+            .iter()
             .find(|c| c.dynamic == Some(true) && c.name == "onSuccess");
-        assert!(then_cb.is_some(), "promise.then must still emit onSuccess as dynamic call");
+        assert!(
+            then_cb.is_some(),
+            "promise.then must still emit onSuccess as dynamic call"
+        );
         assert_eq!(then_cb.unwrap().receiver.as_deref(), Some("handlers"));
     }
 
@@ -5688,19 +6494,28 @@ mod tests {
         // must not be emitted as dynamic calls. Same for `repo.put`, `map.delete`.
         let cache_s = parse_js("cache.get(user.id);");
         assert!(
-            !cache_s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "id"),
+            !cache_s
+                .calls
+                .iter()
+                .any(|c| c.dynamic == Some(true) && c.name == "id"),
             "cache.get(user.id) must not emit `id` as dynamic call",
         );
 
         let repo_s = parse_js("repo.put(record.key, value);");
         assert!(
-            !repo_s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "key"),
+            !repo_s
+                .calls
+                .iter()
+                .any(|c| c.dynamic == Some(true) && c.name == "key"),
             "repo.put(record.key) must not emit `key` as dynamic call",
         );
 
         let map_s = parse_js("map.delete(entry.id);");
         assert!(
-            !map_s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "id"),
+            !map_s
+                .calls
+                .iter()
+                .any(|c| c.dynamic == Some(true) && c.name == "id"),
             "map.delete(entry.id) must not emit `id` as dynamic call",
         );
     }
@@ -5710,15 +6525,25 @@ mod tests {
         // Positive regression guard: HTTP-verb calls with a string-literal
         // first arg (Express route signature) must still emit member-expr args.
         let router_s = parse_js("router.get('/users/:id', auth.check);");
-        let router_cb = router_s.calls.iter()
+        let router_cb = router_s
+            .calls
+            .iter()
             .find(|c| c.dynamic == Some(true) && c.name == "check");
-        assert!(router_cb.is_some(), "Express route with string path must emit auth.check");
+        assert!(
+            router_cb.is_some(),
+            "Express route with string path must emit auth.check"
+        );
         assert_eq!(router_cb.unwrap().receiver.as_deref(), Some("auth"));
 
         let template_s = parse_js("app.post(`/api`, handlers.create);");
-        let template_cb = template_s.calls.iter()
+        let template_cb = template_s
+            .calls
+            .iter()
             .find(|c| c.dynamic == Some(true) && c.name == "create");
-        assert!(template_cb.is_some(), "Express route with template string must emit handlers.create");
+        assert!(
+            template_cb.is_some(),
+            "Express route with template string must emit handlers.create"
+        );
         assert_eq!(template_cb.unwrap().receiver.as_deref(), Some("handlers"));
     }
 
@@ -5728,9 +6553,14 @@ mod tests {
         // represent `obj?.on` as a `member_expression` with an `optional_chain`
         // child, so `extract_callee_name` returns `on` and the allowlist gate works.
         let s = parse_js("emitter?.on('tick', handlers.fn);");
-        let cb = s.calls.iter()
+        let cb = s
+            .calls
+            .iter()
             .find(|c| c.dynamic == Some(true) && c.name == "fn");
-        assert!(cb.is_some(), "optional-chain callee must still gate by allowlist");
+        assert!(
+            cb.is_some(),
+            "optional-chain callee must still gate by allowlist"
+        );
         assert_eq!(cb.unwrap().receiver.as_deref(), Some("handlers"));
     }
 
@@ -5769,7 +6599,9 @@ mod tests {
         // "identifier args are always emitted" trade-off existed to preserve.
         let s = parse_js("arr.forEach(myNamedCallback);");
         assert!(
-            s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "myNamedCallback"),
+            s.calls
+                .iter()
+                .any(|c| c.dynamic == Some(true) && c.name == "myNamedCallback"),
             "arr.forEach must still emit myNamedCallback as dynamic call; got: {:?}",
             s.calls,
         );
@@ -5792,7 +6624,9 @@ mod tests {
              }",
         );
         assert!(
-            s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "logUser"),
+            s.calls
+                .iter()
+                .any(|c| c.dynamic == Some(true) && c.name == "logUser"),
             "processEach(users, logUser) must emit logUser as dynamic call; got: {:?}",
             s.calls,
         );
@@ -5810,7 +6644,9 @@ mod tests {
              }",
         );
         assert!(
-            s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "logUser"),
+            s.calls
+                .iter()
+                .any(|c| c.dynamic == Some(true) && c.name == "logUser"),
             "inline arrow-function-type param must recognize logUser; got: {:?}",
             s.calls,
         );
@@ -5826,7 +6662,9 @@ mod tests {
              }",
         );
         assert!(
-            s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "handler"),
+            s.calls
+                .iter()
+                .any(|c| c.dynamic == Some(true) && c.name == "handler"),
             "Function-typed param must recognize handler; got: {:?}",
             s.calls,
         );
@@ -5843,7 +6681,9 @@ mod tests {
              }",
         );
         assert!(
-            !s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "communities"),
+            !s.calls
+                .iter()
+                .any(|c| c.dynamic == Some(true) && c.name == "communities"),
             "non-function-shaped param must not emit communities as dynamic call; got: {:?}",
             s.calls,
         );
@@ -5861,7 +6701,9 @@ mod tests {
                filterThen(users, hasEmail, logUser);
              }",
         );
-        let dynamic_names: Vec<&str> = s.calls.iter()
+        let dynamic_names: Vec<&str> = s
+            .calls
+            .iter()
             .filter(|c| c.dynamic == Some(true))
             .map(|c| c.name.as_str())
             .collect();
@@ -5882,7 +6724,9 @@ mod tests {
              }",
         );
         assert!(
-            s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "logUser"),
+            s.calls
+                .iter()
+                .any(|c| c.dynamic == Some(true) && c.name == "logUser"),
             "one-level alias indirection must still recognize logUser; got: {:?}",
             s.calls,
         );
@@ -5900,7 +6744,9 @@ mod tests {
              }",
         );
         assert!(
-            s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "logUser"),
+            s.calls
+                .iter()
+                .any(|c| c.dynamic == Some(true) && c.name == "logUser"),
             "class-method function-shaped param must recognize logUser; got: {:?}",
             s.calls,
         );
@@ -5918,7 +6764,9 @@ mod tests {
              }",
         );
         assert!(
-            s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "logUser"),
+            s.calls
+                .iter()
+                .any(|c| c.dynamic == Some(true) && c.name == "logUser"),
             "explicit this param must not misalign the callback param index; got: {:?}",
             s.calls,
         );
@@ -5937,7 +6785,9 @@ mod tests {
              }",
         );
         assert!(
-            s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "logUser"),
+            s.calls
+                .iter()
+                .any(|c| c.dynamic == Some(true) && c.name == "logUser"),
             "arrow-function HOF must recognize logUser; got: {:?}",
             s.calls,
         );
@@ -5956,7 +6806,9 @@ mod tests {
              }",
         );
         assert!(
-            s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "logUser"),
+            s.calls
+                .iter()
+                .any(|c| c.dynamic == Some(true) && c.name == "logUser"),
             "function-expression HOF must recognize logUser; got: {:?}",
             s.calls,
         );
@@ -5976,7 +6828,9 @@ mod tests {
              }",
         );
         assert!(
-            !s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "users"),
+            !s.calls
+                .iter()
+                .any(|c| c.dynamic == Some(true) && c.name == "users"),
             "unrelated same-named methods must not merge callback shapes; got: {:?}",
             s.calls,
         );
@@ -5990,7 +6844,9 @@ mod tests {
         // arg must not be emitted as a dynamic call either.
         let s = parse_js("cache.get(someKey);");
         assert!(
-            !s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "someKey"),
+            !s.calls
+                .iter()
+                .any(|c| c.dynamic == Some(true) && c.name == "someKey"),
             "cache.get(someKey) must not emit `someKey` as dynamic call; got: {:?}",
             s.calls,
         );
@@ -6005,12 +6861,16 @@ mod tests {
         // class #1741 fixes for the data argument; only `mapFn` should resolve.
         let s = parse_js("Array.from(arr, mapCallback);");
         assert!(
-            s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "mapCallback"),
+            s.calls
+                .iter()
+                .any(|c| c.dynamic == Some(true) && c.name == "mapCallback"),
             "Array.from(arr, mapCallback) must emit mapCallback as dynamic call; got: {:?}",
             s.calls,
         );
         assert!(
-            !s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "arr"),
+            !s.calls
+                .iter()
+                .any(|c| c.dynamic == Some(true) && c.name == "arr"),
             "Array.from(arr, mapCallback) must not emit `arr` (index 0) as dynamic call; got: {:?}",
             s.calls,
         );
@@ -6021,13 +6881,17 @@ mod tests {
         // `Array.from(arrayLike, mapFn, thisArg)` — thisArg (index 2) is a `this`
         // binding context, not a callback, and must not be emitted either.
         let s = parse_js("Array.from(arr, mapCallback, thisArg);");
-        let dynamic_names: Vec<&str> = s.calls.iter()
+        let dynamic_names: Vec<&str> = s
+            .calls
+            .iter()
             .filter(|c| c.dynamic == Some(true))
             .map(|c| c.name.as_str())
             .collect();
         assert_eq!(
-            dynamic_names, vec!["mapCallback"],
-            "only index-1 mapCallback should be dynamic; got: {:?}", s.calls,
+            dynamic_names,
+            vec!["mapCallback"],
+            "only index-1 mapCallback should be dynamic; got: {:?}",
+            s.calls,
         );
     }
 
@@ -6039,12 +6903,16 @@ mod tests {
         // uniformly.
         let s = parse_js("Uint8Array.from(arr, mapCallback);");
         assert!(
-            s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "mapCallback"),
+            s.calls
+                .iter()
+                .any(|c| c.dynamic == Some(true) && c.name == "mapCallback"),
             "Uint8Array.from(arr, mapCallback) must emit mapCallback; got: {:?}",
             s.calls,
         );
         assert!(
-            !s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "arr"),
+            !s.calls
+                .iter()
+                .any(|c| c.dynamic == Some(true) && c.name == "arr"),
             "Uint8Array.from(arr, mapCallback) must not emit `arr`; got: {:?}",
             s.calls,
         );
@@ -6060,24 +6928,32 @@ mod tests {
         // emitted with its receiver, while one at index 0 is not.
         let s = parse_js("Array.from(arr, obj.mapper);");
         assert!(
-            s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "mapper" && c.receiver.as_deref() == Some("obj")),
+            s.calls.iter().any(|c| c.dynamic == Some(true)
+                && c.name == "mapper"
+                && c.receiver.as_deref() == Some("obj")),
             "Array.from(arr, obj.mapper) must emit mapper with receiver obj; got: {:?}",
             s.calls,
         );
         assert!(
-            !s.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "arr"),
+            !s.calls
+                .iter()
+                .any(|c| c.dynamic == Some(true) && c.name == "arr"),
             "Array.from(arr, obj.mapper) must not emit `arr` (index 0); got: {:?}",
             s.calls,
         );
 
         let s2 = parse_js("Array.from(obj.arrayLike, mapCallback);");
         assert!(
-            !s2.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "arrayLike"),
+            !s2.calls
+                .iter()
+                .any(|c| c.dynamic == Some(true) && c.name == "arrayLike"),
             "Array.from(obj.arrayLike, mapCallback) must not emit `arrayLike` (index 0); got: {:?}",
             s2.calls,
         );
         assert!(
-            s2.calls.iter().any(|c| c.dynamic == Some(true) && c.name == "mapCallback"),
+            s2.calls
+                .iter()
+                .any(|c| c.dynamic == Some(true) && c.name == "mapCallback"),
             "Array.from(obj.arrayLike, mapCallback) must emit mapCallback; got: {:?}",
             s2.calls,
         );
@@ -6105,9 +6981,19 @@ mod tests {
         // destructured bindings like `handleToken` still resolve when called.
         let s = parse_js("const { handleToken, checkPermissions } = initAuth(config);");
         let names: Vec<&str> = s.definitions.iter().map(|d| d.name.as_str()).collect();
-        assert!(names.contains(&"handleToken"), "should extract handleToken definition");
-        assert!(names.contains(&"checkPermissions"), "should extract checkPermissions definition");
-        let ht = s.definitions.iter().find(|d| d.name == "handleToken").unwrap();
+        assert!(
+            names.contains(&"handleToken"),
+            "should extract handleToken definition"
+        );
+        assert!(
+            names.contains(&"checkPermissions"),
+            "should extract checkPermissions definition"
+        );
+        let ht = s
+            .definitions
+            .iter()
+            .find(|d| d.name == "handleToken")
+            .unwrap();
         assert_eq!(ht.kind, "constant");
     }
 
@@ -6151,7 +7037,9 @@ mod tests {
         // Parity with TS query path (extractDestructuredBindingsWalk), which
         // skips FUNCTION_SCOPE_TYPES. Function-internal destructured const
         // bindings must not be emitted as definitions in the Rust walk path.
-        let s = parse_js("function setup() { const { handleToken, checkPermissions } = initAuth(config); }");
+        let s = parse_js(
+            "function setup() { const { handleToken, checkPermissions } = initAuth(config); }",
+        );
         assert!(
             !s.definitions.iter().any(|d| d.name == "handleToken"),
             "function-nested destructured binding must not be emitted"
@@ -6172,7 +7060,10 @@ mod tests {
             .expect("should use the local alias");
         // kind is "constant" (#1773) — see comment on extracts_destructured_const_bindings.
         assert_eq!(renamed.kind, "constant");
-        assert!(!s.definitions.iter().any(|d| d.name == "original"), "should not use the original key");
+        assert!(
+            !s.definitions.iter().any(|d| d.name == "original"),
+            "should not use the original key"
+        );
     }
 
     /// Regression test for issue #1271: native engine missing receiver edges.
@@ -6206,7 +7097,10 @@ mod tests {
         assert!(
             compute_call.is_some(),
             "calls should contain 'compute'; got: {:?}",
-            s.calls.iter().map(|c| (&c.name, &c.receiver)).collect::<Vec<_>>()
+            s.calls
+                .iter()
+                .map(|c| (&c.name, &c.receiver))
+                .collect::<Vec<_>>()
         );
         assert_eq!(
             compute_call.unwrap().receiver.as_deref(),
@@ -6240,9 +7134,7 @@ mod tests {
     /// constructor) falls back to the un-scoped `this.prop` key.
     #[test]
     fn this_prop_constructor_assignment_outside_class_uses_this_key() {
-        let s = parse_js(
-            "function Service() { this.client = new HttpClient(); }",
-        );
+        let s = parse_js("function Service() { this.client = new HttpClient(); }");
         let tm = s.type_map.iter().find(|t| t.name == "this.client");
         assert!(
             tm.is_some(),
@@ -6311,7 +7203,9 @@ mod tests {
              const b = Math.bind(null);",
         );
         assert!(
-            s.fn_ref_bindings.iter().all(|b| b.lhs != "a" && b.lhs != "b"),
+            s.fn_ref_bindings
+                .iter()
+                .all(|b| b.lhs != "a" && b.lhs != "b"),
             "method-receiver and builtin binds must not be tracked; got: {:?}",
             s.fn_ref_bindings
         );
@@ -6326,10 +7220,17 @@ mod tests {
              C.prototype.foo = function() { return 1; };",
         );
         let def = s.definitions.iter().find(|d| d.name == "C.foo");
-        assert!(def.is_some(), "C.foo definition missing; got: {:?}", s.definitions.iter().map(|d| &d.name).collect::<Vec<_>>());
+        assert!(
+            def.is_some(),
+            "C.foo definition missing; got: {:?}",
+            s.definitions.iter().map(|d| &d.name).collect::<Vec<_>>()
+        );
         let def = def.unwrap();
         assert_eq!(def.kind, "method");
-        assert!(def.complexity.is_some(), "C.foo should have complexity metrics");
+        assert!(
+            def.complexity.is_some(),
+            "C.foo should have complexity metrics"
+        );
         assert!(def.cfg.is_some(), "C.foo should have a CFG");
     }
 
@@ -6340,10 +7241,17 @@ mod tests {
              C.prototype.foo = () => { return 1; };",
         );
         let def = s.definitions.iter().find(|d| d.name == "C.foo");
-        assert!(def.is_some(), "C.foo definition missing; got: {:?}", s.definitions.iter().map(|d| &d.name).collect::<Vec<_>>());
+        assert!(
+            def.is_some(),
+            "C.foo definition missing; got: {:?}",
+            s.definitions.iter().map(|d| &d.name).collect::<Vec<_>>()
+        );
         let def = def.unwrap();
         assert_eq!(def.kind, "method");
-        assert!(def.complexity.is_some(), "C.foo (arrow) should have complexity metrics");
+        assert!(
+            def.complexity.is_some(),
+            "C.foo (arrow) should have complexity metrics"
+        );
         assert!(def.cfg.is_some(), "C.foo (arrow) should have a CFG");
     }
 
@@ -6355,7 +7263,11 @@ mod tests {
              A.prototype.t = f;",
         );
         let entry = s.type_map.iter().find(|e| e.name == "A.t");
-        assert!(entry.is_some(), "type_map entry A.t missing; got: {:?}", s.type_map.iter().map(|e| &e.name).collect::<Vec<_>>());
+        assert!(
+            entry.is_some(),
+            "type_map entry A.t missing; got: {:?}",
+            s.type_map.iter().map(|e| &e.name).collect::<Vec<_>>()
+        );
         assert_eq!(entry.unwrap().type_name, "f");
     }
 
@@ -6373,12 +7285,18 @@ mod tests {
         assert!(foo.is_some(), "C.foo missing");
         let foo = foo.unwrap();
         assert_eq!(foo.kind, "method");
-        assert!(foo.complexity.is_some(), "C.foo should have complexity metrics");
+        assert!(
+            foo.complexity.is_some(),
+            "C.foo should have complexity metrics"
+        );
         assert!(foo.cfg.is_some(), "C.foo should have a CFG");
         assert!(bar.is_some(), "C.bar missing");
         let bar = bar.unwrap();
         assert_eq!(bar.kind, "method");
-        assert!(bar.complexity.is_some(), "C.bar should have complexity metrics");
+        assert!(
+            bar.complexity.is_some(),
+            "C.bar should have complexity metrics"
+        );
         assert!(bar.cfg.is_some(), "C.bar should have a CFG");
     }
 
@@ -6391,10 +7309,17 @@ mod tests {
              };",
         );
         let def = s.definitions.iter().find(|d| d.name == "C.greet");
-        assert!(def.is_some(), "C.greet definition missing; got: {:?}", s.definitions.iter().map(|d| &d.name).collect::<Vec<_>>());
+        assert!(
+            def.is_some(),
+            "C.greet definition missing; got: {:?}",
+            s.definitions.iter().map(|d| &d.name).collect::<Vec<_>>()
+        );
         let def = def.unwrap();
         assert_eq!(def.kind, "method");
-        assert!(def.complexity.is_some(), "C.greet should have complexity metrics");
+        assert!(
+            def.complexity.is_some(),
+            "C.greet should have complexity metrics"
+        );
         assert!(def.cfg.is_some(), "C.greet should have a CFG");
     }
 
@@ -6406,7 +7331,11 @@ mod tests {
              C.prototype = { helper };",
         );
         let entry = s.type_map.iter().find(|e| e.name == "C.helper");
-        assert!(entry.is_some(), "type_map entry C.helper missing; got: {:?}", s.type_map.iter().map(|e| &e.name).collect::<Vec<_>>());
+        assert!(
+            entry.is_some(),
+            "type_map entry C.helper missing; got: {:?}",
+            s.type_map.iter().map(|e| &e.name).collect::<Vec<_>>()
+        );
         assert_eq!(entry.unwrap().type_name, "helper");
     }
 
@@ -6414,7 +7343,11 @@ mod tests {
     fn prototype_builtin_globals_are_excluded() {
         let s = parse_js("Array.prototype.custom = function() {};");
         let def = s.definitions.iter().find(|d| d.name.contains("Array"));
-        assert!(def.is_none(), "built-in prototype assignment should be ignored; got: {:?}", def);
+        assert!(
+            def.is_none(),
+            "built-in prototype assignment should be ignored; got: {:?}",
+            def
+        );
     }
 
     #[test]
@@ -6423,17 +7356,26 @@ mod tests {
             "function C() {}\n\
              C.prototype.foo = function(x, y) { if (true) { return 1; } return 0; };",
         );
-        let def = s.definitions.iter().find(|d| d.name == "C.foo").expect("C.foo missing");
-        assert!(def.complexity.is_some(), "C.foo should have complexity metrics");
+        let def = s
+            .definitions
+            .iter()
+            .find(|d| d.name == "C.foo")
+            .expect("C.foo missing");
+        assert!(
+            def.complexity.is_some(),
+            "C.foo should have complexity metrics"
+        );
         assert!(def.cfg.is_some(), "C.foo should have CFG data");
         let children = def.children.as_deref().unwrap_or(&[]);
         assert!(
             children.iter().any(|c| c.name == "x"),
-            "C.foo should have parameter 'x'; got: {:?}", children
+            "C.foo should have parameter 'x'; got: {:?}",
+            children
         );
         assert!(
             children.iter().any(|c| c.name == "y"),
-            "C.foo should have parameter 'y'; got: {:?}", children
+            "C.foo should have parameter 'y'; got: {:?}",
+            children
         );
     }
 
@@ -6447,10 +7389,17 @@ mod tests {
              f.g = function() { return 1; };",
         );
         let def = s.definitions.iter().find(|d| d.name == "f.g");
-        assert!(def.is_some(), "f.g definition missing; got: {:?}", s.definitions.iter().map(|d| &d.name).collect::<Vec<_>>());
+        assert!(
+            def.is_some(),
+            "f.g definition missing; got: {:?}",
+            s.definitions.iter().map(|d| &d.name).collect::<Vec<_>>()
+        );
         let def = def.unwrap();
         assert_eq!(def.kind, "method");
-        assert!(def.complexity.is_some(), "f.g should have complexity metrics");
+        assert!(
+            def.complexity.is_some(),
+            "f.g should have complexity metrics"
+        );
         assert!(def.cfg.is_some(), "f.g should have a CFG");
     }
 
@@ -6461,7 +7410,11 @@ mod tests {
              f.g = (x) => x + 1;",
         );
         let def = s.definitions.iter().find(|d| d.name == "f.g");
-        assert!(def.is_some(), "f.g definition missing; got: {:?}", s.definitions.iter().map(|d| &d.name).collect::<Vec<_>>());
+        assert!(
+            def.is_some(),
+            "f.g definition missing; got: {:?}",
+            s.definitions.iter().map(|d| &d.name).collect::<Vec<_>>()
+        );
         assert_eq!(def.unwrap().kind, "method");
     }
 
@@ -6471,15 +7424,21 @@ mod tests {
             "function f() {}\n\
              f.process = function(a, b) { return a + b; };",
         );
-        let def = s.definitions.iter().find(|d| d.name == "f.process").expect("f.process missing");
+        let def = s
+            .definitions
+            .iter()
+            .find(|d| d.name == "f.process")
+            .expect("f.process missing");
         let children = def.children.as_deref().unwrap_or(&[]);
         assert!(
             children.iter().any(|c| c.name == "a"),
-            "f.process should have parameter 'a'; got: {:?}", children
+            "f.process should have parameter 'a'; got: {:?}",
+            children
         );
         assert!(
             children.iter().any(|c| c.name == "b"),
-            "f.process should have parameter 'b'; got: {:?}", children
+            "f.process should have parameter 'b'; got: {:?}",
+            children
         );
     }
 
@@ -6487,7 +7446,11 @@ mod tests {
     fn func_prop_builtin_globals_are_excluded() {
         let s = parse_js("console.log = function() {};");
         let def = s.definitions.iter().find(|d| d.name == "console.log");
-        assert!(def.is_none(), "built-in global func-prop assignment should be ignored; got: {:?}", def);
+        assert!(
+            def.is_none(),
+            "built-in global func-prop assignment should be ignored; got: {:?}",
+            def
+        );
     }
 
     #[test]
@@ -6497,7 +7460,11 @@ mod tests {
         // extractor).
         let s = parse_js("const a = { b: {} };\na.b.c = function() {};");
         let def = s.definitions.iter().find(|d| d.name.ends_with(".c"));
-        assert!(def.is_none(), "nested member receiver should be skipped; got: {:?}", def);
+        assert!(
+            def.is_none(),
+            "nested member receiver should be skipped; got: {:?}",
+            def
+        );
     }
 
     #[test]
@@ -6510,7 +7477,11 @@ mod tests {
              C.prototype = function() {};",
         );
         let def = s.definitions.iter().find(|d| d.name == "C.prototype");
-        assert!(def.is_none(), "C.prototype function assignment should not emit a method; got: {:?}", def);
+        assert!(
+            def.is_none(),
+            "C.prototype function assignment should not emit a method; got: {:?}",
+            def
+        );
     }
 
     #[test]
@@ -6519,17 +7490,26 @@ mod tests {
             "function C() {}\n\
              C.prototype.bar = (a, b) => a > 0 ? a : b;",
         );
-        let def = s.definitions.iter().find(|d| d.name == "C.bar").expect("C.bar missing");
-        assert!(def.complexity.is_some(), "C.bar arrow should have complexity metrics");
+        let def = s
+            .definitions
+            .iter()
+            .find(|d| d.name == "C.bar")
+            .expect("C.bar missing");
+        assert!(
+            def.complexity.is_some(),
+            "C.bar arrow should have complexity metrics"
+        );
         assert!(def.cfg.is_some(), "C.bar arrow should have CFG data");
         let children = def.children.as_deref().unwrap_or(&[]);
         assert!(
             children.iter().any(|c| c.name == "a"),
-            "C.bar should have parameter 'a'; got: {:?}", children
+            "C.bar should have parameter 'a'; got: {:?}",
+            children
         );
         assert!(
             children.iter().any(|c| c.name == "b"),
-            "C.bar should have parameter 'b'; got: {:?}", children
+            "C.bar should have parameter 'b'; got: {:?}",
+            children
         );
     }
 
@@ -6541,13 +7521,21 @@ mod tests {
                greet(name) { if (true) { return 'hi'; } return ''; },\n\
              };",
         );
-        let def = s.definitions.iter().find(|d| d.name == "C.greet").expect("C.greet missing");
-        assert!(def.complexity.is_some(), "C.greet should have complexity metrics");
+        let def = s
+            .definitions
+            .iter()
+            .find(|d| d.name == "C.greet")
+            .expect("C.greet missing");
+        assert!(
+            def.complexity.is_some(),
+            "C.greet should have complexity metrics"
+        );
         assert!(def.cfg.is_some(), "C.greet should have CFG data");
         let children = def.children.as_deref().unwrap_or(&[]);
         assert!(
             children.iter().any(|c| c.name == "name"),
-            "C.greet should have parameter 'name'; got: {:?}", children
+            "C.greet should have parameter 'name'; got: {:?}",
+            children
         );
     }
 
@@ -6559,13 +7547,21 @@ mod tests {
                bar: function(n) { if (true) { return 1; } return 0; },\n\
              };",
         );
-        let def = s.definitions.iter().find(|d| d.name == "C.bar").expect("C.bar missing");
-        assert!(def.complexity.is_some(), "C.bar should have complexity metrics");
+        let def = s
+            .definitions
+            .iter()
+            .find(|d| d.name == "C.bar")
+            .expect("C.bar missing");
+        assert!(
+            def.complexity.is_some(),
+            "C.bar should have complexity metrics"
+        );
         assert!(def.cfg.is_some(), "C.bar should have CFG data");
         let children = def.children.as_deref().unwrap_or(&[]);
         assert!(
             children.iter().any(|c| c.name == "n"),
-            "C.bar should have parameter 'n'; got: {:?}", children
+            "C.bar should have parameter 'n'; got: {:?}",
+            children
         );
     }
 
@@ -6578,7 +7574,11 @@ mod tests {
              Object.defineProperty(obj, \"f\", { value: f1 });",
         );
         let entry = s.type_map.iter().find(|e| e.name == "obj.f");
-        assert!(entry.is_some(), "type_map should contain 'obj.f'; got: {:?}", s.type_map);
+        assert!(
+            entry.is_some(),
+            "type_map should contain 'obj.f'; got: {:?}",
+            s.type_map
+        );
         assert_eq!(entry.unwrap().type_name, "f1");
     }
 
@@ -6596,8 +7596,16 @@ mod tests {
         );
         let e1 = s.type_map.iter().find(|e| e.name == "obj.f1");
         let e2 = s.type_map.iter().find(|e| e.name == "obj.f2");
-        assert!(e1.is_some(), "type_map should contain 'obj.f1'; got: {:?}", s.type_map);
-        assert!(e2.is_some(), "type_map should contain 'obj.f2'; got: {:?}", s.type_map);
+        assert!(
+            e1.is_some(),
+            "type_map should contain 'obj.f1'; got: {:?}",
+            s.type_map
+        );
+        assert!(
+            e2.is_some(),
+            "type_map should contain 'obj.f2'; got: {:?}",
+            s.type_map
+        );
         assert_eq!(e1.unwrap().type_name, "f1");
         assert_eq!(e2.unwrap().type_name, "f2");
     }
@@ -6612,8 +7620,16 @@ mod tests {
         );
         let e1 = s.type_map.iter().find(|e| e.name == "obj.f1");
         let e2 = s.type_map.iter().find(|e| e.name == "obj.f2");
-        assert!(e1.is_some(), "type_map should contain 'obj.f1'; got: {:?}", s.type_map);
-        assert!(e2.is_some(), "type_map should contain 'obj.f2'; got: {:?}", s.type_map);
+        assert!(
+            e1.is_some(),
+            "type_map should contain 'obj.f1'; got: {:?}",
+            s.type_map
+        );
+        assert!(
+            e2.is_some(),
+            "type_map should contain 'obj.f2'; got: {:?}",
+            s.type_map
+        );
         assert_eq!(e1.unwrap().type_name, "f1");
         assert_eq!(e2.unwrap().type_name, "f2");
     }
@@ -6633,23 +7649,53 @@ mod tests {
              };",
         );
         let names: Vec<_> = s.definitions.iter().map(|d| (&d.name, &d.kind)).collect();
-        let f_bare_pos = s.definitions.iter().position(|d| d.name == "f" && d.kind == "method");
-        let g_bare_pos = s.definitions.iter().position(|d| d.name == "g" && d.kind == "method");
-        let f_qual_pos = s.definitions.iter().position(|d| d.name == "o1.f" && d.kind == "function");
-        let g_qual_pos = s.definitions.iter().position(|d| d.name == "o1.g" && d.kind == "function");
-        assert!(f_bare_pos.is_some(), "bare f(method) missing; got: {:?}", names);
-        assert!(g_bare_pos.is_some(), "bare g(method) missing; got: {:?}", names);
-        assert!(f_qual_pos.is_some(), "qualified o1.f(function) missing; got: {:?}", names);
-        assert!(g_qual_pos.is_some(), "qualified o1.g(function) missing; got: {:?}", names);
+        let f_bare_pos = s
+            .definitions
+            .iter()
+            .position(|d| d.name == "f" && d.kind == "method");
+        let g_bare_pos = s
+            .definitions
+            .iter()
+            .position(|d| d.name == "g" && d.kind == "method");
+        let f_qual_pos = s
+            .definitions
+            .iter()
+            .position(|d| d.name == "o1.f" && d.kind == "function");
+        let g_qual_pos = s
+            .definitions
+            .iter()
+            .position(|d| d.name == "o1.g" && d.kind == "function");
+        assert!(
+            f_bare_pos.is_some(),
+            "bare f(method) missing; got: {:?}",
+            names
+        );
+        assert!(
+            g_bare_pos.is_some(),
+            "bare g(method) missing; got: {:?}",
+            names
+        );
+        assert!(
+            f_qual_pos.is_some(),
+            "qualified o1.f(function) missing; got: {:?}",
+            names
+        );
+        assert!(
+            g_qual_pos.is_some(),
+            "qualified o1.g(function) missing; got: {:?}",
+            names
+        );
         assert!(
             f_bare_pos.unwrap() < f_qual_pos.unwrap(),
             "f(method) at {} must precede o1.f(function) at {} — equal-span tie-break",
-            f_bare_pos.unwrap(), f_qual_pos.unwrap()
+            f_bare_pos.unwrap(),
+            f_qual_pos.unwrap()
         );
         assert!(
             g_bare_pos.unwrap() < g_qual_pos.unwrap(),
             "g(method) at {} must precede o1.g(function) at {}",
-            g_bare_pos.unwrap(), g_qual_pos.unwrap()
+            g_bare_pos.unwrap(),
+            g_qual_pos.unwrap()
         );
         // typeMap entry must point to bare name for two-step accessor dispatch.
         let tm_f = s.type_map.iter().find(|e| e.name == "o1.f");
@@ -6671,8 +7717,16 @@ mod tests {
              obj.bar();",
         );
         let names: Vec<_> = s.definitions.iter().map(|d| d.name.as_str()).collect();
-        assert!(names.contains(&"obj.foo"), "expected 'obj.foo'; got: {:?}", names);
-        assert!(names.contains(&"obj.bar"), "expected 'obj.bar'; got: {:?}", names);
+        assert!(
+            names.contains(&"obj.foo"),
+            "expected 'obj.foo'; got: {:?}",
+            names
+        );
+        assert!(
+            names.contains(&"obj.bar"),
+            "expected 'obj.bar'; got: {:?}",
+            names
+        );
         assert!(
             !names.iter().any(|n| n.contains('[')),
             "no definition name should retain the bracketed/quoted form; got: {:?}",
@@ -6697,7 +7751,11 @@ mod tests {
             "non-string computed key must not produce a definition; got: {:?}",
             names
         );
-        assert!(names.contains(&"obj.bar"), "expected 'obj.bar'; got: {:?}", names);
+        assert!(
+            names.contains(&"obj.bar"),
+            "expected 'obj.bar'; got: {:?}",
+            names
+        );
     }
 
     /// Issue #1944: a plain quoted (non-computed) method key (`'foo'() {}`, kind `"string"`,
@@ -6708,7 +7766,11 @@ mod tests {
     fn quoted_plain_method_key_resolves_to_plain_name() {
         let s = parse_js("class A {\n  'foo'() { return 1; }\n}");
         let names: Vec<_> = s.definitions.iter().map(|d| d.name.as_str()).collect();
-        assert!(names.contains(&"A.foo"), "expected 'A.foo'; got: {:?}", names);
+        assert!(
+            names.contains(&"A.foo"),
+            "expected 'A.foo'; got: {:?}",
+            names
+        );
         assert!(
             !names.iter().any(|n| n.contains('\'')),
             "no definition name should retain the quoted form; got: {:?}",
@@ -6721,7 +7783,11 @@ mod tests {
     fn quoted_plain_object_literal_method_key_resolves_to_plain_name() {
         let s = parse_js("const obj = { 'quoted'() { return 1; } };");
         let names: Vec<_> = s.definitions.iter().map(|d| d.name.as_str()).collect();
-        assert!(names.contains(&"obj.quoted"), "expected 'obj.quoted'; got: {:?}", names);
+        assert!(
+            names.contains(&"obj.quoted"),
+            "expected 'obj.quoted'; got: {:?}",
+            names
+        );
         assert!(
             !names.iter().any(|n| n.contains('\'')),
             "no definition name should retain the quoted form; got: {:?}",
@@ -6738,9 +7804,21 @@ mod tests {
              var obj3 = { ['computedVar']: () => {} };",
         );
         let names: Vec<_> = s.definitions.iter().map(|d| d.name.as_str()).collect();
-        assert!(names.contains(&"obj2.computedLet"), "expected 'obj2.computedLet'; got: {:?}", names);
-        assert!(names.contains(&"obj2.plain"), "expected 'obj2.plain'; got: {:?}", names);
-        assert!(names.contains(&"obj3.computedVar"), "expected 'obj3.computedVar'; got: {:?}", names);
+        assert!(
+            names.contains(&"obj2.computedLet"),
+            "expected 'obj2.computedLet'; got: {:?}",
+            names
+        );
+        assert!(
+            names.contains(&"obj2.plain"),
+            "expected 'obj2.plain'; got: {:?}",
+            names
+        );
+        assert!(
+            names.contains(&"obj3.computedVar"),
+            "expected 'obj3.computedVar'; got: {:?}",
+            names
+        );
     }
 
     /// Issue #1884: `seed_object_create_entries`'s pair arm must unwrap a computed
@@ -6753,7 +7831,11 @@ mod tests {
              const obj = Object.create({ ['foo']: fn });",
         );
         let entry = s.type_map.iter().find(|e| e.name == "obj.foo");
-        assert!(entry.is_some(), "type_map should contain 'obj.foo'; got: {:?}", s.type_map);
+        assert!(
+            entry.is_some(),
+            "type_map should contain 'obj.foo'; got: {:?}",
+            s.type_map
+        );
         assert_eq!(entry.unwrap().type_name, "fn");
     }
 
@@ -6767,7 +7849,11 @@ mod tests {
              Object.defineProperties(obj, { ['foo']: { value: f1 } });",
         );
         let entry = s.type_map.iter().find(|e| e.name == "obj.foo");
-        assert!(entry.is_some(), "type_map should contain 'obj.foo'; got: {:?}", s.type_map);
+        assert!(
+            entry.is_some(),
+            "type_map should contain 'obj.foo'; got: {:?}",
+            s.type_map
+        );
         assert_eq!(entry.unwrap().type_name, "f1");
     }
 
@@ -6782,7 +7868,8 @@ mod tests {
         );
         assert!(
             !s.type_map.iter().any(|e| e.name.contains("Symbol")),
-            "non-string computed key must not produce a type_map entry; got: {:?}", s.type_map
+            "non-string computed key must not produce a type_map entry; got: {:?}",
+            s.type_map
         );
     }
 
@@ -6795,7 +7882,11 @@ mod tests {
              var routes = { ['get']: handler };",
         );
         let entry = s.type_map.iter().find(|e| e.name == "routes.get");
-        assert!(entry.is_some(), "type_map should contain 'routes.get'; got: {:?}", s.type_map);
+        assert!(
+            entry.is_some(),
+            "type_map should contain 'routes.get'; got: {:?}",
+            s.type_map
+        );
         assert_eq!(entry.unwrap().type_name, "handler");
     }
 
@@ -6809,7 +7900,11 @@ mod tests {
              C.prototype = { ['run']: helper };",
         );
         let entry = s.type_map.iter().find(|e| e.name == "C.run");
-        assert!(entry.is_some(), "type_map should contain 'C.run'; got: {:?}", s.type_map);
+        assert!(
+            entry.is_some(),
+            "type_map should contain 'C.run'; got: {:?}",
+            s.type_map
+        );
         assert_eq!(entry.unwrap().type_name, "helper");
     }
 
@@ -6822,7 +7917,11 @@ mod tests {
              C.prototype = { ['foo']: function() { return 1; } };",
         );
         let names: Vec<_> = s.definitions.iter().map(|d| d.name.as_str()).collect();
-        assert!(names.contains(&"C.foo"), "expected 'C.foo'; got: {:?}", names);
+        assert!(
+            names.contains(&"C.foo"),
+            "expected 'C.foo'; got: {:?}",
+            names
+        );
     }
 
     /// Issue #1884: `collect_object_rest_params`'s pair arm previously skipped ALL computed
@@ -6837,8 +7936,15 @@ mod tests {
                }\n\
              };",
         );
-        let b = s.object_rest_param_bindings.iter().find(|b| b.callee == "process");
-        assert!(b.is_some(), "object_rest_param_bindings missing; got: {:?}", s.object_rest_param_bindings);
+        let b = s
+            .object_rest_param_bindings
+            .iter()
+            .find(|b| b.callee == "process");
+        assert!(
+            b.is_some(),
+            "object_rest_param_bindings missing; got: {:?}",
+            s.object_rest_param_bindings
+        );
         let b = b.unwrap();
         assert_eq!(b.rest_name, "rest");
         assert_eq!(b.arg_index, 0);
@@ -6856,8 +7962,11 @@ mod tests {
              };",
         );
         assert!(
-            !s.object_rest_param_bindings.iter().any(|b| b.rest_name == "rest"),
-            "non-string computed key must not produce a binding; got: {:?}", s.object_rest_param_bindings
+            !s.object_rest_param_bindings
+                .iter()
+                .any(|b| b.rest_name == "rest"),
+            "non-string computed key must not produce a binding; got: {:?}",
+            s.object_rest_param_bindings
         );
     }
 
@@ -6872,14 +7981,33 @@ mod tests {
              obj.f();",
         );
         let tm = s_let_method.type_map.iter().find(|e| e.name == "obj.f");
-        assert!(tm.is_some(), "let obj method: typeMap 'obj.f' missing; got: {:?}",
-            s_let_method.type_map.iter().map(|e| &e.name).collect::<Vec<_>>());
-        assert_eq!(tm.unwrap().type_name, "f",
-            "typeMap 'obj.f' must point at bare name 'f', not the qualified key");
-        let call = s_let_method.calls.iter().find(|c| c.name == "f" && c.receiver.as_deref() == Some("obj"));
-        assert!(call.is_some(),
+        assert!(
+            tm.is_some(),
+            "let obj method: typeMap 'obj.f' missing; got: {:?}",
+            s_let_method
+                .type_map
+                .iter()
+                .map(|e| &e.name)
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            tm.unwrap().type_name,
+            "f",
+            "typeMap 'obj.f' must point at bare name 'f', not the qualified key"
+        );
+        let call = s_let_method
+            .calls
+            .iter()
+            .find(|c| c.name == "f" && c.receiver.as_deref() == Some("obj"));
+        assert!(
+            call.is_some(),
             "calls must contain obj.f() with receiver='obj'; got: {:?}",
-            s_let_method.calls.iter().map(|c| (&c.name, &c.receiver)).collect::<Vec<_>>());
+            s_let_method
+                .calls
+                .iter()
+                .map(|c| (&c.name, &c.receiver))
+                .collect::<Vec<_>>()
+        );
 
         // Shorthand property: `var obj = { e4 }` → typeMap['obj.e4'] = 'e4'
         let s_var_shorthand = parse_js(
@@ -6887,8 +8015,15 @@ mod tests {
              var obj = { e4 };",
         );
         let tm2 = s_var_shorthand.type_map.iter().find(|e| e.name == "obj.e4");
-        assert!(tm2.is_some(), "var obj shorthand: typeMap 'obj.e4' missing; got: {:?}",
-            s_var_shorthand.type_map.iter().map(|e| &e.name).collect::<Vec<_>>());
+        assert!(
+            tm2.is_some(),
+            "var obj shorthand: typeMap 'obj.e4' missing; got: {:?}",
+            s_var_shorthand
+                .type_map
+                .iter()
+                .map(|e| &e.name)
+                .collect::<Vec<_>>()
+        );
         assert_eq!(tm2.unwrap().type_name, "e4");
 
         // Pair with identifier value: `var routes = { get: handler }` → typeMap['routes.get'] = 'handler'
@@ -6897,8 +8032,15 @@ mod tests {
              var routes = { get: handler };",
         );
         let tm3 = s_var_pair.type_map.iter().find(|e| e.name == "routes.get");
-        assert!(tm3.is_some(), "var routes pair: typeMap 'routes.get' missing; got: {:?}",
-            s_var_pair.type_map.iter().map(|e| &e.name).collect::<Vec<_>>());
+        assert!(
+            tm3.is_some(),
+            "var routes pair: typeMap 'routes.get' missing; got: {:?}",
+            s_var_pair
+                .type_map
+                .iter()
+                .map(|e| &e.name)
+                .collect::<Vec<_>>()
+        );
         assert_eq!(tm3.unwrap().type_name, "handler");
 
         // Pair with arrow value: `let api = { save: () => {} }` → typeMap['api.save'] = 'api.save'
@@ -6909,19 +8051,39 @@ mod tests {
              api.save();",
         );
         let tm4 = s_let_arrow.type_map.iter().find(|e| e.name == "api.save");
-        assert!(tm4.is_some(), "let api arrow: typeMap 'api.save' missing; got: {:?}",
-            s_let_arrow.type_map.iter().map(|e| &e.name).collect::<Vec<_>>());
+        assert!(
+            tm4.is_some(),
+            "let api arrow: typeMap 'api.save' missing; got: {:?}",
+            s_let_arrow
+                .type_map
+                .iter()
+                .map(|e| &e.name)
+                .collect::<Vec<_>>()
+        );
         assert_eq!(tm4.unwrap().type_name, "api.save",
             "typeMap 'api.save' must point at the qualified name 'api.save' (qualified definition exists)");
         assert!(
             s_let_arrow.definitions.iter().any(|d| d.name == "api.save"),
             "let api arrow: qualified definition 'api.save' missing; got: {:?}",
-            s_let_arrow.definitions.iter().map(|d| &d.name).collect::<Vec<_>>()
+            s_let_arrow
+                .definitions
+                .iter()
+                .map(|d| &d.name)
+                .collect::<Vec<_>>()
         );
-        let call4 = s_let_arrow.calls.iter().find(|c| c.name == "save" && c.receiver.as_deref() == Some("api"));
-        assert!(call4.is_some(),
+        let call4 = s_let_arrow
+            .calls
+            .iter()
+            .find(|c| c.name == "save" && c.receiver.as_deref() == Some("api"));
+        assert!(
+            call4.is_some(),
             "calls must contain api.save() with receiver='api'; got: {:?}",
-            s_let_arrow.calls.iter().map(|c| (&c.name, &c.receiver)).collect::<Vec<_>>());
+            s_let_arrow
+                .calls
+                .iter()
+                .map(|c| (&c.name, &c.receiver))
+                .collect::<Vec<_>>()
+        );
 
         // Scope guard: object literal inside a function body must NOT seed module-level typeMap.
         let s_scoped = parse_js(
@@ -6933,7 +8095,11 @@ mod tests {
         assert!(
             s_scoped.type_map.iter().all(|e| e.name != "local.run"),
             "function-scoped let obj must not pollute typeMap; got: {:?}",
-            s_scoped.type_map.iter().map(|e| &e.name).collect::<Vec<_>>()
+            s_scoped
+                .type_map
+                .iter()
+                .map(|e| &e.name)
+                .collect::<Vec<_>>()
         );
     }
 
@@ -6949,14 +8115,24 @@ mod tests {
              }",
         );
         let tm = s.type_map.iter().find(|e| e.name == "obj.f");
-        assert!(tm.is_some(), "type_map should contain 'obj.f'; got: {:?}", s.type_map);
+        assert!(
+            tm.is_some(),
+            "type_map should contain 'obj.f'; got: {:?}",
+            s.type_map
+        );
         assert_eq!(tm.unwrap().type_name, "f1");
 
-        let call = s.calls.iter().find(|c| c.name == "f" && c.receiver.as_deref() == Some("obj"));
+        let call = s
+            .calls
+            .iter()
+            .find(|c| c.name == "f" && c.receiver.as_deref() == Some("obj"));
         assert!(
             call.is_some(),
             "calls should contain obj.f() with receiver='obj'; got: {:?}",
-            s.calls.iter().map(|c| (&c.name, &c.receiver)).collect::<Vec<_>>()
+            s.calls
+                .iter()
+                .map(|c| (&c.name, &c.receiver))
+                .collect::<Vec<_>>()
         );
     }
 
@@ -6973,7 +8149,11 @@ mod tests {
             .param_bindings
             .iter()
             .find(|b| b.callee == "hof" && b.arg_name == "target");
-        assert!(b.is_some(), "param_bindings should contain hof←target; got: {:?}", s.param_bindings);
+        assert!(
+            b.is_some(),
+            "param_bindings should contain hof←target; got: {:?}",
+            s.param_bindings
+        );
         assert_eq!(b.unwrap().arg_index, 0);
     }
 
@@ -7047,17 +8227,29 @@ mod tests {
              function runCallThis() { return invoker.call(handler, 10); }",
         );
         assert!(
-            s.calls.iter().any(|c| c.name == "invoker" && c.dynamic == Some(true)),
+            s.calls
+                .iter()
+                .any(|c| c.name == "invoker" && c.dynamic == Some(true)),
             "invoker.call() should emit a dynamic call to invoker; got: {:?}",
-            s.calls.iter().map(|c| (&c.name, c.dynamic)).collect::<Vec<_>>()
+            s.calls
+                .iter()
+                .map(|c| (&c.name, c.dynamic))
+                .collect::<Vec<_>>()
         );
         assert!(
             !s.calls.iter().any(|c| c.name == "handler"),
             ".call() args must not become callback-reference calls; got: {:?}",
-            s.calls.iter().map(|c| (&c.name, c.dynamic)).collect::<Vec<_>>()
+            s.calls
+                .iter()
+                .map(|c| (&c.name, c.dynamic))
+                .collect::<Vec<_>>()
         );
         let b = s.this_call_bindings.iter().find(|b| b.callee == "invoker");
-        assert!(b.is_some(), "this_call_bindings should contain invoker→handler; got: {:?}", s.this_call_bindings);
+        assert!(
+            b.is_some(),
+            "this_call_bindings should contain invoker→handler; got: {:?}",
+            s.this_call_bindings
+        );
         assert_eq!(b.unwrap().this_arg, "handler");
     }
 
@@ -7079,7 +8271,10 @@ mod tests {
         assert!(
             !s.calls.iter().any(|c| c.name == "b"),
             "argument `b` of this(b) must not become a callback-reference call; got: {:?}",
-            s.calls.iter().map(|c| (&c.name, c.dynamic)).collect::<Vec<_>>()
+            s.calls
+                .iter()
+                .map(|c| (&c.name, c.dynamic))
+                .collect::<Vec<_>>()
         );
     }
 
@@ -7097,12 +8292,18 @@ mod tests {
         assert!(
             !s.calls.iter().any(|c| c.name == "a"),
             "argument `a` of super(a, b) must not become a callback-reference call; got: {:?}",
-            s.calls.iter().map(|c| (&c.name, c.dynamic)).collect::<Vec<_>>()
+            s.calls
+                .iter()
+                .map(|c| (&c.name, c.dynamic))
+                .collect::<Vec<_>>()
         );
         assert!(
             !s.calls.iter().any(|c| c.name == "b"),
             "argument `b` of super(a, b) must not become a callback-reference call; got: {:?}",
-            s.calls.iter().map(|c| (&c.name, c.dynamic)).collect::<Vec<_>>()
+            s.calls
+                .iter()
+                .map(|c| (&c.name, c.dynamic))
+                .collect::<Vec<_>>()
         );
     }
 
@@ -7125,7 +8326,10 @@ mod tests {
         assert!(
             super_call.is_some(),
             "bare super(...) must be recorded as a constructor call with receiver=super; got: {:?}",
-            s.calls.iter().map(|c| (&c.name, &c.receiver)).collect::<Vec<_>>()
+            s.calls
+                .iter()
+                .map(|c| (&c.name, &c.receiver))
+                .collect::<Vec<_>>()
         );
     }
 
@@ -7142,8 +8346,16 @@ mod tests {
             .filter(|b| b.array_name == "arr")
             .map(|b| (b.index, b.elem_name.as_str()))
             .collect();
-        assert!(got.contains(&(0, "fn1")), "expected (0, fn1); got: {:?}", got);
-        assert!(got.contains(&(1, "fn2")), "expected (1, fn2); got: {:?}", got);
+        assert!(
+            got.contains(&(0, "fn1")),
+            "expected (0, fn1); got: {:?}",
+            got
+        );
+        assert!(
+            got.contains(&(1, "fn2")),
+            "expected (1, fn2); got: {:?}",
+            got
+        );
     }
 
     #[test]
@@ -7154,7 +8366,11 @@ mod tests {
              callAll(...fns);",
         );
         let b = s.spread_arg_bindings.iter().find(|b| b.callee == "callAll");
-        assert!(b.is_some(), "spread_arg_bindings missing; got: {:?}", s.spread_arg_bindings);
+        assert!(
+            b.is_some(),
+            "spread_arg_bindings missing; got: {:?}",
+            s.spread_arg_bindings
+        );
         let b = b.unwrap();
         assert_eq!(b.array_name, "fns");
         assert_eq!(b.start_index, 0);
@@ -7167,7 +8383,11 @@ mod tests {
              const wrapped = new Set(arr);",
         );
         let b = s.fn_ref_bindings.iter().find(|b| b.lhs == "wrapped[*]");
-        assert!(b.is_some(), "Set wrap should bind wrapped[*] ⊇ arr[*]; got: {:?}", s.fn_ref_bindings);
+        assert!(
+            b.is_some(),
+            "Set wrap should bind wrapped[*] ⊇ arr[*]; got: {:?}",
+            s.fn_ref_bindings
+        );
         assert_eq!(b.unwrap().rhs, "arr[*]");
     }
 
@@ -7179,7 +8399,11 @@ mod tests {
              }",
         );
         let b = s.for_of_bindings.iter().find(|b| b.var_name == "h");
-        assert!(b.is_some(), "for_of_bindings missing; got: {:?}", s.for_of_bindings);
+        assert!(
+            b.is_some(),
+            "for_of_bindings missing; got: {:?}",
+            s.for_of_bindings
+        );
         let b = b.unwrap();
         assert_eq!(b.source_name, "handlers");
         assert_eq!(b.enclosing_func, "run");
@@ -7193,7 +8417,11 @@ mod tests {
              }",
         );
         let b = s.for_of_bindings.iter().find(|b| b.var_name == "g");
-        assert!(b.is_some(), "for_of_bindings missing for g; got: {:?}", s.for_of_bindings);
+        assert!(
+            b.is_some(),
+            "for_of_bindings missing for g; got: {:?}",
+            s.for_of_bindings
+        );
         assert_eq!(b.unwrap().enclosing_func, "Runner.runAll");
     }
 
@@ -7201,7 +8429,11 @@ mod tests {
     fn for_of_binding_at_module_level_uses_module_context() {
         let s = parse_js("for (const cb of callbacks) { cb(); }");
         let b = s.for_of_bindings.iter().find(|b| b.var_name == "cb");
-        assert!(b.is_some(), "for_of_bindings missing; got: {:?}", s.for_of_bindings);
+        assert!(
+            b.is_some(),
+            "for_of_bindings missing; got: {:?}",
+            s.for_of_bindings
+        );
         assert_eq!(b.unwrap().enclosing_func, "<module>");
     }
 
@@ -7215,7 +8447,11 @@ mod tests {
             .array_callback_bindings
             .iter()
             .find(|b| b.callee_name == "makeThing");
-        assert!(b.is_some(), "array_callback_bindings missing; got: {:?}", s.array_callback_bindings);
+        assert!(
+            b.is_some(),
+            "array_callback_bindings missing; got: {:?}",
+            s.array_callback_bindings
+        );
         assert_eq!(b.unwrap().source_name, "items");
     }
 
@@ -7226,7 +8462,11 @@ mod tests {
             .object_rest_param_bindings
             .iter()
             .find(|b| b.callee == "f3");
-        assert!(b.is_some(), "object_rest_param_bindings missing; got: {:?}", s.object_rest_param_bindings);
+        assert!(
+            b.is_some(),
+            "object_rest_param_bindings missing; got: {:?}",
+            s.object_rest_param_bindings
+        );
         let b = b.unwrap();
         assert_eq!(b.rest_name, "eerest");
         assert_eq!(b.arg_index, 0);
@@ -7239,8 +8479,15 @@ mod tests {
                handle({ id, ...rest }) { rest.go(); }\n\
              }",
         );
-        let b = s.object_rest_param_bindings.iter().find(|b| b.rest_name == "rest");
-        assert!(b.is_some(), "object_rest_param_bindings missing; got: {:?}", s.object_rest_param_bindings);
+        let b = s
+            .object_rest_param_bindings
+            .iter()
+            .find(|b| b.rest_name == "rest");
+        assert!(
+            b.is_some(),
+            "object_rest_param_bindings missing; got: {:?}",
+            s.object_rest_param_bindings
+        );
         assert_eq!(b.unwrap().callee, "Svc.handle");
     }
 
@@ -7255,14 +8502,22 @@ mod tests {
             .object_prop_bindings
             .iter()
             .find(|b| b.object_name == "obj" && b.prop_name == "e4");
-        assert!(shorthand.is_some(), "shorthand binding missing; got: {:?}", s.object_prop_bindings);
+        assert!(
+            shorthand.is_some(),
+            "shorthand binding missing; got: {:?}",
+            s.object_prop_bindings
+        );
         assert_eq!(shorthand.unwrap().value_name, "e4");
 
         let pair = s
             .object_prop_bindings
             .iter()
             .find(|b| b.object_name == "obj" && b.prop_name == "alias");
-        assert!(pair.is_some(), "pair binding missing; got: {:?}", s.object_prop_bindings);
+        assert!(
+            pair.is_some(),
+            "pair binding missing; got: {:?}",
+            s.object_prop_bindings
+        );
         assert_eq!(pair.unwrap().value_name, "named");
     }
 
@@ -7298,18 +8553,39 @@ mod tests {
              function runDispatch(key) { ({ a: dtFn1, b: dtFn2 })[key](); }",
         );
         // The call name must be <dt_line_col>[*]
-        let dt_call = s.calls.iter().find(|c| c.name.starts_with("<dt_") && c.name.ends_with(">[*]"));
-        assert!(dt_call.is_some(), "dispatch-table call missing; got: {:?}", s.calls);
+        let dt_call = s
+            .calls
+            .iter()
+            .find(|c| c.name.starts_with("<dt_") && c.name.ends_with(">[*]"));
+        assert!(
+            dt_call.is_some(),
+            "dispatch-table call missing; got: {:?}",
+            s.calls
+        );
         let dt_call = dt_call.unwrap();
         assert_eq!(dt_call.dynamic, Some(true));
         assert_eq!(dt_call.dynamic_kind.as_deref(), Some("dispatch-table"));
 
         // The array_elem_bindings must contain dtFn1 and dtFn2 under the same table name
         let table_name = dt_call.name.trim_end_matches("[*]");
-        let elem1 = s.array_elem_bindings.iter().find(|b| b.array_name == table_name && b.elem_name == "dtFn1");
-        let elem2 = s.array_elem_bindings.iter().find(|b| b.array_name == table_name && b.elem_name == "dtFn2");
-        assert!(elem1.is_some(), "dtFn1 array_elem_binding missing; got: {:?}", s.array_elem_bindings);
-        assert!(elem2.is_some(), "dtFn2 array_elem_binding missing; got: {:?}", s.array_elem_bindings);
+        let elem1 = s
+            .array_elem_bindings
+            .iter()
+            .find(|b| b.array_name == table_name && b.elem_name == "dtFn1");
+        let elem2 = s
+            .array_elem_bindings
+            .iter()
+            .find(|b| b.array_name == table_name && b.elem_name == "dtFn2");
+        assert!(
+            elem1.is_some(),
+            "dtFn1 array_elem_binding missing; got: {:?}",
+            s.array_elem_bindings
+        );
+        assert!(
+            elem2.is_some(),
+            "dtFn2 array_elem_binding missing; got: {:?}",
+            s.array_elem_bindings
+        );
         assert_eq!(elem1.unwrap().index, 0);
         assert_eq!(elem2.unwrap().index, 1);
     }
@@ -7321,8 +8597,15 @@ mod tests {
              function fnB() {}\n\
              function run(k) { ({a: fnA, b: fnB})[k](); }",
         );
-        let dt_call = s.calls.iter().find(|c| c.name.starts_with("<dt_") && c.name.ends_with(">[*]"));
-        assert!(dt_call.is_some(), "dispatch-table call missing for parenthesized object; got: {:?}", s.calls);
+        let dt_call = s
+            .calls
+            .iter()
+            .find(|c| c.name.starts_with("<dt_") && c.name.ends_with(">[*]"));
+        assert!(
+            dt_call.is_some(),
+            "dispatch-table call missing for parenthesized object; got: {:?}",
+            s.calls
+        );
     }
 
     // ── ES6 getter/setter same-file property-read call attribution (#1893) ──
@@ -7336,7 +8619,9 @@ mod tests {
              }",
         );
         assert!(
-            s.calls.iter().any(|c| c.name == "isReady" && c.receiver.as_deref() == Some("this")),
+            s.calls
+                .iter()
+                .any(|c| c.name == "isReady" && c.receiver.as_deref() == Some("this")),
             "expected a call to isReady via this; got: {:?}",
             s.calls
         );
@@ -7353,7 +8638,9 @@ mod tests {
              }",
         );
         assert!(
-            s.calls.iter().any(|c| c.name == "db" && c.receiver.as_deref() == Some("repo")),
+            s.calls
+                .iter()
+                .any(|c| c.name == "db" && c.receiver.as_deref() == Some("repo")),
             "expected a call to db via repo; got: {:?}",
             s.calls
         );
@@ -7368,7 +8655,9 @@ mod tests {
              }",
         );
         assert!(
-            s.calls.iter().any(|c| c.name == "flag" && c.receiver.as_deref() == Some("this")),
+            s.calls
+                .iter()
+                .any(|c| c.name == "flag" && c.receiver.as_deref() == Some("this")),
             "expected a call to flag via this; got: {:?}",
             s.calls
         );
@@ -7400,8 +8689,16 @@ mod tests {
                return w.value();\n\
              }",
         );
-        let matches = s.calls.iter().filter(|c| c.name == "value" && c.receiver.as_deref() == Some("w")).count();
-        assert_eq!(matches, 1, "expected exactly one call to w.value(); got: {:?}", s.calls);
+        let matches = s
+            .calls
+            .iter()
+            .filter(|c| c.name == "value" && c.receiver.as_deref() == Some("w"))
+            .count();
+        assert_eq!(
+            matches, 1,
+            "expected exactly one call to w.value(); got: {:?}",
+            s.calls
+        );
     }
 
     #[test]
@@ -7416,7 +8713,9 @@ mod tests {
              }",
         );
         assert!(
-            !s.calls.iter().any(|c| c.name == "render" && c.receiver.as_deref() == Some("w")),
+            !s.calls
+                .iter()
+                .any(|c| c.name == "render" && c.receiver.as_deref() == Some("w")),
             "plain method reference (no accessor) must not produce a call; got: {:?}",
             s.calls
         );
@@ -7431,7 +8730,9 @@ mod tests {
              }",
         );
         assert!(
-            s.calls.iter().any(|c| c.name == "version" && c.receiver.as_deref() == Some("this")),
+            s.calls
+                .iter()
+                .any(|c| c.name == "version" && c.receiver.as_deref() == Some("this")),
             "expected a call to version via this; got: {:?}",
             s.calls
         );

--- a/crates/codegraph-core/src/extractors/julia.rs
+++ b/crates/codegraph-core/src/extractors/julia.rs
@@ -1,9 +1,9 @@
-use tree_sitter::{Node, Tree};
+use super::helpers::*;
+use super::SymbolExtractor;
 use crate::ast_analysis::cfg::build_function_cfg;
 use crate::ast_analysis::complexity::compute_all_metrics;
 use crate::types::*;
-use super::helpers::*;
-use super::SymbolExtractor;
+use tree_sitter::{Node, Tree};
 
 pub struct JuliaExtractor;
 
@@ -11,7 +11,12 @@ impl SymbolExtractor for JuliaExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_julia(&tree.root_node(), source, &mut symbols, None);
-        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &JULIA_AST_CONFIG);
+        walk_ast_nodes_with_config(
+            &tree.root_node(),
+            source,
+            &mut symbols.ast_nodes,
+            &JULIA_AST_CONFIG,
+        );
         symbols
     }
 }
@@ -21,12 +26,7 @@ impl SymbolExtractor for JuliaExtractor {
 /// definitions inside `module Foo ... end` are prefixed `Foo.bar`. The
 /// generic `walk_tree` helper cannot pass extra state, so we open-code a
 /// recursive walker here.
-fn walk_julia(
-    node: &Node,
-    source: &[u8],
-    symbols: &mut FileSymbols,
-    current_module: Option<&str>,
-) {
+fn walk_julia(node: &Node, source: &[u8], symbols: &mut FileSymbols, current_module: Option<&str>) {
     let mut next_module = current_module.map(|s| s.to_string());
 
     match node.kind() {
@@ -68,6 +68,7 @@ fn handle_module_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) -> O
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 
     Some(name)
@@ -120,6 +121,7 @@ fn handle_function_def(
                 cfg: build_function_cfg(node, "julia", source),
                 children: opt_children(params),
                 bodyless: None,
+                content_hash: None,
             });
             return;
         }
@@ -148,6 +150,7 @@ fn handle_function_def(
         cfg: build_function_cfg(node, "julia", source),
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -189,6 +192,7 @@ fn handle_assignment(
         cfg: build_function_cfg(node, "julia", source),
         children: opt_children(params),
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -202,30 +206,29 @@ fn handle_struct_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         None => return,
     };
 
-    let (name_node, supertype): (Node, Option<Node>) = if let Some(bin) =
-        find_child(&type_head, "binary_expression")
-    {
-        // Walk into each side of the binary expression to find the base-name
-        // identifier — handles parameterized forms like `Vec{T} <: AbstractArray{T,1}`.
-        let mut sides: Vec<Node> = Vec::new();
-        for i in 0..bin.child_count() {
-            if let Some(c) = bin.child(i) {
-                if c.kind() != "operator" {
-                    sides.push(c);
+    let (name_node, supertype): (Node, Option<Node>) =
+        if let Some(bin) = find_child(&type_head, "binary_expression") {
+            // Walk into each side of the binary expression to find the base-name
+            // identifier — handles parameterized forms like `Vec{T} <: AbstractArray{T,1}`.
+            let mut sides: Vec<Node> = Vec::new();
+            for i in 0..bin.child_count() {
+                if let Some(c) = bin.child(i) {
+                    if c.kind() != "operator" {
+                        sides.push(c);
+                    }
                 }
             }
-        }
-        let name_id = sides.first().and_then(|n| find_base_name(n));
-        let super_id = sides.get(1).and_then(|n| find_base_name(n));
-        match name_id {
-            Some(n) => (n, super_id),
-            None => return,
-        }
-    } else if let Some(n) = find_base_name(&type_head) {
-        (n, None)
-    } else {
-        return;
-    };
+            let name_id = sides.first().and_then(|n| find_base_name(n));
+            let super_id = sides.get(1).and_then(|n| find_base_name(n));
+            match name_id {
+                Some(n) => (n, super_id),
+                None => return,
+            }
+        } else if let Some(n) = find_base_name(&type_head) {
+            (n, None)
+        } else {
+            return;
+        };
 
     let struct_name = node_text(&name_node, source).to_string();
 
@@ -271,6 +274,7 @@ fn handle_struct_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: opt_children(children),
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -304,6 +308,7 @@ fn handle_abstract_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -337,9 +342,7 @@ fn find_base_name<'a>(node: &Node<'a>) -> Option<Node<'a>> {
     for i in 0..node.child_count() {
         let Some(child) = node.child(i) else { continue };
         match child.kind() {
-            "binary_expression"
-            | "parametrized_type_expression"
-            | "parameterized_identifier" => {
+            "binary_expression" | "parametrized_type_expression" | "parameterized_identifier" => {
                 if let Some(found) = find_base_name(&child) {
                     return Some(found);
                 }
@@ -383,6 +386,7 @@ fn handle_macro_def(
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -449,7 +453,11 @@ fn handle_import(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     }
 
     if !source_str.is_empty() {
-        let names = if names.is_empty() { vec![source_str.clone()] } else { names };
+        let names = if names.is_empty() {
+            vec![source_str.clone()]
+        } else {
+            names
+        };
         symbols
             .imports
             .push(Import::new(source_str, names, start_line(node)));
@@ -516,7 +524,9 @@ fn extract_julia_params(call_expr: &Node, source: &[u8]) -> Vec<Definition> {
     };
 
     for i in 0..arg_list.child_count() {
-        let Some(child) = arg_list.child(i) else { continue };
+        let Some(child) = arg_list.child(i) else {
+            continue;
+        };
         match child.kind() {
             "identifier" => {
                 params.push(child_def(
@@ -657,13 +667,16 @@ mod tests {
 
     #[test]
     fn extracts_qualified_calls() {
-        let s = parse_jl("function main()\n    Repository.save(repo, 1)\n    println(\"x\")\nend\n");
+        let s =
+            parse_jl("function main()\n    Repository.save(repo, 1)\n    println(\"x\")\nend\n");
         let calls: Vec<(&str, Option<&str>)> = s
             .calls
             .iter()
             .map(|c| (c.name.as_str(), c.receiver.as_deref()))
             .collect();
-        assert!(calls.iter().any(|(n, r)| *n == "save" && *r == Some("Repository")));
+        assert!(calls
+            .iter()
+            .any(|(n, r)| *n == "save" && *r == Some("Repository")));
         assert!(calls.iter().any(|(n, r)| *n == "println" && r.is_none()));
     }
 
@@ -754,7 +767,9 @@ mod tests {
             s.imports[0].names
         );
         assert!(
-            !s.imports[0].names.contains(&"LinearAlgebra.BLAS".to_string()),
+            !s.imports[0]
+                .names
+                .contains(&"LinearAlgebra.BLAS".to_string()),
             "source module leaked into names: {:?}",
             s.imports[0].names
         );

--- a/crates/codegraph-core/src/extractors/julia.rs
+++ b/crates/codegraph-core/src/extractors/julia.rs
@@ -1,9 +1,9 @@
-use super::helpers::*;
-use super::SymbolExtractor;
+use tree_sitter::{Node, Tree};
 use crate::ast_analysis::cfg::build_function_cfg;
 use crate::ast_analysis::complexity::compute_all_metrics;
 use crate::types::*;
-use tree_sitter::{Node, Tree};
+use super::helpers::*;
+use super::SymbolExtractor;
 
 pub struct JuliaExtractor;
 
@@ -11,12 +11,7 @@ impl SymbolExtractor for JuliaExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_julia(&tree.root_node(), source, &mut symbols, None);
-        walk_ast_nodes_with_config(
-            &tree.root_node(),
-            source,
-            &mut symbols.ast_nodes,
-            &JULIA_AST_CONFIG,
-        );
+        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &JULIA_AST_CONFIG);
         symbols
     }
 }
@@ -26,7 +21,12 @@ impl SymbolExtractor for JuliaExtractor {
 /// definitions inside `module Foo ... end` are prefixed `Foo.bar`. The
 /// generic `walk_tree` helper cannot pass extra state, so we open-code a
 /// recursive walker here.
-fn walk_julia(node: &Node, source: &[u8], symbols: &mut FileSymbols, current_module: Option<&str>) {
+fn walk_julia(
+    node: &Node,
+    source: &[u8],
+    symbols: &mut FileSymbols,
+    current_module: Option<&str>,
+) {
     let mut next_module = current_module.map(|s| s.to_string());
 
     match node.kind() {
@@ -206,29 +206,30 @@ fn handle_struct_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         None => return,
     };
 
-    let (name_node, supertype): (Node, Option<Node>) =
-        if let Some(bin) = find_child(&type_head, "binary_expression") {
-            // Walk into each side of the binary expression to find the base-name
-            // identifier — handles parameterized forms like `Vec{T} <: AbstractArray{T,1}`.
-            let mut sides: Vec<Node> = Vec::new();
-            for i in 0..bin.child_count() {
-                if let Some(c) = bin.child(i) {
-                    if c.kind() != "operator" {
-                        sides.push(c);
-                    }
+    let (name_node, supertype): (Node, Option<Node>) = if let Some(bin) =
+        find_child(&type_head, "binary_expression")
+    {
+        // Walk into each side of the binary expression to find the base-name
+        // identifier — handles parameterized forms like `Vec{T} <: AbstractArray{T,1}`.
+        let mut sides: Vec<Node> = Vec::new();
+        for i in 0..bin.child_count() {
+            if let Some(c) = bin.child(i) {
+                if c.kind() != "operator" {
+                    sides.push(c);
                 }
             }
-            let name_id = sides.first().and_then(|n| find_base_name(n));
-            let super_id = sides.get(1).and_then(|n| find_base_name(n));
-            match name_id {
-                Some(n) => (n, super_id),
-                None => return,
-            }
-        } else if let Some(n) = find_base_name(&type_head) {
-            (n, None)
-        } else {
-            return;
-        };
+        }
+        let name_id = sides.first().and_then(|n| find_base_name(n));
+        let super_id = sides.get(1).and_then(|n| find_base_name(n));
+        match name_id {
+            Some(n) => (n, super_id),
+            None => return,
+        }
+    } else if let Some(n) = find_base_name(&type_head) {
+        (n, None)
+    } else {
+        return;
+    };
 
     let struct_name = node_text(&name_node, source).to_string();
 
@@ -342,7 +343,9 @@ fn find_base_name<'a>(node: &Node<'a>) -> Option<Node<'a>> {
     for i in 0..node.child_count() {
         let Some(child) = node.child(i) else { continue };
         match child.kind() {
-            "binary_expression" | "parametrized_type_expression" | "parameterized_identifier" => {
+            "binary_expression"
+            | "parametrized_type_expression"
+            | "parameterized_identifier" => {
                 if let Some(found) = find_base_name(&child) {
                     return Some(found);
                 }
@@ -453,11 +456,7 @@ fn handle_import(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     }
 
     if !source_str.is_empty() {
-        let names = if names.is_empty() {
-            vec![source_str.clone()]
-        } else {
-            names
-        };
+        let names = if names.is_empty() { vec![source_str.clone()] } else { names };
         symbols
             .imports
             .push(Import::new(source_str, names, start_line(node)));
@@ -524,9 +523,7 @@ fn extract_julia_params(call_expr: &Node, source: &[u8]) -> Vec<Definition> {
     };
 
     for i in 0..arg_list.child_count() {
-        let Some(child) = arg_list.child(i) else {
-            continue;
-        };
+        let Some(child) = arg_list.child(i) else { continue };
         match child.kind() {
             "identifier" => {
                 params.push(child_def(
@@ -667,16 +664,13 @@ mod tests {
 
     #[test]
     fn extracts_qualified_calls() {
-        let s =
-            parse_jl("function main()\n    Repository.save(repo, 1)\n    println(\"x\")\nend\n");
+        let s = parse_jl("function main()\n    Repository.save(repo, 1)\n    println(\"x\")\nend\n");
         let calls: Vec<(&str, Option<&str>)> = s
             .calls
             .iter()
             .map(|c| (c.name.as_str(), c.receiver.as_deref()))
             .collect();
-        assert!(calls
-            .iter()
-            .any(|(n, r)| *n == "save" && *r == Some("Repository")));
+        assert!(calls.iter().any(|(n, r)| *n == "save" && *r == Some("Repository")));
         assert!(calls.iter().any(|(n, r)| *n == "println" && r.is_none()));
     }
 
@@ -767,9 +761,7 @@ mod tests {
             s.imports[0].names
         );
         assert!(
-            !s.imports[0]
-                .names
-                .contains(&"LinearAlgebra.BLAS".to_string()),
+            !s.imports[0].names.contains(&"LinearAlgebra.BLAS".to_string()),
             "source module leaked into names: {:?}",
             s.imports[0].names
         );

--- a/crates/codegraph-core/src/extractors/kotlin.rs
+++ b/crates/codegraph-core/src/extractors/kotlin.rs
@@ -1,9 +1,9 @@
-use super::helpers::*;
-use super::SymbolExtractor;
+use tree_sitter::{Node, Tree};
 use crate::ast_analysis::cfg::build_function_cfg;
 use crate::ast_analysis::complexity::compute_all_metrics;
 use crate::types::*;
-use tree_sitter::{Node, Tree};
+use super::helpers::*;
+use super::SymbolExtractor;
 
 pub struct KotlinExtractor;
 
@@ -11,18 +11,8 @@ impl SymbolExtractor for KotlinExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_kotlin_node);
-        walk_ast_nodes_with_config(
-            &tree.root_node(),
-            source,
-            &mut symbols.ast_nodes,
-            &KOTLIN_AST_CONFIG,
-        );
-        walk_tree(
-            &tree.root_node(),
-            source,
-            &mut symbols,
-            match_kotlin_type_map,
-        );
+        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &KOTLIN_AST_CONFIG);
+        walk_tree(&tree.root_node(), source, &mut symbols, match_kotlin_type_map);
         dedup_type_map(&mut symbols.type_map);
         symbols
     }
@@ -36,8 +26,7 @@ fn match_kotlin_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, 
             if let Some(type_node) = node.child_by_field_name("type") {
                 let type_name = node_text(&type_node, source);
                 // Name can be in a pattern child or directly via field
-                let name = node
-                    .child_by_field_name("name")
+                let name = node.child_by_field_name("name")
                     .or_else(|| find_child(node, "simple_identifier"))
                     .map(|n| node_text(&n, source).to_string());
                 if let Some(name) = name {
@@ -51,8 +40,7 @@ fn match_kotlin_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, 
         }
         "parameter" => {
             if let Some(type_node) = node.child_by_field_name("type") {
-                if let Some(name_node) = node
-                    .child_by_field_name("name")
+                if let Some(name_node) = node.child_by_field_name("name")
                     .or_else(|| find_child(node, "simple_identifier"))
                 {
                     symbols.type_map.push(TypeMapEntry {
@@ -120,15 +108,13 @@ fn find_kotlin_parent_class<'a>(node: &Node<'a>, source: &[u8]) -> Option<String
 
 fn extract_kotlin_parameters(node: &Node, source: &[u8]) -> Vec<Definition> {
     let mut params = Vec::new();
-    if let Some(param_list) = node
-        .child_by_field_name("parameters")
+    if let Some(param_list) = node.child_by_field_name("parameters")
         .or_else(|| find_child(node, "function_value_parameters"))
     {
         for i in 0..param_list.child_count() {
             if let Some(child) = param_list.child(i) {
                 if child.kind() == "parameter" {
-                    if let Some(name_node) = child
-                        .child_by_field_name("name")
+                    if let Some(name_node) = child.child_by_field_name("name")
                         .or_else(|| find_child(&child, "simple_identifier"))
                     {
                         params.push(child_def(
@@ -189,12 +175,7 @@ fn extract_kotlin_enum_entries(node: &Node, source: &[u8]) -> Vec<Definition> {
     entries
 }
 
-fn extract_kotlin_delegation_specifiers(
-    node: &Node,
-    source: &[u8],
-    class_name: &str,
-    symbols: &mut FileSymbols,
-) {
+fn extract_kotlin_delegation_specifiers(node: &Node, source: &[u8], class_name: &str, symbols: &mut FileSymbols) {
     for i in 0..node.child_count() {
         if let Some(child) = node.child(i) {
             if child.kind() == "delegation_specifier" {
@@ -309,11 +290,7 @@ fn match_kotlin_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
                     Some(cls) => format!("{}.{}", cls, name),
                     None => name.to_string(),
                 };
-                let kind = if parent_class.is_some() {
-                    "method"
-                } else {
-                    "function"
-                };
+                let kind = if parent_class.is_some() { "method" } else { "function" };
                 let children = extract_kotlin_parameters(node, source);
                 symbols.definitions.push(Definition {
                     name: full_name,
@@ -370,8 +347,7 @@ fn match_kotlin_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
 
         "call_expression" => {
             // function child is the callee
-            if let Some(fn_node) = node
-                .child_by_field_name("function")
+            if let Some(fn_node) = node.child_by_field_name("function")
                 .or_else(|| node.child(0))
             {
                 match fn_node.kind() {
@@ -394,11 +370,7 @@ fn match_kotlin_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
                         // so take the inner identifier — using the suffix's own
                         // text would include the leading dot.
                         let count = fn_node.child_count();
-                        let last = if count > 0 {
-                            fn_node.child(count - 1)
-                        } else {
-                            None
-                        };
+                        let last = if count > 0 { fn_node.child(count - 1) } else { None };
                         let name = fn_node
                             .child_by_field_name("member")
                             .or_else(|| {
@@ -412,7 +384,8 @@ fn match_kotlin_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
                             })
                             .map(|n| node_text(&n, source).to_string())
                             .unwrap_or_else(|| node_text(&fn_node, source).to_string());
-                        let receiver = fn_node.child(0).map(|n| node_text(&n, source).to_string());
+                        let receiver = fn_node.child(0)
+                            .map(|n| node_text(&n, source).to_string());
                         // fn.invoke(args) — callable ref invocation without static type
                         // info; the WASM grammar represents `navigation_expression` with a
                         // `navigation_suffix` child so its `lastChild.type` check misses
@@ -494,11 +467,7 @@ mod tests {
     #[test]
     fn extracts_object() {
         let s = parse_kotlin("object Singleton { val x = 1 }");
-        let obj = s
-            .definitions
-            .iter()
-            .find(|d| d.name == "Singleton")
-            .unwrap();
+        let obj = s.definitions.iter().find(|d| d.name == "Singleton").unwrap();
         assert_eq!(obj.kind, "class");
     }
 

--- a/crates/codegraph-core/src/extractors/kotlin.rs
+++ b/crates/codegraph-core/src/extractors/kotlin.rs
@@ -1,9 +1,9 @@
-use tree_sitter::{Node, Tree};
+use super::helpers::*;
+use super::SymbolExtractor;
 use crate::ast_analysis::cfg::build_function_cfg;
 use crate::ast_analysis::complexity::compute_all_metrics;
 use crate::types::*;
-use super::helpers::*;
-use super::SymbolExtractor;
+use tree_sitter::{Node, Tree};
 
 pub struct KotlinExtractor;
 
@@ -11,8 +11,18 @@ impl SymbolExtractor for KotlinExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_kotlin_node);
-        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &KOTLIN_AST_CONFIG);
-        walk_tree(&tree.root_node(), source, &mut symbols, match_kotlin_type_map);
+        walk_ast_nodes_with_config(
+            &tree.root_node(),
+            source,
+            &mut symbols.ast_nodes,
+            &KOTLIN_AST_CONFIG,
+        );
+        walk_tree(
+            &tree.root_node(),
+            source,
+            &mut symbols,
+            match_kotlin_type_map,
+        );
         dedup_type_map(&mut symbols.type_map);
         symbols
     }
@@ -26,7 +36,8 @@ fn match_kotlin_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, 
             if let Some(type_node) = node.child_by_field_name("type") {
                 let type_name = node_text(&type_node, source);
                 // Name can be in a pattern child or directly via field
-                let name = node.child_by_field_name("name")
+                let name = node
+                    .child_by_field_name("name")
                     .or_else(|| find_child(node, "simple_identifier"))
                     .map(|n| node_text(&n, source).to_string());
                 if let Some(name) = name {
@@ -40,7 +51,8 @@ fn match_kotlin_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, 
         }
         "parameter" => {
             if let Some(type_node) = node.child_by_field_name("type") {
-                if let Some(name_node) = node.child_by_field_name("name")
+                if let Some(name_node) = node
+                    .child_by_field_name("name")
                     .or_else(|| find_child(node, "simple_identifier"))
                 {
                     symbols.type_map.push(TypeMapEntry {
@@ -108,13 +120,15 @@ fn find_kotlin_parent_class<'a>(node: &Node<'a>, source: &[u8]) -> Option<String
 
 fn extract_kotlin_parameters(node: &Node, source: &[u8]) -> Vec<Definition> {
     let mut params = Vec::new();
-    if let Some(param_list) = node.child_by_field_name("parameters")
+    if let Some(param_list) = node
+        .child_by_field_name("parameters")
         .or_else(|| find_child(node, "function_value_parameters"))
     {
         for i in 0..param_list.child_count() {
             if let Some(child) = param_list.child(i) {
                 if child.kind() == "parameter" {
-                    if let Some(name_node) = child.child_by_field_name("name")
+                    if let Some(name_node) = child
+                        .child_by_field_name("name")
                         .or_else(|| find_child(&child, "simple_identifier"))
                     {
                         params.push(child_def(
@@ -175,7 +189,12 @@ fn extract_kotlin_enum_entries(node: &Node, source: &[u8]) -> Vec<Definition> {
     entries
 }
 
-fn extract_kotlin_delegation_specifiers(node: &Node, source: &[u8], class_name: &str, symbols: &mut FileSymbols) {
+fn extract_kotlin_delegation_specifiers(
+    node: &Node,
+    source: &[u8],
+    class_name: &str,
+    symbols: &mut FileSymbols,
+) {
     for i in 0..node.child_count() {
         if let Some(child) = node.child(i) {
             if child.kind() == "delegation_specifier" {
@@ -226,6 +245,7 @@ fn match_kotlin_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
                         cfg: None,
                         children: None,
                         bodyless: None,
+                        content_hash: None,
                     });
                 } else if is_kotlin_enum(node) {
                     let children = extract_kotlin_enum_entries(node, source);
@@ -239,6 +259,7 @@ fn match_kotlin_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
                         cfg: None,
                         children: opt_children(children),
                         bodyless: None,
+                        content_hash: None,
                     });
                 } else {
                     let children = extract_kotlin_class_properties(node, source);
@@ -252,6 +273,7 @@ fn match_kotlin_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
                         cfg: None,
                         children: opt_children(children),
                         bodyless: None,
+                        content_hash: None,
                     });
                 }
 
@@ -273,6 +295,7 @@ fn match_kotlin_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
                     cfg: None,
                     children: opt_children(children),
                     bodyless: None,
+                    content_hash: None,
                 });
                 extract_kotlin_delegation_specifiers(node, source, &obj_name, symbols);
             }
@@ -286,7 +309,11 @@ fn match_kotlin_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
                     Some(cls) => format!("{}.{}", cls, name),
                     None => name.to_string(),
                 };
-                let kind = if parent_class.is_some() { "method" } else { "function" };
+                let kind = if parent_class.is_some() {
+                    "method"
+                } else {
+                    "function"
+                };
                 let children = extract_kotlin_parameters(node, source);
                 symbols.definitions.push(Definition {
                     name: full_name,
@@ -298,6 +325,7 @@ fn match_kotlin_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
                     cfg: build_function_cfg(node, "kotlin", source),
                     children: opt_children(children),
                     bodyless: None,
+                    content_hash: None,
                 });
             }
         }
@@ -342,7 +370,8 @@ fn match_kotlin_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
 
         "call_expression" => {
             // function child is the callee
-            if let Some(fn_node) = node.child_by_field_name("function")
+            if let Some(fn_node) = node
+                .child_by_field_name("function")
                 .or_else(|| node.child(0))
             {
                 match fn_node.kind() {
@@ -365,7 +394,11 @@ fn match_kotlin_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
                         // so take the inner identifier — using the suffix's own
                         // text would include the leading dot.
                         let count = fn_node.child_count();
-                        let last = if count > 0 { fn_node.child(count - 1) } else { None };
+                        let last = if count > 0 {
+                            fn_node.child(count - 1)
+                        } else {
+                            None
+                        };
                         let name = fn_node
                             .child_by_field_name("member")
                             .or_else(|| {
@@ -379,8 +412,7 @@ fn match_kotlin_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
                             })
                             .map(|n| node_text(&n, source).to_string())
                             .unwrap_or_else(|| node_text(&fn_node, source).to_string());
-                        let receiver = fn_node.child(0)
-                            .map(|n| node_text(&n, source).to_string());
+                        let receiver = fn_node.child(0).map(|n| node_text(&n, source).to_string());
                         // fn.invoke(args) — callable ref invocation without static type
                         // info; the WASM grammar represents `navigation_expression` with a
                         // `navigation_suffix` child so its `lastChild.type` check misses
@@ -462,7 +494,11 @@ mod tests {
     #[test]
     fn extracts_object() {
         let s = parse_kotlin("object Singleton { val x = 1 }");
-        let obj = s.definitions.iter().find(|d| d.name == "Singleton").unwrap();
+        let obj = s
+            .definitions
+            .iter()
+            .find(|d| d.name == "Singleton")
+            .unwrap();
         assert_eq!(obj.kind, "class");
     }
 

--- a/crates/codegraph-core/src/extractors/lua.rs
+++ b/crates/codegraph-core/src/extractors/lua.rs
@@ -1,54 +1,23 @@
-use super::helpers::*;
-use super::SymbolExtractor;
+use tree_sitter::{Node, Tree};
 use crate::ast_analysis::cfg::build_function_cfg;
 use crate::ast_analysis::complexity::compute_all_metrics;
 use crate::types::*;
-use tree_sitter::{Node, Tree};
+use super::helpers::*;
+use super::SymbolExtractor;
 
 /// Lua base-library global function names and standard-library module
 /// tables. Mirrors `LUA_BUILTIN_GLOBALS` in `src/extractors/lua.ts` — see
 /// `handle_lua_assignment_statement` (this file) and that file's
 /// `handleLuaAssignmentStatement` for the full rationale (issue #1776).
 const LUA_BUILTIN_GLOBALS: &[&str] = &[
-    "assert",
-    "collectgarbage",
-    "dofile",
-    "error",
-    "getfenv",
-    "getmetatable",
-    "ipairs",
-    "load",
-    "loadfile",
-    "loadstring",
-    "module",
-    "next",
-    "pairs",
-    "pcall",
-    "print",
-    "rawequal",
-    "rawget",
-    "rawlen",
-    "rawset",
-    "require",
-    "select",
-    "setfenv",
-    "setmetatable",
-    "tonumber",
-    "tostring",
-    "type",
-    "unpack",
-    "xpcall",
+    "assert", "collectgarbage", "dofile", "error", "getfenv", "getmetatable",
+    "ipairs", "load", "loadfile", "loadstring", "module", "next", "pairs",
+    "pcall", "print", "rawequal", "rawget", "rawlen", "rawset", "require",
+    "select", "setfenv", "setmetatable", "tonumber", "tostring", "type",
+    "unpack", "xpcall",
     // Standard-library module tables — wholesale replacement (e.g. sandboxing)
     // is the same "escapes local scope" shape as a single builtin function.
-    "string",
-    "table",
-    "math",
-    "io",
-    "os",
-    "coroutine",
-    "debug",
-    "utf8",
-    "bit32",
+    "string", "table", "math", "io", "os", "coroutine", "debug", "utf8", "bit32",
 ];
 
 pub struct LuaExtractor;
@@ -57,12 +26,7 @@ impl SymbolExtractor for LuaExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_lua_node);
-        walk_ast_nodes_with_config(
-            &tree.root_node(),
-            source,
-            &mut symbols.ast_nodes,
-            &LUA_AST_CONFIG,
-        );
+        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &LUA_AST_CONFIG);
         symbols
     }
 }
@@ -160,24 +124,16 @@ fn extract_lua_params(func_node: &Node, source: &[u8]) -> Vec<Definition> {
 /// first), so mixed variable kinds (`t.b, a = f, g`) do not shift the
 /// pairing.
 fn handle_lua_assignment_statement(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(variable_list) = find_child(node, "variable_list") else {
-        return;
-    };
-    let Some(expression_list) = find_child(node, "expression_list") else {
-        return;
-    };
+    let Some(variable_list) = find_child(node, "variable_list") else { return };
+    let Some(expression_list) = find_child(node, "expression_list") else { return };
 
     let pair_count = variable_list
         .named_child_count()
         .min(expression_list.named_child_count());
 
     for i in 0..pair_count {
-        let Some(lhs) = variable_list.named_child(i) else {
-            continue;
-        };
-        let Some(rhs) = expression_list.named_child(i) else {
-            continue;
-        };
+        let Some(lhs) = variable_list.named_child(i) else { continue };
+        let Some(rhs) = expression_list.named_child(i) else { continue };
         if lhs.kind() != "identifier" || rhs.kind() != "identifier" {
             continue;
         }
@@ -267,15 +223,9 @@ fn handle_lua_function_call(node: &Node, source: &[u8], symbols: &mut FileSymbol
             let table_id = table.as_ref().map(|n| n.id());
             let mut key: Option<Node> = None;
             for i in 0..name_node.child_count() {
-                let Some(ch) = name_node.child(i) else {
-                    continue;
-                };
-                if matches!(ch.kind(), "[" | "]") {
-                    continue;
-                }
-                if table_id == Some(ch.id()) {
-                    continue;
-                }
+                let Some(ch) = name_node.child(i) else { continue };
+                if matches!(ch.kind(), "[" | "]") { continue; }
+                if table_id == Some(ch.id()) { continue; }
                 key = Some(ch);
                 break;
             }
@@ -359,46 +309,31 @@ mod tests {
     #[test]
     fn no_value_ref_call_when_lhs_is_not_a_recognized_builtin() {
         let s = parse_lua("local function helper() end\nmyCustomGlobal = helper");
-        assert!(s
-            .calls
-            .iter()
-            .all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
+        assert!(s.calls.iter().all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
     }
 
     #[test]
     fn no_value_ref_call_when_rhs_is_itself_a_builtin() {
         let s = parse_lua("print = tostring");
-        assert!(s
-            .calls
-            .iter()
-            .all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
+        assert!(s.calls.iter().all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
     }
 
     #[test]
     fn no_value_ref_call_for_local_non_builtin_alias() {
         let s = parse_lua("local function helper() end\nlocal orig_helper = helper");
-        assert!(s
-            .calls
-            .iter()
-            .all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
+        assert!(s.calls.iter().all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
     }
 
     #[test]
     fn no_value_ref_call_when_rhs_is_a_call_expression() {
         let s = parse_lua("require = wrapRequire(require)");
-        assert!(s
-            .calls
-            .iter()
-            .all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
+        assert!(s.calls.iter().all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
     }
 
     #[test]
     fn no_value_ref_call_when_rhs_is_a_member_expression() {
         let s = parse_lua("require = mymodule.customRequire");
-        assert!(s
-            .calls
-            .iter()
-            .all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
+        assert!(s.calls.iter().all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
     }
 
     #[test]
@@ -465,9 +400,10 @@ mod tests {
     #[test]
     fn resolves_bracket_index_call_with_string_literal_key_directly() {
         let s = parse_lua("t[\"handler\"]()");
-        assert!(s.calls.iter().any(|c| c.name == "handler"
-            && c.receiver.as_deref() == Some("t")
-            && c.dynamic.is_none()));
+        assert!(s
+            .calls
+            .iter()
+            .any(|c| c.name == "handler" && c.receiver.as_deref() == Some("t") && c.dynamic.is_none()));
     }
 
     #[test]

--- a/crates/codegraph-core/src/extractors/lua.rs
+++ b/crates/codegraph-core/src/extractors/lua.rs
@@ -1,23 +1,54 @@
-use tree_sitter::{Node, Tree};
+use super::helpers::*;
+use super::SymbolExtractor;
 use crate::ast_analysis::cfg::build_function_cfg;
 use crate::ast_analysis::complexity::compute_all_metrics;
 use crate::types::*;
-use super::helpers::*;
-use super::SymbolExtractor;
+use tree_sitter::{Node, Tree};
 
 /// Lua base-library global function names and standard-library module
 /// tables. Mirrors `LUA_BUILTIN_GLOBALS` in `src/extractors/lua.ts` — see
 /// `handle_lua_assignment_statement` (this file) and that file's
 /// `handleLuaAssignmentStatement` for the full rationale (issue #1776).
 const LUA_BUILTIN_GLOBALS: &[&str] = &[
-    "assert", "collectgarbage", "dofile", "error", "getfenv", "getmetatable",
-    "ipairs", "load", "loadfile", "loadstring", "module", "next", "pairs",
-    "pcall", "print", "rawequal", "rawget", "rawlen", "rawset", "require",
-    "select", "setfenv", "setmetatable", "tonumber", "tostring", "type",
-    "unpack", "xpcall",
+    "assert",
+    "collectgarbage",
+    "dofile",
+    "error",
+    "getfenv",
+    "getmetatable",
+    "ipairs",
+    "load",
+    "loadfile",
+    "loadstring",
+    "module",
+    "next",
+    "pairs",
+    "pcall",
+    "print",
+    "rawequal",
+    "rawget",
+    "rawlen",
+    "rawset",
+    "require",
+    "select",
+    "setfenv",
+    "setmetatable",
+    "tonumber",
+    "tostring",
+    "type",
+    "unpack",
+    "xpcall",
     // Standard-library module tables — wholesale replacement (e.g. sandboxing)
     // is the same "escapes local scope" shape as a single builtin function.
-    "string", "table", "math", "io", "os", "coroutine", "debug", "utf8", "bit32",
+    "string",
+    "table",
+    "math",
+    "io",
+    "os",
+    "coroutine",
+    "debug",
+    "utf8",
+    "bit32",
 ];
 
 pub struct LuaExtractor;
@@ -26,7 +57,12 @@ impl SymbolExtractor for LuaExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_lua_node);
-        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &LUA_AST_CONFIG);
+        walk_ast_nodes_with_config(
+            &tree.root_node(),
+            source,
+            &mut symbols.ast_nodes,
+            &LUA_AST_CONFIG,
+        );
         symbols
     }
 }
@@ -84,6 +120,7 @@ fn handle_lua_function_decl(node: &Node, source: &[u8], symbols: &mut FileSymbol
         cfg: build_function_cfg(node, "lua", source),
         children: opt_children(params),
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -123,16 +160,24 @@ fn extract_lua_params(func_node: &Node, source: &[u8]) -> Vec<Definition> {
 /// first), so mixed variable kinds (`t.b, a = f, g`) do not shift the
 /// pairing.
 fn handle_lua_assignment_statement(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(variable_list) = find_child(node, "variable_list") else { return };
-    let Some(expression_list) = find_child(node, "expression_list") else { return };
+    let Some(variable_list) = find_child(node, "variable_list") else {
+        return;
+    };
+    let Some(expression_list) = find_child(node, "expression_list") else {
+        return;
+    };
 
     let pair_count = variable_list
         .named_child_count()
         .min(expression_list.named_child_count());
 
     for i in 0..pair_count {
-        let Some(lhs) = variable_list.named_child(i) else { continue };
-        let Some(rhs) = expression_list.named_child(i) else { continue };
+        let Some(lhs) = variable_list.named_child(i) else {
+            continue;
+        };
+        let Some(rhs) = expression_list.named_child(i) else {
+            continue;
+        };
         if lhs.kind() != "identifier" || rhs.kind() != "identifier" {
             continue;
         }
@@ -222,9 +267,15 @@ fn handle_lua_function_call(node: &Node, source: &[u8], symbols: &mut FileSymbol
             let table_id = table.as_ref().map(|n| n.id());
             let mut key: Option<Node> = None;
             for i in 0..name_node.child_count() {
-                let Some(ch) = name_node.child(i) else { continue };
-                if matches!(ch.kind(), "[" | "]") { continue; }
-                if table_id == Some(ch.id()) { continue; }
+                let Some(ch) = name_node.child(i) else {
+                    continue;
+                };
+                if matches!(ch.kind(), "[" | "]") {
+                    continue;
+                }
+                if table_id == Some(ch.id()) {
+                    continue;
+                }
                 key = Some(ch);
                 break;
             }
@@ -308,31 +359,46 @@ mod tests {
     #[test]
     fn no_value_ref_call_when_lhs_is_not_a_recognized_builtin() {
         let s = parse_lua("local function helper() end\nmyCustomGlobal = helper");
-        assert!(s.calls.iter().all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
+        assert!(s
+            .calls
+            .iter()
+            .all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
     }
 
     #[test]
     fn no_value_ref_call_when_rhs_is_itself_a_builtin() {
         let s = parse_lua("print = tostring");
-        assert!(s.calls.iter().all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
+        assert!(s
+            .calls
+            .iter()
+            .all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
     }
 
     #[test]
     fn no_value_ref_call_for_local_non_builtin_alias() {
         let s = parse_lua("local function helper() end\nlocal orig_helper = helper");
-        assert!(s.calls.iter().all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
+        assert!(s
+            .calls
+            .iter()
+            .all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
     }
 
     #[test]
     fn no_value_ref_call_when_rhs_is_a_call_expression() {
         let s = parse_lua("require = wrapRequire(require)");
-        assert!(s.calls.iter().all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
+        assert!(s
+            .calls
+            .iter()
+            .all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
     }
 
     #[test]
     fn no_value_ref_call_when_rhs_is_a_member_expression() {
         let s = parse_lua("require = mymodule.customRequire");
-        assert!(s.calls.iter().all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
+        assert!(s
+            .calls
+            .iter()
+            .all(|c| c.dynamic_kind.as_deref() != Some("value-ref")));
     }
 
     #[test]
@@ -399,10 +465,9 @@ mod tests {
     #[test]
     fn resolves_bracket_index_call_with_string_literal_key_directly() {
         let s = parse_lua("t[\"handler\"]()");
-        assert!(s
-            .calls
-            .iter()
-            .any(|c| c.name == "handler" && c.receiver.as_deref() == Some("t") && c.dynamic.is_none()));
+        assert!(s.calls.iter().any(|c| c.name == "handler"
+            && c.receiver.as_deref() == Some("t")
+            && c.dynamic.is_none()));
     }
 
     #[test]

--- a/crates/codegraph-core/src/extractors/objc.rs
+++ b/crates/codegraph-core/src/extractors/objc.rs
@@ -1,9 +1,9 @@
-use super::helpers::*;
-use super::SymbolExtractor;
+use tree_sitter::{Node, Tree};
 use crate::ast_analysis::cfg::build_function_cfg;
 use crate::ast_analysis::complexity::compute_all_metrics;
 use crate::types::*;
-use tree_sitter::{Node, Tree};
+use super::helpers::*;
+use super::SymbolExtractor;
 
 /// Objective-C extractor — mirrors `src/extractors/objc.ts`.
 ///
@@ -18,12 +18,7 @@ impl SymbolExtractor for ObjCExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_objc_node);
-        walk_ast_nodes_with_config(
-            &tree.root_node(),
-            source,
-            &mut symbols.ast_nodes,
-            &OBJC_AST_CONFIG,
-        );
+        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &OBJC_AST_CONFIG);
         symbols
     }
 }
@@ -222,17 +217,11 @@ fn handle_import(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     };
     let raw = node_text(&path_node, source);
     // Strip `"..."` or `<...>` wrappers — mirrors the JS extractor regex.
-    let source_path = raw
-        .trim_matches(|c| c == '"' || c == '<' || c == '>')
-        .to_string();
+    let source_path = raw.trim_matches(|c| c == '"' || c == '<' || c == '>').to_string();
     if source_path.is_empty() {
         return;
     }
-    let last_name = source_path
-        .rsplit('/')
-        .next()
-        .unwrap_or(&source_path)
-        .to_string();
+    let last_name = source_path.rsplit('/').next().unwrap_or(&source_path).to_string();
     let mut imp = Import::new(source_path, vec![last_name], start_line(node));
     imp.c_include = Some(true);
     symbols.imports.push(imp);
@@ -243,8 +232,7 @@ fn handle_import(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 /// preprocessor field; `module_import` uses `module`.) Mirrors
 /// `src/extractors/objc.ts`.
 fn handle_at_import(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let module_node = node
-        .child_by_field_name("module")
+    let module_node = node.child_by_field_name("module")
         .or_else(|| find_child(node, "identifier"));
     if let Some(m) = module_node {
         let name = node_text(&m, source).to_string();
@@ -343,12 +331,10 @@ fn handle_c_call_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     };
 
     let (name, receiver) = if fn_node.kind() == "field_expression" {
-        let field = fn_node
-            .child_by_field_name("field")
+        let field = fn_node.child_by_field_name("field")
             .map(|n| node_text(&n, source).to_string())
             .unwrap_or_else(|| node_text(&fn_node, source).to_string());
-        let recv = fn_node
-            .child_by_field_name("argument")
+        let recv = fn_node.child_by_field_name("argument")
             .map(|n| node_text(&n, source).to_string());
         (field, recv)
     } else {
@@ -375,8 +361,7 @@ fn handle_c_call_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 /// keyword identifier the `method` field name; for multi-keyword selectors
 /// we collect them all and join with `:`.
 fn handle_message_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let receiver = node
-        .child_by_field_name("receiver")
+    let receiver = node.child_by_field_name("receiver")
         .map(|n| node_text(&n, source).to_string());
 
     let selector = build_message_selector(node, source);
@@ -469,7 +454,9 @@ fn find_objc_parent_class(node: &Node, source: &[u8]) -> Option<String> {
     let mut current = node.parent();
     while let Some(parent) = current {
         match parent.kind() {
-            "class_interface" | "class_implementation" | "protocol_declaration" => {
+            "class_interface"
+            | "class_implementation"
+            | "protocol_declaration" => {
                 let name_node = find_objc_decl_name(&parent)?;
                 let base = node_text(&name_node, source).to_string();
                 // Categories: include `(Cat)` so methods are grouped per category.
@@ -688,16 +675,9 @@ mod tests {
         let supers: Vec<_> = s.classes.iter().filter(|c| c.extends.is_some()).collect();
         assert_eq!(supers.len(), 1);
         assert_eq!(supers[0].extends.as_deref(), Some("NSObject"));
-        let impls: Vec<_> = s
-            .classes
-            .iter()
-            .filter(|c| c.implements.is_some())
-            .collect();
+        let impls: Vec<_> = s.classes.iter().filter(|c| c.implements.is_some()).collect();
         assert_eq!(impls.len(), 2);
-        let names: Vec<_> = impls
-            .iter()
-            .filter_map(|c| c.implements.as_deref())
-            .collect();
+        let names: Vec<_> = impls.iter().filter_map(|c| c.implements.as_deref()).collect();
         assert!(names.contains(&"Bar"));
         assert!(names.contains(&"Baz"));
     }
@@ -718,11 +698,7 @@ mod tests {
         assert_eq!(foo.kind, "class");
         let do_it = s.definitions.iter().find(|d| d.name == "Foo.doIt").unwrap();
         assert_eq!(do_it.kind, "method");
-        let shared = s
-            .definitions
-            .iter()
-            .find(|d| d.name == "Foo.shared")
-            .unwrap();
+        let shared = s.definitions.iter().find(|d| d.name == "Foo.shared").unwrap();
         assert_eq!(shared.kind, "method");
     }
 
@@ -734,11 +710,7 @@ mod tests {
 }
 @end";
         let s = parse_objc(code);
-        let m = s
-            .definitions
-            .iter()
-            .find(|d| d.name == "Foo.setName:age:")
-            .unwrap();
+        let m = s.definitions.iter().find(|d| d.name == "Foo.setName:age:").unwrap();
         let kids = m.children.as_ref().unwrap();
         assert_eq!(kids.len(), 2);
         assert_eq!(kids[0].name, "name");
@@ -755,17 +727,9 @@ mod tests {
 - (void)catMethod {}
 @end";
         let s = parse_objc(code);
-        let iface = s
-            .definitions
-            .iter()
-            .find(|d| d.name == "Foo(Cat)" && d.line == 1)
-            .unwrap();
+        let iface = s.definitions.iter().find(|d| d.name == "Foo(Cat)" && d.line == 1).unwrap();
         assert_eq!(iface.kind, "class");
-        let m = s
-            .definitions
-            .iter()
-            .find(|d| d.name == "Foo(Cat).catMethod" && d.kind == "method")
-            .unwrap();
+        let m = s.definitions.iter().find(|d| d.name == "Foo(Cat).catMethod" && d.kind == "method").unwrap();
         let _ = m;
     }
 
@@ -852,11 +816,7 @@ mod tests {
 }
 @end";
         let s = parse_objc(code);
-        let dyn_call = s
-            .calls
-            .iter()
-            .find(|c| c.name == "<dynamic:unresolved>")
-            .unwrap();
+        let dyn_call = s.calls.iter().find(|c| c.name == "<dynamic:unresolved>").unwrap();
         assert_eq!(dyn_call.dynamic, Some(true));
         assert_eq!(dyn_call.dynamic_kind.as_deref(), Some("unresolved-dynamic"));
     }
@@ -870,11 +830,7 @@ mod tests {
 }
 @end";
         let s = parse_objc(code);
-        let dyn_call = s
-            .calls
-            .iter()
-            .find(|c| c.name == "<dynamic:unresolved>")
-            .unwrap();
+        let dyn_call = s.calls.iter().find(|c| c.name == "<dynamic:unresolved>").unwrap();
         assert_eq!(dyn_call.dynamic, Some(true));
         assert_eq!(dyn_call.dynamic_kind.as_deref(), Some("unresolved-dynamic"));
     }
@@ -883,11 +839,7 @@ mod tests {
     fn flags_objc_msg_send_as_unresolved_dynamic() {
         let code = "void run(id obj, SEL sel) { objc_msgSend(obj, sel); }";
         let s = parse_objc(code);
-        let dyn_call = s
-            .calls
-            .iter()
-            .find(|c| c.name == "<dynamic:unresolved>")
-            .unwrap();
+        let dyn_call = s.calls.iter().find(|c| c.name == "<dynamic:unresolved>").unwrap();
         assert_eq!(dyn_call.dynamic, Some(true));
         assert_eq!(dyn_call.dynamic_kind.as_deref(), Some("unresolved-dynamic"));
     }

--- a/crates/codegraph-core/src/extractors/objc.rs
+++ b/crates/codegraph-core/src/extractors/objc.rs
@@ -1,9 +1,9 @@
-use tree_sitter::{Node, Tree};
+use super::helpers::*;
+use super::SymbolExtractor;
 use crate::ast_analysis::cfg::build_function_cfg;
 use crate::ast_analysis::complexity::compute_all_metrics;
 use crate::types::*;
-use super::helpers::*;
-use super::SymbolExtractor;
+use tree_sitter::{Node, Tree};
 
 /// Objective-C extractor — mirrors `src/extractors/objc.ts`.
 ///
@@ -18,7 +18,12 @@ impl SymbolExtractor for ObjCExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_objc_node);
-        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &OBJC_AST_CONFIG);
+        walk_ast_nodes_with_config(
+            &tree.root_node(),
+            source,
+            &mut symbols.ast_nodes,
+            &OBJC_AST_CONFIG,
+        );
         symbols
     }
 }
@@ -73,6 +78,7 @@ fn handle_class_interface(node: &Node, source: &[u8], symbols: &mut FileSymbols)
         cfg: None,
         children: opt_children(members),
         bodyless: None,
+        content_hash: None,
     });
 
     // Superclass — use the bare class name (categories already recorded above)
@@ -135,6 +141,7 @@ fn handle_class_implementation(node: &Node, source: &[u8], symbols: &mut FileSym
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -154,6 +161,7 @@ fn handle_protocol_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -181,6 +189,7 @@ fn handle_method(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: build_function_cfg(node, "objc", source),
         children: opt_children(params),
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -200,6 +209,7 @@ fn handle_function_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: build_function_cfg(node, "objc", source),
         children: opt_children(params),
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -212,11 +222,17 @@ fn handle_import(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     };
     let raw = node_text(&path_node, source);
     // Strip `"..."` or `<...>` wrappers — mirrors the JS extractor regex.
-    let source_path = raw.trim_matches(|c| c == '"' || c == '<' || c == '>').to_string();
+    let source_path = raw
+        .trim_matches(|c| c == '"' || c == '<' || c == '>')
+        .to_string();
     if source_path.is_empty() {
         return;
     }
-    let last_name = source_path.rsplit('/').next().unwrap_or(&source_path).to_string();
+    let last_name = source_path
+        .rsplit('/')
+        .next()
+        .unwrap_or(&source_path)
+        .to_string();
     let mut imp = Import::new(source_path, vec![last_name], start_line(node));
     imp.c_include = Some(true);
     symbols.imports.push(imp);
@@ -227,7 +243,8 @@ fn handle_import(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 /// preprocessor field; `module_import` uses `module`.) Mirrors
 /// `src/extractors/objc.ts`.
 fn handle_at_import(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let module_node = node.child_by_field_name("module")
+    let module_node = node
+        .child_by_field_name("module")
         .or_else(|| find_child(node, "identifier"));
     if let Some(m) = module_node {
         let name = node_text(&m, source).to_string();
@@ -249,6 +266,7 @@ fn handle_struct_specifier(node: &Node, source: &[u8], symbols: &mut FileSymbols
             cfg: None,
             children: None,
             bodyless: None,
+            content_hash: None,
         });
     }
 }
@@ -265,6 +283,7 @@ fn handle_enum_specifier(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
             cfg: None,
             children: None,
             bodyless: None,
+            content_hash: None,
         });
     }
 }
@@ -293,6 +312,7 @@ fn handle_typedef(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             cfg: None,
             children: None,
             bodyless: None,
+            content_hash: None,
         });
     }
 }
@@ -323,10 +343,12 @@ fn handle_c_call_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     };
 
     let (name, receiver) = if fn_node.kind() == "field_expression" {
-        let field = fn_node.child_by_field_name("field")
+        let field = fn_node
+            .child_by_field_name("field")
             .map(|n| node_text(&n, source).to_string())
             .unwrap_or_else(|| node_text(&fn_node, source).to_string());
-        let recv = fn_node.child_by_field_name("argument")
+        let recv = fn_node
+            .child_by_field_name("argument")
             .map(|n| node_text(&n, source).to_string());
         (field, recv)
     } else {
@@ -353,7 +375,8 @@ fn handle_c_call_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 /// keyword identifier the `method` field name; for multi-keyword selectors
 /// we collect them all and join with `:`.
 fn handle_message_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let receiver = node.child_by_field_name("receiver")
+    let receiver = node
+        .child_by_field_name("receiver")
         .map(|n| node_text(&n, source).to_string());
 
     let selector = build_message_selector(node, source);
@@ -446,9 +469,7 @@ fn find_objc_parent_class(node: &Node, source: &[u8]) -> Option<String> {
     let mut current = node.parent();
     while let Some(parent) = current {
         match parent.kind() {
-            "class_interface"
-            | "class_implementation"
-            | "protocol_declaration" => {
+            "class_interface" | "class_implementation" | "protocol_declaration" => {
                 let name_node = find_objc_decl_name(&parent)?;
                 let base = node_text(&name_node, source).to_string();
                 // Categories: include `(Cat)` so methods are grouped per category.
@@ -667,9 +688,16 @@ mod tests {
         let supers: Vec<_> = s.classes.iter().filter(|c| c.extends.is_some()).collect();
         assert_eq!(supers.len(), 1);
         assert_eq!(supers[0].extends.as_deref(), Some("NSObject"));
-        let impls: Vec<_> = s.classes.iter().filter(|c| c.implements.is_some()).collect();
+        let impls: Vec<_> = s
+            .classes
+            .iter()
+            .filter(|c| c.implements.is_some())
+            .collect();
         assert_eq!(impls.len(), 2);
-        let names: Vec<_> = impls.iter().filter_map(|c| c.implements.as_deref()).collect();
+        let names: Vec<_> = impls
+            .iter()
+            .filter_map(|c| c.implements.as_deref())
+            .collect();
         assert!(names.contains(&"Bar"));
         assert!(names.contains(&"Baz"));
     }
@@ -690,7 +718,11 @@ mod tests {
         assert_eq!(foo.kind, "class");
         let do_it = s.definitions.iter().find(|d| d.name == "Foo.doIt").unwrap();
         assert_eq!(do_it.kind, "method");
-        let shared = s.definitions.iter().find(|d| d.name == "Foo.shared").unwrap();
+        let shared = s
+            .definitions
+            .iter()
+            .find(|d| d.name == "Foo.shared")
+            .unwrap();
         assert_eq!(shared.kind, "method");
     }
 
@@ -702,7 +734,11 @@ mod tests {
 }
 @end";
         let s = parse_objc(code);
-        let m = s.definitions.iter().find(|d| d.name == "Foo.setName:age:").unwrap();
+        let m = s
+            .definitions
+            .iter()
+            .find(|d| d.name == "Foo.setName:age:")
+            .unwrap();
         let kids = m.children.as_ref().unwrap();
         assert_eq!(kids.len(), 2);
         assert_eq!(kids[0].name, "name");
@@ -719,9 +755,17 @@ mod tests {
 - (void)catMethod {}
 @end";
         let s = parse_objc(code);
-        let iface = s.definitions.iter().find(|d| d.name == "Foo(Cat)" && d.line == 1).unwrap();
+        let iface = s
+            .definitions
+            .iter()
+            .find(|d| d.name == "Foo(Cat)" && d.line == 1)
+            .unwrap();
         assert_eq!(iface.kind, "class");
-        let m = s.definitions.iter().find(|d| d.name == "Foo(Cat).catMethod" && d.kind == "method").unwrap();
+        let m = s
+            .definitions
+            .iter()
+            .find(|d| d.name == "Foo(Cat).catMethod" && d.kind == "method")
+            .unwrap();
         let _ = m;
     }
 
@@ -808,7 +852,11 @@ mod tests {
 }
 @end";
         let s = parse_objc(code);
-        let dyn_call = s.calls.iter().find(|c| c.name == "<dynamic:unresolved>").unwrap();
+        let dyn_call = s
+            .calls
+            .iter()
+            .find(|c| c.name == "<dynamic:unresolved>")
+            .unwrap();
         assert_eq!(dyn_call.dynamic, Some(true));
         assert_eq!(dyn_call.dynamic_kind.as_deref(), Some("unresolved-dynamic"));
     }
@@ -822,7 +870,11 @@ mod tests {
 }
 @end";
         let s = parse_objc(code);
-        let dyn_call = s.calls.iter().find(|c| c.name == "<dynamic:unresolved>").unwrap();
+        let dyn_call = s
+            .calls
+            .iter()
+            .find(|c| c.name == "<dynamic:unresolved>")
+            .unwrap();
         assert_eq!(dyn_call.dynamic, Some(true));
         assert_eq!(dyn_call.dynamic_kind.as_deref(), Some("unresolved-dynamic"));
     }
@@ -831,7 +883,11 @@ mod tests {
     fn flags_objc_msg_send_as_unresolved_dynamic() {
         let code = "void run(id obj, SEL sel) { objc_msgSend(obj, sel); }";
         let s = parse_objc(code);
-        let dyn_call = s.calls.iter().find(|c| c.name == "<dynamic:unresolved>").unwrap();
+        let dyn_call = s
+            .calls
+            .iter()
+            .find(|c| c.name == "<dynamic:unresolved>")
+            .unwrap();
         assert_eq!(dyn_call.dynamic, Some(true));
         assert_eq!(dyn_call.dynamic_kind.as_deref(), Some("unresolved-dynamic"));
     }

--- a/crates/codegraph-core/src/extractors/ocaml.rs
+++ b/crates/codegraph-core/src/extractors/ocaml.rs
@@ -1,9 +1,9 @@
-use super::helpers::*;
-use super::SymbolExtractor;
+use tree_sitter::{Node, Tree};
 use crate::ast_analysis::cfg::build_function_cfg;
 use crate::ast_analysis::complexity::compute_all_metrics;
 use crate::types::*;
-use tree_sitter::{Node, Tree};
+use super::helpers::*;
+use super::SymbolExtractor;
 
 pub struct OcamlExtractor;
 
@@ -11,12 +11,7 @@ impl SymbolExtractor for OcamlExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_ocaml_node);
-        walk_ast_nodes_with_config(
-            &tree.root_node(),
-            source,
-            &mut symbols.ast_nodes,
-            &OCAML_AST_CONFIG,
-        );
+        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &OCAML_AST_CONFIG);
         symbols
     }
 }
@@ -49,10 +44,7 @@ fn handle_ocaml_value_def(node: &Node, source: &[u8], symbols: &mut FileSymbols)
 }
 
 fn handle_ocaml_let_binding(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let pattern = match node
-        .child_by_field_name("pattern")
-        .or_else(|| node.child(0))
-    {
+    let pattern = match node.child_by_field_name("pattern").or_else(|| node.child(0)) {
         Some(p) => p,
         None => return,
     };
@@ -98,9 +90,11 @@ fn extract_ocaml_pattern_name(pattern: &Node, source: &[u8]) -> Option<String> {
     match pattern.kind() {
         "value_name" | "identifier" => Some(node_text(pattern, source).to_string()),
         "parenthesized_operator" => Some(node_text(pattern, source).to_string()),
-        _ => find_child(pattern, "value_name")
-            .or_else(|| find_child(pattern, "identifier"))
-            .map(|n| node_text(&n, source).to_string()),
+        _ => {
+            find_child(pattern, "value_name")
+                .or_else(|| find_child(pattern, "identifier"))
+                .map(|n| node_text(&n, source).to_string())
+        }
     }
 }
 
@@ -121,8 +115,7 @@ fn handle_ocaml_module_def(node: &Node, source: &[u8], symbols: &mut FileSymbols
         None => return,
     };
 
-    let name_node = binding
-        .child_by_field_name("name")
+    let name_node = binding.child_by_field_name("name")
         .or_else(|| find_child(&binding, "module_name"))
         .or_else(|| find_child(&binding, "identifier"));
     if let Some(name) = name_node {
@@ -148,8 +141,7 @@ fn handle_ocaml_type_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
                 continue;
             }
 
-            let name_node = child
-                .child_by_field_name("name")
+            let name_node = child.child_by_field_name("name")
                 .or_else(|| find_child(&child, "type_constructor"))
                 .or_else(|| find_child(&child, "identifier"));
             if let Some(name) = name_node {
@@ -173,11 +165,7 @@ fn handle_ocaml_type_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
     }
 }
 
-fn extract_ocaml_type_constructors(
-    type_binding: &Node,
-    source: &[u8],
-    children: &mut Vec<Definition>,
-) {
+fn extract_ocaml_type_constructors(type_binding: &Node, source: &[u8], children: &mut Vec<Definition>) {
     for i in 0..type_binding.child_count() {
         if let Some(child) = type_binding.child(i) {
             if child.kind() == "constructor_declaration" {
@@ -201,8 +189,7 @@ fn handle_ocaml_class_def(node: &Node, source: &[u8], symbols: &mut FileSymbols)
         None => return,
     };
 
-    let name_node = binding
-        .child_by_field_name("name")
+    let name_node = binding.child_by_field_name("name")
         .or_else(|| find_child(&binding, "identifier"));
     if let Some(name) = name_node {
         symbols.definitions.push(Definition {
@@ -236,20 +223,17 @@ fn handle_ocaml_open(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 
     if let Some(name) = module_name {
         let last = name.split('.').last().unwrap_or(&name).to_string();
-        symbols
-            .imports
-            .push(Import::new(name, vec![last], start_line(node)));
+        symbols.imports.push(Import::new(name, vec![last], start_line(node)));
     }
 }
 
 /// Handle `val name : type` declarations in .mli files.
 fn handle_ocaml_value_spec(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let name_node =
-        find_child(node, "value_name").or_else(|| find_child(node, "parenthesized_operator"));
+    let name_node = find_child(node, "value_name")
+        .or_else(|| find_child(node, "parenthesized_operator"));
     if let Some(name) = name_node {
         // Check if the type signature contains `->` (function type)
-        let has_arrow = node
-            .child_by_field_name("type")
+        let has_arrow = node.child_by_field_name("type")
             .map(|t| has_descendant_kind(&t, "function_type"))
             .unwrap_or(false);
         symbols.definitions.push(Definition {
@@ -269,8 +253,8 @@ fn handle_ocaml_value_spec(node: &Node, source: &[u8], symbols: &mut FileSymbols
 
 /// Handle `external name : type = "c_name"` declarations in .mli files.
 fn handle_ocaml_external(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let name_node =
-        find_child(node, "value_name").or_else(|| find_child(node, "parenthesized_operator"));
+    let name_node = find_child(node, "value_name")
+        .or_else(|| find_child(node, "parenthesized_operator"));
     if let Some(name) = name_node {
         symbols.definitions.push(Definition {
             name: node_text(&name, source).to_string(),
@@ -364,8 +348,7 @@ fn handle_ocaml_application(node: &Node, source: &[u8], symbols: &mut FileSymbol
             });
         }
         "field_get_expression" => {
-            let field = func_node
-                .child_by_field_name("field")
+            let field = func_node.child_by_field_name("field")
                 .or_else(|| find_child(&func_node, "value_name"))
                 .or_else(|| find_child(&func_node, "identifier"));
             let record = func_node.child(0);
@@ -375,11 +358,7 @@ fn handle_ocaml_application(node: &Node, source: &[u8], symbols: &mut FileSymbol
                     line: start_line(node),
                     dynamic: None,
                     receiver: record.and_then(|r| {
-                        if r.id() != f.id() {
-                            Some(node_text(&r, source).to_string())
-                        } else {
-                            None
-                        }
+                        if r.id() != f.id() { Some(node_text(&r, source).to_string()) } else { None }
                     }),
                     ..Default::default()
                 });

--- a/crates/codegraph-core/src/extractors/ocaml.rs
+++ b/crates/codegraph-core/src/extractors/ocaml.rs
@@ -1,9 +1,9 @@
-use tree_sitter::{Node, Tree};
+use super::helpers::*;
+use super::SymbolExtractor;
 use crate::ast_analysis::cfg::build_function_cfg;
 use crate::ast_analysis::complexity::compute_all_metrics;
 use crate::types::*;
-use super::helpers::*;
-use super::SymbolExtractor;
+use tree_sitter::{Node, Tree};
 
 pub struct OcamlExtractor;
 
@@ -11,7 +11,12 @@ impl SymbolExtractor for OcamlExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_ocaml_node);
-        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &OCAML_AST_CONFIG);
+        walk_ast_nodes_with_config(
+            &tree.root_node(),
+            source,
+            &mut symbols.ast_nodes,
+            &OCAML_AST_CONFIG,
+        );
         symbols
     }
 }
@@ -44,7 +49,10 @@ fn handle_ocaml_value_def(node: &Node, source: &[u8], symbols: &mut FileSymbols)
 }
 
 fn handle_ocaml_let_binding(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let pattern = match node.child_by_field_name("pattern").or_else(|| node.child(0)) {
+    let pattern = match node
+        .child_by_field_name("pattern")
+        .or_else(|| node.child(0))
+    {
         Some(p) => p,
         None => return,
     };
@@ -68,6 +76,7 @@ fn handle_ocaml_let_binding(node: &Node, source: &[u8], symbols: &mut FileSymbol
             cfg: build_function_cfg(node, "ocaml", source),
             children: None,
             bodyless: None,
+            content_hash: None,
         });
     } else {
         symbols.definitions.push(Definition {
@@ -80,6 +89,7 @@ fn handle_ocaml_let_binding(node: &Node, source: &[u8], symbols: &mut FileSymbol
             cfg: None,
             children: None,
             bodyless: None,
+            content_hash: None,
         });
     }
 }
@@ -88,11 +98,9 @@ fn extract_ocaml_pattern_name(pattern: &Node, source: &[u8]) -> Option<String> {
     match pattern.kind() {
         "value_name" | "identifier" => Some(node_text(pattern, source).to_string()),
         "parenthesized_operator" => Some(node_text(pattern, source).to_string()),
-        _ => {
-            find_child(pattern, "value_name")
-                .or_else(|| find_child(pattern, "identifier"))
-                .map(|n| node_text(&n, source).to_string())
-        }
+        _ => find_child(pattern, "value_name")
+            .or_else(|| find_child(pattern, "identifier"))
+            .map(|n| node_text(&n, source).to_string()),
     }
 }
 
@@ -113,7 +121,8 @@ fn handle_ocaml_module_def(node: &Node, source: &[u8], symbols: &mut FileSymbols
         None => return,
     };
 
-    let name_node = binding.child_by_field_name("name")
+    let name_node = binding
+        .child_by_field_name("name")
         .or_else(|| find_child(&binding, "module_name"))
         .or_else(|| find_child(&binding, "identifier"));
     if let Some(name) = name_node {
@@ -127,6 +136,7 @@ fn handle_ocaml_module_def(node: &Node, source: &[u8], symbols: &mut FileSymbols
             cfg: None,
             children: None,
             bodyless: None,
+            content_hash: None,
         });
     }
 }
@@ -138,7 +148,8 @@ fn handle_ocaml_type_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
                 continue;
             }
 
-            let name_node = child.child_by_field_name("name")
+            let name_node = child
+                .child_by_field_name("name")
                 .or_else(|| find_child(&child, "type_constructor"))
                 .or_else(|| find_child(&child, "identifier"));
             if let Some(name) = name_node {
@@ -155,13 +166,18 @@ fn handle_ocaml_type_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
                     cfg: None,
                     children: opt_children(children),
                     bodyless: None,
+                    content_hash: None,
                 });
             }
         }
     }
 }
 
-fn extract_ocaml_type_constructors(type_binding: &Node, source: &[u8], children: &mut Vec<Definition>) {
+fn extract_ocaml_type_constructors(
+    type_binding: &Node,
+    source: &[u8],
+    children: &mut Vec<Definition>,
+) {
     for i in 0..type_binding.child_count() {
         if let Some(child) = type_binding.child(i) {
             if child.kind() == "constructor_declaration" {
@@ -185,7 +201,8 @@ fn handle_ocaml_class_def(node: &Node, source: &[u8], symbols: &mut FileSymbols)
         None => return,
     };
 
-    let name_node = binding.child_by_field_name("name")
+    let name_node = binding
+        .child_by_field_name("name")
         .or_else(|| find_child(&binding, "identifier"));
     if let Some(name) = name_node {
         symbols.definitions.push(Definition {
@@ -198,6 +215,7 @@ fn handle_ocaml_class_def(node: &Node, source: &[u8], symbols: &mut FileSymbols)
             cfg: None,
             children: None,
             bodyless: None,
+            content_hash: None,
         });
     }
 }
@@ -218,17 +236,20 @@ fn handle_ocaml_open(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 
     if let Some(name) = module_name {
         let last = name.split('.').last().unwrap_or(&name).to_string();
-        symbols.imports.push(Import::new(name, vec![last], start_line(node)));
+        symbols
+            .imports
+            .push(Import::new(name, vec![last], start_line(node)));
     }
 }
 
 /// Handle `val name : type` declarations in .mli files.
 fn handle_ocaml_value_spec(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let name_node = find_child(node, "value_name")
-        .or_else(|| find_child(node, "parenthesized_operator"));
+    let name_node =
+        find_child(node, "value_name").or_else(|| find_child(node, "parenthesized_operator"));
     if let Some(name) = name_node {
         // Check if the type signature contains `->` (function type)
-        let has_arrow = node.child_by_field_name("type")
+        let has_arrow = node
+            .child_by_field_name("type")
             .map(|t| has_descendant_kind(&t, "function_type"))
             .unwrap_or(false);
         symbols.definitions.push(Definition {
@@ -241,14 +262,15 @@ fn handle_ocaml_value_spec(node: &Node, source: &[u8], symbols: &mut FileSymbols
             cfg: None,
             children: None,
             bodyless: None,
+            content_hash: None,
         });
     }
 }
 
 /// Handle `external name : type = "c_name"` declarations in .mli files.
 fn handle_ocaml_external(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let name_node = find_child(node, "value_name")
-        .or_else(|| find_child(node, "parenthesized_operator"));
+    let name_node =
+        find_child(node, "value_name").or_else(|| find_child(node, "parenthesized_operator"));
     if let Some(name) = name_node {
         symbols.definitions.push(Definition {
             name: node_text(&name, source).to_string(),
@@ -260,6 +282,7 @@ fn handle_ocaml_external(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
             cfg: None,
             children: None,
             bodyless: None,
+            content_hash: None,
         });
     }
 }
@@ -278,6 +301,7 @@ fn handle_ocaml_module_type_def(node: &Node, source: &[u8], symbols: &mut FileSy
             cfg: None,
             children: None,
             bodyless: None,
+            content_hash: None,
         });
     }
 }
@@ -303,6 +327,7 @@ fn handle_ocaml_exception_def(node: &Node, source: &[u8], symbols: &mut FileSymb
             cfg: None,
             children: None,
             bodyless: None,
+            content_hash: None,
         });
     }
 }
@@ -339,7 +364,8 @@ fn handle_ocaml_application(node: &Node, source: &[u8], symbols: &mut FileSymbol
             });
         }
         "field_get_expression" => {
-            let field = func_node.child_by_field_name("field")
+            let field = func_node
+                .child_by_field_name("field")
                 .or_else(|| find_child(&func_node, "value_name"))
                 .or_else(|| find_child(&func_node, "identifier"));
             let record = func_node.child(0);
@@ -349,7 +375,11 @@ fn handle_ocaml_application(node: &Node, source: &[u8], symbols: &mut FileSymbol
                     line: start_line(node),
                     dynamic: None,
                     receiver: record.and_then(|r| {
-                        if r.id() != f.id() { Some(node_text(&r, source).to_string()) } else { None }
+                        if r.id() != f.id() {
+                            Some(node_text(&r, source).to_string())
+                        } else {
+                            None
+                        }
                     }),
                     ..Default::default()
                 });

--- a/crates/codegraph-core/src/extractors/php.rs
+++ b/crates/codegraph-core/src/extractors/php.rs
@@ -12,7 +12,12 @@ impl SymbolExtractor for PhpExtractor {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_php_node);
         walk_tree(&tree.root_node(), source, &mut symbols, match_php_type_map);
-        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &PHP_AST_CONFIG);
+        walk_ast_nodes_with_config(
+            &tree.root_node(),
+            source,
+            &mut symbols.ast_nodes,
+            &PHP_AST_CONFIG,
+        );
         dedup_type_map(&mut symbols.type_map);
         symbols
     }
@@ -56,12 +61,15 @@ fn handle_function_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             cfg: build_function_cfg(node, "php", source),
             children: opt_children(children),
             bodyless: None,
+            content_hash: None,
         });
     }
 }
 
 fn handle_class_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else { return };
+    let Some(name_node) = node.child_by_field_name("name") else {
+        return;
+    };
     let class_name = node_text(&name_node, source).to_string();
     let children = extract_php_class_properties(node, source);
     symbols.definitions.push(Definition {
@@ -74,6 +82,7 @@ fn handle_class_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: opt_children(children),
         bodyless: None,
+        content_hash: None,
     });
 
     // Extends
@@ -115,7 +124,9 @@ fn handle_class_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 }
 
 fn handle_interface_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else { return };
+    let Some(name_node) = node.child_by_field_name("name") else {
+        return;
+    };
     let iface_name = node_text(&name_node, source).to_string();
     symbols.definitions.push(Definition {
         name: iface_name.clone(),
@@ -127,11 +138,14 @@ fn handle_interface_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
     if let Some(body) = node.child_by_field_name("body") {
         for i in 0..body.child_count() {
             let Some(child) = body.child(i) else { continue };
-            if child.kind() != "method_declaration" { continue; }
+            if child.kind() != "method_declaration" {
+                continue;
+            }
             if let Some(meth_name) = child.child_by_field_name("name") {
                 symbols.definitions.push(Definition {
                     name: format!("{}.{}", iface_name, node_text(&meth_name, source)),
@@ -143,6 +157,7 @@ fn handle_interface_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
                     cfg: build_function_cfg(&child, "php", source),
                     children: None,
                     bodyless: Some(child.child_by_field_name("body").is_none()),
+                    content_hash: None,
                 });
             }
         }
@@ -161,6 +176,7 @@ fn handle_trait_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             cfg: None,
             children: None,
             bodyless: None,
+            content_hash: None,
         });
     }
 }
@@ -179,6 +195,7 @@ fn handle_enum_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             cfg: None,
             children: opt_children(children),
             bodyless: None,
+            content_hash: None,
         });
     }
 }
@@ -202,6 +219,7 @@ fn handle_method_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             cfg: build_function_cfg(node, "php", source),
             children: opt_children(children),
             bodyless: Some(node.child_by_field_name("body").is_none()),
+            content_hash: None,
         });
     }
 }
@@ -210,8 +228,8 @@ fn handle_namespace_use(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     for i in 0..node.child_count() {
         let Some(child) = node.child(i) else { continue };
         if child.kind() == "namespace_use_clause" {
-            let name_node = find_child(&child, "qualified_name")
-                .or_else(|| find_child(&child, "name"));
+            let name_node =
+                find_child(&child, "qualified_name").or_else(|| find_child(&child, "name"));
             if let Some(name_node) = name_node {
                 let full_path = node_text(&name_node, source).to_string();
                 let last_name = full_path.split('\\').last().unwrap_or("").to_string();
@@ -236,7 +254,9 @@ fn handle_namespace_use(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 }
 
 fn handle_function_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let fn_node = node.child_by_field_name("function").or_else(|| node.child(0));
+    let fn_node = node
+        .child_by_field_name("function")
+        .or_else(|| node.child(0));
     let Some(fn_node) = fn_node else { return };
     match fn_node.kind() {
         "name" | "identifier" => {
@@ -265,8 +285,7 @@ fn handle_function_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 
 fn handle_member_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     if let Some(name) = node.child_by_field_name("name") {
-        let receiver = named_child_text(node, "object", source)
-            .map(|s| s.to_string());
+        let receiver = named_child_text(node, "object", source).map(|s| s.to_string());
         symbols.calls.push(Call {
             name: node_text(&name, source).to_string(),
             line: start_line(node),
@@ -279,8 +298,7 @@ fn handle_member_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 
 fn handle_scoped_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     if let Some(name) = node.child_by_field_name("name") {
-        let receiver = named_child_text(node, "scope", source)
-            .map(|s| s.to_string());
+        let receiver = named_child_text(node, "scope", source).map(|s| s.to_string());
         symbols.calls.push(Call {
             name: node_text(&name, source).to_string(),
             line: start_line(node),
@@ -292,8 +310,12 @@ fn handle_scoped_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 }
 
 fn handle_object_creation(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(class_node) = node.child(1) else { return };
-    if class_node.kind() != "name" && class_node.kind() != "qualified_name" { return; }
+    let Some(class_node) = node.child(1) else {
+        return;
+    };
+    if class_node.kind() != "name" && class_node.kind() != "qualified_name" {
+        return;
+    }
     let text = node_text(&class_node, source);
     let last = text.split('\\').last().unwrap_or("");
     symbols.calls.push(Call {
@@ -309,7 +331,8 @@ fn handle_object_creation(node: &Node, source: &[u8], symbols: &mut FileSymbols)
 
 fn extract_php_parameters(node: &Node, source: &[u8]) -> Vec<Definition> {
     let mut params = Vec::new();
-    let params_node = node.child_by_field_name("parameters")
+    let params_node = node
+        .child_by_field_name("parameters")
         .or_else(|| find_child(node, "formal_parameters"));
     if let Some(params_node) = params_node {
         for i in 0..params_node.child_count() {
@@ -334,7 +357,8 @@ fn extract_php_parameters(node: &Node, source: &[u8]) -> Vec<Definition> {
 
 fn extract_php_class_properties(node: &Node, source: &[u8]) -> Vec<Definition> {
     let mut props = Vec::new();
-    let body = node.child_by_field_name("body")
+    let body = node
+        .child_by_field_name("body")
         .or_else(|| find_child(node, "declaration_list"));
     let Some(body) = body else { return props };
     for i in 0..body.child_count() {
@@ -349,8 +373,12 @@ fn extract_php_class_properties(node: &Node, source: &[u8]) -> Vec<Definition> {
 fn collect_property_element_names(decl: &Node, source: &[u8], props: &mut Vec<Definition>) {
     for j in 0..decl.child_count() {
         let Some(elem) = decl.child(j) else { continue };
-        if elem.kind() != "property_element" { continue; }
-        let Some(name_node) = elem.child(0) else { continue };
+        if elem.kind() != "property_element" {
+            continue;
+        }
+        let Some(name_node) = elem.child(0) else {
+            continue;
+        };
         if name_node.kind() == "variable_name" {
             props.push(child_def(
                 node_text(&name_node, source).to_string(),
@@ -363,7 +391,8 @@ fn collect_property_element_names(decl: &Node, source: &[u8], props: &mut Vec<De
 
 fn extract_php_enum_cases(node: &Node, source: &[u8]) -> Vec<Definition> {
     let mut cases = Vec::new();
-    let body = node.child_by_field_name("body")
+    let body = node
+        .child_by_field_name("body")
         .or_else(|| find_child(node, "enum_declaration_list"));
     if let Some(body) = body {
         for i in 0..body.child_count() {
@@ -388,7 +417,8 @@ fn extract_php_type_name<'a>(type_node: &Node<'a>, source: &'a [u8]) -> Option<&
         "named_type" | "name" | "qualified_name" => Some(node_text(type_node, source)),
         "optional_type" => {
             // ?MyType → skip the ? and get inner type
-            type_node.child(1)
+            type_node
+                .child(1)
                 .or_else(|| type_node.child(0))
                 .and_then(|inner| extract_php_type_name(&inner, source))
         }
@@ -403,7 +433,8 @@ fn match_php_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, _de
         "simple_parameter" | "variadic_parameter" | "property_promotion_parameter" => {
             if let Some(type_node) = node.child_by_field_name("type") {
                 if let Some(type_name) = extract_php_type_name(&type_node, source) {
-                    let name_node = node.child_by_field_name("name")
+                    let name_node = node
+                        .child_by_field_name("name")
                         .or_else(|| find_child(node, "variable_name"));
                     if let Some(name_node) = name_node {
                         symbols.type_map.push(TypeMapEntry {

--- a/crates/codegraph-core/src/extractors/php.rs
+++ b/crates/codegraph-core/src/extractors/php.rs
@@ -12,12 +12,7 @@ impl SymbolExtractor for PhpExtractor {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_php_node);
         walk_tree(&tree.root_node(), source, &mut symbols, match_php_type_map);
-        walk_ast_nodes_with_config(
-            &tree.root_node(),
-            source,
-            &mut symbols.ast_nodes,
-            &PHP_AST_CONFIG,
-        );
+        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &PHP_AST_CONFIG);
         dedup_type_map(&mut symbols.type_map);
         symbols
     }
@@ -67,9 +62,7 @@ fn handle_function_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 }
 
 fn handle_class_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else {
-        return;
-    };
+    let Some(name_node) = node.child_by_field_name("name") else { return };
     let class_name = node_text(&name_node, source).to_string();
     let children = extract_php_class_properties(node, source);
     symbols.definitions.push(Definition {
@@ -124,9 +117,7 @@ fn handle_class_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 }
 
 fn handle_interface_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else {
-        return;
-    };
+    let Some(name_node) = node.child_by_field_name("name") else { return };
     let iface_name = node_text(&name_node, source).to_string();
     symbols.definitions.push(Definition {
         name: iface_name.clone(),
@@ -143,9 +134,7 @@ fn handle_interface_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
     if let Some(body) = node.child_by_field_name("body") {
         for i in 0..body.child_count() {
             let Some(child) = body.child(i) else { continue };
-            if child.kind() != "method_declaration" {
-                continue;
-            }
+            if child.kind() != "method_declaration" { continue; }
             if let Some(meth_name) = child.child_by_field_name("name") {
                 symbols.definitions.push(Definition {
                     name: format!("{}.{}", iface_name, node_text(&meth_name, source)),
@@ -228,8 +217,8 @@ fn handle_namespace_use(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     for i in 0..node.child_count() {
         let Some(child) = node.child(i) else { continue };
         if child.kind() == "namespace_use_clause" {
-            let name_node =
-                find_child(&child, "qualified_name").or_else(|| find_child(&child, "name"));
+            let name_node = find_child(&child, "qualified_name")
+                .or_else(|| find_child(&child, "name"));
             if let Some(name_node) = name_node {
                 let full_path = node_text(&name_node, source).to_string();
                 let last_name = full_path.split('\\').last().unwrap_or("").to_string();
@@ -254,9 +243,7 @@ fn handle_namespace_use(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 }
 
 fn handle_function_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let fn_node = node
-        .child_by_field_name("function")
-        .or_else(|| node.child(0));
+    let fn_node = node.child_by_field_name("function").or_else(|| node.child(0));
     let Some(fn_node) = fn_node else { return };
     match fn_node.kind() {
         "name" | "identifier" => {
@@ -285,7 +272,8 @@ fn handle_function_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 
 fn handle_member_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     if let Some(name) = node.child_by_field_name("name") {
-        let receiver = named_child_text(node, "object", source).map(|s| s.to_string());
+        let receiver = named_child_text(node, "object", source)
+            .map(|s| s.to_string());
         symbols.calls.push(Call {
             name: node_text(&name, source).to_string(),
             line: start_line(node),
@@ -298,7 +286,8 @@ fn handle_member_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 
 fn handle_scoped_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     if let Some(name) = node.child_by_field_name("name") {
-        let receiver = named_child_text(node, "scope", source).map(|s| s.to_string());
+        let receiver = named_child_text(node, "scope", source)
+            .map(|s| s.to_string());
         symbols.calls.push(Call {
             name: node_text(&name, source).to_string(),
             line: start_line(node),
@@ -310,12 +299,8 @@ fn handle_scoped_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 }
 
 fn handle_object_creation(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(class_node) = node.child(1) else {
-        return;
-    };
-    if class_node.kind() != "name" && class_node.kind() != "qualified_name" {
-        return;
-    }
+    let Some(class_node) = node.child(1) else { return };
+    if class_node.kind() != "name" && class_node.kind() != "qualified_name" { return; }
     let text = node_text(&class_node, source);
     let last = text.split('\\').last().unwrap_or("");
     symbols.calls.push(Call {
@@ -331,8 +316,7 @@ fn handle_object_creation(node: &Node, source: &[u8], symbols: &mut FileSymbols)
 
 fn extract_php_parameters(node: &Node, source: &[u8]) -> Vec<Definition> {
     let mut params = Vec::new();
-    let params_node = node
-        .child_by_field_name("parameters")
+    let params_node = node.child_by_field_name("parameters")
         .or_else(|| find_child(node, "formal_parameters"));
     if let Some(params_node) = params_node {
         for i in 0..params_node.child_count() {
@@ -357,8 +341,7 @@ fn extract_php_parameters(node: &Node, source: &[u8]) -> Vec<Definition> {
 
 fn extract_php_class_properties(node: &Node, source: &[u8]) -> Vec<Definition> {
     let mut props = Vec::new();
-    let body = node
-        .child_by_field_name("body")
+    let body = node.child_by_field_name("body")
         .or_else(|| find_child(node, "declaration_list"));
     let Some(body) = body else { return props };
     for i in 0..body.child_count() {
@@ -373,12 +356,8 @@ fn extract_php_class_properties(node: &Node, source: &[u8]) -> Vec<Definition> {
 fn collect_property_element_names(decl: &Node, source: &[u8], props: &mut Vec<Definition>) {
     for j in 0..decl.child_count() {
         let Some(elem) = decl.child(j) else { continue };
-        if elem.kind() != "property_element" {
-            continue;
-        }
-        let Some(name_node) = elem.child(0) else {
-            continue;
-        };
+        if elem.kind() != "property_element" { continue; }
+        let Some(name_node) = elem.child(0) else { continue };
         if name_node.kind() == "variable_name" {
             props.push(child_def(
                 node_text(&name_node, source).to_string(),
@@ -391,8 +370,7 @@ fn collect_property_element_names(decl: &Node, source: &[u8], props: &mut Vec<De
 
 fn extract_php_enum_cases(node: &Node, source: &[u8]) -> Vec<Definition> {
     let mut cases = Vec::new();
-    let body = node
-        .child_by_field_name("body")
+    let body = node.child_by_field_name("body")
         .or_else(|| find_child(node, "enum_declaration_list"));
     if let Some(body) = body {
         for i in 0..body.child_count() {
@@ -417,8 +395,7 @@ fn extract_php_type_name<'a>(type_node: &Node<'a>, source: &'a [u8]) -> Option<&
         "named_type" | "name" | "qualified_name" => Some(node_text(type_node, source)),
         "optional_type" => {
             // ?MyType → skip the ? and get inner type
-            type_node
-                .child(1)
+            type_node.child(1)
                 .or_else(|| type_node.child(0))
                 .and_then(|inner| extract_php_type_name(&inner, source))
         }
@@ -433,8 +410,7 @@ fn match_php_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, _de
         "simple_parameter" | "variadic_parameter" | "property_promotion_parameter" => {
             if let Some(type_node) = node.child_by_field_name("type") {
                 if let Some(type_name) = extract_php_type_name(&type_node, source) {
-                    let name_node = node
-                        .child_by_field_name("name")
+                    let name_node = node.child_by_field_name("name")
                         .or_else(|| find_child(node, "variable_name"));
                     if let Some(name_node) = name_node {
                         symbols.type_map.push(TypeMapEntry {

--- a/crates/codegraph-core/src/extractors/python.rs
+++ b/crates/codegraph-core/src/extractors/python.rs
@@ -1,9 +1,9 @@
-use tree_sitter::{Node, Tree};
+use super::helpers::*;
+use super::SymbolExtractor;
 use crate::ast_analysis::cfg::build_function_cfg;
 use crate::ast_analysis::complexity::compute_all_metrics;
 use crate::types::*;
-use super::helpers::*;
-use super::SymbolExtractor;
+use tree_sitter::{Node, Tree};
 
 pub struct PythonExtractor;
 
@@ -11,8 +11,18 @@ impl SymbolExtractor for PythonExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_python_node);
-        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &PYTHON_AST_CONFIG);
-        walk_tree(&tree.root_node(), source, &mut symbols, match_python_type_map);
+        walk_ast_nodes_with_config(
+            &tree.root_node(),
+            source,
+            &mut symbols.ast_nodes,
+            &PYTHON_AST_CONFIG,
+        );
+        walk_tree(
+            &tree.root_node(),
+            source,
+            &mut symbols,
+            match_python_type_map,
+        );
         dedup_type_map(&mut symbols.type_map);
         symbols
     }
@@ -33,7 +43,9 @@ fn match_python_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
 // ── Per-node-kind handlers for walk_node_depth ───────────────────────────────
 
 fn handle_function_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else { return };
+    let Some(name_node) = node.child_by_field_name("name") else {
+        return;
+    };
     let name_text = node_text(&name_node, source);
     let mut decorators = Vec::new();
     if let Some(prev) = node.prev_sibling() {
@@ -52,16 +64,23 @@ fn handle_function_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         kind,
         line: start_line(node),
         end_line: Some(end_line(node)),
-        decorators: if decorators.is_empty() { None } else { Some(decorators) },
+        decorators: if decorators.is_empty() {
+            None
+        } else {
+            Some(decorators)
+        },
         complexity: compute_all_metrics(node, source, "python"),
         cfg: build_function_cfg(node, "python", source),
         children: opt_children(children),
         bodyless: None,
+        content_hash: None,
     });
 }
 
 fn handle_class_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else { return };
+    let Some(name_node) = node.child_by_field_name("name") else {
+        return;
+    };
     let class_name = node_text(&name_node, source).to_string();
     let children = extract_python_class_properties(node, source);
     symbols.definitions.push(Definition {
@@ -74,6 +93,7 @@ fn handle_class_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: opt_children(children),
         bodyless: None,
+        content_hash: None,
     });
     let superclasses = node
         .child_by_field_name("superclasses")
@@ -95,13 +115,23 @@ fn handle_class_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 }
 
 fn handle_expr_stmt(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    if !is_module_level(node) { return; }
+    if !is_module_level(node) {
+        return;
+    }
     let Some(expr) = node.child(0) else { return };
-    if expr.kind() != "assignment" { return; }
-    let Some(left) = expr.child_by_field_name("left") else { return };
-    if left.kind() != "identifier" { return; }
+    if expr.kind() != "assignment" {
+        return;
+    }
+    let Some(left) = expr.child_by_field_name("left") else {
+        return;
+    };
+    if left.kind() != "identifier" {
+        return;
+    }
     let name = node_text(&left, source);
-    if !is_upper_snake_case(name) { return; }
+    if !is_upper_snake_case(name) {
+        return;
+    }
     symbols.definitions.push(Definition {
         name: name.to_string(),
         kind: "constant".to_string(),
@@ -112,18 +142,19 @@ fn handle_expr_stmt(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
 fn handle_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(fn_node) = node.child_by_field_name("function") else { return };
+    let Some(fn_node) = node.child_by_field_name("function") else {
+        return;
+    };
     let (call_name, receiver) = match fn_node.kind() {
         "identifier" => (Some(node_text(&fn_node, source).to_string()), None),
         "attribute" => {
-            let name = named_child_text(&fn_node, "attribute", source)
-                .map(|s| s.to_string());
-            let recv = named_child_text(&fn_node, "object", source)
-                .map(|s| s.to_string());
+            let name = named_child_text(&fn_node, "attribute", source).map(|s| s.to_string());
+            let recv = named_child_text(&fn_node, "object", source).map(|s| s.to_string());
             (name, recv)
         }
         _ => (None, None),
@@ -143,7 +174,9 @@ fn handle_import_stmt(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     let mut names = Vec::new();
     for i in 0..node.child_count() {
         let Some(child) = node.child(i) else { continue };
-        if child.kind() != "dotted_name" && child.kind() != "aliased_import" { continue; }
+        if child.kind() != "dotted_name" && child.kind() != "aliased_import" {
+            continue;
+        }
         let name = if child.kind() == "aliased_import" {
             child
                 .child_by_field_name("alias")
@@ -177,9 +210,7 @@ fn handle_import_from_stmt(node: &Node, source: &[u8], symbols: &mut FileSymbols
                 }
             }
             "aliased_import" => {
-                let n = child
-                    .child_by_field_name("name")
-                    .or_else(|| child.child(0));
+                let n = child.child_by_field_name("name").or_else(|| child.child(0));
                 if let Some(n) = n {
                     names.push(node_text(&n, source).to_string());
                 }
@@ -211,18 +242,19 @@ fn extract_python_parameters(node: &Node, source: &[u8], is_method: bool) -> Vec
                         Some(text.to_string())
                     }
                     "default_parameter" | "typed_default_parameter" => {
-                        named_child_text(&child, "name", source)
-                            .map(|s| s.to_string())
+                        named_child_text(&child, "name", source).map(|s| s.to_string())
                     }
                     "typed_parameter" => {
                         // typed_parameter: first child is the identifier
-                        child.child(0)
+                        child
+                            .child(0)
                             .filter(|c| c.kind() == "identifier")
                             .map(|c| node_text(&c, source).to_string())
                     }
                     "list_splat_pattern" | "dictionary_splat_pattern" => {
                         // *args, **kwargs
-                        child.child(0)
+                        child
+                            .child(0)
                             .filter(|c| c.kind() == "identifier")
                             .map(|c| node_text(&c, source).to_string())
                     }
@@ -268,8 +300,10 @@ fn collect_self_assignments(node: &Node, source: &[u8], props: &mut Vec<Definiti
             try_extract_self_assignment(&child, source, props);
         }
         // Recurse into blocks (if/for/etc inside __init__)
-        if child.kind() == "block" || child.kind() == "if_statement"
-            || child.kind() == "for_statement" || child.kind() == "while_statement"
+        if child.kind() == "block"
+            || child.kind() == "if_statement"
+            || child.kind() == "for_statement"
+            || child.kind() == "while_statement"
         {
             collect_self_assignments(&child, source, props);
         }
@@ -278,12 +312,24 @@ fn collect_self_assignments(node: &Node, source: &[u8], props: &mut Vec<Definiti
 
 fn try_extract_self_assignment(stmt: &Node, source: &[u8], props: &mut Vec<Definition>) {
     let Some(expr) = stmt.child(0) else { return };
-    if expr.kind() != "assignment" { return; }
-    let Some(left) = expr.child_by_field_name("left") else { return };
-    if left.kind() != "attribute" { return; }
-    let Some(obj) = left.child_by_field_name("object") else { return };
-    if node_text(&obj, source) != "self" { return; }
-    let Some(attr) = left.child_by_field_name("attribute") else { return };
+    if expr.kind() != "assignment" {
+        return;
+    }
+    let Some(left) = expr.child_by_field_name("left") else {
+        return;
+    };
+    if left.kind() != "attribute" {
+        return;
+    }
+    let Some(obj) = left.child_by_field_name("object") else {
+        return;
+    };
+    if node_text(&obj, source) != "self" {
+        return;
+    }
+    let Some(attr) = left.child_by_field_name("attribute") else {
+        return;
+    };
     let name = node_text(&attr, source);
     if !props.iter().any(|p| p.name == name) {
         props.push(child_def(name.to_string(), "property", start_line(stmt)));
@@ -299,8 +345,12 @@ fn is_module_level(node: &Node) -> bool {
 
 fn is_upper_snake_case(s: &str) -> bool {
     !s.is_empty()
-        && s.chars().all(|c| c.is_ascii_uppercase() || c == '_' || c.is_ascii_digit())
-        && s.chars().next().map(|c| c.is_ascii_uppercase()).unwrap_or(false)
+        && s.chars()
+            .all(|c| c.is_ascii_uppercase() || c == '_' || c.is_ascii_digit())
+        && s.chars()
+            .next()
+            .map(|c| c.is_ascii_uppercase())
+            .unwrap_or(false)
 }
 
 // ── Existing helpers ────────────────────────────────────────────────────────
@@ -378,9 +428,7 @@ fn match_python_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, 
                     let name = node_text(&name_node, source);
                     if name != "self" && name != "cls" {
                         if let Some(type_node) = node.child_by_field_name("type") {
-                            if let Some(type_name) =
-                                extract_python_type_name(&type_node, source)
-                            {
+                            if let Some(type_name) = extract_python_type_name(&type_node, source) {
                                 symbols.type_map.push(TypeMapEntry {
                                     name: name.to_string(),
                                     type_name: type_name.to_string(),
@@ -396,9 +444,7 @@ fn match_python_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, 
             if let Some(name_node) = node.child_by_field_name("name") {
                 if name_node.kind() == "identifier" {
                     if let Some(type_node) = node.child_by_field_name("type") {
-                        if let Some(type_name) =
-                            extract_python_type_name(&type_node, source)
-                        {
+                        if let Some(type_name) = extract_python_type_name(&type_node, source) {
                             symbols.type_map.push(TypeMapEntry {
                                 name: node_text(&name_node, source).to_string(),
                                 type_name: type_name.to_string(),
@@ -421,16 +467,29 @@ fn match_python_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, 
 
 /// Seed typeMap from plain Python assignments where the RHS is a constructor or factory call.
 fn infer_py_assignment_type(node: &Node, source: &[u8], type_map: &mut Vec<TypeMapEntry>) {
-    let Some(left) = node.child_by_field_name("left") else { return };
-    let Some(right) = node.child_by_field_name("right") else { return };
-    if left.kind() != "identifier" || right.kind() != "call" { return; }
+    let Some(left) = node.child_by_field_name("left") else {
+        return;
+    };
+    let Some(right) = node.child_by_field_name("right") else {
+        return;
+    };
+    if left.kind() != "identifier" || right.kind() != "call" {
+        return;
+    }
     let var_name = node_text(&left, source).to_string();
-    let Some(fn_node) = right.child_by_field_name("function") else { return };
+    let Some(fn_node) = right.child_by_field_name("function") else {
+        return;
+    };
     match fn_node.kind() {
         "identifier" => {
             // `order = Order(...)` — uppercase first char → constructor, conf 1.0.
             let name = node_text(&fn_node, source);
-            if name.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
+            if name
+                .chars()
+                .next()
+                .map(|c| c.is_uppercase())
+                .unwrap_or(false)
+            {
                 type_map.push(TypeMapEntry {
                     name: var_name,
                     type_name: name.to_string(),
@@ -443,7 +502,11 @@ fn infer_py_assignment_type(node: &Node, source: &[u8], type_map: &mut Vec<TypeM
             if let Some(obj_node) = fn_node.child_by_field_name("object") {
                 if obj_node.kind() == "identifier" {
                     let obj_name = node_text(&obj_node, source);
-                    if obj_name.chars().next().map(|c| c.is_uppercase()).unwrap_or(false)
+                    if obj_name
+                        .chars()
+                        .next()
+                        .map(|c| c.is_uppercase())
+                        .unwrap_or(false)
                         && !is_python_builtin(obj_name)
                     {
                         type_map.push(TypeMapEntry {
@@ -538,7 +601,8 @@ mod tests {
 
     #[test]
     fn extracts_class_properties_from_init() {
-        let s = parse_py("class User:\n  def __init__(self, x, y):\n    self.x = x\n    self.y = y\n");
+        let s =
+            parse_py("class User:\n  def __init__(self, x, y):\n    self.x = x\n    self.y = y\n");
         let user = s.definitions.iter().find(|d| d.name == "User").unwrap();
         let children = user.children.as_ref().unwrap();
         let names: Vec<&str> = children.iter().map(|c| c.name.as_str()).collect();
@@ -550,7 +614,11 @@ mod tests {
     #[test]
     fn extracts_module_level_constant() {
         let s = parse_py("MAX_RETRIES = 3");
-        let c = s.definitions.iter().find(|d| d.name == "MAX_RETRIES").unwrap();
+        let c = s
+            .definitions
+            .iter()
+            .find(|d| d.name == "MAX_RETRIES")
+            .unwrap();
         assert_eq!(c.kind, "constant");
     }
 
@@ -573,7 +641,10 @@ mod tests {
         // The object name must be uppercase to match the JS heuristic.
         let s = parse_py("def run():\n    svc = Models.UserService(db)\n    svc.create()\n");
         let entry = s.type_map.iter().find(|e| e.name == "svc");
-        assert!(entry.is_some(), "expected svc in type_map for Module.Class(...)");
+        assert!(
+            entry.is_some(),
+            "expected svc in type_map for Module.Class(...)"
+        );
         let entry = entry.unwrap();
         assert_eq!(entry.type_name, "Models");
         assert!((entry.confidence - 0.7).abs() < f64::EPSILON);

--- a/crates/codegraph-core/src/extractors/python.rs
+++ b/crates/codegraph-core/src/extractors/python.rs
@@ -1,9 +1,9 @@
-use super::helpers::*;
-use super::SymbolExtractor;
+use tree_sitter::{Node, Tree};
 use crate::ast_analysis::cfg::build_function_cfg;
 use crate::ast_analysis::complexity::compute_all_metrics;
 use crate::types::*;
-use tree_sitter::{Node, Tree};
+use super::helpers::*;
+use super::SymbolExtractor;
 
 pub struct PythonExtractor;
 
@@ -11,18 +11,8 @@ impl SymbolExtractor for PythonExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_python_node);
-        walk_ast_nodes_with_config(
-            &tree.root_node(),
-            source,
-            &mut symbols.ast_nodes,
-            &PYTHON_AST_CONFIG,
-        );
-        walk_tree(
-            &tree.root_node(),
-            source,
-            &mut symbols,
-            match_python_type_map,
-        );
+        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &PYTHON_AST_CONFIG);
+        walk_tree(&tree.root_node(), source, &mut symbols, match_python_type_map);
         dedup_type_map(&mut symbols.type_map);
         symbols
     }
@@ -43,9 +33,7 @@ fn match_python_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
 // ── Per-node-kind handlers for walk_node_depth ───────────────────────────────
 
 fn handle_function_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else {
-        return;
-    };
+    let Some(name_node) = node.child_by_field_name("name") else { return };
     let name_text = node_text(&name_node, source);
     let mut decorators = Vec::new();
     if let Some(prev) = node.prev_sibling() {
@@ -64,11 +52,7 @@ fn handle_function_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         kind,
         line: start_line(node),
         end_line: Some(end_line(node)),
-        decorators: if decorators.is_empty() {
-            None
-        } else {
-            Some(decorators)
-        },
+        decorators: if decorators.is_empty() { None } else { Some(decorators) },
         complexity: compute_all_metrics(node, source, "python"),
         cfg: build_function_cfg(node, "python", source),
         children: opt_children(children),
@@ -78,9 +62,7 @@ fn handle_function_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 }
 
 fn handle_class_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else {
-        return;
-    };
+    let Some(name_node) = node.child_by_field_name("name") else { return };
     let class_name = node_text(&name_node, source).to_string();
     let children = extract_python_class_properties(node, source);
     symbols.definitions.push(Definition {
@@ -115,23 +97,13 @@ fn handle_class_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 }
 
 fn handle_expr_stmt(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    if !is_module_level(node) {
-        return;
-    }
+    if !is_module_level(node) { return; }
     let Some(expr) = node.child(0) else { return };
-    if expr.kind() != "assignment" {
-        return;
-    }
-    let Some(left) = expr.child_by_field_name("left") else {
-        return;
-    };
-    if left.kind() != "identifier" {
-        return;
-    }
+    if expr.kind() != "assignment" { return; }
+    let Some(left) = expr.child_by_field_name("left") else { return };
+    if left.kind() != "identifier" { return; }
     let name = node_text(&left, source);
-    if !is_upper_snake_case(name) {
-        return;
-    }
+    if !is_upper_snake_case(name) { return; }
     symbols.definitions.push(Definition {
         name: name.to_string(),
         kind: "constant".to_string(),
@@ -147,14 +119,14 @@ fn handle_expr_stmt(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 }
 
 fn handle_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(fn_node) = node.child_by_field_name("function") else {
-        return;
-    };
+    let Some(fn_node) = node.child_by_field_name("function") else { return };
     let (call_name, receiver) = match fn_node.kind() {
         "identifier" => (Some(node_text(&fn_node, source).to_string()), None),
         "attribute" => {
-            let name = named_child_text(&fn_node, "attribute", source).map(|s| s.to_string());
-            let recv = named_child_text(&fn_node, "object", source).map(|s| s.to_string());
+            let name = named_child_text(&fn_node, "attribute", source)
+                .map(|s| s.to_string());
+            let recv = named_child_text(&fn_node, "object", source)
+                .map(|s| s.to_string());
             (name, recv)
         }
         _ => (None, None),
@@ -174,9 +146,7 @@ fn handle_import_stmt(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     let mut names = Vec::new();
     for i in 0..node.child_count() {
         let Some(child) = node.child(i) else { continue };
-        if child.kind() != "dotted_name" && child.kind() != "aliased_import" {
-            continue;
-        }
+        if child.kind() != "dotted_name" && child.kind() != "aliased_import" { continue; }
         let name = if child.kind() == "aliased_import" {
             child
                 .child_by_field_name("alias")
@@ -210,7 +180,9 @@ fn handle_import_from_stmt(node: &Node, source: &[u8], symbols: &mut FileSymbols
                 }
             }
             "aliased_import" => {
-                let n = child.child_by_field_name("name").or_else(|| child.child(0));
+                let n = child
+                    .child_by_field_name("name")
+                    .or_else(|| child.child(0));
                 if let Some(n) = n {
                     names.push(node_text(&n, source).to_string());
                 }
@@ -242,19 +214,18 @@ fn extract_python_parameters(node: &Node, source: &[u8], is_method: bool) -> Vec
                         Some(text.to_string())
                     }
                     "default_parameter" | "typed_default_parameter" => {
-                        named_child_text(&child, "name", source).map(|s| s.to_string())
+                        named_child_text(&child, "name", source)
+                            .map(|s| s.to_string())
                     }
                     "typed_parameter" => {
                         // typed_parameter: first child is the identifier
-                        child
-                            .child(0)
+                        child.child(0)
                             .filter(|c| c.kind() == "identifier")
                             .map(|c| node_text(&c, source).to_string())
                     }
                     "list_splat_pattern" | "dictionary_splat_pattern" => {
                         // *args, **kwargs
-                        child
-                            .child(0)
+                        child.child(0)
                             .filter(|c| c.kind() == "identifier")
                             .map(|c| node_text(&c, source).to_string())
                     }
@@ -300,10 +271,8 @@ fn collect_self_assignments(node: &Node, source: &[u8], props: &mut Vec<Definiti
             try_extract_self_assignment(&child, source, props);
         }
         // Recurse into blocks (if/for/etc inside __init__)
-        if child.kind() == "block"
-            || child.kind() == "if_statement"
-            || child.kind() == "for_statement"
-            || child.kind() == "while_statement"
+        if child.kind() == "block" || child.kind() == "if_statement"
+            || child.kind() == "for_statement" || child.kind() == "while_statement"
         {
             collect_self_assignments(&child, source, props);
         }
@@ -312,24 +281,12 @@ fn collect_self_assignments(node: &Node, source: &[u8], props: &mut Vec<Definiti
 
 fn try_extract_self_assignment(stmt: &Node, source: &[u8], props: &mut Vec<Definition>) {
     let Some(expr) = stmt.child(0) else { return };
-    if expr.kind() != "assignment" {
-        return;
-    }
-    let Some(left) = expr.child_by_field_name("left") else {
-        return;
-    };
-    if left.kind() != "attribute" {
-        return;
-    }
-    let Some(obj) = left.child_by_field_name("object") else {
-        return;
-    };
-    if node_text(&obj, source) != "self" {
-        return;
-    }
-    let Some(attr) = left.child_by_field_name("attribute") else {
-        return;
-    };
+    if expr.kind() != "assignment" { return; }
+    let Some(left) = expr.child_by_field_name("left") else { return };
+    if left.kind() != "attribute" { return; }
+    let Some(obj) = left.child_by_field_name("object") else { return };
+    if node_text(&obj, source) != "self" { return; }
+    let Some(attr) = left.child_by_field_name("attribute") else { return };
     let name = node_text(&attr, source);
     if !props.iter().any(|p| p.name == name) {
         props.push(child_def(name.to_string(), "property", start_line(stmt)));
@@ -345,12 +302,8 @@ fn is_module_level(node: &Node) -> bool {
 
 fn is_upper_snake_case(s: &str) -> bool {
     !s.is_empty()
-        && s.chars()
-            .all(|c| c.is_ascii_uppercase() || c == '_' || c.is_ascii_digit())
-        && s.chars()
-            .next()
-            .map(|c| c.is_ascii_uppercase())
-            .unwrap_or(false)
+        && s.chars().all(|c| c.is_ascii_uppercase() || c == '_' || c.is_ascii_digit())
+        && s.chars().next().map(|c| c.is_ascii_uppercase()).unwrap_or(false)
 }
 
 // ── Existing helpers ────────────────────────────────────────────────────────
@@ -428,7 +381,9 @@ fn match_python_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, 
                     let name = node_text(&name_node, source);
                     if name != "self" && name != "cls" {
                         if let Some(type_node) = node.child_by_field_name("type") {
-                            if let Some(type_name) = extract_python_type_name(&type_node, source) {
+                            if let Some(type_name) =
+                                extract_python_type_name(&type_node, source)
+                            {
                                 symbols.type_map.push(TypeMapEntry {
                                     name: name.to_string(),
                                     type_name: type_name.to_string(),
@@ -444,7 +399,9 @@ fn match_python_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, 
             if let Some(name_node) = node.child_by_field_name("name") {
                 if name_node.kind() == "identifier" {
                     if let Some(type_node) = node.child_by_field_name("type") {
-                        if let Some(type_name) = extract_python_type_name(&type_node, source) {
+                        if let Some(type_name) =
+                            extract_python_type_name(&type_node, source)
+                        {
                             symbols.type_map.push(TypeMapEntry {
                                 name: node_text(&name_node, source).to_string(),
                                 type_name: type_name.to_string(),
@@ -467,29 +424,16 @@ fn match_python_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, 
 
 /// Seed typeMap from plain Python assignments where the RHS is a constructor or factory call.
 fn infer_py_assignment_type(node: &Node, source: &[u8], type_map: &mut Vec<TypeMapEntry>) {
-    let Some(left) = node.child_by_field_name("left") else {
-        return;
-    };
-    let Some(right) = node.child_by_field_name("right") else {
-        return;
-    };
-    if left.kind() != "identifier" || right.kind() != "call" {
-        return;
-    }
+    let Some(left) = node.child_by_field_name("left") else { return };
+    let Some(right) = node.child_by_field_name("right") else { return };
+    if left.kind() != "identifier" || right.kind() != "call" { return; }
     let var_name = node_text(&left, source).to_string();
-    let Some(fn_node) = right.child_by_field_name("function") else {
-        return;
-    };
+    let Some(fn_node) = right.child_by_field_name("function") else { return };
     match fn_node.kind() {
         "identifier" => {
             // `order = Order(...)` — uppercase first char → constructor, conf 1.0.
             let name = node_text(&fn_node, source);
-            if name
-                .chars()
-                .next()
-                .map(|c| c.is_uppercase())
-                .unwrap_or(false)
-            {
+            if name.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
                 type_map.push(TypeMapEntry {
                     name: var_name,
                     type_name: name.to_string(),
@@ -502,11 +446,7 @@ fn infer_py_assignment_type(node: &Node, source: &[u8], type_map: &mut Vec<TypeM
             if let Some(obj_node) = fn_node.child_by_field_name("object") {
                 if obj_node.kind() == "identifier" {
                     let obj_name = node_text(&obj_node, source);
-                    if obj_name
-                        .chars()
-                        .next()
-                        .map(|c| c.is_uppercase())
-                        .unwrap_or(false)
+                    if obj_name.chars().next().map(|c| c.is_uppercase()).unwrap_or(false)
                         && !is_python_builtin(obj_name)
                     {
                         type_map.push(TypeMapEntry {
@@ -601,8 +541,7 @@ mod tests {
 
     #[test]
     fn extracts_class_properties_from_init() {
-        let s =
-            parse_py("class User:\n  def __init__(self, x, y):\n    self.x = x\n    self.y = y\n");
+        let s = parse_py("class User:\n  def __init__(self, x, y):\n    self.x = x\n    self.y = y\n");
         let user = s.definitions.iter().find(|d| d.name == "User").unwrap();
         let children = user.children.as_ref().unwrap();
         let names: Vec<&str> = children.iter().map(|c| c.name.as_str()).collect();
@@ -614,11 +553,7 @@ mod tests {
     #[test]
     fn extracts_module_level_constant() {
         let s = parse_py("MAX_RETRIES = 3");
-        let c = s
-            .definitions
-            .iter()
-            .find(|d| d.name == "MAX_RETRIES")
-            .unwrap();
+        let c = s.definitions.iter().find(|d| d.name == "MAX_RETRIES").unwrap();
         assert_eq!(c.kind, "constant");
     }
 
@@ -641,10 +576,7 @@ mod tests {
         // The object name must be uppercase to match the JS heuristic.
         let s = parse_py("def run():\n    svc = Models.UserService(db)\n    svc.create()\n");
         let entry = s.type_map.iter().find(|e| e.name == "svc");
-        assert!(
-            entry.is_some(),
-            "expected svc in type_map for Module.Class(...)"
-        );
+        assert!(entry.is_some(), "expected svc in type_map for Module.Class(...)");
         let entry = entry.unwrap();
         assert_eq!(entry.type_name, "Models");
         assert!((entry.confidence - 0.7).abs() < f64::EPSILON);

--- a/crates/codegraph-core/src/extractors/r_lang.rs
+++ b/crates/codegraph-core/src/extractors/r_lang.rs
@@ -1,9 +1,9 @@
-use tree_sitter::{Node, Tree};
+use super::helpers::*;
+use super::SymbolExtractor;
 use crate::ast_analysis::cfg::build_function_cfg;
 use crate::ast_analysis::complexity::compute_all_metrics;
 use crate::types::*;
-use super::helpers::*;
-use super::SymbolExtractor;
+use tree_sitter::{Node, Tree};
 
 /// R symbol extractor — ports `src/extractors/r.ts` from the JS engine.
 ///
@@ -19,7 +19,12 @@ impl SymbolExtractor for RExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_r_node);
-        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &R_AST_CONFIG);
+        walk_ast_nodes_with_config(
+            &tree.root_node(),
+            source,
+            &mut symbols.ast_nodes,
+            &R_AST_CONFIG,
+        );
         symbols
     }
 }
@@ -40,7 +45,10 @@ fn handle_binary_op(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         Some(n) => n,
         None => return,
     };
-    let op = match node.child_by_field_name("operator").or_else(|| node.child(1)) {
+    let op = match node
+        .child_by_field_name("operator")
+        .or_else(|| node.child(1))
+    {
         Some(n) => n,
         None => return,
     };
@@ -71,6 +79,7 @@ fn handle_binary_op(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             cfg: build_function_cfg(&rhs, "r", source),
             children: opt_children(params),
             bodyless: None,
+            content_hash: None,
         });
     } else if is_program_level(node) {
         // Only record top-level variable assignments (matches JS extractor).
@@ -84,12 +93,15 @@ fn handle_binary_op(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             cfg: None,
             children: None,
             bodyless: None,
+            content_hash: None,
         });
     }
 }
 
 fn is_program_level(node: &Node) -> bool {
-    node.parent().map(|p| p.kind() == "program").unwrap_or(false)
+    node.parent()
+        .map(|p| p.kind() == "program")
+        .unwrap_or(false)
 }
 
 fn extract_r_params(func_def: &Node, source: &[u8]) -> Vec<Definition> {
@@ -100,7 +112,9 @@ fn extract_r_params(func_def: &Node, source: &[u8]) -> Vec<Definition> {
     };
 
     for i in 0..params_node.child_count() {
-        let Some(child) = params_node.child(i) else { continue };
+        let Some(child) = params_node.child(i) else {
+            continue;
+        };
         match child.kind() {
             "parameter" => {
                 // parameter has `name` field, e.g. `x` or `y = 10`.
@@ -142,7 +156,10 @@ fn extract_r_params(func_def: &Node, source: &[u8]) -> Vec<Definition> {
 fn handle_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     // call: function field is the callee (identifier or namespace_operator),
     // arguments field is the arguments list.
-    let func_node = match node.child_by_field_name("function").or_else(|| node.child(0)) {
+    let func_node = match node
+        .child_by_field_name("function")
+        .or_else(|| node.child(0))
+    {
         Some(n) => n,
         None => return,
     };
@@ -204,7 +221,9 @@ fn handle_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 /// grammar exposes a `value` field on the `argument` node — we prefer that
 /// over a positional child scan so we extract `dplyr`, not `package`.
 fn first_argument_value(node: &Node, source: &[u8], accept_identifier: bool) -> Option<String> {
-    let args = node.child_by_field_name("arguments").or_else(|| find_child(node, "arguments"))?;
+    let args = node
+        .child_by_field_name("arguments")
+        .or_else(|| find_child(node, "arguments"))?;
     for i in 0..args.child_count() {
         let Some(arg) = args.child(i) else { continue };
         match arg.kind() {
@@ -302,6 +321,7 @@ fn handle_set_class(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             cfg: None,
             children: None,
             bodyless: None,
+            content_hash: None,
         });
     }
 }
@@ -318,6 +338,7 @@ fn handle_set_generic(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             cfg: None,
             children: None,
             bodyless: None,
+            content_hash: None,
         });
     }
 }
@@ -374,7 +395,11 @@ mod tests {
     #[test]
     fn finds_top_level_variable() {
         let s = parse_r("user_store <- list()\n");
-        let v = s.definitions.iter().find(|d| d.name == "user_store").unwrap();
+        let v = s
+            .definitions
+            .iter()
+            .find(|d| d.name == "user_store")
+            .unwrap();
         assert_eq!(v.kind, "variable");
     }
 
@@ -416,8 +441,10 @@ mod tests {
     #[test]
     fn source_call_is_import_not_call() {
         let s = parse_r("source(\"service.R\")\n");
-        assert!(s.calls.iter().all(|c| c.name != "source"),
-            "source() should be classified as import, not as a generic call");
+        assert!(
+            s.calls.iter().all(|c| c.name != "source"),
+            "source() should be classified as import, not as a generic call"
+        );
     }
 
     #[test]
@@ -467,23 +494,30 @@ setMethod("greet", "Animal", function(x) paste("Hi", x@species))
         // setMethod registers an implementation of the generic. The fix emits
         // a call edge to the generic so the dispatch relationship is visible
         // in the graph.
-        let s = parse_r(
-            "setMethod(\"greet\", \"Person\", function(x) paste(\"Hello\", x@name))\n",
-        );
+        let s = parse_r("setMethod(\"greet\", \"Person\", function(x) paste(\"Hello\", x@name))\n");
         let calls: Vec<&Call> = s.calls.iter().filter(|c| c.name == "greet").collect();
-        assert_eq!(calls.len(), 1, "expected setMethod to emit one call to `greet`");
+        assert_eq!(
+            calls.len(),
+            1,
+            "expected setMethod to emit one call to `greet`"
+        );
     }
 
     #[test]
     fn set_method_body_calls_are_still_captured() {
         // The recursive walk visits the anonymous function passed to
         // setMethod, so calls inside the method body must still appear.
-        let s = parse_r(
-            "setMethod(\"greet\", \"Person\", function(x) { helper(x); validate(x) })\n",
-        );
+        let s =
+            parse_r("setMethod(\"greet\", \"Person\", function(x) { helper(x); validate(x) })\n");
         let names: Vec<&str> = s.calls.iter().map(|c| c.name.as_str()).collect();
-        assert!(names.contains(&"helper"), "method body call `helper` not captured");
-        assert!(names.contains(&"validate"), "method body call `validate` not captured");
+        assert!(
+            names.contains(&"helper"),
+            "method body call `helper` not captured"
+        );
+        assert!(
+            names.contains(&"validate"),
+            "method body call `validate` not captured"
+        );
     }
 
     #[test]

--- a/crates/codegraph-core/src/extractors/r_lang.rs
+++ b/crates/codegraph-core/src/extractors/r_lang.rs
@@ -1,9 +1,9 @@
-use super::helpers::*;
-use super::SymbolExtractor;
+use tree_sitter::{Node, Tree};
 use crate::ast_analysis::cfg::build_function_cfg;
 use crate::ast_analysis::complexity::compute_all_metrics;
 use crate::types::*;
-use tree_sitter::{Node, Tree};
+use super::helpers::*;
+use super::SymbolExtractor;
 
 /// R symbol extractor — ports `src/extractors/r.ts` from the JS engine.
 ///
@@ -19,12 +19,7 @@ impl SymbolExtractor for RExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_r_node);
-        walk_ast_nodes_with_config(
-            &tree.root_node(),
-            source,
-            &mut symbols.ast_nodes,
-            &R_AST_CONFIG,
-        );
+        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &R_AST_CONFIG);
         symbols
     }
 }
@@ -45,10 +40,7 @@ fn handle_binary_op(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         Some(n) => n,
         None => return,
     };
-    let op = match node
-        .child_by_field_name("operator")
-        .or_else(|| node.child(1))
-    {
+    let op = match node.child_by_field_name("operator").or_else(|| node.child(1)) {
         Some(n) => n,
         None => return,
     };
@@ -99,9 +91,7 @@ fn handle_binary_op(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 }
 
 fn is_program_level(node: &Node) -> bool {
-    node.parent()
-        .map(|p| p.kind() == "program")
-        .unwrap_or(false)
+    node.parent().map(|p| p.kind() == "program").unwrap_or(false)
 }
 
 fn extract_r_params(func_def: &Node, source: &[u8]) -> Vec<Definition> {
@@ -112,9 +102,7 @@ fn extract_r_params(func_def: &Node, source: &[u8]) -> Vec<Definition> {
     };
 
     for i in 0..params_node.child_count() {
-        let Some(child) = params_node.child(i) else {
-            continue;
-        };
+        let Some(child) = params_node.child(i) else { continue };
         match child.kind() {
             "parameter" => {
                 // parameter has `name` field, e.g. `x` or `y = 10`.
@@ -156,10 +144,7 @@ fn extract_r_params(func_def: &Node, source: &[u8]) -> Vec<Definition> {
 fn handle_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     // call: function field is the callee (identifier or namespace_operator),
     // arguments field is the arguments list.
-    let func_node = match node
-        .child_by_field_name("function")
-        .or_else(|| node.child(0))
-    {
+    let func_node = match node.child_by_field_name("function").or_else(|| node.child(0)) {
         Some(n) => n,
         None => return,
     };
@@ -221,9 +206,7 @@ fn handle_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 /// grammar exposes a `value` field on the `argument` node — we prefer that
 /// over a positional child scan so we extract `dplyr`, not `package`.
 fn first_argument_value(node: &Node, source: &[u8], accept_identifier: bool) -> Option<String> {
-    let args = node
-        .child_by_field_name("arguments")
-        .or_else(|| find_child(node, "arguments"))?;
+    let args = node.child_by_field_name("arguments").or_else(|| find_child(node, "arguments"))?;
     for i in 0..args.child_count() {
         let Some(arg) = args.child(i) else { continue };
         match arg.kind() {
@@ -395,11 +378,7 @@ mod tests {
     #[test]
     fn finds_top_level_variable() {
         let s = parse_r("user_store <- list()\n");
-        let v = s
-            .definitions
-            .iter()
-            .find(|d| d.name == "user_store")
-            .unwrap();
+        let v = s.definitions.iter().find(|d| d.name == "user_store").unwrap();
         assert_eq!(v.kind, "variable");
     }
 
@@ -441,10 +420,8 @@ mod tests {
     #[test]
     fn source_call_is_import_not_call() {
         let s = parse_r("source(\"service.R\")\n");
-        assert!(
-            s.calls.iter().all(|c| c.name != "source"),
-            "source() should be classified as import, not as a generic call"
-        );
+        assert!(s.calls.iter().all(|c| c.name != "source"),
+            "source() should be classified as import, not as a generic call");
     }
 
     #[test]
@@ -494,30 +471,23 @@ setMethod("greet", "Animal", function(x) paste("Hi", x@species))
         // setMethod registers an implementation of the generic. The fix emits
         // a call edge to the generic so the dispatch relationship is visible
         // in the graph.
-        let s = parse_r("setMethod(\"greet\", \"Person\", function(x) paste(\"Hello\", x@name))\n");
-        let calls: Vec<&Call> = s.calls.iter().filter(|c| c.name == "greet").collect();
-        assert_eq!(
-            calls.len(),
-            1,
-            "expected setMethod to emit one call to `greet`"
+        let s = parse_r(
+            "setMethod(\"greet\", \"Person\", function(x) paste(\"Hello\", x@name))\n",
         );
+        let calls: Vec<&Call> = s.calls.iter().filter(|c| c.name == "greet").collect();
+        assert_eq!(calls.len(), 1, "expected setMethod to emit one call to `greet`");
     }
 
     #[test]
     fn set_method_body_calls_are_still_captured() {
         // The recursive walk visits the anonymous function passed to
         // setMethod, so calls inside the method body must still appear.
-        let s =
-            parse_r("setMethod(\"greet\", \"Person\", function(x) { helper(x); validate(x) })\n");
+        let s = parse_r(
+            "setMethod(\"greet\", \"Person\", function(x) { helper(x); validate(x) })\n",
+        );
         let names: Vec<&str> = s.calls.iter().map(|c| c.name.as_str()).collect();
-        assert!(
-            names.contains(&"helper"),
-            "method body call `helper` not captured"
-        );
-        assert!(
-            names.contains(&"validate"),
-            "method body call `validate` not captured"
-        );
+        assert!(names.contains(&"helper"), "method body call `helper` not captured");
+        assert!(names.contains(&"validate"), "method body call `validate` not captured");
     }
 
     #[test]

--- a/crates/codegraph-core/src/extractors/ruby.rs
+++ b/crates/codegraph-core/src/extractors/ruby.rs
@@ -11,12 +11,7 @@ impl SymbolExtractor for RubyExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_ruby_node);
-        walk_ast_nodes_with_config(
-            &tree.root_node(),
-            source,
-            &mut symbols.ast_nodes,
-            &RUBY_AST_CONFIG,
-        );
+        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &RUBY_AST_CONFIG);
         symbols
     }
 }
@@ -47,9 +42,7 @@ fn handle_assignment(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     if node.parent().map(|p| p.kind()) != Some("program") {
         return;
     }
-    let Some(left) = node.child_by_field_name("left") else {
-        return;
-    };
+    let Some(left) = node.child_by_field_name("left") else { return };
     if left.kind() != "constant" {
         return;
     }
@@ -70,9 +63,7 @@ fn handle_assignment(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 // ── Per-node-kind handlers for walk_node_depth ───────────────────────────────
 
 fn handle_class(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else {
-        return;
-    };
+    let Some(name_node) = node.child_by_field_name("name") else { return };
     let class_name = node_text(&name_node, source).to_string();
     let children = extract_ruby_class_children(node, source);
     symbols.definitions.push(Definition {
@@ -110,9 +101,7 @@ fn handle_module(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 }
 
 fn handle_method(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else {
-        return;
-    };
+    let Some(name_node) = node.child_by_field_name("name") else { return };
     let parent_class = find_ruby_parent_class(node, source);
     let name = node_text(&name_node, source);
     let full_name = match &parent_class {
@@ -135,9 +124,7 @@ fn handle_method(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 }
 
 fn handle_singleton_method(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else {
-        return;
-    };
+    let Some(name_node) = node.child_by_field_name("name") else { return };
     let parent_class = find_ruby_parent_class(node, source);
     let name = node_text(&name_node, source);
     let full_name = match &parent_class {
@@ -160,9 +147,7 @@ fn handle_singleton_method(node: &Node, source: &[u8], symbols: &mut FileSymbols
 }
 
 fn handle_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(method_node) = node.child_by_field_name("method") else {
-        return;
-    };
+    let Some(method_node) = node.child_by_field_name("method") else { return };
     let method_text = node_text(&method_node, source);
 
     if method_text == "require" || method_text == "require_relative" {
@@ -170,7 +155,8 @@ fn handle_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     } else if method_text == "include" || method_text == "extend" || method_text == "prepend" {
         handle_mixin_call(node, source, symbols);
     } else {
-        let receiver = named_child_text(node, "receiver", source).map(|s| s.to_string());
+        let receiver = named_child_text(node, "receiver", source)
+            .map(|s| s.to_string());
         symbols.calls.push(Call {
             name: method_text.to_string(),
             line: start_line(node),
@@ -182,9 +168,7 @@ fn handle_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 }
 
 fn handle_require_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(args) = node.child_by_field_name("arguments") else {
-        return;
-    };
+    let Some(args) = node.child_by_field_name("arguments") else { return };
     for i in 0..args.child_count() {
         let Some(arg) = args.child(i) else { continue };
         if let Some(content) = extract_ruby_string_content(&arg, source) {
@@ -198,12 +182,8 @@ fn handle_require_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 }
 
 fn handle_mixin_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(parent_class) = find_ruby_parent_class(node, source) else {
-        return;
-    };
-    let Some(args) = node.child_by_field_name("arguments") else {
-        return;
-    };
+    let Some(parent_class) = find_ruby_parent_class(node, source) else { return };
+    let Some(args) = node.child_by_field_name("arguments") else { return };
     for i in 0..args.child_count() {
         let Some(arg) = args.child(i) else { continue };
         if arg.kind() == "constant" || arg.kind() == "scope_resolution" {
@@ -221,8 +201,7 @@ fn handle_mixin_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 
 fn extract_ruby_parameters(node: &Node, source: &[u8]) -> Vec<Definition> {
     let mut params = Vec::new();
-    let params_node = node
-        .child_by_field_name("parameters")
+    let params_node = node.child_by_field_name("parameters")
         .or_else(|| find_child(node, "method_parameters"));
     if let Some(params_node) = params_node {
         for i in 0..params_node.child_count() {
@@ -290,9 +269,7 @@ fn collect_ruby_class_children(node: &Node, source: &[u8], children: &mut Vec<De
 }
 
 fn try_collect_ruby_assignment(assign: &Node, source: &[u8], children: &mut Vec<Definition>) {
-    let Some(left) = assign.child_by_field_name("left") else {
-        return;
-    };
+    let Some(left) = assign.child_by_field_name("left") else { return };
     match left.kind() {
         "instance_variable" => {
             let name = node_text(&left, source);

--- a/crates/codegraph-core/src/extractors/ruby.rs
+++ b/crates/codegraph-core/src/extractors/ruby.rs
@@ -11,7 +11,12 @@ impl SymbolExtractor for RubyExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_ruby_node);
-        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &RUBY_AST_CONFIG);
+        walk_ast_nodes_with_config(
+            &tree.root_node(),
+            source,
+            &mut symbols.ast_nodes,
+            &RUBY_AST_CONFIG,
+        );
         symbols
     }
 }
@@ -42,7 +47,9 @@ fn handle_assignment(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     if node.parent().map(|p| p.kind()) != Some("program") {
         return;
     }
-    let Some(left) = node.child_by_field_name("left") else { return };
+    let Some(left) = node.child_by_field_name("left") else {
+        return;
+    };
     if left.kind() != "constant" {
         return;
     }
@@ -56,13 +63,16 @@ fn handle_assignment(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
 // ── Per-node-kind handlers for walk_node_depth ───────────────────────────────
 
 fn handle_class(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else { return };
+    let Some(name_node) = node.child_by_field_name("name") else {
+        return;
+    };
     let class_name = node_text(&name_node, source).to_string();
     let children = extract_ruby_class_children(node, source);
     symbols.definitions.push(Definition {
@@ -75,6 +85,7 @@ fn handle_class(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: opt_children(children),
         bodyless: None,
+        content_hash: None,
     });
     if let Some(superclass) = node.child_by_field_name("superclass") {
         extract_ruby_superclass(&superclass, &class_name, node, source, symbols);
@@ -93,12 +104,15 @@ fn handle_module(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             cfg: None,
             children: None,
             bodyless: None,
+            content_hash: None,
         });
     }
 }
 
 fn handle_method(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else { return };
+    let Some(name_node) = node.child_by_field_name("name") else {
+        return;
+    };
     let parent_class = find_ruby_parent_class(node, source);
     let name = node_text(&name_node, source);
     let full_name = match &parent_class {
@@ -116,11 +130,14 @@ fn handle_method(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: build_function_cfg(node, "ruby", source),
         children: opt_children(children),
         bodyless: None,
+        content_hash: None,
     });
 }
 
 fn handle_singleton_method(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else { return };
+    let Some(name_node) = node.child_by_field_name("name") else {
+        return;
+    };
     let parent_class = find_ruby_parent_class(node, source);
     let name = node_text(&name_node, source);
     let full_name = match &parent_class {
@@ -138,11 +155,14 @@ fn handle_singleton_method(node: &Node, source: &[u8], symbols: &mut FileSymbols
         cfg: build_function_cfg(node, "ruby", source),
         children: opt_children(children),
         bodyless: None,
+        content_hash: None,
     });
 }
 
 fn handle_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(method_node) = node.child_by_field_name("method") else { return };
+    let Some(method_node) = node.child_by_field_name("method") else {
+        return;
+    };
     let method_text = node_text(&method_node, source);
 
     if method_text == "require" || method_text == "require_relative" {
@@ -150,8 +170,7 @@ fn handle_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     } else if method_text == "include" || method_text == "extend" || method_text == "prepend" {
         handle_mixin_call(node, source, symbols);
     } else {
-        let receiver = named_child_text(node, "receiver", source)
-            .map(|s| s.to_string());
+        let receiver = named_child_text(node, "receiver", source).map(|s| s.to_string());
         symbols.calls.push(Call {
             name: method_text.to_string(),
             line: start_line(node),
@@ -163,7 +182,9 @@ fn handle_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 }
 
 fn handle_require_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(args) = node.child_by_field_name("arguments") else { return };
+    let Some(args) = node.child_by_field_name("arguments") else {
+        return;
+    };
     for i in 0..args.child_count() {
         let Some(arg) = args.child(i) else { continue };
         if let Some(content) = extract_ruby_string_content(&arg, source) {
@@ -177,8 +198,12 @@ fn handle_require_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 }
 
 fn handle_mixin_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(parent_class) = find_ruby_parent_class(node, source) else { return };
-    let Some(args) = node.child_by_field_name("arguments") else { return };
+    let Some(parent_class) = find_ruby_parent_class(node, source) else {
+        return;
+    };
+    let Some(args) = node.child_by_field_name("arguments") else {
+        return;
+    };
     for i in 0..args.child_count() {
         let Some(arg) = args.child(i) else { continue };
         if arg.kind() == "constant" || arg.kind() == "scope_resolution" {
@@ -196,7 +221,8 @@ fn handle_mixin_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 
 fn extract_ruby_parameters(node: &Node, source: &[u8]) -> Vec<Definition> {
     let mut params = Vec::new();
-    let params_node = node.child_by_field_name("parameters")
+    let params_node = node
+        .child_by_field_name("parameters")
         .or_else(|| find_child(node, "method_parameters"));
     if let Some(params_node) = params_node {
         for i in 0..params_node.child_count() {
@@ -264,7 +290,9 @@ fn collect_ruby_class_children(node: &Node, source: &[u8], children: &mut Vec<De
 }
 
 fn try_collect_ruby_assignment(assign: &Node, source: &[u8], children: &mut Vec<Definition>) {
-    let Some(left) = assign.child_by_field_name("left") else { return };
+    let Some(left) = assign.child_by_field_name("left") else {
+        return;
+    };
     match left.kind() {
         "instance_variable" => {
             let name = node_text(&left, source);

--- a/crates/codegraph-core/src/extractors/rust_lang.rs
+++ b/crates/codegraph-core/src/extractors/rust_lang.rs
@@ -11,12 +11,27 @@ impl SymbolExtractor for RustExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_rust_node);
-        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &RUST_AST_CONFIG);
+        walk_ast_nodes_with_config(
+            &tree.root_node(),
+            source,
+            &mut symbols.ast_nodes,
+            &RUST_AST_CONFIG,
+        );
         walk_tree(&tree.root_node(), source, &mut symbols, match_rust_type_map);
-        walk_tree(&tree.root_node(), source, &mut symbols, match_rust_return_type_map);
+        walk_tree(
+            &tree.root_node(),
+            source,
+            &mut symbols,
+            match_rust_return_type_map,
+        );
         // Must run after type_map is populated — resolves `receiver.method()` call
         // assignments against locally-typed receivers (mirrors javascript.rs's ordering).
-        walk_tree(&tree.root_node(), source, &mut symbols, match_rust_call_assignments);
+        walk_tree(
+            &tree.root_node(),
+            source,
+            &mut symbols,
+            match_rust_call_assignments,
+        );
         dedup_type_map(&mut symbols.type_map);
         dedup_type_map(&mut symbols.return_type_map);
         symbols
@@ -27,8 +42,7 @@ fn find_current_impl<'a>(node: &Node<'a>, source: &[u8]) -> Option<String> {
     let mut current = node.parent();
     while let Some(parent) = current {
         if parent.kind() == "impl_item" {
-            return named_child_text(&parent, "type", source)
-                .map(|s| s.to_string());
+            return named_child_text(&parent, "type", source).map(|s| s.to_string());
         }
         current = parent.parent();
     }
@@ -54,13 +68,16 @@ fn match_rust_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth
 
 fn handle_function_item(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     // Skip default-impl functions inside traits — already emitted by trait_item handler
-    if node.parent()
+    if node
+        .parent()
         .and_then(|p| p.parent())
         .map_or(false, |gp| gp.kind() == "trait_item")
     {
         return;
     }
-    let Some(name_node) = node.child_by_field_name("name") else { return };
+    let Some(name_node) = node.child_by_field_name("name") else {
+        return;
+    };
     let name = node_text(&name_node, source);
     let impl_type = find_current_impl(node, source);
     let (full_name, kind) = match &impl_type {
@@ -78,6 +95,7 @@ fn handle_function_item(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: build_function_cfg(node, "rust", source),
         children: opt_children(children),
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -95,6 +113,7 @@ fn handle_struct_item(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             cfg: None,
             children: opt_children(children),
             bodyless: None,
+            content_hash: None,
         });
         seed_rust_struct_field_types(node, &struct_name, source, symbols);
     }
@@ -104,14 +123,29 @@ fn handle_struct_item(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 /// so `self.field.method()` inside the struct's own impl methods resolves via
 /// the class-scoped receiver lookup — mirrors JS's `this.field` class-scoped
 /// typing (issues #1323, #1458) and fixes #1876's `self.field` false negatives.
-fn seed_rust_struct_field_types(node: &Node, struct_name: &str, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(body) = node.child_by_field_name("body") else { return };
+fn seed_rust_struct_field_types(
+    node: &Node,
+    struct_name: &str,
+    source: &[u8],
+    symbols: &mut FileSymbols,
+) {
+    let Some(body) = node.child_by_field_name("body") else {
+        return;
+    };
     for i in 0..body.child_count() {
         let Some(field) = body.child(i) else { continue };
-        if field.kind() != "field_declaration" { continue }
-        let Some(field_name) = field.child_by_field_name("name") else { continue };
-        let Some(type_node) = field.child_by_field_name("type") else { continue };
-        let Some(type_name) = extract_rust_type_name(&type_node, source) else { continue };
+        if field.kind() != "field_declaration" {
+            continue;
+        }
+        let Some(field_name) = field.child_by_field_name("name") else {
+            continue;
+        };
+        let Some(type_node) = field.child_by_field_name("type") else {
+            continue;
+        };
+        let Some(type_name) = extract_rust_type_name(&type_node, source) else {
+            continue;
+        };
         push_type_map_entry(
             symbols,
             format!("{}.{}", struct_name, node_text(&field_name, source)),
@@ -133,6 +167,7 @@ fn handle_enum_item(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             cfg: None,
             children: opt_children(children),
             bodyless: None,
+            content_hash: None,
         });
     }
 }
@@ -149,12 +184,15 @@ fn handle_const_item(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             cfg: None,
             children: None,
             bodyless: None,
+            content_hash: None,
         });
     }
 }
 
 fn handle_trait_item(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else { return };
+    let Some(name_node) = node.child_by_field_name("name") else {
+        return;
+    };
     let trait_name = node_text(&name_node, source).to_string();
     symbols.definitions.push(Definition {
         name: trait_name.clone(),
@@ -166,6 +204,7 @@ fn handle_trait_item(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
     if let Some(body) = node.child_by_field_name("body") {
         for i in 0..body.child_count() {
@@ -184,6 +223,7 @@ fn handle_trait_item(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                     cfg: build_function_cfg(&child, "rust", source),
                     children: None,
                     bodyless: Some(child.kind() == "function_signature_item"),
+                    content_hash: None,
                 });
             }
         }
@@ -215,7 +255,9 @@ fn handle_use_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 }
 
 fn handle_call_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(fn_node) = node.child_by_field_name("function") else { return };
+    let Some(fn_node) = node.child_by_field_name("function") else {
+        return;
+    };
     match fn_node.kind() {
         "identifier" => {
             symbols.calls.push(Call {
@@ -228,8 +270,7 @@ fn handle_call_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         }
         "field_expression" => {
             if let Some(field) = fn_node.child_by_field_name("field") {
-                let receiver = named_child_text(&fn_node, "value", source)
-                    .map(|s| s.to_string());
+                let receiver = named_child_text(&fn_node, "value", source).map(|s| s.to_string());
                 symbols.calls.push(Call {
                     name: node_text(&field, source).to_string(),
                     line: start_line(node),
@@ -241,8 +282,7 @@ fn handle_call_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         }
         "scoped_identifier" => {
             if let Some(name) = fn_node.child_by_field_name("name") {
-                let receiver = named_child_text(&fn_node, "path", source)
-                    .map(|s| s.to_string());
+                let receiver = named_child_text(&fn_node, "path", source).map(|s| s.to_string());
                 symbols.calls.push(Call {
                     name: node_text(&name, source).to_string(),
                     line: start_line(node),
@@ -280,7 +320,11 @@ fn extract_rust_parameters(node: &Node, source: &[u8]) -> Vec<Definition> {
                     if let Some(pattern) = child.child_by_field_name("pattern") {
                         let name = node_text(&pattern, source);
                         // Skip self parameters
-                        if name == "self" || name == "&self" || name == "&mut self" || name == "mut self" {
+                        if name == "self"
+                            || name == "&self"
+                            || name == "&mut self"
+                            || name == "mut self"
+                        {
                             continue;
                         }
                         params.push(child_def(name.to_string(), "parameter", start_line(&child)));
@@ -297,7 +341,8 @@ fn extract_rust_parameters(node: &Node, source: &[u8]) -> Vec<Definition> {
 
 fn extract_rust_struct_fields(node: &Node, source: &[u8]) -> Vec<Definition> {
     let mut fields = Vec::new();
-    let body = node.child_by_field_name("body")
+    let body = node
+        .child_by_field_name("body")
         .or_else(|| find_child(node, "field_declaration_list"));
     if let Some(body) = body {
         for i in 0..body.child_count() {
@@ -319,7 +364,8 @@ fn extract_rust_struct_fields(node: &Node, source: &[u8]) -> Vec<Definition> {
 
 fn extract_rust_enum_variants(node: &Node, source: &[u8]) -> Vec<Definition> {
     let mut variants = Vec::new();
-    let body = node.child_by_field_name("body")
+    let body = node
+        .child_by_field_name("body")
         .or_else(|| find_child(node, "enum_variant_list"));
     if let Some(body) = body {
         for i in 0..body.child_count() {
@@ -357,7 +403,10 @@ fn extract_rust_use_path(node: &Node, source: &[u8]) -> Vec<(String, Vec<String>
                 .child_by_field_name("alias")
                 .or_else(|| node.child_by_field_name("name"))
                 .map(|n| node_text(&n, source).to_string());
-            vec![(node_text(node, source).to_string(), name.into_iter().collect())]
+            vec![(
+                node_text(node, source).to_string(),
+                name.into_iter().collect(),
+            )]
         }
         "use_wildcard" => {
             let src = named_child_text(&node, "path", source)
@@ -383,7 +432,9 @@ fn extract_scoped_use_list(node: &Node, source: &[u8]) -> Vec<(String, Vec<Strin
     };
     let mut names = Vec::new();
     for i in 0..list_node.child_count() {
-        let Some(child) = list_node.child(i) else { continue };
+        let Some(child) = list_node.child(i) else {
+            continue;
+        };
         match child.kind() {
             "identifier" | "self" => {
                 names.push(node_text(&child, source).to_string());
@@ -405,16 +456,22 @@ fn extract_scoped_use_list(node: &Node, source: &[u8]) -> Vec<(String, Vec<Strin
 
 /// True if `name` matches a struct defined in this file (match_rust_node runs before this).
 fn is_known_unit_struct(name: &str, symbols: &FileSymbols) -> bool {
-    symbols.definitions.iter().any(|d| d.kind == "struct" && d.name == name)
+    symbols
+        .definitions
+        .iter()
+        .any(|d| d.kind == "struct" && d.name == name)
 }
 
 fn extract_rust_type_name<'a>(type_node: &Node<'a>, source: &'a [u8]) -> Option<&'a str> {
     match type_node.kind() {
-        "type_identifier" | "identifier" | "scoped_type_identifier" => Some(node_text(type_node, source)),
+        "type_identifier" | "identifier" | "scoped_type_identifier" => {
+            Some(node_text(type_node, source))
+        }
         "reference_type" => {
             for i in 0..type_node.child_count() {
                 if let Some(child) = type_node.child(i) {
-                    if child.kind() == "type_identifier" || child.kind() == "scoped_type_identifier" {
+                    if child.kind() == "type_identifier" || child.kind() == "scoped_type_identifier"
+                    {
                         return Some(node_text(&child, source));
                     }
                 }
@@ -469,7 +526,11 @@ fn match_rust_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, _d
             if let Some(pattern) = node.child_by_field_name("pattern") {
                 if pattern.kind() == "identifier" {
                     let name = node_text(&pattern, source);
-                    if name != "self" && name != "&self" && name != "&mut self" && name != "mut self" {
+                    if name != "self"
+                        && name != "&self"
+                        && name != "&mut self"
+                        && name != "mut self"
+                    {
                         if let Some(type_node) = node.child_by_field_name("type") {
                             if let Some(type_name) = extract_rust_type_name(&type_node, source) {
                                 symbols.type_map.push(TypeMapEntry {
@@ -497,16 +558,33 @@ fn match_rust_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, _d
 /// feeds — so a local var typed from a cross-file call's return value
 /// (`let service = build_service();`) resolves without any Rust-specific
 /// propagation logic.
-fn match_rust_return_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: usize) {
-    if node.kind() != "function_item" { return }
-    // Skip default-impl functions inside traits, matching handle_function_item —
-    // their return type is not tied to a concrete implementing type.
-    if node.parent().and_then(|p| p.parent()).map_or(false, |gp| gp.kind() == "trait_item") {
+fn match_rust_return_type_map(
+    node: &Node,
+    source: &[u8],
+    symbols: &mut FileSymbols,
+    _depth: usize,
+) {
+    if node.kind() != "function_item" {
         return;
     }
-    let Some(name_node) = node.child_by_field_name("name") else { return };
-    let Some(return_type_node) = node.child_by_field_name("return_type") else { return };
-    let Some(raw_type) = extract_rust_type_name(&return_type_node, source) else { return };
+    // Skip default-impl functions inside traits, matching handle_function_item —
+    // their return type is not tied to a concrete implementing type.
+    if node
+        .parent()
+        .and_then(|p| p.parent())
+        .map_or(false, |gp| gp.kind() == "trait_item")
+    {
+        return;
+    }
+    let Some(name_node) = node.child_by_field_name("name") else {
+        return;
+    };
+    let Some(return_type_node) = node.child_by_field_name("return_type") else {
+        return;
+    };
+    let Some(raw_type) = extract_rust_type_name(&return_type_node, source) else {
+        return;
+    };
     let impl_type = find_current_impl(node, source);
     // `-> Self` inside an impl block returns the concrete implementing type.
     let type_name = if raw_type == "Self" {
@@ -518,7 +596,9 @@ fn match_rust_return_type_map(node: &Node, source: &[u8], symbols: &mut FileSymb
         Some(t) => format!("{}.{}", t, node_text(&name_node, source)),
         None => node_text(&name_node, source).to_string(),
     };
-    let existing_confidence = symbols.return_type_map.iter()
+    let existing_confidence = symbols
+        .return_type_map
+        .iter()
         .find(|e| e.name == full_name)
         .map(|e| e.confidence);
     if existing_confidence.map_or(true, |c| c < 1.0) {
@@ -538,13 +618,30 @@ fn match_rust_return_type_map(node: &Node, source: &[u8], symbols: &mut FileSymb
 /// `src/extractors/rust.ts` — see that function's doc comment for the three
 /// call shapes handled (bare function call, `Type::assoc_fn()`, and method
 /// call on a locally-typed receiver).
-fn match_rust_call_assignments(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: usize) {
-    if node.kind() != "let_declaration" { return }
-    let Some(pattern) = node.child_by_field_name("pattern") else { return };
-    if pattern.kind() != "identifier" { return }
-    let Some(value) = node.child_by_field_name("value") else { return };
-    if value.kind() != "call_expression" { return }
-    let Some(fn_node) = value.child_by_field_name("function") else { return };
+fn match_rust_call_assignments(
+    node: &Node,
+    source: &[u8],
+    symbols: &mut FileSymbols,
+    _depth: usize,
+) {
+    if node.kind() != "let_declaration" {
+        return;
+    }
+    let Some(pattern) = node.child_by_field_name("pattern") else {
+        return;
+    };
+    if pattern.kind() != "identifier" {
+        return;
+    }
+    let Some(value) = node.child_by_field_name("value") else {
+        return;
+    };
+    if value.kind() != "call_expression" {
+        return;
+    }
+    let Some(fn_node) = value.child_by_field_name("function") else {
+        return;
+    };
     let var_name = node_text(&pattern, source).to_string();
 
     match fn_node.kind() {
@@ -571,7 +668,9 @@ fn match_rust_call_assignments(node: &Node, source: &[u8], symbols: &mut FileSym
             let receiver = fn_node.child_by_field_name("value");
             if let (Some(field), Some(receiver)) = (field, receiver) {
                 if receiver.kind() == "identifier" {
-                    let receiver_type = symbols.type_map.iter()
+                    let receiver_type = symbols
+                        .type_map
+                        .iter()
                         .find(|e| e.name == node_text(&receiver, source))
                         .map(|e| e.type_name.clone());
                     symbols.call_assignments.push(NativeCallAssignment {
@@ -627,10 +726,18 @@ mod tests {
                }\n\
              }\n",
         );
-        let save = s.definitions.iter().find(|d| d.name == "Repo.save").unwrap();
+        let save = s
+            .definitions
+            .iter()
+            .find(|d| d.name == "Repo.save")
+            .unwrap();
         assert_eq!(save.bodyless, Some(true));
 
-        let find = s.definitions.iter().find(|d| d.name == "Repo.find").unwrap();
+        let find = s
+            .definitions
+            .iter()
+            .find(|d| d.name == "Repo.find")
+            .unwrap();
         assert_ne!(find.bodyless, Some(true));
     }
 
@@ -678,7 +785,11 @@ mod tests {
     #[test]
     fn seeds_struct_field_type_map() {
         let s = parse_rust("struct UserService { repo: UserRepository }");
-        let entry = s.type_map.iter().find(|e| e.name == "UserService.repo").unwrap();
+        let entry = s
+            .type_map
+            .iter()
+            .find(|e| e.name == "UserService.repo")
+            .unwrap();
         assert_eq!(entry.type_name, "UserRepository");
     }
 
@@ -707,7 +818,11 @@ mod tests {
     #[test]
     fn stores_return_type_for_free_function() {
         let s = parse_rust("fn build_service() -> UserService { todo!() }");
-        let entry = s.return_type_map.iter().find(|e| e.name == "build_service").unwrap();
+        let entry = s
+            .return_type_map
+            .iter()
+            .find(|e| e.name == "build_service")
+            .unwrap();
         assert_eq!(entry.type_name, "UserService");
         assert_eq!(entry.confidence, 1.0);
     }
@@ -715,14 +830,22 @@ mod tests {
     #[test]
     fn resolves_self_return_type_to_impl_type() {
         let s = parse_rust("struct UserRepository;\nimpl UserRepository {\n  fn new() -> Self { UserRepository }\n}");
-        let entry = s.return_type_map.iter().find(|e| e.name == "UserRepository.new").unwrap();
+        let entry = s
+            .return_type_map
+            .iter()
+            .find(|e| e.name == "UserRepository.new")
+            .unwrap();
         assert_eq!(entry.type_name, "UserRepository");
     }
 
     #[test]
     fn records_call_assignment_for_bare_function_call() {
         let s = parse_rust("fn f() { let service = build_service(); }");
-        let ca = s.call_assignments.iter().find(|c| c.var_name == "service").unwrap();
+        let ca = s
+            .call_assignments
+            .iter()
+            .find(|c| c.var_name == "service")
+            .unwrap();
         assert_eq!(ca.callee_name, "build_service");
         assert_eq!(ca.receiver_type_name, None);
     }
@@ -730,7 +853,11 @@ mod tests {
     #[test]
     fn records_call_assignment_for_associated_function_call() {
         let s = parse_rust("fn f() { let repo = UserRepository::new(); }");
-        let ca = s.call_assignments.iter().find(|c| c.var_name == "repo").unwrap();
+        let ca = s
+            .call_assignments
+            .iter()
+            .find(|c| c.var_name == "repo")
+            .unwrap();
         assert_eq!(ca.callee_name, "new");
         assert_eq!(ca.receiver_type_name.as_deref(), Some("UserRepository"));
     }
@@ -740,7 +867,11 @@ mod tests {
         let s = parse_rust(
             "fn f() {\n  let repo: UserRepository = make();\n  let user = repo.find_by_id(1);\n}",
         );
-        let ca = s.call_assignments.iter().find(|c| c.var_name == "user").unwrap();
+        let ca = s
+            .call_assignments
+            .iter()
+            .find(|c| c.var_name == "user")
+            .unwrap();
         assert_eq!(ca.callee_name, "find_by_id");
         assert_eq!(ca.receiver_type_name.as_deref(), Some("UserRepository"));
     }

--- a/crates/codegraph-core/src/extractors/rust_lang.rs
+++ b/crates/codegraph-core/src/extractors/rust_lang.rs
@@ -11,27 +11,12 @@ impl SymbolExtractor for RustExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_rust_node);
-        walk_ast_nodes_with_config(
-            &tree.root_node(),
-            source,
-            &mut symbols.ast_nodes,
-            &RUST_AST_CONFIG,
-        );
+        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &RUST_AST_CONFIG);
         walk_tree(&tree.root_node(), source, &mut symbols, match_rust_type_map);
-        walk_tree(
-            &tree.root_node(),
-            source,
-            &mut symbols,
-            match_rust_return_type_map,
-        );
+        walk_tree(&tree.root_node(), source, &mut symbols, match_rust_return_type_map);
         // Must run after type_map is populated — resolves `receiver.method()` call
         // assignments against locally-typed receivers (mirrors javascript.rs's ordering).
-        walk_tree(
-            &tree.root_node(),
-            source,
-            &mut symbols,
-            match_rust_call_assignments,
-        );
+        walk_tree(&tree.root_node(), source, &mut symbols, match_rust_call_assignments);
         dedup_type_map(&mut symbols.type_map);
         dedup_type_map(&mut symbols.return_type_map);
         symbols
@@ -42,7 +27,8 @@ fn find_current_impl<'a>(node: &Node<'a>, source: &[u8]) -> Option<String> {
     let mut current = node.parent();
     while let Some(parent) = current {
         if parent.kind() == "impl_item" {
-            return named_child_text(&parent, "type", source).map(|s| s.to_string());
+            return named_child_text(&parent, "type", source)
+                .map(|s| s.to_string());
         }
         current = parent.parent();
     }
@@ -68,16 +54,13 @@ fn match_rust_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth
 
 fn handle_function_item(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     // Skip default-impl functions inside traits — already emitted by trait_item handler
-    if node
-        .parent()
+    if node.parent()
         .and_then(|p| p.parent())
         .map_or(false, |gp| gp.kind() == "trait_item")
     {
         return;
     }
-    let Some(name_node) = node.child_by_field_name("name") else {
-        return;
-    };
+    let Some(name_node) = node.child_by_field_name("name") else { return };
     let name = node_text(&name_node, source);
     let impl_type = find_current_impl(node, source);
     let (full_name, kind) = match &impl_type {
@@ -123,29 +106,14 @@ fn handle_struct_item(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 /// so `self.field.method()` inside the struct's own impl methods resolves via
 /// the class-scoped receiver lookup — mirrors JS's `this.field` class-scoped
 /// typing (issues #1323, #1458) and fixes #1876's `self.field` false negatives.
-fn seed_rust_struct_field_types(
-    node: &Node,
-    struct_name: &str,
-    source: &[u8],
-    symbols: &mut FileSymbols,
-) {
-    let Some(body) = node.child_by_field_name("body") else {
-        return;
-    };
+fn seed_rust_struct_field_types(node: &Node, struct_name: &str, source: &[u8], symbols: &mut FileSymbols) {
+    let Some(body) = node.child_by_field_name("body") else { return };
     for i in 0..body.child_count() {
         let Some(field) = body.child(i) else { continue };
-        if field.kind() != "field_declaration" {
-            continue;
-        }
-        let Some(field_name) = field.child_by_field_name("name") else {
-            continue;
-        };
-        let Some(type_node) = field.child_by_field_name("type") else {
-            continue;
-        };
-        let Some(type_name) = extract_rust_type_name(&type_node, source) else {
-            continue;
-        };
+        if field.kind() != "field_declaration" { continue }
+        let Some(field_name) = field.child_by_field_name("name") else { continue };
+        let Some(type_node) = field.child_by_field_name("type") else { continue };
+        let Some(type_name) = extract_rust_type_name(&type_node, source) else { continue };
         push_type_map_entry(
             symbols,
             format!("{}.{}", struct_name, node_text(&field_name, source)),
@@ -190,9 +158,7 @@ fn handle_const_item(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 }
 
 fn handle_trait_item(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = node.child_by_field_name("name") else {
-        return;
-    };
+    let Some(name_node) = node.child_by_field_name("name") else { return };
     let trait_name = node_text(&name_node, source).to_string();
     symbols.definitions.push(Definition {
         name: trait_name.clone(),
@@ -255,9 +221,7 @@ fn handle_use_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 }
 
 fn handle_call_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(fn_node) = node.child_by_field_name("function") else {
-        return;
-    };
+    let Some(fn_node) = node.child_by_field_name("function") else { return };
     match fn_node.kind() {
         "identifier" => {
             symbols.calls.push(Call {
@@ -270,7 +234,8 @@ fn handle_call_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         }
         "field_expression" => {
             if let Some(field) = fn_node.child_by_field_name("field") {
-                let receiver = named_child_text(&fn_node, "value", source).map(|s| s.to_string());
+                let receiver = named_child_text(&fn_node, "value", source)
+                    .map(|s| s.to_string());
                 symbols.calls.push(Call {
                     name: node_text(&field, source).to_string(),
                     line: start_line(node),
@@ -282,7 +247,8 @@ fn handle_call_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         }
         "scoped_identifier" => {
             if let Some(name) = fn_node.child_by_field_name("name") {
-                let receiver = named_child_text(&fn_node, "path", source).map(|s| s.to_string());
+                let receiver = named_child_text(&fn_node, "path", source)
+                    .map(|s| s.to_string());
                 symbols.calls.push(Call {
                     name: node_text(&name, source).to_string(),
                     line: start_line(node),
@@ -320,11 +286,7 @@ fn extract_rust_parameters(node: &Node, source: &[u8]) -> Vec<Definition> {
                     if let Some(pattern) = child.child_by_field_name("pattern") {
                         let name = node_text(&pattern, source);
                         // Skip self parameters
-                        if name == "self"
-                            || name == "&self"
-                            || name == "&mut self"
-                            || name == "mut self"
-                        {
+                        if name == "self" || name == "&self" || name == "&mut self" || name == "mut self" {
                             continue;
                         }
                         params.push(child_def(name.to_string(), "parameter", start_line(&child)));
@@ -341,8 +303,7 @@ fn extract_rust_parameters(node: &Node, source: &[u8]) -> Vec<Definition> {
 
 fn extract_rust_struct_fields(node: &Node, source: &[u8]) -> Vec<Definition> {
     let mut fields = Vec::new();
-    let body = node
-        .child_by_field_name("body")
+    let body = node.child_by_field_name("body")
         .or_else(|| find_child(node, "field_declaration_list"));
     if let Some(body) = body {
         for i in 0..body.child_count() {
@@ -364,8 +325,7 @@ fn extract_rust_struct_fields(node: &Node, source: &[u8]) -> Vec<Definition> {
 
 fn extract_rust_enum_variants(node: &Node, source: &[u8]) -> Vec<Definition> {
     let mut variants = Vec::new();
-    let body = node
-        .child_by_field_name("body")
+    let body = node.child_by_field_name("body")
         .or_else(|| find_child(node, "enum_variant_list"));
     if let Some(body) = body {
         for i in 0..body.child_count() {
@@ -403,10 +363,7 @@ fn extract_rust_use_path(node: &Node, source: &[u8]) -> Vec<(String, Vec<String>
                 .child_by_field_name("alias")
                 .or_else(|| node.child_by_field_name("name"))
                 .map(|n| node_text(&n, source).to_string());
-            vec![(
-                node_text(node, source).to_string(),
-                name.into_iter().collect(),
-            )]
+            vec![(node_text(node, source).to_string(), name.into_iter().collect())]
         }
         "use_wildcard" => {
             let src = named_child_text(&node, "path", source)
@@ -432,9 +389,7 @@ fn extract_scoped_use_list(node: &Node, source: &[u8]) -> Vec<(String, Vec<Strin
     };
     let mut names = Vec::new();
     for i in 0..list_node.child_count() {
-        let Some(child) = list_node.child(i) else {
-            continue;
-        };
+        let Some(child) = list_node.child(i) else { continue };
         match child.kind() {
             "identifier" | "self" => {
                 names.push(node_text(&child, source).to_string());
@@ -456,22 +411,16 @@ fn extract_scoped_use_list(node: &Node, source: &[u8]) -> Vec<(String, Vec<Strin
 
 /// True if `name` matches a struct defined in this file (match_rust_node runs before this).
 fn is_known_unit_struct(name: &str, symbols: &FileSymbols) -> bool {
-    symbols
-        .definitions
-        .iter()
-        .any(|d| d.kind == "struct" && d.name == name)
+    symbols.definitions.iter().any(|d| d.kind == "struct" && d.name == name)
 }
 
 fn extract_rust_type_name<'a>(type_node: &Node<'a>, source: &'a [u8]) -> Option<&'a str> {
     match type_node.kind() {
-        "type_identifier" | "identifier" | "scoped_type_identifier" => {
-            Some(node_text(type_node, source))
-        }
+        "type_identifier" | "identifier" | "scoped_type_identifier" => Some(node_text(type_node, source)),
         "reference_type" => {
             for i in 0..type_node.child_count() {
                 if let Some(child) = type_node.child(i) {
-                    if child.kind() == "type_identifier" || child.kind() == "scoped_type_identifier"
-                    {
+                    if child.kind() == "type_identifier" || child.kind() == "scoped_type_identifier" {
                         return Some(node_text(&child, source));
                     }
                 }
@@ -526,11 +475,7 @@ fn match_rust_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, _d
             if let Some(pattern) = node.child_by_field_name("pattern") {
                 if pattern.kind() == "identifier" {
                     let name = node_text(&pattern, source);
-                    if name != "self"
-                        && name != "&self"
-                        && name != "&mut self"
-                        && name != "mut self"
-                    {
+                    if name != "self" && name != "&self" && name != "&mut self" && name != "mut self" {
                         if let Some(type_node) = node.child_by_field_name("type") {
                             if let Some(type_name) = extract_rust_type_name(&type_node, source) {
                                 symbols.type_map.push(TypeMapEntry {
@@ -558,33 +503,16 @@ fn match_rust_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, _d
 /// feeds — so a local var typed from a cross-file call's return value
 /// (`let service = build_service();`) resolves without any Rust-specific
 /// propagation logic.
-fn match_rust_return_type_map(
-    node: &Node,
-    source: &[u8],
-    symbols: &mut FileSymbols,
-    _depth: usize,
-) {
-    if node.kind() != "function_item" {
-        return;
-    }
+fn match_rust_return_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: usize) {
+    if node.kind() != "function_item" { return }
     // Skip default-impl functions inside traits, matching handle_function_item —
     // their return type is not tied to a concrete implementing type.
-    if node
-        .parent()
-        .and_then(|p| p.parent())
-        .map_or(false, |gp| gp.kind() == "trait_item")
-    {
+    if node.parent().and_then(|p| p.parent()).map_or(false, |gp| gp.kind() == "trait_item") {
         return;
     }
-    let Some(name_node) = node.child_by_field_name("name") else {
-        return;
-    };
-    let Some(return_type_node) = node.child_by_field_name("return_type") else {
-        return;
-    };
-    let Some(raw_type) = extract_rust_type_name(&return_type_node, source) else {
-        return;
-    };
+    let Some(name_node) = node.child_by_field_name("name") else { return };
+    let Some(return_type_node) = node.child_by_field_name("return_type") else { return };
+    let Some(raw_type) = extract_rust_type_name(&return_type_node, source) else { return };
     let impl_type = find_current_impl(node, source);
     // `-> Self` inside an impl block returns the concrete implementing type.
     let type_name = if raw_type == "Self" {
@@ -596,9 +524,7 @@ fn match_rust_return_type_map(
         Some(t) => format!("{}.{}", t, node_text(&name_node, source)),
         None => node_text(&name_node, source).to_string(),
     };
-    let existing_confidence = symbols
-        .return_type_map
-        .iter()
+    let existing_confidence = symbols.return_type_map.iter()
         .find(|e| e.name == full_name)
         .map(|e| e.confidence);
     if existing_confidence.map_or(true, |c| c < 1.0) {
@@ -618,30 +544,13 @@ fn match_rust_return_type_map(
 /// `src/extractors/rust.ts` — see that function's doc comment for the three
 /// call shapes handled (bare function call, `Type::assoc_fn()`, and method
 /// call on a locally-typed receiver).
-fn match_rust_call_assignments(
-    node: &Node,
-    source: &[u8],
-    symbols: &mut FileSymbols,
-    _depth: usize,
-) {
-    if node.kind() != "let_declaration" {
-        return;
-    }
-    let Some(pattern) = node.child_by_field_name("pattern") else {
-        return;
-    };
-    if pattern.kind() != "identifier" {
-        return;
-    }
-    let Some(value) = node.child_by_field_name("value") else {
-        return;
-    };
-    if value.kind() != "call_expression" {
-        return;
-    }
-    let Some(fn_node) = value.child_by_field_name("function") else {
-        return;
-    };
+fn match_rust_call_assignments(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: usize) {
+    if node.kind() != "let_declaration" { return }
+    let Some(pattern) = node.child_by_field_name("pattern") else { return };
+    if pattern.kind() != "identifier" { return }
+    let Some(value) = node.child_by_field_name("value") else { return };
+    if value.kind() != "call_expression" { return }
+    let Some(fn_node) = value.child_by_field_name("function") else { return };
     let var_name = node_text(&pattern, source).to_string();
 
     match fn_node.kind() {
@@ -668,9 +577,7 @@ fn match_rust_call_assignments(
             let receiver = fn_node.child_by_field_name("value");
             if let (Some(field), Some(receiver)) = (field, receiver) {
                 if receiver.kind() == "identifier" {
-                    let receiver_type = symbols
-                        .type_map
-                        .iter()
+                    let receiver_type = symbols.type_map.iter()
                         .find(|e| e.name == node_text(&receiver, source))
                         .map(|e| e.type_name.clone());
                     symbols.call_assignments.push(NativeCallAssignment {
@@ -726,18 +633,10 @@ mod tests {
                }\n\
              }\n",
         );
-        let save = s
-            .definitions
-            .iter()
-            .find(|d| d.name == "Repo.save")
-            .unwrap();
+        let save = s.definitions.iter().find(|d| d.name == "Repo.save").unwrap();
         assert_eq!(save.bodyless, Some(true));
 
-        let find = s
-            .definitions
-            .iter()
-            .find(|d| d.name == "Repo.find")
-            .unwrap();
+        let find = s.definitions.iter().find(|d| d.name == "Repo.find").unwrap();
         assert_ne!(find.bodyless, Some(true));
     }
 
@@ -785,11 +684,7 @@ mod tests {
     #[test]
     fn seeds_struct_field_type_map() {
         let s = parse_rust("struct UserService { repo: UserRepository }");
-        let entry = s
-            .type_map
-            .iter()
-            .find(|e| e.name == "UserService.repo")
-            .unwrap();
+        let entry = s.type_map.iter().find(|e| e.name == "UserService.repo").unwrap();
         assert_eq!(entry.type_name, "UserRepository");
     }
 
@@ -818,11 +713,7 @@ mod tests {
     #[test]
     fn stores_return_type_for_free_function() {
         let s = parse_rust("fn build_service() -> UserService { todo!() }");
-        let entry = s
-            .return_type_map
-            .iter()
-            .find(|e| e.name == "build_service")
-            .unwrap();
+        let entry = s.return_type_map.iter().find(|e| e.name == "build_service").unwrap();
         assert_eq!(entry.type_name, "UserService");
         assert_eq!(entry.confidence, 1.0);
     }
@@ -830,22 +721,14 @@ mod tests {
     #[test]
     fn resolves_self_return_type_to_impl_type() {
         let s = parse_rust("struct UserRepository;\nimpl UserRepository {\n  fn new() -> Self { UserRepository }\n}");
-        let entry = s
-            .return_type_map
-            .iter()
-            .find(|e| e.name == "UserRepository.new")
-            .unwrap();
+        let entry = s.return_type_map.iter().find(|e| e.name == "UserRepository.new").unwrap();
         assert_eq!(entry.type_name, "UserRepository");
     }
 
     #[test]
     fn records_call_assignment_for_bare_function_call() {
         let s = parse_rust("fn f() { let service = build_service(); }");
-        let ca = s
-            .call_assignments
-            .iter()
-            .find(|c| c.var_name == "service")
-            .unwrap();
+        let ca = s.call_assignments.iter().find(|c| c.var_name == "service").unwrap();
         assert_eq!(ca.callee_name, "build_service");
         assert_eq!(ca.receiver_type_name, None);
     }
@@ -853,11 +736,7 @@ mod tests {
     #[test]
     fn records_call_assignment_for_associated_function_call() {
         let s = parse_rust("fn f() { let repo = UserRepository::new(); }");
-        let ca = s
-            .call_assignments
-            .iter()
-            .find(|c| c.var_name == "repo")
-            .unwrap();
+        let ca = s.call_assignments.iter().find(|c| c.var_name == "repo").unwrap();
         assert_eq!(ca.callee_name, "new");
         assert_eq!(ca.receiver_type_name.as_deref(), Some("UserRepository"));
     }
@@ -867,11 +746,7 @@ mod tests {
         let s = parse_rust(
             "fn f() {\n  let repo: UserRepository = make();\n  let user = repo.find_by_id(1);\n}",
         );
-        let ca = s
-            .call_assignments
-            .iter()
-            .find(|c| c.var_name == "user")
-            .unwrap();
+        let ca = s.call_assignments.iter().find(|c| c.var_name == "user").unwrap();
         assert_eq!(ca.callee_name, "find_by_id");
         assert_eq!(ca.receiver_type_name.as_deref(), Some("UserRepository"));
     }

--- a/crates/codegraph-core/src/extractors/scala.rs
+++ b/crates/codegraph-core/src/extractors/scala.rs
@@ -1,9 +1,9 @@
-use super::helpers::*;
-use super::SymbolExtractor;
+use tree_sitter::{Node, Tree};
 use crate::ast_analysis::cfg::build_function_cfg;
 use crate::ast_analysis::complexity::compute_all_metrics;
 use crate::types::*;
-use tree_sitter::{Node, Tree};
+use super::helpers::*;
+use super::SymbolExtractor;
 
 pub struct ScalaExtractor;
 
@@ -11,18 +11,8 @@ impl SymbolExtractor for ScalaExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_scala_node);
-        walk_ast_nodes_with_config(
-            &tree.root_node(),
-            source,
-            &mut symbols.ast_nodes,
-            &SCALA_AST_CONFIG,
-        );
-        walk_tree(
-            &tree.root_node(),
-            source,
-            &mut symbols,
-            match_scala_type_map,
-        );
+        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &SCALA_AST_CONFIG);
+        walk_tree(&tree.root_node(), source, &mut symbols, match_scala_type_map);
         dedup_type_map(&mut symbols.type_map);
         symbols
     }
@@ -33,12 +23,10 @@ impl SymbolExtractor for ScalaExtractor {
 fn match_scala_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: usize) {
     match node.kind() {
         "val_definition" | "var_definition" => {
-            if let Some(type_node) = node
-                .child_by_field_name("type")
+            if let Some(type_node) = node.child_by_field_name("type")
                 .or_else(|| find_child(node, "type_identifier"))
             {
-                if let Some(pat) = node
-                    .child_by_field_name("pattern")
+                if let Some(pat) = node.child_by_field_name("pattern")
                     .or_else(|| find_child(node, "identifier"))
                 {
                     symbols.type_map.push(TypeMapEntry {
@@ -51,8 +39,7 @@ fn match_scala_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, _
         }
         "parameter" => {
             if let Some(type_node) = node.child_by_field_name("type") {
-                if let Some(name_node) = node
-                    .child_by_field_name("name")
+                if let Some(name_node) = node.child_by_field_name("name")
                     .or_else(|| find_child(node, "identifier"))
                 {
                     symbols.type_map.push(TypeMapEntry {
@@ -74,8 +61,7 @@ fn find_scala_parent_class<'a>(node: &Node<'a>, source: &[u8]) -> Option<String>
     while let Some(parent) = current {
         match parent.kind() {
             "class_definition" | "object_definition" | "trait_definition" => {
-                return parent
-                    .child_by_field_name("name")
+                return parent.child_by_field_name("name")
                     .or_else(|| find_child(&parent, "identifier"))
                     .map(|n| node_text(&n, source).to_string());
             }
@@ -88,15 +74,13 @@ fn find_scala_parent_class<'a>(node: &Node<'a>, source: &[u8]) -> Option<String>
 
 fn extract_scala_parameters(node: &Node, source: &[u8]) -> Vec<Definition> {
     let mut params = Vec::new();
-    if let Some(param_list) = node
-        .child_by_field_name("parameters")
+    if let Some(param_list) = node.child_by_field_name("parameters")
         .or_else(|| find_child(node, "parameters"))
     {
         for i in 0..param_list.child_count() {
             if let Some(child) = param_list.child(i) {
                 if child.kind() == "parameter" {
-                    if let Some(name_node) = child
-                        .child_by_field_name("name")
+                    if let Some(name_node) = child.child_by_field_name("name")
                         .or_else(|| find_child(&child, "identifier"))
                     {
                         params.push(child_def(
@@ -119,8 +103,7 @@ fn extract_scala_class_members(node: &Node, source: &[u8]) -> Vec<Definition> {
             if let Some(child) = body.child(i) {
                 match child.kind() {
                     "val_definition" | "var_definition" => {
-                        let name = child
-                            .child_by_field_name("pattern")
+                        let name = child.child_by_field_name("pattern")
                             .or_else(|| find_child(&child, "identifier"))
                             .map(|n| node_text(&n, source).to_string());
                         if let Some(name) = name {
@@ -216,8 +199,7 @@ fn extract_scala_import_path(node: &Node, source: &[u8]) -> String {
 // ── Per-node-kind handlers ──────────────────────────────────────────────────
 
 fn handle_scala_class_definition(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let name_node = node
-        .child_by_field_name("name")
+    let name_node = node.child_by_field_name("name")
         .or_else(|| find_child(node, "identifier"));
     if let Some(name_node) = name_node {
         let class_name = node_text(&name_node, source).to_string();
@@ -239,8 +221,7 @@ fn handle_scala_class_definition(node: &Node, source: &[u8], symbols: &mut FileS
 }
 
 fn handle_scala_trait_definition(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let name_node = node
-        .child_by_field_name("name")
+    let name_node = node.child_by_field_name("name")
         .or_else(|| find_child(node, "identifier"));
     if let Some(name_node) = name_node {
         let trait_name = node_text(&name_node, source).to_string();
@@ -261,8 +242,7 @@ fn handle_scala_trait_definition(node: &Node, source: &[u8], symbols: &mut FileS
 }
 
 fn handle_scala_object_definition(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let name_node = node
-        .child_by_field_name("name")
+    let name_node = node.child_by_field_name("name")
         .or_else(|| find_child(node, "identifier"));
     if let Some(name_node) = name_node {
         let obj_name = node_text(&name_node, source).to_string();
@@ -284,8 +264,7 @@ fn handle_scala_object_definition(node: &Node, source: &[u8], symbols: &mut File
 }
 
 fn handle_scala_function_definition(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let name_node = node
-        .child_by_field_name("name")
+    let name_node = node.child_by_field_name("name")
         .or_else(|| find_child(node, "identifier"));
     if let Some(name_node) = name_node {
         let parent_class = find_scala_parent_class(node, source);
@@ -294,11 +273,7 @@ fn handle_scala_function_definition(node: &Node, source: &[u8], symbols: &mut Fi
             Some(cls) => format!("{}.{}", cls, name),
             None => name.to_string(),
         };
-        let kind = if parent_class.is_some() {
-            "method"
-        } else {
-            "function"
-        };
+        let kind = if parent_class.is_some() { "method" } else { "function" };
         let children = extract_scala_parameters(node, source);
         symbols.definitions.push(Definition {
             name: full_name,
@@ -326,8 +301,7 @@ fn handle_scala_import_declaration(node: &Node, source: &[u8], symbols: &mut Fil
 }
 
 fn handle_scala_call_expression(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    if let Some(fn_node) = node
-        .child_by_field_name("function")
+    if let Some(fn_node) = node.child_by_field_name("function")
         .or_else(|| node.child(0))
     {
         match fn_node.kind() {
@@ -341,13 +315,11 @@ fn handle_scala_call_expression(node: &Node, source: &[u8], symbols: &mut FileSy
                 });
             }
             "field_expression" => {
-                let name = fn_node
-                    .child_by_field_name("field")
+                let name = fn_node.child_by_field_name("field")
                     .or_else(|| fn_node.child_by_field_name("member"))
                     .map(|n| node_text(&n, source).to_string())
                     .unwrap_or_else(|| node_text(&fn_node, source).to_string());
-                let receiver = fn_node
-                    .child_by_field_name("value")
+                let receiver = fn_node.child_by_field_name("value")
                     .or_else(|| fn_node.child(0))
                     .map(|n| node_text(&n, source).to_string());
                 let call_line = start_line(node);
@@ -373,8 +345,7 @@ fn handle_scala_call_expression(node: &Node, source: &[u8], symbols: &mut FileSy
                     "getMethod" | "getDeclaredMethod" if receiver.is_some() => {
                         // Extract first string arg from the call_expression (not fn_node)
                         let mut literal: Option<String> = None;
-                        if let Some(args) = node
-                            .child_by_field_name("arguments")
+                        if let Some(args) = node.child_by_field_name("arguments")
                             .or_else(|| find_child(node, "arguments"))
                         {
                             for i in 0..args.child_count() {
@@ -382,10 +353,8 @@ fn handle_scala_call_expression(node: &Node, source: &[u8], symbols: &mut FileSy
                                     match child.kind() {
                                         "(" | ")" | "," => continue,
                                         "string" | "string_literal" => {
-                                            literal = Some(
-                                                node_text(&child, source)
-                                                    .replace(&['"', '\''][..], ""),
-                                            );
+                                            literal = Some(node_text(&child, source)
+                                                .replace(&['"', '\''][..], ""));
                                             break;
                                         }
                                         _ => break,
@@ -480,11 +449,7 @@ mod tests {
     #[test]
     fn extracts_object() {
         let s = parse_scala("object Singleton { val x = 1 }");
-        let obj = s
-            .definitions
-            .iter()
-            .find(|d| d.name == "Singleton")
-            .unwrap();
+        let obj = s.definitions.iter().find(|d| d.name == "Singleton").unwrap();
         assert_eq!(obj.kind, "class");
     }
 

--- a/crates/codegraph-core/src/extractors/scala.rs
+++ b/crates/codegraph-core/src/extractors/scala.rs
@@ -1,9 +1,9 @@
-use tree_sitter::{Node, Tree};
+use super::helpers::*;
+use super::SymbolExtractor;
 use crate::ast_analysis::cfg::build_function_cfg;
 use crate::ast_analysis::complexity::compute_all_metrics;
 use crate::types::*;
-use super::helpers::*;
-use super::SymbolExtractor;
+use tree_sitter::{Node, Tree};
 
 pub struct ScalaExtractor;
 
@@ -11,8 +11,18 @@ impl SymbolExtractor for ScalaExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_scala_node);
-        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &SCALA_AST_CONFIG);
-        walk_tree(&tree.root_node(), source, &mut symbols, match_scala_type_map);
+        walk_ast_nodes_with_config(
+            &tree.root_node(),
+            source,
+            &mut symbols.ast_nodes,
+            &SCALA_AST_CONFIG,
+        );
+        walk_tree(
+            &tree.root_node(),
+            source,
+            &mut symbols,
+            match_scala_type_map,
+        );
         dedup_type_map(&mut symbols.type_map);
         symbols
     }
@@ -23,10 +33,12 @@ impl SymbolExtractor for ScalaExtractor {
 fn match_scala_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: usize) {
     match node.kind() {
         "val_definition" | "var_definition" => {
-            if let Some(type_node) = node.child_by_field_name("type")
+            if let Some(type_node) = node
+                .child_by_field_name("type")
                 .or_else(|| find_child(node, "type_identifier"))
             {
-                if let Some(pat) = node.child_by_field_name("pattern")
+                if let Some(pat) = node
+                    .child_by_field_name("pattern")
                     .or_else(|| find_child(node, "identifier"))
                 {
                     symbols.type_map.push(TypeMapEntry {
@@ -39,7 +51,8 @@ fn match_scala_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, _
         }
         "parameter" => {
             if let Some(type_node) = node.child_by_field_name("type") {
-                if let Some(name_node) = node.child_by_field_name("name")
+                if let Some(name_node) = node
+                    .child_by_field_name("name")
                     .or_else(|| find_child(node, "identifier"))
                 {
                     symbols.type_map.push(TypeMapEntry {
@@ -61,7 +74,8 @@ fn find_scala_parent_class<'a>(node: &Node<'a>, source: &[u8]) -> Option<String>
     while let Some(parent) = current {
         match parent.kind() {
             "class_definition" | "object_definition" | "trait_definition" => {
-                return parent.child_by_field_name("name")
+                return parent
+                    .child_by_field_name("name")
                     .or_else(|| find_child(&parent, "identifier"))
                     .map(|n| node_text(&n, source).to_string());
             }
@@ -74,13 +88,15 @@ fn find_scala_parent_class<'a>(node: &Node<'a>, source: &[u8]) -> Option<String>
 
 fn extract_scala_parameters(node: &Node, source: &[u8]) -> Vec<Definition> {
     let mut params = Vec::new();
-    if let Some(param_list) = node.child_by_field_name("parameters")
+    if let Some(param_list) = node
+        .child_by_field_name("parameters")
         .or_else(|| find_child(node, "parameters"))
     {
         for i in 0..param_list.child_count() {
             if let Some(child) = param_list.child(i) {
                 if child.kind() == "parameter" {
-                    if let Some(name_node) = child.child_by_field_name("name")
+                    if let Some(name_node) = child
+                        .child_by_field_name("name")
                         .or_else(|| find_child(&child, "identifier"))
                     {
                         params.push(child_def(
@@ -103,7 +119,8 @@ fn extract_scala_class_members(node: &Node, source: &[u8]) -> Vec<Definition> {
             if let Some(child) = body.child(i) {
                 match child.kind() {
                     "val_definition" | "var_definition" => {
-                        let name = child.child_by_field_name("pattern")
+                        let name = child
+                            .child_by_field_name("pattern")
                             .or_else(|| find_child(&child, "identifier"))
                             .map(|n| node_text(&n, source).to_string());
                         if let Some(name) = name {
@@ -199,7 +216,8 @@ fn extract_scala_import_path(node: &Node, source: &[u8]) -> String {
 // ── Per-node-kind handlers ──────────────────────────────────────────────────
 
 fn handle_scala_class_definition(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let name_node = node.child_by_field_name("name")
+    let name_node = node
+        .child_by_field_name("name")
         .or_else(|| find_child(node, "identifier"));
     if let Some(name_node) = name_node {
         let class_name = node_text(&name_node, source).to_string();
@@ -214,13 +232,15 @@ fn handle_scala_class_definition(node: &Node, source: &[u8], symbols: &mut FileS
             cfg: None,
             children: opt_children(children),
             bodyless: None,
+            content_hash: None,
         });
         extract_scala_extends(node, source, &class_name, symbols);
     }
 }
 
 fn handle_scala_trait_definition(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let name_node = node.child_by_field_name("name")
+    let name_node = node
+        .child_by_field_name("name")
         .or_else(|| find_child(node, "identifier"));
     if let Some(name_node) = name_node {
         let trait_name = node_text(&name_node, source).to_string();
@@ -234,13 +254,15 @@ fn handle_scala_trait_definition(node: &Node, source: &[u8], symbols: &mut FileS
             cfg: None,
             children: None,
             bodyless: None,
+            content_hash: None,
         });
         extract_scala_extends(node, source, &trait_name, symbols);
     }
 }
 
 fn handle_scala_object_definition(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let name_node = node.child_by_field_name("name")
+    let name_node = node
+        .child_by_field_name("name")
         .or_else(|| find_child(node, "identifier"));
     if let Some(name_node) = name_node {
         let obj_name = node_text(&name_node, source).to_string();
@@ -255,13 +277,15 @@ fn handle_scala_object_definition(node: &Node, source: &[u8], symbols: &mut File
             cfg: None,
             children: opt_children(children),
             bodyless: None,
+            content_hash: None,
         });
         extract_scala_extends(node, source, &obj_name, symbols);
     }
 }
 
 fn handle_scala_function_definition(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let name_node = node.child_by_field_name("name")
+    let name_node = node
+        .child_by_field_name("name")
         .or_else(|| find_child(node, "identifier"));
     if let Some(name_node) = name_node {
         let parent_class = find_scala_parent_class(node, source);
@@ -270,7 +294,11 @@ fn handle_scala_function_definition(node: &Node, source: &[u8], symbols: &mut Fi
             Some(cls) => format!("{}.{}", cls, name),
             None => name.to_string(),
         };
-        let kind = if parent_class.is_some() { "method" } else { "function" };
+        let kind = if parent_class.is_some() {
+            "method"
+        } else {
+            "function"
+        };
         let children = extract_scala_parameters(node, source);
         symbols.definitions.push(Definition {
             name: full_name,
@@ -282,6 +310,7 @@ fn handle_scala_function_definition(node: &Node, source: &[u8], symbols: &mut Fi
             cfg: build_function_cfg(node, "scala", source),
             children: opt_children(children),
             bodyless: None,
+            content_hash: None,
         });
     }
 }
@@ -297,7 +326,8 @@ fn handle_scala_import_declaration(node: &Node, source: &[u8], symbols: &mut Fil
 }
 
 fn handle_scala_call_expression(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    if let Some(fn_node) = node.child_by_field_name("function")
+    if let Some(fn_node) = node
+        .child_by_field_name("function")
         .or_else(|| node.child(0))
     {
         match fn_node.kind() {
@@ -311,11 +341,13 @@ fn handle_scala_call_expression(node: &Node, source: &[u8], symbols: &mut FileSy
                 });
             }
             "field_expression" => {
-                let name = fn_node.child_by_field_name("field")
+                let name = fn_node
+                    .child_by_field_name("field")
                     .or_else(|| fn_node.child_by_field_name("member"))
                     .map(|n| node_text(&n, source).to_string())
                     .unwrap_or_else(|| node_text(&fn_node, source).to_string());
-                let receiver = fn_node.child_by_field_name("value")
+                let receiver = fn_node
+                    .child_by_field_name("value")
                     .or_else(|| fn_node.child(0))
                     .map(|n| node_text(&n, source).to_string());
                 let call_line = start_line(node);
@@ -341,7 +373,8 @@ fn handle_scala_call_expression(node: &Node, source: &[u8], symbols: &mut FileSy
                     "getMethod" | "getDeclaredMethod" if receiver.is_some() => {
                         // Extract first string arg from the call_expression (not fn_node)
                         let mut literal: Option<String> = None;
-                        if let Some(args) = node.child_by_field_name("arguments")
+                        if let Some(args) = node
+                            .child_by_field_name("arguments")
                             .or_else(|| find_child(node, "arguments"))
                         {
                             for i in 0..args.child_count() {
@@ -349,8 +382,10 @@ fn handle_scala_call_expression(node: &Node, source: &[u8], symbols: &mut FileSy
                                     match child.kind() {
                                         "(" | ")" | "," => continue,
                                         "string" | "string_literal" => {
-                                            literal = Some(node_text(&child, source)
-                                                .replace(&['"', '\''][..], ""));
+                                            literal = Some(
+                                                node_text(&child, source)
+                                                    .replace(&['"', '\''][..], ""),
+                                            );
                                             break;
                                         }
                                         _ => break,
@@ -445,7 +480,11 @@ mod tests {
     #[test]
     fn extracts_object() {
         let s = parse_scala("object Singleton { val x = 1 }");
-        let obj = s.definitions.iter().find(|d| d.name == "Singleton").unwrap();
+        let obj = s
+            .definitions
+            .iter()
+            .find(|d| d.name == "Singleton")
+            .unwrap();
         assert_eq!(obj.kind, "class");
     }
 

--- a/crates/codegraph-core/src/extractors/solidity.rs
+++ b/crates/codegraph-core/src/extractors/solidity.rs
@@ -51,12 +51,7 @@ fn match_solidity_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _d
 
 // ── Contracts / interfaces / libraries ───────────────────────────────────────
 
-fn handle_contract_decl(
-    node: &Node,
-    source: &[u8],
-    symbols: &mut FileSymbols,
-    kind: &str,
-) {
+fn handle_contract_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols, kind: &str) {
     let Some(name_node) = node.child_by_field_name("name") else {
         return;
     };
@@ -80,6 +75,7 @@ fn handle_contract_decl(
         cfg: None,
         children: opt_children(members),
         bodyless: None,
+        content_hash: None,
     });
 
     extract_inheritance(node, &name, source, symbols);
@@ -130,6 +126,7 @@ fn extract_contract_member(child: &Node, source: &[u8]) -> Option<Definition> {
                 cfg: None,
                 children: None,
                 bodyless: None,
+                content_hash: None,
             })
         }
         "error_declaration" => {
@@ -144,6 +141,7 @@ fn extract_contract_member(child: &Node, source: &[u8]) -> Option<Definition> {
                 cfg: None,
                 children: None,
                 bodyless: None,
+                content_hash: None,
             })
         }
         "modifier_definition" => {
@@ -158,6 +156,7 @@ fn extract_contract_member(child: &Node, source: &[u8]) -> Option<Definition> {
                 cfg: None,
                 children: None,
                 bodyless: None,
+                content_hash: None,
             })
         }
         _ => None,
@@ -236,6 +235,7 @@ fn handle_struct_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: opt_children(members),
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -276,6 +276,7 @@ fn handle_enum_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: opt_children(members),
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -290,7 +291,11 @@ fn handle_function_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         Some(p) => format!("{}.{}", p, node_text(&name_node, source)),
         None => node_text(&name_node, source).to_string(),
     };
-    let kind = if parent.is_some() { "method" } else { "function" };
+    let kind = if parent.is_some() {
+        "method"
+    } else {
+        "function"
+    };
 
     let params = extract_sol_params(node, source);
     symbols.definitions.push(Definition {
@@ -303,6 +308,7 @@ fn handle_function_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: opt_children(params),
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -326,6 +332,7 @@ fn handle_modifier_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -349,6 +356,7 @@ fn handle_event_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -372,6 +380,7 @@ fn handle_error_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -395,6 +404,7 @@ fn handle_state_var_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -432,12 +442,15 @@ fn handle_import_directive(node: &Node, source: &[u8], symbols: &mut FileSymbols
         }
         // source_import / import_clause: `import * as Alias from "path"`
         if child.kind() == "source_import" || child.kind() == "import_clause" {
-            let str_node = find_child(&child, "string").or_else(|| find_child(&child, "string_literal"));
+            let str_node =
+                find_child(&child, "string").or_else(|| find_child(&child, "string_literal"));
             if let Some(str_node) = str_node {
                 let source_path = strip_quotes(node_text(&str_node, source));
-                symbols
-                    .imports
-                    .push(Import::new(source_path, vec!["*".to_string()], start_line(node)));
+                symbols.imports.push(Import::new(
+                    source_path,
+                    vec!["*".to_string()],
+                    start_line(node),
+                ));
                 return;
             }
         }
@@ -463,7 +476,8 @@ fn handle_call_expression(node: &Node, source: &[u8], symbols: &mut FileSymbols)
                 .child_by_field_name("object")
                 .or_else(|| func_node.child_by_field_name("expression"));
             (
-                prop.map(|n| node_text(&n, source).to_string()).unwrap_or_default(),
+                prop.map(|n| node_text(&n, source).to_string())
+                    .unwrap_or_default(),
                 obj.map(|n| node_text(&n, source).to_string()),
             )
         }
@@ -538,7 +552,11 @@ mod tests {
         let s = parse_sol(
             "library Validators { function v(string memory n) internal pure returns (bool) { return true; } }",
         );
-        let d = s.definitions.iter().find(|d| d.name == "Validators").unwrap();
+        let d = s
+            .definitions
+            .iter()
+            .find(|d| d.name == "Validators")
+            .unwrap();
         assert_eq!(d.kind, "module");
     }
 
@@ -547,7 +565,11 @@ mod tests {
         let s = parse_sol(
             "contract Token { function transfer(address to, uint256 amount) public returns (bool) { return true; } }",
         );
-        let d = s.definitions.iter().find(|d| d.name == "Token.transfer").unwrap();
+        let d = s
+            .definitions
+            .iter()
+            .find(|d| d.name == "Token.transfer")
+            .unwrap();
         assert_eq!(d.kind, "method");
         // NOTE: matches WASM/JS behaviour — neither a `parameters` field nor a
         // `parameter_list` node exists in the Solidity tree-sitter grammar
@@ -559,14 +581,22 @@ mod tests {
     #[test]
     fn extracts_import() {
         let s = parse_sol("import \"./IERC20.sol\";");
-        let imp = s.imports.iter().find(|i| i.source == "./IERC20.sol").unwrap();
+        let imp = s
+            .imports
+            .iter()
+            .find(|i| i.source == "./IERC20.sol")
+            .unwrap();
         assert_eq!(imp.names, vec!["*".to_string()]);
     }
 
     #[test]
     fn extracts_named_import() {
         let s = parse_sol("import { Foo, Bar } from \"./Stuff.sol\";");
-        let imp = s.imports.iter().find(|i| i.source == "./Stuff.sol").unwrap();
+        let imp = s
+            .imports
+            .iter()
+            .find(|i| i.source == "./Stuff.sol")
+            .unwrap();
         assert!(imp.names.contains(&"Foo".to_string()));
         assert!(imp.names.contains(&"Bar".to_string()));
     }

--- a/crates/codegraph-core/src/extractors/solidity.rs
+++ b/crates/codegraph-core/src/extractors/solidity.rs
@@ -51,7 +51,12 @@ fn match_solidity_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _d
 
 // ── Contracts / interfaces / libraries ───────────────────────────────────────
 
-fn handle_contract_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols, kind: &str) {
+fn handle_contract_decl(
+    node: &Node,
+    source: &[u8],
+    symbols: &mut FileSymbols,
+    kind: &str,
+) {
     let Some(name_node) = node.child_by_field_name("name") else {
         return;
     };
@@ -291,11 +296,7 @@ fn handle_function_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         Some(p) => format!("{}.{}", p, node_text(&name_node, source)),
         None => node_text(&name_node, source).to_string(),
     };
-    let kind = if parent.is_some() {
-        "method"
-    } else {
-        "function"
-    };
+    let kind = if parent.is_some() { "method" } else { "function" };
 
     let params = extract_sol_params(node, source);
     symbols.definitions.push(Definition {
@@ -442,15 +443,12 @@ fn handle_import_directive(node: &Node, source: &[u8], symbols: &mut FileSymbols
         }
         // source_import / import_clause: `import * as Alias from "path"`
         if child.kind() == "source_import" || child.kind() == "import_clause" {
-            let str_node =
-                find_child(&child, "string").or_else(|| find_child(&child, "string_literal"));
+            let str_node = find_child(&child, "string").or_else(|| find_child(&child, "string_literal"));
             if let Some(str_node) = str_node {
                 let source_path = strip_quotes(node_text(&str_node, source));
-                symbols.imports.push(Import::new(
-                    source_path,
-                    vec!["*".to_string()],
-                    start_line(node),
-                ));
+                symbols
+                    .imports
+                    .push(Import::new(source_path, vec!["*".to_string()], start_line(node)));
                 return;
             }
         }
@@ -476,8 +474,7 @@ fn handle_call_expression(node: &Node, source: &[u8], symbols: &mut FileSymbols)
                 .child_by_field_name("object")
                 .or_else(|| func_node.child_by_field_name("expression"));
             (
-                prop.map(|n| node_text(&n, source).to_string())
-                    .unwrap_or_default(),
+                prop.map(|n| node_text(&n, source).to_string()).unwrap_or_default(),
                 obj.map(|n| node_text(&n, source).to_string()),
             )
         }
@@ -552,11 +549,7 @@ mod tests {
         let s = parse_sol(
             "library Validators { function v(string memory n) internal pure returns (bool) { return true; } }",
         );
-        let d = s
-            .definitions
-            .iter()
-            .find(|d| d.name == "Validators")
-            .unwrap();
+        let d = s.definitions.iter().find(|d| d.name == "Validators").unwrap();
         assert_eq!(d.kind, "module");
     }
 
@@ -565,11 +558,7 @@ mod tests {
         let s = parse_sol(
             "contract Token { function transfer(address to, uint256 amount) public returns (bool) { return true; } }",
         );
-        let d = s
-            .definitions
-            .iter()
-            .find(|d| d.name == "Token.transfer")
-            .unwrap();
+        let d = s.definitions.iter().find(|d| d.name == "Token.transfer").unwrap();
         assert_eq!(d.kind, "method");
         // NOTE: matches WASM/JS behaviour — neither a `parameters` field nor a
         // `parameter_list` node exists in the Solidity tree-sitter grammar
@@ -581,22 +570,14 @@ mod tests {
     #[test]
     fn extracts_import() {
         let s = parse_sol("import \"./IERC20.sol\";");
-        let imp = s
-            .imports
-            .iter()
-            .find(|i| i.source == "./IERC20.sol")
-            .unwrap();
+        let imp = s.imports.iter().find(|i| i.source == "./IERC20.sol").unwrap();
         assert_eq!(imp.names, vec!["*".to_string()]);
     }
 
     #[test]
     fn extracts_named_import() {
         let s = parse_sol("import { Foo, Bar } from \"./Stuff.sol\";");
-        let imp = s
-            .imports
-            .iter()
-            .find(|i| i.source == "./Stuff.sol")
-            .unwrap();
+        let imp = s.imports.iter().find(|i| i.source == "./Stuff.sol").unwrap();
         assert!(imp.names.contains(&"Foo".to_string()));
         assert!(imp.names.contains(&"Bar".to_string()));
     }

--- a/crates/codegraph-core/src/extractors/swift.rs
+++ b/crates/codegraph-core/src/extractors/swift.rs
@@ -1,9 +1,9 @@
-use tree_sitter::{Node, Tree};
+use super::helpers::*;
+use super::SymbolExtractor;
 use crate::ast_analysis::cfg::build_function_cfg;
 use crate::ast_analysis::complexity::compute_all_metrics;
 use crate::types::*;
-use super::helpers::*;
-use super::SymbolExtractor;
+use tree_sitter::{Node, Tree};
 
 pub struct SwiftExtractor;
 
@@ -11,8 +11,18 @@ impl SymbolExtractor for SwiftExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_swift_node);
-        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &SWIFT_AST_CONFIG);
-        walk_tree(&tree.root_node(), source, &mut symbols, match_swift_type_map);
+        walk_ast_nodes_with_config(
+            &tree.root_node(),
+            source,
+            &mut symbols.ast_nodes,
+            &SWIFT_AST_CONFIG,
+        );
+        walk_tree(
+            &tree.root_node(),
+            source,
+            &mut symbols,
+            match_swift_type_map,
+        );
         dedup_type_map(&mut symbols.type_map);
         symbols
     }
@@ -22,12 +32,14 @@ impl SymbolExtractor for SwiftExtractor {
 
 fn match_swift_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: usize) {
     if node.kind() == "property_declaration" {
-        if let Some(type_ann) = node.child_by_field_name("type")
+        if let Some(type_ann) = node
+            .child_by_field_name("type")
             .or_else(|| find_child(node, "type_annotation"))
         {
             // type_annotation contains the actual type as a child
             let type_name = if type_ann.kind() == "type_annotation" {
-                type_ann.child(type_ann.child_count().saturating_sub(1))
+                type_ann
+                    .child(type_ann.child_count().saturating_sub(1))
                     .map(|n| node_text(&n, source))
                     .unwrap_or("")
             } else {
@@ -96,7 +108,8 @@ fn extract_swift_parameters(node: &Node, source: &[u8]) -> Vec<Definition> {
                         if param.kind() == "parameter" {
                             // Swift params have external and internal names
                             // The internal name (or only name) is what we want
-                            let name = param.child_by_field_name("internal_name")
+                            let name = param
+                                .child_by_field_name("internal_name")
                                 .or_else(|| param.child_by_field_name("name"))
                                 .or_else(|| find_child(&param, "simple_identifier"))
                                 .map(|n| node_text(&n, source).to_string());
@@ -114,8 +127,7 @@ fn extract_swift_parameters(node: &Node, source: &[u8]) -> Vec<Definition> {
 
 fn extract_swift_class_properties(node: &Node, source: &[u8]) -> Vec<Definition> {
     let mut props = Vec::new();
-    let body = find_child(node, "class_body")
-        .or_else(|| find_child(node, "enum_class_body"));
+    let body = find_child(node, "class_body").or_else(|| find_child(node, "enum_class_body"));
     if let Some(body) = body {
         for i in 0..body.child_count() {
             if let Some(child) = body.child(i) {
@@ -136,8 +148,7 @@ fn extract_swift_class_properties(node: &Node, source: &[u8]) -> Vec<Definition>
 
 fn extract_swift_enum_cases(node: &Node, source: &[u8]) -> Vec<Definition> {
     let mut cases = Vec::new();
-    let body = find_child(node, "enum_class_body")
-        .or_else(|| find_child(node, "class_body"));
+    let body = find_child(node, "enum_class_body").or_else(|| find_child(node, "class_body"));
     if let Some(body) = body {
         for i in 0..body.child_count() {
             if let Some(child) = body.child(i) {
@@ -156,7 +167,12 @@ fn extract_swift_enum_cases(node: &Node, source: &[u8]) -> Vec<Definition> {
     cases
 }
 
-fn extract_swift_inheritance(node: &Node, source: &[u8], class_name: &str, symbols: &mut FileSymbols) {
+fn extract_swift_inheritance(
+    node: &Node,
+    source: &[u8],
+    class_name: &str,
+    symbols: &mut FileSymbols,
+) {
     let mut first = true;
     for i in 0..node.child_count() {
         if let Some(child) = node.child(i) {
@@ -193,12 +209,15 @@ fn extract_swift_inheritance(node: &Node, source: &[u8], class_name: &str, symbo
 /// Inspects call_suffix → value_arguments → value_argument → line_string_literal.
 fn get_swift_first_string_literal(call_node: &Node, source: &[u8]) -> Option<String> {
     let call_suffix = find_child(call_node, "call_suffix")?;
-    let value_args = find_child(&call_suffix, "value_arguments")
-        .unwrap_or(call_suffix);
+    let value_args = find_child(&call_suffix, "value_arguments").unwrap_or(call_suffix);
     for i in 0..value_args.child_count() {
-        let Some(arg) = value_args.child(i) else { continue };
+        let Some(arg) = value_args.child(i) else {
+            continue;
+        };
         let t = arg.kind();
-        if matches!(t, "(" | ")" | ",") { continue; }
+        if matches!(t, "(" | ")" | ",") {
+            continue;
+        }
         let value_node = if t == "value_argument" {
             arg.child_by_field_name("value")
                 .or_else(|| arg.child(arg.child_count().saturating_sub(1)))
@@ -209,7 +228,9 @@ fn get_swift_first_string_literal(call_node: &Node, source: &[u8]) -> Option<Str
         let vt = value_node.kind();
         if vt == "line_string_literal" || vt == "string_literal" {
             for j in 0..value_node.child_count() {
-                let Some(ch) = value_node.child(j) else { continue };
+                let Some(ch) = value_node.child(j) else {
+                    continue;
+                };
                 if ch.kind() == "line_str_text" || ch.kind() == "string_content" {
                     return Some(node_text(&ch, source).to_string());
                 }
@@ -225,8 +246,8 @@ fn get_swift_first_string_literal(call_node: &Node, source: &[u8]) -> Option<Str
 fn match_swift_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: usize) {
     match node.kind() {
         "class_declaration" => {
-            let name_node = find_child(node, "simple_identifier")
-                .or_else(|| node.child_by_field_name("name"));
+            let name_node =
+                find_child(node, "simple_identifier").or_else(|| node.child_by_field_name("name"));
             if let Some(name_node) = name_node {
                 let class_name = node_text(&name_node, source).to_string();
                 let kind = swift_class_kind(node, source);
@@ -244,6 +265,7 @@ fn match_swift_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dept
                             cfg: None,
                             children: opt_children(children),
                             bodyless: None,
+                            content_hash: None,
                         });
                     }
                     _ => {
@@ -258,6 +280,7 @@ fn match_swift_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dept
                             cfg: None,
                             children: opt_children(children),
                             bodyless: None,
+                            content_hash: None,
                         });
                     }
                 }
@@ -267,8 +290,8 @@ fn match_swift_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dept
         }
 
         "protocol_declaration" => {
-            let name_node = find_child(node, "simple_identifier")
-                .or_else(|| node.child_by_field_name("name"));
+            let name_node =
+                find_child(node, "simple_identifier").or_else(|| node.child_by_field_name("name"));
             if let Some(name_node) = name_node {
                 let proto_name = node_text(&name_node, source).to_string();
                 symbols.definitions.push(Definition {
@@ -281,6 +304,7 @@ fn match_swift_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dept
                     cfg: None,
                     children: None,
                     bodyless: None,
+                    content_hash: None,
                 });
                 // Protocol can also have inheritance
                 extract_swift_inheritance(node, source, &proto_name, symbols);
@@ -288,8 +312,8 @@ fn match_swift_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dept
         }
 
         "function_declaration" => {
-            let name_node = find_child(node, "simple_identifier")
-                .or_else(|| node.child_by_field_name("name"));
+            let name_node =
+                find_child(node, "simple_identifier").or_else(|| node.child_by_field_name("name"));
             if let Some(name_node) = name_node {
                 let parent_class = find_swift_parent_class(node, source);
                 let name = node_text(&name_node, source);
@@ -297,7 +321,11 @@ fn match_swift_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dept
                     Some(cls) => format!("{}.{}", cls, name),
                     None => name.to_string(),
                 };
-                let kind = if parent_class.is_some() { "method" } else { "function" };
+                let kind = if parent_class.is_some() {
+                    "method"
+                } else {
+                    "function"
+                };
                 let children = extract_swift_parameters(node, source);
                 symbols.definitions.push(Definition {
                     name: full_name,
@@ -309,6 +337,7 @@ fn match_swift_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dept
                     cfg: build_function_cfg(node, "swift", source),
                     children: opt_children(children),
                     bodyless: None,
+                    content_hash: None,
                 });
             }
         }
@@ -333,20 +362,21 @@ fn match_swift_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dept
                         // (e.g. `.save` text), not a bare `simple_identifier`. Descend into
                         // navigation_suffix to get the inner simple_identifier so the resolved
                         // name is "save" not ".save". Mirrors WASM extractors/swift.ts fix.
-                        let name = last.map(|n| {
-                            if n.kind() == "navigation_suffix" {
-                                find_child(&n, "simple_identifier")
-                                    .map(|id| node_text(&id, source).to_string())
-                                    .unwrap_or_else(|| {
-                                        let t = node_text(&n, source);
-                                        t.trim_start_matches('.').to_string()
-                                    })
-                            } else {
-                                node_text(&n, source).to_string()
-                            }
-                        }).unwrap_or_else(|| node_text(&fn_node, source).to_string());
-                        let receiver = fn_node.child(0)
-                            .map(|n| node_text(&n, source).to_string());
+                        let name = last
+                            .map(|n| {
+                                if n.kind() == "navigation_suffix" {
+                                    find_child(&n, "simple_identifier")
+                                        .map(|id| node_text(&id, source).to_string())
+                                        .unwrap_or_else(|| {
+                                            let t = node_text(&n, source);
+                                            t.trim_start_matches('.').to_string()
+                                        })
+                                } else {
+                                    node_text(&n, source).to_string()
+                                }
+                            })
+                            .unwrap_or_else(|| node_text(&fn_node, source).to_string());
+                        let receiver = fn_node.child(0).map(|n| node_text(&n, source).to_string());
                         (name, receiver)
                     }
                     _ => (node_text(&fn_node, source).to_string(), None),
@@ -373,7 +403,9 @@ fn match_swift_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dept
                 if call_name == "NSSelectorFromString" {
                     let literal = get_swift_first_string_literal(node, source);
                     symbols.calls.push(Call {
-                        name: literal.clone().unwrap_or_else(|| "<dynamic:unresolved>".to_string()),
+                        name: literal
+                            .clone()
+                            .unwrap_or_else(|| "<dynamic:unresolved>".to_string()),
                         line: call_line,
                         dynamic: Some(true),
                         dynamic_kind: Some(if literal.is_some() {
@@ -455,8 +487,15 @@ mod tests {
     #[test]
     fn extracts_navigation_call_bare_name() {
         let s = parse_swift("func f() { repo.save(x) }");
-        let call = s.calls.iter().find(|c| c.receiver.as_deref() == Some("repo")).unwrap();
-        assert_eq!(call.name, "save", "method name must not include leading dot");
+        let call = s
+            .calls
+            .iter()
+            .find(|c| c.receiver.as_deref() == Some("repo"))
+            .unwrap();
+        assert_eq!(
+            call.name, "save",
+            "method name must not include leading dot"
+        );
         assert_eq!(call.receiver.as_deref(), Some("repo"));
     }
 

--- a/crates/codegraph-core/src/extractors/swift.rs
+++ b/crates/codegraph-core/src/extractors/swift.rs
@@ -1,9 +1,9 @@
-use super::helpers::*;
-use super::SymbolExtractor;
+use tree_sitter::{Node, Tree};
 use crate::ast_analysis::cfg::build_function_cfg;
 use crate::ast_analysis::complexity::compute_all_metrics;
 use crate::types::*;
-use tree_sitter::{Node, Tree};
+use super::helpers::*;
+use super::SymbolExtractor;
 
 pub struct SwiftExtractor;
 
@@ -11,18 +11,8 @@ impl SymbolExtractor for SwiftExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_swift_node);
-        walk_ast_nodes_with_config(
-            &tree.root_node(),
-            source,
-            &mut symbols.ast_nodes,
-            &SWIFT_AST_CONFIG,
-        );
-        walk_tree(
-            &tree.root_node(),
-            source,
-            &mut symbols,
-            match_swift_type_map,
-        );
+        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &SWIFT_AST_CONFIG);
+        walk_tree(&tree.root_node(), source, &mut symbols, match_swift_type_map);
         dedup_type_map(&mut symbols.type_map);
         symbols
     }
@@ -32,14 +22,12 @@ impl SymbolExtractor for SwiftExtractor {
 
 fn match_swift_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: usize) {
     if node.kind() == "property_declaration" {
-        if let Some(type_ann) = node
-            .child_by_field_name("type")
+        if let Some(type_ann) = node.child_by_field_name("type")
             .or_else(|| find_child(node, "type_annotation"))
         {
             // type_annotation contains the actual type as a child
             let type_name = if type_ann.kind() == "type_annotation" {
-                type_ann
-                    .child(type_ann.child_count().saturating_sub(1))
+                type_ann.child(type_ann.child_count().saturating_sub(1))
                     .map(|n| node_text(&n, source))
                     .unwrap_or("")
             } else {
@@ -108,8 +96,7 @@ fn extract_swift_parameters(node: &Node, source: &[u8]) -> Vec<Definition> {
                         if param.kind() == "parameter" {
                             // Swift params have external and internal names
                             // The internal name (or only name) is what we want
-                            let name = param
-                                .child_by_field_name("internal_name")
+                            let name = param.child_by_field_name("internal_name")
                                 .or_else(|| param.child_by_field_name("name"))
                                 .or_else(|| find_child(&param, "simple_identifier"))
                                 .map(|n| node_text(&n, source).to_string());
@@ -127,7 +114,8 @@ fn extract_swift_parameters(node: &Node, source: &[u8]) -> Vec<Definition> {
 
 fn extract_swift_class_properties(node: &Node, source: &[u8]) -> Vec<Definition> {
     let mut props = Vec::new();
-    let body = find_child(node, "class_body").or_else(|| find_child(node, "enum_class_body"));
+    let body = find_child(node, "class_body")
+        .or_else(|| find_child(node, "enum_class_body"));
     if let Some(body) = body {
         for i in 0..body.child_count() {
             if let Some(child) = body.child(i) {
@@ -148,7 +136,8 @@ fn extract_swift_class_properties(node: &Node, source: &[u8]) -> Vec<Definition>
 
 fn extract_swift_enum_cases(node: &Node, source: &[u8]) -> Vec<Definition> {
     let mut cases = Vec::new();
-    let body = find_child(node, "enum_class_body").or_else(|| find_child(node, "class_body"));
+    let body = find_child(node, "enum_class_body")
+        .or_else(|| find_child(node, "class_body"));
     if let Some(body) = body {
         for i in 0..body.child_count() {
             if let Some(child) = body.child(i) {
@@ -167,12 +156,7 @@ fn extract_swift_enum_cases(node: &Node, source: &[u8]) -> Vec<Definition> {
     cases
 }
 
-fn extract_swift_inheritance(
-    node: &Node,
-    source: &[u8],
-    class_name: &str,
-    symbols: &mut FileSymbols,
-) {
+fn extract_swift_inheritance(node: &Node, source: &[u8], class_name: &str, symbols: &mut FileSymbols) {
     let mut first = true;
     for i in 0..node.child_count() {
         if let Some(child) = node.child(i) {
@@ -209,15 +193,12 @@ fn extract_swift_inheritance(
 /// Inspects call_suffix → value_arguments → value_argument → line_string_literal.
 fn get_swift_first_string_literal(call_node: &Node, source: &[u8]) -> Option<String> {
     let call_suffix = find_child(call_node, "call_suffix")?;
-    let value_args = find_child(&call_suffix, "value_arguments").unwrap_or(call_suffix);
+    let value_args = find_child(&call_suffix, "value_arguments")
+        .unwrap_or(call_suffix);
     for i in 0..value_args.child_count() {
-        let Some(arg) = value_args.child(i) else {
-            continue;
-        };
+        let Some(arg) = value_args.child(i) else { continue };
         let t = arg.kind();
-        if matches!(t, "(" | ")" | ",") {
-            continue;
-        }
+        if matches!(t, "(" | ")" | ",") { continue; }
         let value_node = if t == "value_argument" {
             arg.child_by_field_name("value")
                 .or_else(|| arg.child(arg.child_count().saturating_sub(1)))
@@ -228,9 +209,7 @@ fn get_swift_first_string_literal(call_node: &Node, source: &[u8]) -> Option<Str
         let vt = value_node.kind();
         if vt == "line_string_literal" || vt == "string_literal" {
             for j in 0..value_node.child_count() {
-                let Some(ch) = value_node.child(j) else {
-                    continue;
-                };
+                let Some(ch) = value_node.child(j) else { continue };
                 if ch.kind() == "line_str_text" || ch.kind() == "string_content" {
                     return Some(node_text(&ch, source).to_string());
                 }
@@ -246,8 +225,8 @@ fn get_swift_first_string_literal(call_node: &Node, source: &[u8]) -> Option<Str
 fn match_swift_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: usize) {
     match node.kind() {
         "class_declaration" => {
-            let name_node =
-                find_child(node, "simple_identifier").or_else(|| node.child_by_field_name("name"));
+            let name_node = find_child(node, "simple_identifier")
+                .or_else(|| node.child_by_field_name("name"));
             if let Some(name_node) = name_node {
                 let class_name = node_text(&name_node, source).to_string();
                 let kind = swift_class_kind(node, source);
@@ -290,8 +269,8 @@ fn match_swift_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dept
         }
 
         "protocol_declaration" => {
-            let name_node =
-                find_child(node, "simple_identifier").or_else(|| node.child_by_field_name("name"));
+            let name_node = find_child(node, "simple_identifier")
+                .or_else(|| node.child_by_field_name("name"));
             if let Some(name_node) = name_node {
                 let proto_name = node_text(&name_node, source).to_string();
                 symbols.definitions.push(Definition {
@@ -312,8 +291,8 @@ fn match_swift_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dept
         }
 
         "function_declaration" => {
-            let name_node =
-                find_child(node, "simple_identifier").or_else(|| node.child_by_field_name("name"));
+            let name_node = find_child(node, "simple_identifier")
+                .or_else(|| node.child_by_field_name("name"));
             if let Some(name_node) = name_node {
                 let parent_class = find_swift_parent_class(node, source);
                 let name = node_text(&name_node, source);
@@ -321,11 +300,7 @@ fn match_swift_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dept
                     Some(cls) => format!("{}.{}", cls, name),
                     None => name.to_string(),
                 };
-                let kind = if parent_class.is_some() {
-                    "method"
-                } else {
-                    "function"
-                };
+                let kind = if parent_class.is_some() { "method" } else { "function" };
                 let children = extract_swift_parameters(node, source);
                 symbols.definitions.push(Definition {
                     name: full_name,
@@ -362,21 +337,20 @@ fn match_swift_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dept
                         // (e.g. `.save` text), not a bare `simple_identifier`. Descend into
                         // navigation_suffix to get the inner simple_identifier so the resolved
                         // name is "save" not ".save". Mirrors WASM extractors/swift.ts fix.
-                        let name = last
-                            .map(|n| {
-                                if n.kind() == "navigation_suffix" {
-                                    find_child(&n, "simple_identifier")
-                                        .map(|id| node_text(&id, source).to_string())
-                                        .unwrap_or_else(|| {
-                                            let t = node_text(&n, source);
-                                            t.trim_start_matches('.').to_string()
-                                        })
-                                } else {
-                                    node_text(&n, source).to_string()
-                                }
-                            })
-                            .unwrap_or_else(|| node_text(&fn_node, source).to_string());
-                        let receiver = fn_node.child(0).map(|n| node_text(&n, source).to_string());
+                        let name = last.map(|n| {
+                            if n.kind() == "navigation_suffix" {
+                                find_child(&n, "simple_identifier")
+                                    .map(|id| node_text(&id, source).to_string())
+                                    .unwrap_or_else(|| {
+                                        let t = node_text(&n, source);
+                                        t.trim_start_matches('.').to_string()
+                                    })
+                            } else {
+                                node_text(&n, source).to_string()
+                            }
+                        }).unwrap_or_else(|| node_text(&fn_node, source).to_string());
+                        let receiver = fn_node.child(0)
+                            .map(|n| node_text(&n, source).to_string());
                         (name, receiver)
                     }
                     _ => (node_text(&fn_node, source).to_string(), None),
@@ -403,9 +377,7 @@ fn match_swift_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dept
                 if call_name == "NSSelectorFromString" {
                     let literal = get_swift_first_string_literal(node, source);
                     symbols.calls.push(Call {
-                        name: literal
-                            .clone()
-                            .unwrap_or_else(|| "<dynamic:unresolved>".to_string()),
+                        name: literal.clone().unwrap_or_else(|| "<dynamic:unresolved>".to_string()),
                         line: call_line,
                         dynamic: Some(true),
                         dynamic_kind: Some(if literal.is_some() {
@@ -487,15 +459,8 @@ mod tests {
     #[test]
     fn extracts_navigation_call_bare_name() {
         let s = parse_swift("func f() { repo.save(x) }");
-        let call = s
-            .calls
-            .iter()
-            .find(|c| c.receiver.as_deref() == Some("repo"))
-            .unwrap();
-        assert_eq!(
-            call.name, "save",
-            "method name must not include leading dot"
-        );
+        let call = s.calls.iter().find(|c| c.receiver.as_deref() == Some("repo")).unwrap();
+        assert_eq!(call.name, "save", "method name must not include leading dot");
         assert_eq!(call.receiver.as_deref(), Some("repo"));
     }
 

--- a/crates/codegraph-core/src/extractors/verilog.rs
+++ b/crates/codegraph-core/src/extractors/verilog.rs
@@ -1,7 +1,7 @@
+use tree_sitter::{Node, Tree};
+use crate::types::*;
 use super::helpers::*;
 use super::SymbolExtractor;
-use crate::types::*;
-use tree_sitter::{Node, Tree};
 
 /// Verilog/SystemVerilog symbol extractor.
 ///
@@ -32,12 +32,7 @@ impl SymbolExtractor for VerilogExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_verilog_node);
-        walk_ast_nodes_with_config(
-            &tree.root_node(),
-            source,
-            &mut symbols.ast_nodes,
-            &VERILOG_AST_CONFIG,
-        );
+        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &VERILOG_AST_CONFIG);
         symbols
     }
 }
@@ -274,9 +269,11 @@ fn handle_package_import(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
                 // the empty-string fallback is unreachable in practice.
                 let pkg = parts.next().unwrap_or("").to_string();
                 let item = parts.next().unwrap_or("*").to_string();
-                symbols
-                    .imports
-                    .push(Import::new(pkg, vec![item], start_line(node)));
+                symbols.imports.push(Import::new(
+                    pkg,
+                    vec![item],
+                    start_line(node),
+                ));
             }
         }
     }
@@ -287,8 +284,7 @@ fn handle_include_directive(node: &Node, source: &[u8], symbols: &mut FileSymbol
     for i in 0..node.child_count() {
         if let Some(child) = node.child(i) {
             let kind = child.kind();
-            if kind == "string_literal" || kind == "quoted_string" || kind == "double_quoted_string"
-            {
+            if kind == "string_literal" || kind == "quoted_string" || kind == "double_quoted_string" {
                 let raw = node_text(&child, source);
                 let source_path = raw
                     .trim_matches(|c: char| c == '"' || c == '\'')
@@ -319,8 +315,8 @@ fn find_module_name(node: &Node, source: &[u8]) -> Option<String> {
         return Some(text.to_string());
     }
     if let Some(header) = find_child(node, "module_header") {
-        let id =
-            find_child(&header, "simple_identifier").or_else(|| find_child(&header, "identifier"));
+        let id = find_child(&header, "simple_identifier")
+            .or_else(|| find_child(&header, "identifier"));
         if let Some(id) = id {
             return Some(node_text(&id, source).to_string());
         }
@@ -514,11 +510,7 @@ mod tests {
              endmodule\n",
         );
         let calls: Vec<&Call> = s.calls.iter().filter(|c| c.name == "sub").collect();
-        assert_eq!(
-            calls.len(),
-            1,
-            "module instantiation should appear as a call"
-        );
+        assert_eq!(calls.len(), 1, "module instantiation should appear as a call");
     }
 
     #[test]
@@ -640,3 +632,4 @@ mod tests {
         assert_eq!(t.kind, "function");
     }
 }
+

--- a/crates/codegraph-core/src/extractors/verilog.rs
+++ b/crates/codegraph-core/src/extractors/verilog.rs
@@ -1,7 +1,7 @@
-use tree_sitter::{Node, Tree};
-use crate::types::*;
 use super::helpers::*;
 use super::SymbolExtractor;
+use crate::types::*;
+use tree_sitter::{Node, Tree};
 
 /// Verilog/SystemVerilog symbol extractor.
 ///
@@ -32,7 +32,12 @@ impl SymbolExtractor for VerilogExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_verilog_node);
-        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &VERILOG_AST_CONFIG);
+        walk_ast_nodes_with_config(
+            &tree.root_node(),
+            source,
+            &mut symbols.ast_nodes,
+            &VERILOG_AST_CONFIG,
+        );
         symbols
     }
 }
@@ -70,6 +75,7 @@ fn handle_module_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: opt_children(ports),
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -88,6 +94,7 @@ fn handle_interface_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -106,6 +113,7 @@ fn handle_package_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -132,6 +140,7 @@ fn handle_class_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 
     if let Some(superclass) = find_class_superclass(node, source) {
@@ -198,6 +207,7 @@ fn handle_function_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -221,6 +231,7 @@ fn handle_task_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -263,11 +274,9 @@ fn handle_package_import(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
                 // the empty-string fallback is unreachable in practice.
                 let pkg = parts.next().unwrap_or("").to_string();
                 let item = parts.next().unwrap_or("*").to_string();
-                symbols.imports.push(Import::new(
-                    pkg,
-                    vec![item],
-                    start_line(node),
-                ));
+                symbols
+                    .imports
+                    .push(Import::new(pkg, vec![item], start_line(node)));
             }
         }
     }
@@ -278,7 +287,8 @@ fn handle_include_directive(node: &Node, source: &[u8], symbols: &mut FileSymbol
     for i in 0..node.child_count() {
         if let Some(child) = node.child(i) {
             let kind = child.kind();
-            if kind == "string_literal" || kind == "quoted_string" || kind == "double_quoted_string" {
+            if kind == "string_literal" || kind == "quoted_string" || kind == "double_quoted_string"
+            {
                 let raw = node_text(&child, source);
                 let source_path = raw
                     .trim_matches(|c: char| c == '"' || c == '\'')
@@ -309,8 +319,8 @@ fn find_module_name(node: &Node, source: &[u8]) -> Option<String> {
         return Some(text.to_string());
     }
     if let Some(header) = find_child(node, "module_header") {
-        let id = find_child(&header, "simple_identifier")
-            .or_else(|| find_child(&header, "identifier"));
+        let id =
+            find_child(&header, "simple_identifier").or_else(|| find_child(&header, "identifier"));
         if let Some(id) = id {
             return Some(node_text(&id, source).to_string());
         }
@@ -504,7 +514,11 @@ mod tests {
              endmodule\n",
         );
         let calls: Vec<&Call> = s.calls.iter().filter(|c| c.name == "sub").collect();
-        assert_eq!(calls.len(), 1, "module instantiation should appear as a call");
+        assert_eq!(
+            calls.len(),
+            1,
+            "module instantiation should appear as a call"
+        );
     }
 
     #[test]
@@ -626,4 +640,3 @@ mod tests {
         assert_eq!(t.kind, "function");
     }
 }
-

--- a/crates/codegraph-core/src/extractors/zig.rs
+++ b/crates/codegraph-core/src/extractors/zig.rs
@@ -1,9 +1,9 @@
-use super::helpers::*;
-use super::SymbolExtractor;
+use tree_sitter::{Node, Tree};
 use crate::ast_analysis::cfg::build_function_cfg;
 use crate::ast_analysis::complexity::compute_all_metrics;
 use crate::types::*;
-use tree_sitter::{Node, Tree};
+use super::helpers::*;
+use super::SymbolExtractor;
 
 pub struct ZigExtractor;
 
@@ -11,12 +11,7 @@ impl SymbolExtractor for ZigExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_zig_node);
-        walk_ast_nodes_with_config(
-            &tree.root_node(),
-            source,
-            &mut symbols.ast_nodes,
-            &ZIG_AST_CONFIG,
-        );
+        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &ZIG_AST_CONFIG);
         symbols
     }
 }
@@ -81,9 +76,7 @@ fn extract_zig_params(func_node: &Node, source: &[u8]) -> Vec<Definition> {
 }
 
 fn handle_zig_variable(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = find_child(node, "identifier") else {
-        return;
-    };
+    let Some(name_node) = find_child(node, "identifier") else { return };
     let name = node_text(&name_node, source).to_string();
 
     // Check for struct/enum/union type definition
@@ -112,19 +105,11 @@ fn handle_zig_variable(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     });
 }
 
-fn try_handle_zig_type_def(
-    node: &Node,
-    source: &[u8],
-    symbols: &mut FileSymbols,
-    name: &str,
-) -> bool {
+fn try_handle_zig_type_def(node: &Node, source: &[u8], symbols: &mut FileSymbols, name: &str) -> bool {
     for i in 0..node.child_count() {
         let Some(child) = node.child(i) else { continue };
         let (kind, children) = match child.kind() {
-            "struct_declaration" => (
-                "struct",
-                opt_children(extract_zig_container_fields(&child, source)),
-            ),
+            "struct_declaration" => ("struct", opt_children(extract_zig_container_fields(&child, source))),
             "enum_declaration" => ("enum", None),
             "union_declaration" => ("struct", None),
             _ => continue,
@@ -146,21 +131,12 @@ fn try_handle_zig_type_def(
     false
 }
 
-fn try_handle_zig_import(
-    node: &Node,
-    source: &[u8],
-    symbols: &mut FileSymbols,
-    name: String,
-) -> bool {
+fn try_handle_zig_import(node: &Node, source: &[u8], symbols: &mut FileSymbols, name: String) -> bool {
     for i in 0..node.child_count() {
         let Some(child) = node.child(i) else { continue };
-        if child.kind() != "builtin_function" {
-            continue;
-        }
+        if child.kind() != "builtin_function" { continue; }
         if let Some(path) = extract_zig_import_path(&child, source) {
-            symbols
-                .imports
-                .push(Import::new(path, vec![name], start_line(node)));
+            symbols.imports.push(Import::new(path, vec![name], start_line(node)));
             return true;
         }
     }
@@ -169,9 +145,7 @@ fn try_handle_zig_import(
 
 fn extract_zig_import_path(builtin: &Node, source: &[u8]) -> Option<String> {
     let builtin_id = find_child(builtin, "builtin_identifier")?;
-    if node_text(&builtin_id, source) != "@import" {
-        return None;
-    }
+    if node_text(&builtin_id, source) != "@import" { return None; }
     let args = find_child(builtin, "arguments")?;
     for j in 0..args.child_count() {
         let Some(arg) = args.child(j) else { continue };
@@ -188,8 +162,7 @@ fn extract_zig_container_fields(container: &Node, source: &[u8]) -> Vec<Definiti
     for i in 0..container.child_count() {
         if let Some(child) = container.child(i) {
             if child.kind() == "container_field" {
-                let name_node = child
-                    .child_by_field_name("name")
+                let name_node = child.child_by_field_name("name")
                     .or_else(|| find_child(&child, "identifier"));
                 if let Some(n) = name_node {
                     fields.push(child_def(
@@ -205,18 +178,14 @@ fn extract_zig_container_fields(container: &Node, source: &[u8]) -> Vec<Definiti
 }
 
 fn handle_zig_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let func_node = match node
-        .child_by_field_name("function")
-        .or_else(|| node.child(0))
-    {
+    let func_node = match node.child_by_field_name("function").or_else(|| node.child(0)) {
         Some(n) => n,
         None => return,
     };
 
     match func_node.kind() {
         "field_expression" | "field_access" => {
-            let field = func_node
-                .child_by_field_name("field")
+            let field = func_node.child_by_field_name("field")
                 .or_else(|| func_node.child_by_field_name("member"));
             let value = func_node.child(0);
             if let Some(f) = field {

--- a/crates/codegraph-core/src/extractors/zig.rs
+++ b/crates/codegraph-core/src/extractors/zig.rs
@@ -1,9 +1,9 @@
-use tree_sitter::{Node, Tree};
+use super::helpers::*;
+use super::SymbolExtractor;
 use crate::ast_analysis::cfg::build_function_cfg;
 use crate::ast_analysis::complexity::compute_all_metrics;
 use crate::types::*;
-use super::helpers::*;
-use super::SymbolExtractor;
+use tree_sitter::{Node, Tree};
 
 pub struct ZigExtractor;
 
@@ -11,7 +11,12 @@ impl SymbolExtractor for ZigExtractor {
     fn extract(&self, tree: &Tree, source: &[u8], file_path: &str) -> FileSymbols {
         let mut symbols = FileSymbols::new(file_path.to_string());
         walk_tree(&tree.root_node(), source, &mut symbols, match_zig_node);
-        walk_ast_nodes_with_config(&tree.root_node(), source, &mut symbols.ast_nodes, &ZIG_AST_CONFIG);
+        walk_ast_nodes_with_config(
+            &tree.root_node(),
+            source,
+            &mut symbols.ast_nodes,
+            &ZIG_AST_CONFIG,
+        );
         symbols
     }
 }
@@ -51,6 +56,7 @@ fn handle_zig_function(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: build_function_cfg(node, "zig", source),
         children: opt_children(params),
         bodyless: None,
+        content_hash: None,
     });
 }
 
@@ -75,7 +81,9 @@ fn extract_zig_params(func_node: &Node, source: &[u8]) -> Vec<Definition> {
 }
 
 fn handle_zig_variable(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let Some(name_node) = find_child(node, "identifier") else { return };
+    let Some(name_node) = find_child(node, "identifier") else {
+        return;
+    };
     let name = node_text(&name_node, source).to_string();
 
     // Check for struct/enum/union type definition
@@ -100,14 +108,23 @@ fn handle_zig_variable(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 
-fn try_handle_zig_type_def(node: &Node, source: &[u8], symbols: &mut FileSymbols, name: &str) -> bool {
+fn try_handle_zig_type_def(
+    node: &Node,
+    source: &[u8],
+    symbols: &mut FileSymbols,
+    name: &str,
+) -> bool {
     for i in 0..node.child_count() {
         let Some(child) = node.child(i) else { continue };
         let (kind, children) = match child.kind() {
-            "struct_declaration" => ("struct", opt_children(extract_zig_container_fields(&child, source))),
+            "struct_declaration" => (
+                "struct",
+                opt_children(extract_zig_container_fields(&child, source)),
+            ),
             "enum_declaration" => ("enum", None),
             "union_declaration" => ("struct", None),
             _ => continue,
@@ -122,18 +139,28 @@ fn try_handle_zig_type_def(node: &Node, source: &[u8], symbols: &mut FileSymbols
             cfg: None,
             children,
             bodyless: None,
+            content_hash: None,
         });
         return true;
     }
     false
 }
 
-fn try_handle_zig_import(node: &Node, source: &[u8], symbols: &mut FileSymbols, name: String) -> bool {
+fn try_handle_zig_import(
+    node: &Node,
+    source: &[u8],
+    symbols: &mut FileSymbols,
+    name: String,
+) -> bool {
     for i in 0..node.child_count() {
         let Some(child) = node.child(i) else { continue };
-        if child.kind() != "builtin_function" { continue; }
+        if child.kind() != "builtin_function" {
+            continue;
+        }
         if let Some(path) = extract_zig_import_path(&child, source) {
-            symbols.imports.push(Import::new(path, vec![name], start_line(node)));
+            symbols
+                .imports
+                .push(Import::new(path, vec![name], start_line(node)));
             return true;
         }
     }
@@ -142,7 +169,9 @@ fn try_handle_zig_import(node: &Node, source: &[u8], symbols: &mut FileSymbols, 
 
 fn extract_zig_import_path(builtin: &Node, source: &[u8]) -> Option<String> {
     let builtin_id = find_child(builtin, "builtin_identifier")?;
-    if node_text(&builtin_id, source) != "@import" { return None; }
+    if node_text(&builtin_id, source) != "@import" {
+        return None;
+    }
     let args = find_child(builtin, "arguments")?;
     for j in 0..args.child_count() {
         let Some(arg) = args.child(j) else { continue };
@@ -159,7 +188,8 @@ fn extract_zig_container_fields(container: &Node, source: &[u8]) -> Vec<Definiti
     for i in 0..container.child_count() {
         if let Some(child) = container.child(i) {
             if child.kind() == "container_field" {
-                let name_node = child.child_by_field_name("name")
+                let name_node = child
+                    .child_by_field_name("name")
                     .or_else(|| find_child(&child, "identifier"));
                 if let Some(n) = name_node {
                     fields.push(child_def(
@@ -175,14 +205,18 @@ fn extract_zig_container_fields(container: &Node, source: &[u8]) -> Vec<Definiti
 }
 
 fn handle_zig_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let func_node = match node.child_by_field_name("function").or_else(|| node.child(0)) {
+    let func_node = match node
+        .child_by_field_name("function")
+        .or_else(|| node.child(0))
+    {
         Some(n) => n,
         None => return,
     };
 
     match func_node.kind() {
         "field_expression" | "field_access" => {
-            let field = func_node.child_by_field_name("field")
+            let field = func_node
+                .child_by_field_name("field")
                 .or_else(|| func_node.child_by_field_name("member"));
             let value = func_node.child(0);
             if let Some(f) = field {
@@ -263,6 +297,7 @@ fn handle_zig_test(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         cfg: None,
         children: None,
         bodyless: None,
+        content_hash: None,
     });
 }
 

--- a/crates/codegraph-core/src/types.rs
+++ b/crates/codegraph-core/src/types.rs
@@ -107,6 +107,15 @@ pub struct Definition {
     /// does not imply this: it's the normal qualified name for real bodied
     /// class/struct/impl/module methods across every extractor.
     pub bodyless: Option<bool>,
+    /// SHA-256 hash of this declaration's own source text (`line`..`end_line`),
+    /// computed centrally after extraction (see `compute_declaration_hashes`
+    /// in `domain/parallel.rs`) rather than per-extractor, since every
+    /// extractor already populates `line`/`end_line` uniformly. Gives
+    /// reverse-dep-edge reconnection during incremental rebuilds a true
+    /// identity signal beyond line position (issue #2015). `None` when
+    /// `end_line` is unavailable.
+    #[napi(js_name = "contentHash")]
+    pub content_hash: Option<String>,
 }
 
 #[napi(object)]

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -371,6 +371,22 @@ export const MIGRATIONS: Migration[] = [
       CREATE INDEX IF NOT EXISTS idx_dataflow_call_edge ON dataflow(call_edge_id);
     `,
   },
+  {
+    // Per-declaration content hash (issue #2015): reverse-dep-edge
+    // reconnection during incremental rebuilds previously matched siblings
+    // by line position alone, which is provably unsafe when a same-named/
+    // same-kind sibling group has one member renamed away and a different
+    // one added in the same edit — the group's size stays unchanged, so the
+    // line-alignment fast path matches by rank and can silently reconnect a
+    // caller to the wrong declaration. A content hash gives reconnection a
+    // true identity signal to try first, falling back to line alignment
+    // only when a hash is unavailable (e.g. rows from before this
+    // migration).
+    version: 24,
+    up: `
+      ALTER TABLE nodes ADD COLUMN content_hash TEXT;
+    `,
+  },
 ];
 
 interface PragmaColumnInfo {
@@ -462,6 +478,7 @@ function ensureNodeColumns(db: BetterSqlite3Database): void {
   if (missing('qualified_name')) db.exec('ALTER TABLE nodes ADD COLUMN qualified_name TEXT');
   if (missing('scope')) db.exec('ALTER TABLE nodes ADD COLUMN scope TEXT');
   if (missing('visibility')) db.exec('ALTER TABLE nodes ADD COLUMN visibility TEXT');
+  if (missing('content_hash')) db.exec('ALTER TABLE nodes ADD COLUMN content_hash TEXT');
   db.exec('UPDATE nodes SET qualified_name = name WHERE qualified_name IS NULL');
   db.exec('CREATE INDEX IF NOT EXISTS idx_nodes_qualified_name ON nodes(qualified_name)');
   db.exec('CREATE INDEX IF NOT EXISTS idx_nodes_scope ON nodes(scope)');

--- a/src/domain/graph/builder/context.ts
+++ b/src/domain/graph/builder/context.ts
@@ -101,6 +101,16 @@ export class PipelineContext {
     dynamic: number;
     technique: string | null;
     dynamicKind: string | null;
+    /**
+     * The target declaration's `content_hash` at save time, or `null` when
+     * unavailable (rows from before the content_hash migration). Lets
+     * `pickReconnectTarget` try an exact-hash match before falling back to
+     * line-position alignment — a true identity signal that line position
+     * alone cannot provide when a sibling group's size stays unchanged
+     * because one member was renamed away and a different one added in the
+     * same edit (issue #2015).
+     */
+    tgtHash: string | null;
   }> = [];
 
   /**

--- a/src/domain/graph/builder/helpers.ts
+++ b/src/domain/graph/builder/helpers.ts
@@ -361,9 +361,9 @@ const edgeStmtCache = new WeakMap<BetterSqlite3Database, Map<number, SqliteState
 
 function getNodeStmt(db: BetterSqlite3Database, chunkSize: number): SqliteStatement {
   return getOrCreatePerDbChunkStmt(nodeStmtCache, db, chunkSize, (n) => {
-    const ph = '(?,?,?,?,?,?,?,?,?)';
+    const ph = '(?,?,?,?,?,?,?,?,?,?)';
     return (
-      'INSERT OR IGNORE INTO nodes (name,kind,file,line,end_line,parent_id,qualified_name,scope,visibility) VALUES ' +
+      'INSERT OR IGNORE INTO nodes (name,kind,file,line,end_line,parent_id,qualified_name,scope,visibility,content_hash) VALUES ' +
       Array.from({ length: n }, () => ph).join(',')
     );
   });
@@ -407,11 +407,11 @@ function runBatchInsert(
 
 /**
  * Batch-insert node rows via multi-value INSERT statements.
- * Each row: [name, kind, file, line, end_line, parent_id, qualified_name, scope, visibility]
+ * Each row: [name, kind, file, line, end_line, parent_id, qualified_name, scope, visibility, content_hash]
  */
 export function batchInsertNodes(db: BetterSqlite3Database, rows: unknown[][]): void {
   runBatchInsert(db, rows, getNodeStmt, (r, vals) => {
-    vals.push(r[0], r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8]);
+    vals.push(r[0], r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8], r[9] ?? null);
   });
 }
 

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -2078,6 +2078,17 @@ function pickReconnectTarget(
   maxAlignGroupSize: number,
 ): number | null {
   if (candidates.length === 0) return null;
+  // A lone candidate is trusted unconditionally, without consulting the
+  // hash: unlike the multi-candidate case, there is no sibling to
+  // corroborate a hash mismatch as "an unrelated declaration," and the
+  // overwhelmingly common cause of a sole candidate's hash differing from
+  // the saved one is simply that its OWN body was edited in the same
+  // change — contentHash is a hash of the declaration's source text, so any
+  // in-place edit changes it. Gating on the hash here would silently drop
+  // the edge for that ordinary case (caught by #1744's regression test),
+  // trading a common, legitimate scenario for a rare rename-away-and-replace
+  // collision that a hash comparison cannot even reliably distinguish from
+  // a body edit when there is only one candidate to compare against.
   if (candidates.length === 1) return candidates[0]!.id;
 
   if (tgtHash) {

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -2046,17 +2046,32 @@ function alignSiblingLines(oldLines: number[], newLines: number[]): Map<number, 
  * Picks the correct reconnect target among same-(name,kind,file) candidates.
  *
  * A single candidate is an unambiguous match. With several candidates (e.g.
- * multiple object-literal `close() {}` methods in one file), the saved
- * sibling-group snapshot from before purge is aligned against the current
- * candidate lines (see `alignSiblingLines`) to find which new line the saved
- * target's old line maps to — correct even when the whole group shifted and
- * its size changed in the same edit. Falls back to nearest-line only when no
- * sibling-group snapshot is available, or the group is too large to align
- * cheaply.
+ * multiple object-literal `close() {}` methods in one file), an exact
+ * `content_hash` match is tried first (see the `tgtHash` param doc) since
+ * it's a true identity signal, not just position — falling back to the
+ * saved sibling-group snapshot from before purge, aligned against the
+ * current candidate lines (see `alignSiblingLines`) to find which new line
+ * the saved target's old line maps to. That line-position fallback is
+ * correct even when the whole group shifted and its size changed in the
+ * same edit, EXCEPT the one compound case a hash catches and line
+ * position provably cannot: a same-named/same-kind sibling both removed
+ * (renamed away) and a different one added in the same edit, leaving the
+ * group's size unchanged (issue #2015). Falls back to nearest-line only
+ * when no sibling-group snapshot is available, or the group is too large
+ * to align cheaply.
  */
 function pickReconnectTarget(
-  candidates: Array<{ id: number; line: number }>,
+  candidates: Array<{ id: number; line: number; contentHash: string | null }>,
   tgtLine: number,
+  /**
+   * The saved edge's target declaration's `content_hash` at save time, or
+   * `null` when unavailable (pre-migration rows). Only trusted when exactly
+   * one candidate in this group shares it — if two or more candidates have
+   * byte-identical bodies (rare but possible), the hash can't disambiguate
+   * between them, so this falls through to line alignment instead of
+   * guessing.
+   */
+  tgtHash: string | null,
   groupKey: string,
   savedSiblingGroups: ReadonlyMap<string, number[]>,
   alignmentCache: Map<string, Map<number, number>>,
@@ -2064,6 +2079,26 @@ function pickReconnectTarget(
 ): number | null {
   if (candidates.length === 0) return null;
   if (candidates.length === 1) return candidates[0]!.id;
+
+  if (tgtHash) {
+    // Only trust a hash-based verdict when there's actual hash data among
+    // this group's candidates to compare against — if none carry a hash
+    // (e.g. their endLine was unavailable to compute one), fall through to
+    // line alignment entirely rather than treating a vacuous "0 matches"
+    // as proof the target is gone.
+    const candidatesWithHash = candidates.filter((c) => c.contentHash !== null);
+    if (candidatesWithHash.length > 0) {
+      const hashMatches = candidatesWithHash.filter((c) => c.contentHash === tgtHash);
+      if (hashMatches.length === 1) return hashMatches[0]!.id;
+      // Zero matches means the exact body no longer exists among any
+      // current candidate — a stronger, more direct identity signal than
+      // line position, so this is a confident drop, not a cue to fall
+      // through and guess by rank/line (the exact silent-miswire #2015
+      // describes). More than one match is a rare byte-identical
+      // duplicate — genuinely ambiguous, so THAT case still falls through.
+      if (hashMatches.length === 0) return null;
+    }
+  }
 
   const oldLines = savedSiblingGroups.get(groupKey);
   if (
@@ -2125,7 +2160,7 @@ function pickReconnectTarget(
 function reconnectReverseDepEdges(ctx: PipelineContext): void {
   const { db } = ctx;
   const candidatesStmt = db.prepare(
-    'SELECT id, line FROM nodes WHERE name = ? AND kind = ? AND file = ? ORDER BY line',
+    'SELECT id, line, content_hash AS contentHash FROM nodes WHERE name = ? AND kind = ? AND file = ? ORDER BY line',
   );
   const reconnectedRows: EdgeRowTuple[] = [];
   let dropped = 0;
@@ -2133,7 +2168,10 @@ function reconnectReverseDepEdges(ctx: PipelineContext): void {
   // Cache candidate lists per (name, kind, file) group — many saved edges
   // often share the same target (e.g. several callers of the same
   // function), so this avoids re-querying per edge.
-  const candidatesCache = new Map<string, Array<{ id: number; line: number }>>();
+  const candidatesCache = new Map<
+    string,
+    Array<{ id: number; line: number; contentHash: string | null }>
+  >();
   // Cache the (potentially expensive) alignment result per group too —
   // shared across every saved edge targeting the same sibling group.
   const alignmentCache = new Map<string, Map<number, number>>();
@@ -2146,6 +2184,7 @@ function reconnectReverseDepEdges(ctx: PipelineContext): void {
       candidates = candidatesStmt.all(saved.tgtName, saved.tgtKind, saved.tgtFile) as Array<{
         id: number;
         line: number;
+        contentHash: string | null;
       }>;
       candidatesCache.set(cacheKey, candidates);
     }
@@ -2153,6 +2192,7 @@ function reconnectReverseDepEdges(ctx: PipelineContext): void {
     const newId = pickReconnectTarget(
       candidates,
       saved.tgtLine,
+      saved.tgtHash,
       cacheKey,
       ctx.savedSiblingGroups,
       alignmentCache,

--- a/src/domain/graph/builder/stages/detect-changes.ts
+++ b/src/domain/graph/builder/stages/detect-changes.ts
@@ -488,6 +488,7 @@ function addReverseDeps(
     SELECT e.source_id, n_tgt.name AS tgt_name, n_tgt.kind AS tgt_kind,
            n_tgt.file AS tgt_file, n_tgt.line AS tgt_line,
            e.kind AS edge_kind, e.confidence, e.dynamic, e.technique, e.dynamic_kind,
+           n_tgt.content_hash AS tgt_hash,
            n_src.file AS src_file
     FROM edges e
     JOIN nodes n_src ON e.source_id = n_src.id
@@ -510,6 +511,7 @@ function addReverseDeps(
       dynamic: number;
       technique: string | null;
       dynamic_kind: string | null;
+      tgt_hash: string | null;
       src_file: string;
     }>) {
       // Skip edges whose source is also being purged — buildEdges will
@@ -533,6 +535,7 @@ function addReverseDeps(
         dynamic: row.dynamic,
         technique: row.technique,
         dynamicKind: row.dynamic_kind,
+        tgtHash: row.tgt_hash,
       });
     }
   }

--- a/src/domain/graph/builder/stages/insert-nodes.ts
+++ b/src/domain/graph/builder/stages/insert-nodes.ts
@@ -56,12 +56,14 @@ interface InsertNodesBatch {
     line: number;
     endLine?: number;
     visibility?: string;
+    contentHash?: string;
     children: Array<{
       name: string;
       kind: string;
       line: number;
       endLine?: number;
       visibility?: string;
+      contentHash?: string;
     }>;
   }>;
   exports: Array<{ name: string; kind: string; line: number }>;
@@ -79,12 +81,14 @@ function marshalSymbolBatches(allSymbols: Map<string, ExtractorOutput>): InsertN
         line: def.line,
         endLine: def.endLine ?? undefined,
         visibility: def.visibility ?? undefined,
+        contentHash: def.contentHash ?? undefined,
         children: (def.children ?? []).map((c) => ({
           name: c.name,
           kind: c.kind,
           line: c.line,
           endLine: c.endLine ?? undefined,
           visibility: c.visibility ?? undefined,
+          contentHash: c.contentHash ?? undefined,
         })),
       })),
       exports: symbols.exports.map((exp) => ({
@@ -264,7 +268,7 @@ function insertDefinitionsAndExports(
   const phase1Rows: unknown[][] = [];
   const exportKeys: unknown[][] = [];
   for (const [relPath, symbols] of allSymbols) {
-    phase1Rows.push([relPath, 'file', relPath, 0, null, null, null, null, null]);
+    phase1Rows.push([relPath, 'file', relPath, 0, null, null, null, null, null, null]);
     for (const def of symbols.definitions) {
       const dotIdx = def.name.lastIndexOf('.');
       const scope = dotIdx !== -1 ? def.name.slice(0, dotIdx) : null;
@@ -278,10 +282,22 @@ function insertDefinitionsAndExports(
         def.name,
         scope,
         def.visibility || null,
+        def.contentHash || null,
       ]);
     }
     for (const exp of symbols.exports) {
-      phase1Rows.push([exp.name, exp.kind, relPath, exp.line, null, null, exp.name, null, null]);
+      phase1Rows.push([
+        exp.name,
+        exp.kind,
+        relPath,
+        exp.line,
+        null,
+        null,
+        exp.name,
+        null,
+        null,
+        null,
+      ]);
       exportKeys.push([exp.name, exp.kind, relPath, exp.line]);
     }
   }
@@ -333,6 +349,7 @@ function collectChildRowsAndFileEdges(
           `${def.name}.${child.name}`,
           def.name,
           child.visibility || null,
+          child.contentHash || null,
         ]);
       }
     }

--- a/src/domain/graph/builder/stages/native-orchestrator.ts
+++ b/src/domain/graph/builder/stages/native-orchestrator.ts
@@ -1884,7 +1884,7 @@ function insertBackfilledNodes(
   const exportKeys: unknown[][] = [];
   for (const [relPath, symbols] of wasmResults) {
     // File row — mirrors insertDefinitionsAndExports: qualified_name is null.
-    rows.push([relPath, 'file', relPath, 0, null, null, null, null, null]);
+    rows.push([relPath, 'file', relPath, 0, null, null, null, null, null, null]);
     for (const def of symbols.definitions ?? []) {
       // Populate qualified_name/scope the same way the JS fallback does so
       // downstream queries (cross-file references, "go to definition") find
@@ -1901,13 +1901,14 @@ function insertBackfilledNodes(
         def.name,
         scope,
         def.visibility ?? null,
+        def.contentHash ?? null,
       ]);
     }
     // Exports: insert the row (INSERT OR IGNORE — a matching definition row
     // is a no-op) and queue a key for the second-pass exported=1 update, so
     // queries filtering on exported=1 find backfilled symbols (#970).
     for (const exp of symbols.exports ?? []) {
-      rows.push([exp.name, exp.kind, relPath, exp.line, null, null, exp.name, null, null]);
+      rows.push([exp.name, exp.kind, relPath, exp.line, null, null, exp.name, null, null, null]);
       exportKeys.push([exp.name, exp.kind, relPath, exp.line]);
     }
   }

--- a/src/domain/parser.ts
+++ b/src/domain/parser.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -7,10 +8,12 @@ import { debug, warn } from '../infrastructure/logger.js';
 import { getNative, getNativePackageVersion, loadNative } from '../infrastructure/native.js';
 import { ParseError, toErrorMessage } from '../shared/errors.js';
 import type {
+  Definition,
   EngineMode,
   ExtractorOutput,
   LanguageId,
   LanguageRegistryEntry,
+  SubDeclaration,
   TypeMapEntry,
 } from '../types.js';
 import { disposeWasmWorkerPool, getWasmWorkerPool } from './wasm-worker-pool.js';
@@ -652,6 +655,46 @@ function resolveEngine(opts: ParseEngineOpts = {}): ResolvedEngine {
  *  - Backward compat for older native binaries missing js_name annotations
  *  - dataflow argFlows/mutations bindingType -> binding wrapper
  */
+/**
+ * SHA-256 hash of a declaration's own source text (1-based, inclusive
+ * `startLine`..`endLine`), or `undefined` when `endLine` is unavailable — a
+ * declaration with no reliable body range has nothing meaningful to hash.
+ * Gives reverse-dep-edge reconnection during incremental rebuilds a true
+ * identity signal beyond line position (issue #2015).
+ */
+function computeDeclarationHash(
+  lines: string[],
+  startLine: number,
+  endLine: number | undefined,
+): string | undefined {
+  if (endLine === undefined || startLine < 1 || endLine < startLine) return undefined;
+  const startIdx = startLine - 1;
+  if (startIdx >= lines.length) return undefined;
+  const endIdx = Math.min(endLine - 1, lines.length - 1);
+  const body = lines.slice(startIdx, endIdx + 1).join('\n');
+  return createHash('sha256').update(body).digest('hex');
+}
+
+/**
+ * Recursively populates `contentHash` on every definition (and its direct
+ * `children`) using the already-in-scope raw source — computed once,
+ * centrally, here rather than per-extractor, since every extractor already
+ * populates `line`/`endLine` uniformly. WASM-only: the native engine
+ * computes this itself (crates/codegraph-core/src/domain/parallel.rs)
+ * before results cross the FFI boundary.
+ */
+function computeDeclarationHashes(definitions: Definition[] | undefined, source: string): void {
+  if (!definitions || definitions.length === 0) return;
+  const lines = source.split('\n');
+  const visit = (def: Definition | SubDeclaration): void => {
+    def.contentHash = computeDeclarationHash(lines, def.line, def.endLine);
+  };
+  for (const def of definitions) {
+    visit(def);
+    def.children?.forEach(visit);
+  }
+}
+
 /** Patch definition fields for backward compat with older native binaries. */
 function patchDefinitions(definitions: any[]): void {
   for (const d of definitions) {
@@ -1136,7 +1179,9 @@ export async function parseFileAuto(
 
   // WASM path — dispatch to isolated worker
   const pool = getWasmWorkerPool();
-  return pool.parse(filePath, source, FULL_ANALYSIS);
+  const output = await pool.parse(filePath, source, FULL_ANALYSIS);
+  if (output) computeDeclarationHashes(output.definitions, source);
+  return output;
 }
 
 /** Backfill typeMap via WASM for TS/TSX files parsed by the native engine. */
@@ -1197,6 +1242,7 @@ async function parseFilesWasm(
     }
     const output = await pool.parse(filePath, code, analysis);
     if (output) {
+      computeDeclarationHashes(output.definitions, code);
       const relPath = path.relative(rootDir, filePath).split(path.sep).join('/');
       result.set(relPath, output);
     }
@@ -1277,6 +1323,7 @@ async function parseFilesWasmInline(
       (extracted.tree as any).delete();
     }
     symbols._langId = extracted.langId;
+    computeDeclarationHashes(symbols.definitions, code);
     result.set(relPath, symbols);
   }
   return result;
@@ -1448,3 +1495,7 @@ export async function parseFileIncremental(
   }
   return parseFileAuto(filePath, source, opts);
 }
+
+// ── Exported for testing ────────────────────────────────────────────
+
+export { computeDeclarationHash, computeDeclarationHashes };

--- a/src/types.ts
+++ b/src/types.ts
@@ -476,6 +476,18 @@ export interface Definition {
   complexity?: DefinitionComplexity;
   /** Populated post-analysis by the CFG visitor. */
   cfg?: { blocks: CfgBlock[]; edges: CfgEdge[] } | null;
+  /**
+   * SHA-256 hash of this declaration's own source text (`line`..`endLine`),
+   * computed centrally after extraction (see `computeDeclarationHashes` in
+   * domain/parser.ts) rather than per-extractor, since every extractor
+   * already populates `line`/`endLine` uniformly. Gives reverse-dep-edge
+   * reconnection during incremental rebuilds a true identity signal beyond
+   * line position — needed to disambiguate a same-named/same-kind sibling
+   * group where one member was renamed away and a different one added in
+   * the same edit (a net-zero group-size change; issue #2015). `undefined`
+   * when `endLine` is unavailable (no reliable body range to hash).
+   */
+  contentHash?: string;
 }
 
 /** Sub-declaration (child) within a definition. */
@@ -486,6 +498,8 @@ export interface SubDeclaration {
   endLine?: number;
   visibility?: 'public' | 'private' | 'protected';
   decorators?: string[];
+  /** See `Definition.contentHash` — same signal, same computation, for method/property children. */
+  contentHash?: string;
 }
 
 /** Complexity metrics attached to a definition post-analysis. */

--- a/tests/integration/issue-2015-reverse-dep-compound-rename-and-add.test.ts
+++ b/tests/integration/issue-2015-reverse-dep-compound-rename-and-add.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Regression test for #2015: the residual gap in #1865's fix for
+ * `reconnectReverseDepEdges` (`build-edges.ts`, WASM/JS engine).
+ *
+ * #1865 correctly handles a sibling group whose SIZE changes (a same-named
+ * sibling added or removed) by falling back to the dominant-line-shift
+ * alignment instead of naive nearest-line matching. But when a same-named/
+ * same-kind sibling is BOTH removed (renamed away) AND a different one
+ * added in the SAME edit, the group's size stays unchanged (e.g. 4 -> 4),
+ * so #1865's own "count unchanged -> match by rank" fast path takes over —
+ * and rank alone cannot distinguish "this is genuinely the same
+ * declaration, just shifted" from "a different declaration happens to now
+ * occupy this rank."
+ *
+ * Fixed by giving reconnection a true identity signal beyond line
+ * position: a SHA-256 hash of each declaration's own source text
+ * (`nodes.content_hash`, migration v24), computed centrally after
+ * extraction and threaded through node insertion on both engines.
+ * `pickReconnectTarget` now tries an exact hash match first — if the saved
+ * target's hash matches none of the current candidates, the edge is
+ * confidently dropped instead of falling through to the rank-based guess
+ * (see `build-edges.ts`; mirrored in Rust as `pick_reconnect_target` in
+ * `detect_changes.rs`, covered by dedicated Rust unit + end-to-end tests
+ * there — `pick_reconnect_target_drops_when_hash_matches_nothing_even_with_unchanged_count`,
+ * `reconnect_drops_edge_on_compound_rename_and_add_leaving_group_size_unchanged`).
+ *
+ * Reuses the exact fixture/seeding strategy from
+ * `issue-1865-reverse-dep-sibling-count-change.test.ts` (see that file's
+ * module doc comment for why a real source pattern can no longer naturally
+ * produce the ambiguous same-file/same-name/same-kind call topology this
+ * test needs — #1863 changed such resolution to no-edge instead of
+ * fanning out).
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+
+const REL_CONN_FILE = 'src/db/conn.ts';
+
+/** Four distinct functions, each returning an object with its own `close()` method. */
+function connSource(): string {
+  return `export function openA() {
+  return {
+    close() {
+      return 'A';
+    },
+  };
+}
+
+export function openB() {
+  return {
+    close() {
+      return 'B';
+    },
+  };
+}
+
+export function openC() {
+  return {
+    close() {
+      return 'C';
+    },
+  };
+}
+
+export function openD() {
+  return {
+    close() {
+      return 'D';
+    },
+  };
+}
+`;
+}
+
+/**
+ * Compound edit in one pass: `openB`'s `close` is renamed to `shutdown`
+ * (removing it from the "close"/"method" sibling group) AND a brand-new
+ * `openE` function with its OWN `close()` is inserted in `openB`'s old
+ * position — landing the new sibling at the same rank `openB`'s `close`
+ * used to hold. The group's size for (name="close", kind="method") stays
+ * unchanged at 4 (A, E, C, D) even though the actual membership changed —
+ * exactly the net-zero-count compound edit #1865's rank-based fast path
+ * cannot see through, but a content hash can.
+ */
+function editedConnSourceCompound(): string {
+  return `export function openA() {
+  return {
+    close() {
+      return 'A';
+    },
+  };
+}
+
+export function openB() {
+  return {
+    shutdown() {
+      return 'B';
+    },
+  };
+}
+
+export function openE() {
+  return {
+    close() {
+      return 'E';
+    },
+  };
+}
+
+export function openC() {
+  return {
+    close() {
+      return 'C';
+    },
+  };
+}
+
+export function openD() {
+  return {
+    close() {
+      return 'D';
+    },
+  };
+}
+`;
+}
+
+function callerSource(name: string, openFn: string): string {
+  return `import { ${openFn} } from '../db/conn.js';
+
+export function ${name}(): void {
+  ${openFn}();
+}
+`;
+}
+
+function writeFixture(root: string, conn: string): void {
+  fs.mkdirSync(path.join(root, 'src', 'db'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'src', 'features'), { recursive: true });
+  fs.writeFileSync(path.join(root, REL_CONN_FILE), conn);
+  fs.writeFileSync(path.join(root, 'src/features/useA.ts'), callerSource('useA', 'openA'));
+  fs.writeFileSync(path.join(root, 'src/features/useB.ts'), callerSource('useB', 'openB'));
+  fs.writeFileSync(path.join(root, 'src/features/useC.ts'), callerSource('useC', 'openC'));
+  fs.writeFileSync(path.join(root, 'src/features/useD.ts'), callerSource('useD', 'openD'));
+}
+
+/** Seeds one synthetic `calls` edge from each `use*` caller to its corresponding `close()` method node. */
+function seedReverseDepEdges(dbPath: string): void {
+  const db = new Database(dbPath);
+  try {
+    const closeNodes = db
+      .prepare(
+        "SELECT id, line FROM nodes WHERE name = 'close' AND kind = 'method' AND file = ? ORDER BY line",
+      )
+      .all(REL_CONN_FILE) as Array<{ id: number; line: number }>;
+    expect(closeNodes).toHaveLength(4);
+    const callerIds: Record<string, number> = {};
+    for (const name of ['useA', 'useB', 'useC', 'useD']) {
+      const row = db
+        .prepare("SELECT id FROM nodes WHERE name = ? AND kind = 'function'")
+        .get(name) as { id: number } | undefined;
+      expect(row, `caller node ${name} must exist`).toBeDefined();
+      callerIds[name] = row!.id;
+    }
+    const insert = db.prepare(
+      "INSERT INTO edges (source_id, target_id, kind, confidence, dynamic) VALUES (?, ?, 'calls', 0.9, 0)",
+    );
+    insert.run(callerIds.useA, closeNodes[0]!.id);
+    insert.run(callerIds.useB, closeNodes[1]!.id);
+    insert.run(callerIds.useC, closeNodes[2]!.id);
+    insert.run(callerIds.useD, closeNodes[3]!.id);
+  } finally {
+    db.close();
+  }
+}
+
+/** Sorted list of target lines every `close()` reverse-dep edge points to, keyed by caller. */
+function findCloseTargetLines(dbPath: string): Record<string, number | null> {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    const result: Record<string, number | null> = {};
+    for (const caller of ['useA', 'useB', 'useC', 'useD']) {
+      const row = db
+        .prepare(
+          `SELECT t.line AS line
+           FROM edges e
+           JOIN nodes s ON e.source_id = s.id
+           JOIN nodes t ON e.target_id = t.id
+           WHERE s.name = ? AND e.kind = 'calls' AND t.file = ? AND t.kind = 'method'`,
+        )
+        .get(caller, REL_CONN_FILE) as { line: number } | undefined;
+      result[caller] = row?.line ?? null;
+    }
+    return result;
+  } finally {
+    db.close();
+  }
+}
+
+describe.each(['wasm', 'native'] as const)(
+  'Issue #2015: reverse-dep edges survive a compound rename+add leaving sibling count unchanged (%s)',
+  (engine) => {
+    let projDir: string;
+    const tmpDirs: string[] = [];
+    const dbPath = () => path.join(projDir, '.codegraph', 'graph.db');
+
+    function mkTmp(prefix: string): string {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+      tmpDirs.push(dir);
+      return dir;
+    }
+
+    beforeAll(async () => {
+      projDir = mkTmp(`cg-2015-${engine}-`);
+      writeFixture(projDir, connSource());
+      await buildGraph(projDir, { engine, incremental: false, skipRegistry: true });
+      seedReverseDepEdges(dbPath());
+    }, 60_000);
+
+    afterAll(() => {
+      for (const dir of tmpDirs) fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    it('baseline: each seeded caller points to its own close() line', () => {
+      expect(findCloseTargetLines(dbPath())).toEqual({ useA: 3, useB: 11, useC: 19, useD: 27 });
+    });
+
+    it('incremental rebuild that renames one sibling away AND adds a different one in the ' +
+      'same edit (sibling count unchanged, 4 -> 4) reconnects the untouched siblings ' +
+      "correctly, drops the renamed-away sibling's edge, and never reconnects anything " +
+      'to the new sibling', async () => {
+      fs.writeFileSync(path.join(projDir, REL_CONN_FILE), editedConnSourceCompound());
+      await buildGraph(projDir, { engine, skipRegistry: true }); // incremental (default)
+
+      const afterIncremental = findCloseTargetLines(dbPath());
+
+      // Ground truth: A/C/D's own close() lines in the edited file — each
+      // is byte-identical to its pre-edit body, just at a new position.
+      const newConnLines = fs
+        .readFileSync(path.join(projDir, REL_CONN_FILE), 'utf8')
+        .split('\n')
+        .reduce<number[]>((acc, line, idx) => {
+          if (line.trim() === 'close() {') acc.push(idx + 1);
+          return acc;
+        }, []);
+      // A, E (new), C, D — 4 close() methods total, count unchanged from
+      // the original 4 (A, B, C, D) despite B being renamed away.
+      expect(newConnLines).toHaveLength(4);
+      const [aLine, eLine, cLine, dLine] = newConnLines;
+
+      expect(
+        afterIncremental,
+        `incremental reconnection result: ${JSON.stringify(afterIncremental)}`,
+      ).toEqual({
+        useA: aLine,
+        useB: null, // openB's close() no longer exists — must be dropped, never reattached to E
+        useC: cLine,
+        useD: dLine,
+      });
+
+      // Nothing at all points at the new sibling's close() line.
+      const db = new Database(dbPath(), { readonly: true });
+      try {
+        const reconnectedToE = db
+          .prepare(
+            `SELECT COUNT(*) AS n FROM edges e
+               JOIN nodes t ON e.target_id = t.id
+               WHERE t.file = ? AND t.kind = 'method' AND t.line = ? AND e.kind = 'calls'`,
+          )
+          .get(REL_CONN_FILE, eLine) as { n: number };
+        expect(reconnectedToE.n).toBe(0);
+      } finally {
+        db.close();
+      }
+    }, 60_000);
+  },
+);

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -4,7 +4,13 @@
 
 import fs from 'node:fs';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { isWasmAvailable, LANGUAGE_REGISTRY } from '../../src/domain/parser.js';
+import {
+  computeDeclarationHash,
+  computeDeclarationHashes,
+  isWasmAvailable,
+  LANGUAGE_REGISTRY,
+} from '../../src/domain/parser.js';
+import type { Definition } from '../../src/types.js';
 
 describe('isWasmAvailable', () => {
   afterEach(() => {
@@ -57,5 +63,58 @@ describe('isWasmAvailable', () => {
     for (const call of spy.mock.calls) {
       expect(call[0]).toContain('grammars');
     }
+  });
+});
+
+// ─── computeDeclarationHash / computeDeclarationHashes (#2015) ──────────
+
+function makeDefinition(overrides: Partial<Definition> = {}): Definition {
+  return { name: 'f', kind: 'function', line: 1, ...overrides };
+}
+
+describe('computeDeclarationHash', () => {
+  it('hashes identical body text identically', () => {
+    const lines = ['fn a() {', '  1', '}', 'fn a() {', '  1', '}'];
+    const hashA = computeDeclarationHash(lines, 1, 3);
+    const hashB = computeDeclarationHash(lines, 4, 6);
+    expect(hashA).toBeDefined();
+    expect(hashA).toBe(hashB);
+  });
+
+  it('hashes different body text differently', () => {
+    const lines = ['fn a() {', '  1', '}', 'fn b() {', '  2', '}'];
+    const hashA = computeDeclarationHash(lines, 1, 3);
+    const hashB = computeDeclarationHash(lines, 4, 6);
+    expect(hashA).not.toBe(hashB);
+  });
+
+  it('returns undefined when endLine is unavailable', () => {
+    expect(computeDeclarationHash(['fn a() {', '}'], 1, undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for an out-of-range start line', () => {
+    expect(computeDeclarationHash(['fn a() {', '}'], 99, 100)).toBeUndefined();
+  });
+});
+
+describe('computeDeclarationHashes', () => {
+  it('populates contentHash on top-level definitions and their children', () => {
+    const source = 'function f() {\n  return 1;\n}\n';
+    const defs: Definition[] = [
+      makeDefinition({
+        name: 'f',
+        line: 1,
+        endLine: 3,
+        children: [{ name: 'child', kind: 'method', line: 1, endLine: 3 }],
+      }),
+    ];
+    computeDeclarationHashes(defs, source);
+    expect(defs[0]?.contentHash).toBeDefined();
+    expect(defs[0]?.children?.[0]?.contentHash).toBeDefined();
+  });
+
+  it('does nothing for an empty or undefined definitions list', () => {
+    expect(() => computeDeclarationHashes(undefined, 'code')).not.toThrow();
+    expect(() => computeDeclarationHashes([], 'code')).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- `reconnectReverseDepEdges`/`pick_reconnect_target` previously matched siblings by line position and rank alone during incremental rebuilds. When a same-named/same-kind sibling is both renamed away and a different one added in the same edit, the sibling group's size stays unchanged (e.g. 4 -> 4), so the existing rank-based fallback silently reattaches the edge to whichever new declaration now occupies the old rank.
- Add a per-declaration `content_hash` (SHA-256 of the declaration's own source text), computed centrally once per file right after extraction in both engines, persisted via a new `nodes.content_hash` column (migration v24).
- `pickReconnectTarget`/`pick_reconnect_target` now try an exact hash match first. If the saved target's hash matches none of the current candidates, the edge is confidently dropped instead of falling through to the rank-based guess. Line-based sibling alignment (#1865) remains the fallback when hash data is unavailable or ambiguous (2+ candidates share a hash).
- Both engines verified to produce byte-identical `content_hash` values and identical reconnect behavior for the compound rename+add scenario.

## Test plan
- [x] `npm test` — 263 test files, 4294 tests passing (both wasm/native engine variants of the new integration test)
- [x] `cargo test --manifest-path crates/codegraph-core/Cargo.toml --lib` — 698 tests passing, including new hash-matching unit tests and one full end-to-end reconnection test
- [x] `cargo clippy --manifest-path crates/codegraph-core/Cargo.toml --lib` — no new warnings vs `origin/main`
- [x] `npx biome check src/ tests/` and `npx tsc --noEmit -p .` — clean
- [x] New regression test `tests/integration/issue-2015-reverse-dep-compound-rename-and-add.test.ts` reproduces the exact compound rename+add scenario and fails without the fix (verified via a stale pre-fix native binary reproducing the bug), passes with it

Closes #2015