### PR TITLE
fix: apply configured busy_timeout to remaining raw new Database() call sites

### DIFF
--- a/src/cli/commands/info.ts
+++ b/src/cli/commands/info.ts
@@ -46,8 +46,11 @@ function printEngineInfo(
   console.log();
 }
 
-/** Print the "Build metadata" block read from the graph DB, if one exists. Never throws. */
-async function printBuildMetadata(
+/**
+ * Print the "Build metadata" block read from the graph DB, if one exists. Never throws.
+ * Exported for direct testing of its own busy_timeout pragma (issue #2020).
+ */
+export async function printBuildMetadata(
   ctx: CliContext,
   opts: CommandOpts,
   activeName: string,

--- a/src/cli/commands/info.ts
+++ b/src/cli/commands/info.ts
@@ -53,12 +53,13 @@ async function printBuildMetadata(
   activeName: string,
 ): Promise<void> {
   try {
-    const { findDbPath, getBuildMeta } = await import('../../db/index.js');
+    const { findDbPath, getBuildMeta, resolveBusyTimeoutMs } = await import('../../db/index.js');
     const Database = (await import('better-sqlite3')).default;
     const dbPath = findDbPath(opts.db as string | undefined);
     const fs = await import('node:fs');
     if (fs.existsSync(dbPath)) {
       const db = new Database(dbPath, { readonly: true });
+      db.pragma(`busy_timeout = ${resolveBusyTimeoutMs(dbPath)}`);
       const buildEngine = getBuildMeta(db, 'engine');
       const buildVersion = getBuildMeta(db, 'codegraph_version');
       const builtAt = getBuildMeta(db, 'built_at');

--- a/src/db/repository/native-repository.ts
+++ b/src/db/repository/native-repository.ts
@@ -45,6 +45,7 @@ import type {
   TriageNodeRow,
   TriageQueryOpts,
 } from '../../types.js';
+import { resolveBusyTimeoutMs } from '../connection.js';
 import { normalizeFileFilter } from '../query-builder.js';
 import {
   type FnDepsCallerNode,
@@ -238,7 +239,9 @@ export class NativeRepository extends Repository {
     if (this.#fallbackDb) return this.#fallbackDb;
     if (!this.#dbPath) return undefined;
     try {
-      this.#fallbackDb = new Database(this.#dbPath, { readonly: true });
+      const db = new Database(this.#dbPath, { readonly: true });
+      db.pragma(`busy_timeout = ${resolveBusyTimeoutMs(this.#dbPath)}`);
+      this.#fallbackDb = db;
       return this.#fallbackDb;
     } catch {
       return undefined;

--- a/src/features/branch-compare.ts
+++ b/src/features/branch-compare.ts
@@ -197,13 +197,15 @@ function buildSymbolsViaJsFallback(
   return symbols;
 }
 
-function loadSymbolsFromDb(
+/** Exported for direct testing of its own busy_timeout pragma (issue #2020), mirroring `openNativeDbForFanMetrics`. */
+export function loadSymbolsFromDb(
   dbPath: string,
   changedFiles: string[],
   noTests: boolean,
 ): Map<string, SymbolInfo> {
   const Database = getDatabase();
   const db = new Database(dbPath, { readonly: true });
+  db.pragma(`busy_timeout = ${resolveBusyTimeoutMs(dbPath)}`);
   const nativeDb = openNativeDbForFanMetrics(dbPath);
 
   try {
@@ -235,7 +237,8 @@ function loadSymbolsFromDb(
 
 // ─── Caller BFS ─────────────────────────────────────────────────────────
 
-function loadCallersFromDb(
+/** Exported for direct testing of its own busy_timeout pragma (issue #2020), mirroring `openNativeDbForFanMetrics`. */
+export function loadCallersFromDb(
   dbPath: string,
   nodeIds: number[],
   maxDepth: number,
@@ -245,6 +248,7 @@ function loadCallersFromDb(
 
   const Database = getDatabase();
   const db = new Database(dbPath, { readonly: true });
+  db.pragma(`busy_timeout = ${resolveBusyTimeoutMs(dbPath)}`);
   try {
     const allCallers = new Set<string>();
 

--- a/src/features/sequence.ts
+++ b/src/features/sequence.ts
@@ -165,7 +165,8 @@ function bfsCallees(
   return { messages, fileSet, idToNode, truncated };
 }
 
-function annotateDataflow(
+/** Exported for direct testing of its own busy_timeout pragma (issue #2020). */
+export function annotateDataflow(
   repo: Repository,
   messages: SequenceMessage[],
   idToNode: Map<number, { id: number; name: string; file: string; kind: string; line: number }>,

--- a/src/features/sequence.ts
+++ b/src/features/sequence.ts
@@ -1,5 +1,5 @@
 import Database from 'better-sqlite3';
-import { openRepo, type Repository, resolveDbConfig } from '../db/index.js';
+import { openRepo, type Repository, resolveBusyTimeoutMs, resolveDbConfig } from '../db/index.js';
 import { SqliteRepository } from '../db/repository/sqlite-repository.js';
 import { findMatchingNodes } from '../domain/queries.js';
 import { isTestFile } from '../infrastructure/test-filter.js';
@@ -180,6 +180,7 @@ function annotateDataflow(
     db = repo.db;
   } else if (dbPath) {
     db = new Database(dbPath, { readonly: true }) as unknown as BetterSqlite3Database;
+    db.pragma(`busy_timeout = ${resolveBusyTimeoutMs(dbPath)}`);
     ownDb = true;
   } else {
     return;

--- a/src/features/snapshot.ts
+++ b/src/features/snapshot.ts
@@ -2,7 +2,7 @@ import { randomBytes } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { getDatabase } from '../db/better-sqlite3.js';
-import { findDbPath } from '../db/index.js';
+import { findDbPath, resolveBusyTimeoutMs } from '../db/index.js';
 import { debug } from '../infrastructure/logger.js';
 import { ConfigError, DbError } from '../shared/errors.js';
 
@@ -101,6 +101,7 @@ export function snapshotSave(
 
   const Database = getDatabase();
   const db = new Database(dbPath, { readonly: true });
+  db.pragma(`busy_timeout = ${resolveBusyTimeoutMs(dbPath)}`);
   try {
     db.exec(`VACUUM INTO '${tmp.replace(/'/g, "''")}'`);
   } finally {

--- a/src/mcp/tools/export-graph.ts
+++ b/src/mcp/tools/export-graph.ts
@@ -1,4 +1,4 @@
-import { findDbPath } from '../../db/index.js';
+import { findDbPath, resolveBusyTimeoutMs } from '../../db/index.js';
 import { effectiveOffset, MCP_DEFAULTS, MCP_MAX_LIMIT } from '../middleware.js';
 import type { McpToolContext } from '../types.js';
 
@@ -14,8 +14,10 @@ interface ExportGraphArgs {
 export async function handler(args: ExportGraphArgs, ctx: McpToolContext): Promise<unknown> {
   const { exportDOT, exportGraphML, exportGraphSON, exportJSON, exportMermaid, exportNeo4jCSV } =
     await import('../../features/export.js');
+  const dbPath = findDbPath(ctx.dbPath);
   const Database = ctx.getDatabase();
-  const db = new Database(findDbPath(ctx.dbPath), { readonly: true });
+  const db = new Database(dbPath, { readonly: true });
+  db.pragma(`busy_timeout = ${resolveBusyTimeoutMs(dbPath)}`);
   const fileLevel = args.file_level !== false;
   const exportLimit = args.limit
     ? Math.min(args.limit, MCP_MAX_LIMIT)

--- a/src/mcp/tools/find-cycles.ts
+++ b/src/mcp/tools/find-cycles.ts
@@ -1,4 +1,4 @@
-import { findDbPath } from '../../db/index.js';
+import { findDbPath, resolveBusyTimeoutMs } from '../../db/index.js';
 import type { Cycle } from '../../domain/graph/cycles.js';
 import { findCycles } from '../../domain/graph/cycles.js';
 import type { McpToolContext } from '../types.js';
@@ -9,8 +9,10 @@ export async function handler(
   _args: Record<string, unknown>,
   ctx: McpToolContext,
 ): Promise<{ cycles: Cycle[]; count: number }> {
+  const dbPath = findDbPath(ctx.dbPath);
   const Database = ctx.getDatabase();
-  const db = new Database(findDbPath(ctx.dbPath), { readonly: true });
+  const db = new Database(dbPath, { readonly: true });
+  db.pragma(`busy_timeout = ${resolveBusyTimeoutMs(dbPath)}`);
   try {
     const cycles = findCycles(db);
     return { cycles, count: cycles.length };

--- a/tests/unit/busy-timeout-raw-database-sites-2020.test.ts
+++ b/tests/unit/busy-timeout-raw-database-sites-2020.test.ts
@@ -131,6 +131,10 @@ describe('configured busyTimeoutMs reaches the remaining raw new Database() call
       repo.getFileHash('src/whatever.ts');
     } finally {
       capture.restore();
+      // The fallback handle is cached on the instance and never closed by
+      // getFileHash() itself — must close it explicitly, or the open file
+      // handle blocks tmpDir cleanup in afterAll() on Windows (EBUSY).
+      repo.closeFallback();
     }
     expect(capture.calls).toContain(`busy_timeout = ${CUSTOM_BUSY_TIMEOUT_MS}`);
   });

--- a/tests/unit/busy-timeout-raw-database-sites-2020.test.ts
+++ b/tests/unit/busy-timeout-raw-database-sites-2020.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Regression tests for issue #2020: several call sites opened better-sqlite3
+ * directly via `new Database(dbPath, { readonly: true })`, bypassing
+ * `openReadonlyOrFail()`/`resolveBusyTimeoutMs()` entirely — so they never
+ * set `PRAGMA busy_timeout` at all (not even the hardcoded default), unlike
+ * every other read-only call site fixed by #1763/#1881.
+ *
+ * Mirrors the `captureBusyTimeoutPragmas()` technique from
+ * `busy-timeout-query-sites.test.ts` (#1763): each test opens a real
+ * temp project with a configured `db.busyTimeoutMs`, exercises the fixed
+ * call site, and asserts the configured value actually reached
+ * `PRAGMA busy_timeout`.
+ *
+ * `src/features/branch-compare.ts`'s two fixed call sites
+ * (`loadSymbolsFromDb`/`loadCallersFromDb`) are exported specifically for
+ * this direct testing, mirroring the same file's existing
+ * `openNativeDbForFanMetrics` export (added for the same reason during
+ * #1882). Testing them only through `branchCompareData()`'s full
+ * git-worktree flow would be a decoy: `buildGraph()` and other already-fixed
+ * call sites in that flow already call `busy_timeout` correctly, so a bare
+ * "was busy_timeout called at all" assertion would pass even with these two
+ * functions' own fix reverted.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { closeDb, initSchema, openDb } from '../../src/db/index.js';
+import { NativeRepository } from '../../src/db/repository/native-repository.js';
+import { loadCallersFromDb, loadSymbolsFromDb } from '../../src/features/branch-compare.js';
+import { snapshotSave } from '../../src/features/snapshot.js';
+import type { McpToolContext, NativeDatabase } from '../../src/types.js';
+
+const CUSTOM_BUSY_TIMEOUT_MS = 42424;
+
+let tmpDir: string;
+let dbPath: string;
+
+/** Capture every `busy_timeout = N` pragma issued against a real Database instance. */
+function captureBusyTimeoutPragmas(): { calls: string[]; restore: () => void } {
+  const original = Database.prototype.pragma;
+  const calls: string[] = [];
+  const spy = vi.spyOn(Database.prototype, 'pragma').mockImplementation(function (
+    this: unknown,
+    sql: string,
+    ...rest: unknown[]
+  ) {
+    if (typeof sql === 'string' && sql.startsWith('busy_timeout')) calls.push(sql);
+    return original.apply(this, [sql, ...rest] as Parameters<typeof original>);
+  });
+  return { calls, restore: () => spy.mockRestore() };
+}
+
+beforeAll(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-2020-raw-db-'));
+  dbPath = path.join(tmpDir, '.codegraph', 'graph.db');
+  const db = openDb(dbPath);
+  initSchema(db);
+  closeDb(db);
+  fs.writeFileSync(
+    path.join(tmpDir, '.codegraphrc.json'),
+    JSON.stringify({ db: { busyTimeoutMs: CUSTOM_BUSY_TIMEOUT_MS } }),
+  );
+});
+
+afterAll(() => {
+  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('configured busyTimeoutMs reaches the remaining raw new Database() call sites (issue #2020)', () => {
+  it('snapshotSave applies the configured busy_timeout', () => {
+    const capture = captureBusyTimeoutPragmas();
+    try {
+      snapshotSave('snap1', { dbPath });
+    } finally {
+      capture.restore();
+    }
+    expect(capture.calls).toContain(`busy_timeout = ${CUSTOM_BUSY_TIMEOUT_MS}`);
+  });
+
+  it('find_cycles MCP tool handler applies the configured busy_timeout', async () => {
+    const { handler } = await import('../../src/mcp/tools/find-cycles.js');
+    const ctx: McpToolContext = {
+      dbPath,
+      getQueries: async () => ({}),
+      getDatabase: () => Database,
+      findDbPath: (await import('../../src/db/index.js')).findDbPath,
+      allowedRepos: undefined,
+      MCP_MAX_LIMIT: 500,
+    };
+    const capture = captureBusyTimeoutPragmas();
+    try {
+      await handler({}, ctx);
+    } finally {
+      capture.restore();
+    }
+    expect(capture.calls).toContain(`busy_timeout = ${CUSTOM_BUSY_TIMEOUT_MS}`);
+  });
+
+  it('export_graph MCP tool handler applies the configured busy_timeout', async () => {
+    const { handler } = await import('../../src/mcp/tools/export-graph.js');
+    const ctx: McpToolContext = {
+      dbPath,
+      getQueries: async () => ({}),
+      getDatabase: () => Database,
+      findDbPath: (await import('../../src/db/index.js')).findDbPath,
+      allowedRepos: undefined,
+      MCP_MAX_LIMIT: 500,
+    };
+    const capture = captureBusyTimeoutPragmas();
+    try {
+      await handler({ format: 'json' }, ctx);
+    } finally {
+      capture.restore();
+    }
+    expect(capture.calls).toContain(`busy_timeout = ${CUSTOM_BUSY_TIMEOUT_MS}`);
+  });
+
+  it("NativeRepository's lazy fallback DB applies the configured busy_timeout", () => {
+    // A native handle missing getFileHash forces the better-sqlite3 fallback
+    // path (#getFallbackDb) — an empty stub is enough since getFileHash()
+    // only checks `typeof this.#ndb.getFileHash === 'function'` before
+    // falling back.
+    const repo = new NativeRepository({} as unknown as NativeDatabase, dbPath);
+    const capture = captureBusyTimeoutPragmas();
+    try {
+      repo.getFileHash('src/whatever.ts');
+    } finally {
+      capture.restore();
+    }
+    expect(capture.calls).toContain(`busy_timeout = ${CUSTOM_BUSY_TIMEOUT_MS}`);
+  });
+
+  it('branch-compare loadSymbolsFromDb applies the configured busy_timeout', () => {
+    const capture = captureBusyTimeoutPragmas();
+    try {
+      loadSymbolsFromDb(dbPath, [], false);
+    } finally {
+      capture.restore();
+    }
+    expect(capture.calls).toContain(`busy_timeout = ${CUSTOM_BUSY_TIMEOUT_MS}`);
+  });
+
+  it('branch-compare loadCallersFromDb applies the configured busy_timeout', () => {
+    const capture = captureBusyTimeoutPragmas();
+    try {
+      loadCallersFromDb(dbPath, [1], 5, false);
+    } finally {
+      capture.restore();
+    }
+    expect(capture.calls).toContain(`busy_timeout = ${CUSTOM_BUSY_TIMEOUT_MS}`);
+  });
+});

--- a/tests/unit/busy-timeout-raw-database-sites-2020.test.ts
+++ b/tests/unit/busy-timeout-raw-database-sites-2020.test.ts
@@ -26,9 +26,12 @@ import os from 'node:os';
 import path from 'node:path';
 import Database from 'better-sqlite3';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import type { CliContext } from '../../src/cli/types.js';
 import { closeDb, initSchema, openDb } from '../../src/db/index.js';
+import type { Repository } from '../../src/db/repository/base.js';
 import { NativeRepository } from '../../src/db/repository/native-repository.js';
 import { loadCallersFromDb, loadSymbolsFromDb } from '../../src/features/branch-compare.js';
+import { annotateDataflow } from '../../src/features/sequence.js';
 import { snapshotSave } from '../../src/features/snapshot.js';
 import type { McpToolContext, NativeDatabase } from '../../src/types.js';
 
@@ -146,6 +149,32 @@ describe('configured busyTimeoutMs reaches the remaining raw new Database() call
     const capture = captureBusyTimeoutPragmas();
     try {
       loadCallersFromDb(dbPath, [1], 5, false);
+    } finally {
+      capture.restore();
+    }
+    expect(capture.calls).toContain(`busy_timeout = ${CUSTOM_BUSY_TIMEOUT_MS}`);
+  });
+
+  it("sequence.ts's annotateDataflow native-fallback branch applies the configured busy_timeout", () => {
+    // A plain object (not `instanceof SqliteRepository`) with hasDataflowTable()
+    // true forces the native-fallback branch that opens its own better-sqlite3
+    // handle; empty messages/idToNode let it return safely right after.
+    const repo = { hasDataflowTable: () => true } as unknown as Repository;
+    const capture = captureBusyTimeoutPragmas();
+    try {
+      annotateDataflow(repo, [], new Map(), dbPath);
+    } finally {
+      capture.restore();
+    }
+    expect(capture.calls).toContain(`busy_timeout = ${CUSTOM_BUSY_TIMEOUT_MS}`);
+  });
+
+  it('info command printBuildMetadata applies the configured busy_timeout', async () => {
+    const { printBuildMetadata } = await import('../../src/cli/commands/info.js');
+    const ctx = {} as CliContext;
+    const capture = captureBusyTimeoutPragmas();
+    try {
+      await printBuildMetadata(ctx, { db: dbPath }, 'wasm');
     } finally {
       capture.restore();
     }


### PR DESCRIPTION
## Summary
- Issue #1763 threaded `config.db.busyTimeoutMs` through every call site going via `openReadonlyOrFail()`/`openReadonlyWithNative()`. Several call sites bypassed that helper entirely by opening better-sqlite3 directly with `new Database(dbPath, { readonly: true })`, so they never set `PRAGMA busy_timeout` at all — not even the hardcoded 5000ms default, worse than the pre-#1763 baseline.
- On a busy/locked DB (e.g. a concurrent `codegraph build` holding the write lock), these call sites got `SQLITE_BUSY` immediately instead of waiting up to the configured timeout.
- Added `db.pragma(\`busy_timeout = ${resolveBusyTimeoutMs(dbPath)}\`)` right after each raw `new Database()` call, matching the pattern already established by #1763:
  - `src/features/snapshot.ts` (`snapshotSave`)
  - `src/features/sequence.ts` (`annotateDataflow`'s native-fallback branch)
  - `src/features/branch-compare.ts` (`loadSymbolsFromDb`, `loadCallersFromDb` — exported for direct testing, mirroring the same file's existing `openNativeDbForFanMetrics` export)
  - `src/mcp/tools/find-cycles.ts` and `export-graph.ts`
  - `src/cli/commands/info.ts` (`printBuildMetadata`)
  - `src/db/repository/native-repository.ts` (`#getFallbackDb`'s lazy fallback handle)

## Test plan
- [x] New regression test `tests/unit/busy-timeout-raw-database-sites-2020.test.ts` covers all sites except `branch-compare.ts`'s two (now-exported) functions directly
- [x] Verified each assertion actually catches the bug by temporarily reverting each fix and confirming the corresponding test fails — an early version of the `branch-compare.ts` test (going through the full `branchCompareData()` git-worktree flow) was a decoy that passed even with the bug present, since `buildGraph()` and other already-fixed call sites in that flow already call `busy_timeout` correctly; fixed by exporting `loadSymbolsFromDb`/`loadCallersFromDb` for direct testing instead
- [x] `npm test` — 266 test files, 4317 tests passing
- [x] `npx tsc --noEmit -p .` and `npx biome check src/ tests/` — clean (this is a pure TypeScript change, no Rust/native involved)

Closes #2020