### PR TITLE
fix: pragma() crashes on any PRAGMA that returns a non-TEXT value

### DIFF
--- a/crates/codegraph-core/src/db/connection.rs
+++ b/crates/codegraph-core/src/db/connection.rs
@@ -628,14 +628,17 @@ impl NativeDatabase {
             .map_err(|e| napi::Error::from_reason(format!("exec failed: {e}")))
     }
 
-    /// Execute a read-only PRAGMA statement and return the first result as a string.
-    /// Returns `null` if the pragma produces no output.
+    /// Execute a read-only PRAGMA statement and return its first result column.
+    /// Returns `null` if the pragma produces no output. Most pragmas return an
+    /// INTEGER (e.g. `busy_timeout`, `page_count`, `user_version`) or TEXT (e.g.
+    /// `journal_mode`) result — the return type mirrors whichever affinity the
+    /// pragma actually produced (see `value_ref_to_json`'s contract doc).
     ///
     /// **Note:** This method is intended for read-only PRAGMAs (e.g. `journal_mode`,
     /// `page_count`). Write-mode PRAGMAs (e.g. `journal_mode = DELETE`) should use
     /// `exec()` instead. No validation is performed — callers are trusted internal code.
     #[napi]
-    pub fn pragma(&self, sql: String) -> napi::Result<Option<String>> {
+    pub fn pragma(&self, sql: String) -> napi::Result<Option<serde_json::Value>> {
         let conn = self.conn()?;
         let query = format!("PRAGMA {sql}");
         let mut stmt = conn
@@ -645,12 +648,7 @@ impl NativeDatabase {
             .query([])
             .map_err(|e| napi::Error::from_reason(format!("pragma query failed: {e}")))?;
         match rows.next() {
-            Ok(Some(row)) => {
-                let val: String = row
-                    .get(0)
-                    .map_err(|e| napi::Error::from_reason(format!("pragma get failed: {e}")))?;
-                Ok(Some(val))
-            }
+            Ok(Some(row)) => Ok(Some(value_ref_to_json(row.get_ref(0)))),
             Ok(None) => Ok(None),
             Err(e) => Err(napi::Error::from_reason(format!("pragma next failed: {e}"))),
         }
@@ -1650,12 +1648,28 @@ fn json_to_rusqlite_params(
         .collect()
 }
 
-/// Convert a rusqlite row to a serde_json::Value object.
+/// Convert a single rusqlite cell read result to a serde_json::Value.
 ///
 /// **Contract**: Only Integer, Real, Text, and Null column types are supported.
 /// BLOB columns are mapped to `null` because the current codegraph schema has no
 /// BLOB columns and the generic query path is not designed for binary data.
-/// Cell-level read errors are also mapped to `null` to avoid partial-row failures.
+/// Cell-level read errors are also mapped to `null` to avoid partial-row/partial-value
+/// failures. Shared by `row_to_json` (per-column) and `pragma` (single scalar result).
+fn value_ref_to_json(value: rusqlite::Result<ValueRef<'_>>) -> serde_json::Value {
+    match value {
+        Ok(ValueRef::Integer(n)) => serde_json::json!(n),
+        Ok(ValueRef::Real(f)) => serde_json::json!(f),
+        Ok(ValueRef::Text(s)) => serde_json::Value::String(String::from_utf8_lossy(s).into_owned()),
+        Ok(ValueRef::Null) => serde_json::Value::Null,
+        // BLOB: no codegraph schema columns use BLOB; map to null (see contract above)
+        Ok(ValueRef::Blob(_)) => serde_json::Value::Null,
+        // Cell read error: map to null to avoid partial-row/partial-value failures
+        Err(_) => serde_json::Value::Null,
+    }
+}
+
+/// Convert a rusqlite row to a serde_json::Value object. See `value_ref_to_json`'s
+/// contract doc for supported column types.
 fn row_to_json(
     row: &rusqlite::Row<'_>,
     col_count: usize,
@@ -1663,19 +1677,7 @@ fn row_to_json(
 ) -> serde_json::Value {
     let mut map = serde_json::Map::with_capacity(col_count);
     for i in 0..col_count {
-        let val = match row.get_ref(i) {
-            Ok(ValueRef::Integer(n)) => serde_json::json!(n),
-            Ok(ValueRef::Real(f)) => serde_json::json!(f),
-            Ok(ValueRef::Text(s)) => {
-                serde_json::Value::String(String::from_utf8_lossy(s).into_owned())
-            }
-            Ok(ValueRef::Null) => serde_json::Value::Null,
-            // BLOB: no codegraph schema columns use BLOB; map to null (see contract above)
-            Ok(ValueRef::Blob(_)) => serde_json::Value::Null,
-            // Cell read error: map to null to avoid partial-row failures
-            Err(_) => serde_json::Value::Null,
-        };
-        map.insert(col_names[i].clone(), val);
+        map.insert(col_names[i].clone(), value_ref_to_json(row.get_ref(i)));
     }
     serde_json::Value::Object(map)
 }
@@ -1822,5 +1824,60 @@ mod tests {
             has_column(conn, "edges", "dynamic_kind"),
             "edges.dynamic_kind was not repaired for a database already stamped past v20"
         );
+    }
+
+    // ── pragma() (#2019) ─────────────────────────────────────────────────
+
+    /// Regression for #2019: `pragma()` hardcoded a `String` read of the
+    /// result column, so any PRAGMA whose result has INTEGER affinity (the
+    /// overwhelming majority — `busy_timeout`, `page_count`, `user_version`,
+    /// `application_id`, `cache_size`, `mmap_size`, `wal_autocheckpoint`,
+    /// etc.) threw "Invalid column type Integer" instead of returning the
+    /// value. Only TEXT-affinity pragmas like `journal_mode` happened to work.
+    #[test]
+    fn pragma_returns_integer_affinity_results_instead_of_throwing() {
+        let db = NativeDatabase::open_read_write(":memory:".to_string(), None)
+            .expect("open_read_write should succeed for :memory:");
+
+        let busy_timeout = db
+            .pragma("busy_timeout".to_string())
+            .expect("pragma('busy_timeout') should not throw");
+        // open_read_write applies DEFAULT_BUSY_TIMEOUT_MS (5000) when none is given.
+        assert_eq!(busy_timeout, Some(serde_json::json!(DEFAULT_BUSY_TIMEOUT_MS)));
+
+        let page_count = db
+            .pragma("page_count".to_string())
+            .expect("pragma('page_count') should not throw");
+        assert_eq!(page_count, Some(serde_json::json!(0)));
+
+        let user_version = db
+            .pragma("user_version".to_string())
+            .expect("pragma('user_version') should not throw");
+        assert_eq!(user_version, Some(serde_json::json!(0)));
+    }
+
+    #[test]
+    fn pragma_still_returns_text_affinity_results() {
+        let db = NativeDatabase::open_read_write(":memory:".to_string(), None)
+            .expect("open_read_write should succeed for :memory:");
+
+        let journal_mode = db
+            .pragma("journal_mode".to_string())
+            .expect("pragma('journal_mode') should not throw");
+        // In-memory databases report journal_mode as "memory".
+        assert_eq!(journal_mode, Some(serde_json::json!("memory")));
+    }
+
+    #[test]
+    fn pragma_returns_none_when_the_pragma_produces_no_output() {
+        let db = NativeDatabase::open_read_write(":memory:".to_string(), None)
+            .expect("open_read_write should succeed for :memory:");
+
+        // wal_checkpoint on a non-WAL (in-memory) database is a valid,
+        // side-effect-only pragma with no result row.
+        let result = db
+            .pragma("optimize".to_string())
+            .expect("pragma('optimize') should not throw");
+        assert_eq!(result, None);
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2679,7 +2679,8 @@ export interface NativeDatabase {
   getBuildMeta(key: string): string | null;
   setBuildMeta(entries: Array<{ key: string; value: string }>): void;
   exec(sql: string): void;
-  pragma(sql: string): string | null;
+  /** Returns the pragma's first result column — whichever type it actually has (most are number or string). */
+  pragma(sql: string): string | number | null;
   close(): void;
   readonly dbPath: string;
   readonly isOpen: boolean;

--- a/tests/unit/native-db-pragma.test.ts
+++ b/tests/unit/native-db-pragma.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Regression tests for issue #2019: `NativeDatabase.pragma()` hardcoded a
+ * `String` read of the result column, so any PRAGMA whose result has INTEGER
+ * affinity (the overwhelming majority — `busy_timeout`, `page_count`,
+ * `user_version`, etc.) threw "Invalid column type Integer" instead of
+ * returning the value. Only TEXT-affinity pragmas like `journal_mode`
+ * happened to work.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getNative, isNativeAvailable } from '../../src/infrastructure/native.js';
+import type { NativeDatabase } from '../../src/types.js';
+
+const hasNativeDb =
+  isNativeAvailable() && typeof getNative().NativeDatabase?.prototype?.pragma === 'function';
+
+describe.skipIf(!hasNativeDb)('NativeDatabase.pragma (issue #2019)', () => {
+  let nativeDb: NativeDatabase;
+  let dbPath: string;
+
+  beforeEach(() => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-native-pragma-'));
+    dbPath = path.join(tmpDir, 'test.db');
+    const NativeDB = getNative().NativeDatabase;
+    nativeDb = NativeDB.openReadWrite(dbPath, 424242);
+  });
+
+  afterEach(() => {
+    nativeDb.close();
+    fs.rmSync(path.dirname(dbPath), { recursive: true, force: true });
+  });
+
+  it('returns an INTEGER-affinity pragma result instead of throwing (busy_timeout)', () => {
+    expect(nativeDb.pragma('busy_timeout')).toBe(424242);
+  });
+
+  it('returns an INTEGER-affinity pragma result instead of throwing (page_count)', () => {
+    const pageCount = nativeDb.pragma('page_count');
+    expect(typeof pageCount).toBe('number');
+    expect(pageCount as number).toBeGreaterThanOrEqual(0);
+  });
+
+  it('returns an INTEGER-affinity pragma result instead of throwing (user_version)', () => {
+    expect(nativeDb.pragma('user_version')).toBe(0);
+  });
+
+  it('still returns a TEXT-affinity pragma result (journal_mode)', () => {
+    expect(typeof nativeDb.pragma('journal_mode')).toBe('string');
+  });
+
+  it('returns null when the pragma produces no output', () => {
+    expect(nativeDb.pragma('optimize')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- `NativeDatabase::pragma()` (`crates/codegraph-core/src/db/connection.rs`) hardcoded `row.get::<_, String>(0)` when reading the pragma result, but most common SQLite pragmas return `INTEGER` (`busy_timeout`, `page_count`, `user_version`, `application_id`, `cache_size`, `mmap_size`, `wal_autocheckpoint`, etc.), not `TEXT`. Calling `pragma()` with any of those threw `"Invalid column type Integer"` instead of returning the value — only TEXT-affinity pragmas like `journal_mode` happened to work.
- Fixed by extracting the existing Integer/Real/Text/Null conversion logic already used by `query_all`/`query_get`'s `row_to_json` into a shared `value_ref_to_json` helper, and using it for `pragma()`'s single-column result too.
- Return type changes from `napi::Result<Option<String>>` to `napi::Result<Option<serde_json::Value>>` (TS: `string | number | null`). Checked all current callers before making this change: three `wal_checkpoint` call sites that discard the return value, and `NativeDbProxy.pragma()`'s wrapper, whose TS interface already declares `unknown` — no caller depends on the narrower `String` type.

## Test plan
- [x] New Rust unit tests (`pragma_returns_integer_affinity_results_instead_of_throwing`, `pragma_still_returns_text_affinity_results`, `pragma_returns_none_when_the_pragma_produces_no_output`) using the issue's own repro pragmas
- [x] Verified these tests fail (compile error — the old `Option<String>` return type doesn't match the new assertions) against the pre-fix implementation
- [x] New end-to-end TS test `tests/unit/native-db-pragma.test.ts` exercises the real compiled native binding directly (`busy_timeout`, `page_count`, `user_version`, `journal_mode`, and the no-output case)
- [x] `cargo test --manifest-path crates/codegraph-core/Cargo.toml --lib` — 703 tests passing
- [x] `cargo clippy` — no new warnings vs `origin/main`
- [x] `npm test` — 265 test files, 4311 tests passing
- [x] `npx tsc --noEmit -p .` and `npx biome check src/ tests/` — clean

Closes #2019