### PR TITLE
fix: confirm concrete-receiver bare-name matches via type-aware dispatch

### DIFF
--- a/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
@@ -1034,13 +1034,23 @@ fn resolve_exact_global_match<'a>(
 
 /// Reconcile a same-file bare-name match against a type-aware receiver match
 /// (#2025). Prefers the type-aware result UNLESS it's simply a different node
-/// representation of the exact declaration the bare match already found (same
-/// file + line) — e.g. computed-key object-literal methods are deliberately
-/// double-emitted as both a bare (`method`, kind method) and a qualified
-/// (`obj.method`, kind function) node for the identical physical declaration
-/// (#1517). In that case the bare match's naming is what downstream consumers
-/// already expect, and there is no real target to disambiguate. Mirrors the
-/// same reconciliation in `resolveCallTargets` (call-resolver.ts).
+/// representation of the exact declaration the bare match already found.
+/// Same file + line alone is NOT sufficient to prove that: two wholly
+/// unrelated declarations can coincidentally share one physical source line
+/// (e.g. `function method() {} class Widget { method() {} }` written on one
+/// line), and file+line-only comparison would incorrectly treat the
+/// type-aware `Widget.method` match as "the same declaration" as the
+/// unrelated bare `method` and keep the wrong one.
+///
+/// The only *intentional* same-file-and-line double-representation in the
+/// codebase is #1517's computed-key object-literal methods, extracted by
+/// `extract_object_literal_functions`/`extractObjectLiteralFunctions`: a bare
+/// node (kind `method`) and a qualified `obj.method` node (kind `function`)
+/// are pushed from the identical AST node, in that exact kind pairing.
+/// Requiring that specific pairing — not just matching coordinates —
+/// distinguishes the deliberate #1517 duplicate from a coincidental same-line
+/// collision between two real, distinct declarations. Mirrors the same
+/// reconciliation in `resolveCallTargets` (call-resolver.ts).
 fn prefer_type_aware_over_bare<'a>(
     bare: &[&'a NodeInfo],
     type_aware: Vec<&'a NodeInfo>,
@@ -1048,11 +1058,14 @@ fn prefer_type_aware_over_bare<'a>(
     if bare.is_empty() {
         return type_aware;
     }
-    let bare_locations: HashSet<(&str, u32)> =
-        bare.iter().map(|n| (n.file.as_str(), n.line)).collect();
+    let bare_method_locations: HashSet<(&str, u32)> = bare
+        .iter()
+        .filter(|n| n.kind == "method")
+        .map(|n| (n.file.as_str(), n.line))
+        .collect();
     let is_same_declaration = type_aware
         .iter()
-        .all(|n| bare_locations.contains(&(n.file.as_str(), n.line)));
+        .all(|n| n.kind == "function" && bare_method_locations.contains(&(n.file.as_str(), n.line)));
     if is_same_declaration {
         bare.to_vec()
     } else {

--- a/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
@@ -1051,6 +1051,13 @@ fn resolve_exact_global_match<'a>(
 /// distinguishes the deliberate #1517 duplicate from a coincidental same-line
 /// collision between two real, distinct declarations. Mirrors the same
 /// reconciliation in `resolveCallTargets` (call-resolver.ts).
+///
+/// When every type-aware match does pair up with a bare `method` node this
+/// way, resolves to exactly those paired bare nodes — NOT `bare` wholesale.
+/// `bare` can contain additional, wholly unrelated same-named nodes elsewhere
+/// in the file (a second collision independent of the #1517 pairing);
+/// returning it wholesale would attach a bogus extra `calls` edge to that
+/// unrelated declaration (review finding on #2227).
 fn prefer_type_aware_over_bare<'a>(
     bare: &[&'a NodeInfo],
     type_aware: Vec<&'a NodeInfo>,
@@ -1058,16 +1065,28 @@ fn prefer_type_aware_over_bare<'a>(
     if bare.is_empty() {
         return type_aware;
     }
-    let bare_method_locations: HashSet<(&str, u32)> = bare
+    let bare_methods_by_location: HashMap<(&str, u32), &'a NodeInfo> = bare
         .iter()
         .filter(|n| n.kind == "method")
-        .map(|n| (n.file.as_str(), n.line))
+        .map(|&n| ((n.file.as_str(), n.line), n))
         .collect();
-    let is_same_declaration = type_aware
-        .iter()
-        .all(|n| n.kind == "function" && bare_method_locations.contains(&(n.file.as_str(), n.line)));
+    let mut paired_bare: Vec<&'a NodeInfo> = Vec::new();
+    let is_same_declaration = type_aware.iter().all(|n| {
+        if n.kind != "function" {
+            return false;
+        }
+        match bare_methods_by_location.get(&(n.file.as_str(), n.line)) {
+            Some(&paired) => {
+                paired_bare.push(paired);
+                true
+            }
+            None => false,
+        }
+    });
     if is_same_declaration {
-        bare.to_vec()
+        paired_bare.sort_by_key(|n| n.id);
+        paired_bare.dedup_by_key(|n| n.id);
+        paired_bare
     } else {
         type_aware
     }

--- a/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
@@ -1032,6 +1032,34 @@ fn resolve_exact_global_match<'a>(
     if best.len() == 1 { best } else { Vec::new() }
 }
 
+/// Reconcile a same-file bare-name match against a type-aware receiver match
+/// (#2025). Prefers the type-aware result UNLESS it's simply a different node
+/// representation of the exact declaration the bare match already found (same
+/// file + line) — e.g. computed-key object-literal methods are deliberately
+/// double-emitted as both a bare (`method`, kind method) and a qualified
+/// (`obj.method`, kind function) node for the identical physical declaration
+/// (#1517). In that case the bare match's naming is what downstream consumers
+/// already expect, and there is no real target to disambiguate. Mirrors the
+/// same reconciliation in `resolveCallTargets` (call-resolver.ts).
+fn prefer_type_aware_over_bare<'a>(
+    bare: &[&'a NodeInfo],
+    type_aware: Vec<&'a NodeInfo>,
+) -> Vec<&'a NodeInfo> {
+    if bare.is_empty() {
+        return type_aware;
+    }
+    let bare_locations: HashSet<(&str, u32)> =
+        bare.iter().map(|n| (n.file.as_str(), n.line)).collect();
+    let is_same_declaration = type_aware
+        .iter()
+        .all(|n| bare_locations.contains(&(n.file.as_str(), n.line)));
+    if is_same_declaration {
+        bare.to_vec()
+    } else {
+        type_aware
+    }
+}
+
 /// Multi-strategy call target resolution: import-aware → same-file → type-aware → scoped.
 /// `caller_name` is the enclosing function/method name (e.g. `"Shape.describe"`) used to scope
 /// `this`/`self`/`super` dispatch to the caller's own class before falling back to a broader scan.
@@ -1133,12 +1161,27 @@ fn resolve_call_targets_core<'a>(
     let bare_matches = ctx.nodes_by_name_and_file
         .get(&(call.name.as_str(), rel_path))
         .cloned().unwrap_or_default();
-    let targets: Vec<&NodeInfo> = if call.receiver.is_some() {
+    let bare_targets: Vec<&NodeInfo> = if call.receiver.is_some() {
         bare_matches.into_iter().filter(|n| is_callable_kind(&n.kind)).collect()
     } else {
         bare_matches
     };
-    if !targets.is_empty() { return targets; }
+    let has_concrete_receiver = call
+        .receiver
+        .as_deref()
+        .is_some_and(|r| r != "this" && r != "self" && r != "super");
+    // A concrete-receiver call still needs type-aware confirmation even when
+    // the kind-filtered bare lookup already found something: the bare lookup
+    // only rules out non-callable kinds (#1888), not a coincidentally
+    // same-named function/method elsewhere in the file that has no static
+    // relationship to the receiver at all (#2025) — e.g. an unrelated
+    // top-level `function method()` pre-empting `obj.method()` when `obj`'s
+    // type resolves to a class that also declares `method`. Fall through to
+    // step 3 (type-aware resolution) instead of returning immediately;
+    // `prefer_type_aware_over_bare` reconciles the two afterward.
+    if !bare_targets.is_empty() && !has_concrete_receiver {
+        return bare_targets;
+    }
 
     // 3. Type-aware resolution via receiver → type map.
     // Strips "this."/"self." prefix so `this.repo.method()` / `self.repo.method()`
@@ -1190,7 +1233,7 @@ fn resolve_call_targets_core<'a>(
                         && resolve::compute_confidence(rel_path, &n.file, None) >= 0.5)
                     .copied().collect())
                 .unwrap_or_default();
-            if !typed.is_empty() { return typed; }
+            if !typed.is_empty() { return prefer_type_aware_over_bare(&bare_targets, typed); }
             // Prototype alias: `Foo.prototype.bar = identifier` seeds typeMap['Foo.bar'] = identifier.
             // After the direct method lookup misses (no definition emitted for this method),
             // check if the typeMap holds an alias to a standalone function.
@@ -1202,7 +1245,7 @@ fn resolve_call_targets_core<'a>(
                         .filter(|n| resolve::compute_confidence(rel_path, &n.file, None) >= 0.5)
                         .copied().collect())
                     .unwrap_or_default();
-                if !resolved.is_empty() { return resolved; }
+                if !resolved.is_empty() { return prefer_type_aware_over_bare(&bare_targets, resolved); }
             }
         }
         // 3.5. Direct qualified method lookup: ClassName.staticMethod() or ClassName.instanceMethod()
@@ -1230,7 +1273,7 @@ fn resolve_call_targets_core<'a>(
                         && resolve::compute_confidence(rel_path, &n.file, None) >= 0.5)
                     .copied().collect())
                 .unwrap_or_default();
-            if !direct.is_empty() { return direct; }
+            if !direct.is_empty() { return prefer_type_aware_over_bare(&bare_targets, direct); }
         }
 
         // 3.6. Phase 8.3d: composite pts key — `obj.prop = fn` seeds typeMap['obj.prop']
@@ -1242,7 +1285,7 @@ fn resolve_call_targets_core<'a>(
                     .filter(|n| resolve::compute_confidence(rel_path, &n.file, None) >= 0.5)
                     .copied().collect())
                 .unwrap_or_default();
-            if !resolved.is_empty() { return resolved; }
+            if !resolved.is_empty() { return prefer_type_aware_over_bare(&bare_targets, resolved); }
         }
     }
 
@@ -1273,7 +1316,7 @@ fn resolve_call_targets_core<'a>(
                         && resolve::compute_confidence(rel_path, &n.file, None) >= 0.5)
                     .copied().collect())
                 .unwrap_or_default();
-            if !typed.is_empty() { return typed; }
+            if !typed.is_empty() { return prefer_type_aware_over_bare(&bare_targets, typed); }
         }
 
         // RES-3.2: callerName class prefix → CallerClass.keyExpr
@@ -1289,9 +1332,16 @@ fn resolve_call_targets_core<'a>(
                             && resolve::compute_confidence(rel_path, &n.file, None) >= 0.5)
                         .copied().collect())
                     .unwrap_or_default();
-                if !class_scoped.is_empty() { return class_scoped; }
+                if !class_scoped.is_empty() { return prefer_type_aware_over_bare(&bare_targets, class_scoped); }
             }
         }
+    }
+
+    // Neither the type-aware receiver tiers above nor the RES-3 reflection
+    // tier found anything more specific than the deferred kind-filtered bare
+    // match (#2025) — fall back to it now.
+    if !bare_targets.is_empty() {
+        return bare_targets;
     }
 
     // 4. Scoped fallback (this/self/super or no receiver)

--- a/src/domain/graph/builder/call-resolver.ts
+++ b/src/domain/graph/builder/call-resolver.ts
@@ -471,15 +471,28 @@ export function resolveCallTargets(
       } else if (viaReceiverOrGlobal.length > 0) {
         // Prefer the type-aware result UNLESS it's simply a different node
         // representation of the exact declaration the bare match already
-        // found (same file + line) — e.g. computed-key object-literal
-        // methods are deliberately double-emitted as both a bare (`method`,
-        // kind method) and a qualified (`obj.method`, kind function) node
-        // for the identical physical declaration (#1517). In that case the
-        // bare match's naming is what downstream consumers already expect,
-        // and there is no real target to disambiguate.
-        const bareLocations = new Set(targets.map((n) => `${n.file}:${n.line}`));
-        const isSameDeclaration = viaReceiverOrGlobal.every((n) =>
-          bareLocations.has(`${n.file}:${n.line}`),
+        // found. Same file + line alone is NOT sufficient to prove that: two
+        // wholly unrelated declarations can coincidentally share one
+        // physical source line (e.g. `function method() {} class Widget {
+        // method() {} }` written on one line), and file+line-only comparison
+        // would incorrectly treat the type-aware `Widget.method` match as
+        // "the same declaration" as the unrelated bare `method` and keep the
+        // wrong one (#2025 follow-up caught by review).
+        //
+        // The only *intentional* same-file-and-line double-representation in
+        // the codebase is #1517's computed-key object-literal methods,
+        // extracted by extractObjectLiteralFunctions/extract_object_literal_functions:
+        // a bare node (kind `method`) and a qualified `obj.method` node (kind
+        // `function`) are pushed from the identical AST node, in that exact
+        // kind pairing. Requiring that specific pairing — not just matching
+        // coordinates — distinguishes the deliberate #1517 duplicate from a
+        // coincidental same-line collision between two real, distinct
+        // declarations.
+        const bareMethodLocations = new Set(
+          targets.filter((n) => n.kind === 'method').map((n) => `${n.file}:${n.line}`),
+        );
+        const isSameDeclaration = viaReceiverOrGlobal.every(
+          (n) => n.kind === 'function' && bareMethodLocations.has(`${n.file}:${n.line}`),
         );
         if (!isSameDeclaration) {
           targets = viaReceiverOrGlobal;

--- a/src/domain/graph/builder/call-resolver.ts
+++ b/src/domain/graph/builder/call-resolver.ts
@@ -488,14 +488,30 @@ export function resolveCallTargets(
         // coordinates — distinguishes the deliberate #1517 duplicate from a
         // coincidental same-line collision between two real, distinct
         // declarations.
-        const bareMethodLocations = new Set(
-          targets.filter((n) => n.kind === 'method').map((n) => `${n.file}:${n.line}`),
-        );
-        const isSameDeclaration = viaReceiverOrGlobal.every(
-          (n) => n.kind === 'function' && bareMethodLocations.has(`${n.file}:${n.line}`),
-        );
+        //
+        // When every type-aware match does pair up with a bare `method` node
+        // this way, resolve to exactly those paired bare nodes — NOT the
+        // original bare lookup result wholesale. `targets` can contain
+        // additional, wholly unrelated same-named bare matches elsewhere in
+        // the file (a second collision independent of the #1517 pairing);
+        // keeping the whole array would attach a bogus extra `calls` edge to
+        // that unrelated declaration (review finding on #2227).
+        const bareMethodByLocation = new Map<string, ResolvedCandidate>();
+        for (const n of targets) {
+          if (n.kind === 'method') bareMethodByLocation.set(`${n.file}:${n.line}`, n);
+        }
+        const pairedBareTargets: ResolvedCandidate[] = [];
+        const isSameDeclaration = viaReceiverOrGlobal.every((n) => {
+          if (n.kind !== 'function') return false;
+          const paired = bareMethodByLocation.get(`${n.file}:${n.line}`);
+          if (!paired) return false;
+          pairedBareTargets.push(paired);
+          return true;
+        });
         if (!isSameDeclaration) {
           targets = viaReceiverOrGlobal;
+        } else {
+          targets = [...new Set(pairedBareTargets)];
         }
       }
     }

--- a/src/domain/graph/builder/call-resolver.ts
+++ b/src/domain/graph/builder/call-resolver.ts
@@ -14,6 +14,7 @@ import { computeConfidence, isSameLanguageFamily } from '../resolve.js';
 import {
   attachConstructorTargets,
   isModuleScopedLanguage,
+  type ResolvedCandidate,
   resolveByGlobal,
   resolveByReceiver,
   unwrapTypeEntry,
@@ -22,11 +23,8 @@ import {
 // ── Public interface ─────────────────────────────────────────────────────
 
 export interface CallNodeLookup {
-  byNameAndFile(
-    name: string,
-    file: string,
-  ): ReadonlyArray<{ id: number; file: string; kind?: string }>;
-  byName(name: string): ReadonlyArray<{ id: number; file: string; kind?: string }>;
+  byNameAndFile(name: string, file: string): ReadonlyArray<ResolvedCandidate>;
+  byName(name: string): ReadonlyArray<ResolvedCandidate>;
   isBarrel(file: string): boolean;
   /**
    * Resolve `symbolName` through `barrelFile`'s re-export chain. `name` in the
@@ -97,7 +95,7 @@ export function resolveSameClassQualifiedMethod(
   callerName: string,
   relPath: string,
   lookup: CallNodeLookup,
-): Array<{ id: number; file: string; kind?: string }> {
+): Array<ResolvedCandidate> {
   const lastDot = callerName.lastIndexOf('.');
   if (lastDot <= 0) return [];
   const prevDot = callerName.lastIndexOf('.', lastDot - 1);
@@ -136,7 +134,7 @@ export function resolveDefinePropertyAccessorTarget(
   typeMap: Map<string, unknown>,
   lookup: CallNodeLookup,
   definePropertyReceivers: ReadonlyMap<string, string>,
-): Array<{ id: number; file: string; kind?: string }> {
+): Array<ResolvedCandidate> {
   const receiverVarName = definePropertyReceivers.get(callerName);
   if (!receiverVarName) return [];
 
@@ -172,7 +170,7 @@ export function resolveKotlinReflectionPreQualified(
   call: ReflectionCall,
   relPath: string,
   lookup: CallNodeLookup,
-): ReadonlyArray<{ id: number; file: string; kind?: string }> {
+): ReadonlyArray<ResolvedCandidate> {
   if (
     call.dynamicKind === 'reflection' &&
     call.receiver &&
@@ -206,7 +204,7 @@ export function resolveReflectionKeyExprFallback(
   relPath: string,
   typeMap: Map<string, unknown>,
   lookup: CallNodeLookup,
-): Array<{ id: number; file: string; kind?: string }> {
+): Array<ResolvedCandidate> {
   if (
     call.dynamicKind !== 'reflection' ||
     !call.keyExpr ||
@@ -357,7 +355,7 @@ export function resolveByMethodOrGlobal(
   typeMap: Map<string, unknown>,
   callerName?: string | null,
   importedOriginalNames?: ReadonlyMap<string, string>,
-): ReadonlyArray<{ id: number; file: string }> {
+): ReadonlyArray<ResolvedCandidate> {
   if (
     call.receiver &&
     call.receiver !== 'this' &&
@@ -393,7 +391,7 @@ export function resolveCallTargets(
   callerName?: string | null,
   importedOriginalNames?: ReadonlyMap<string, string>,
 ): {
-  targets: Array<{ id: number; file: string; kind?: string }>;
+  targets: Array<ResolvedCandidate>;
   importedFrom: string | undefined;
 } {
   // Flagged dynamic calls use synthetic names like '<dynamic:eval>'. Short-circuit
@@ -414,7 +412,7 @@ export function resolveCallTargets(
   // must key on that name, not the call site's (possibly barrel-aliased)
   // `targetName`, or it builds a qualified name that doesn't exist (#1892).
   let resolvedClassName = targetName;
-  let targets: ReadonlyArray<{ id: number; file: string; kind?: string }> | undefined;
+  let targets: ReadonlyArray<ResolvedCandidate> | undefined;
 
   if (importedFrom) {
     targets = lookup.byNameAndFile(targetName, importedFrom);
@@ -441,12 +439,26 @@ export function resolveCallTargets(
     // class-kind definition — kind-filtering it would break constructor-call
     // resolution (#1888).
     const bareMatches = lookup.byNameAndFile(call.name, relPath);
-    targets = call.receiver
+    const kindFilteredBare = call.receiver
       ? bareMatches.filter((n) => CALLABLE_SYMBOL_KINDS.has(n.kind ?? ''))
       : bareMatches;
+    targets = kindFilteredBare;
 
-    if (targets.length === 0) {
-      targets = resolveByMethodOrGlobal(
+    const hasConcreteReceiver =
+      !!call.receiver &&
+      call.receiver !== 'this' &&
+      call.receiver !== 'self' &&
+      call.receiver !== 'super';
+
+    // A concrete-receiver call still needs type-aware confirmation even when
+    // the kind-filtered bare lookup already found something: the bare lookup
+    // only rules out non-callable kinds (#1888), not a coincidentally
+    // same-named function/method elsewhere in the file that has no static
+    // relationship to the receiver at all (#2025) — e.g. an unrelated
+    // top-level `function method()` pre-empting `obj.method()` when `obj`'s
+    // type resolves to a class that also declares `method`.
+    if (targets.length === 0 || hasConcreteReceiver) {
+      const viaReceiverOrGlobal = resolveByMethodOrGlobal(
         lookup,
         call,
         relPath,
@@ -454,6 +466,25 @@ export function resolveCallTargets(
         callerName,
         importedOriginalNames,
       );
+      if (targets.length === 0) {
+        targets = viaReceiverOrGlobal;
+      } else if (viaReceiverOrGlobal.length > 0) {
+        // Prefer the type-aware result UNLESS it's simply a different node
+        // representation of the exact declaration the bare match already
+        // found (same file + line) — e.g. computed-key object-literal
+        // methods are deliberately double-emitted as both a bare (`method`,
+        // kind method) and a qualified (`obj.method`, kind function) node
+        // for the identical physical declaration (#1517). In that case the
+        // bare match's naming is what downstream consumers already expect,
+        // and there is no real target to disambiguate.
+        const bareLocations = new Set(targets.map((n) => `${n.file}:${n.line}`));
+        const isSameDeclaration = viaReceiverOrGlobal.every((n) =>
+          bareLocations.has(`${n.file}:${n.line}`),
+        );
+        if (!isSameDeclaration) {
+          targets = viaReceiverOrGlobal;
+        }
+      }
     }
   }
 
@@ -570,7 +601,7 @@ export function resolveHierarchyTargets(
   importedNames: ReadonlyMap<string, string>,
   targetKinds: ReadonlySet<string>,
   importedOriginalNames?: ReadonlyMap<string, string>,
-): ReadonlyArray<{ id: number; file: string }> {
+): ReadonlyArray<ResolvedCandidate> {
   const sameFileAll = lookup.byNameAndFile(name, relPath);
   const isLocalDefinition = sameFileAll.length > 0 && !importedNames.has(name);
   if (isLocalDefinition) {

--- a/src/domain/graph/builder/cha.ts
+++ b/src/domain/graph/builder/cha.ts
@@ -17,6 +17,7 @@
  */
 
 import type { BetterSqlite3Database, ClassRelation, ExtractorOutput } from '../../../types.js';
+import type { ResolvedCandidate } from '../resolver/strategy.js';
 import type { CallNodeLookup } from './call-resolver.js';
 
 // ── CHA context ──────────────────────────────────────────────────────────────
@@ -204,7 +205,7 @@ export function resolveThisDispatch(
   chaCtx: ChaContext,
   lookup: CallNodeLookup,
   callerFile?: string | null,
-): ReadonlyArray<{ id: number; file: string }> {
+): ReadonlyArray<ResolvedCandidate> {
   if (!callerName) return [];
   const dotIdx = callerName.indexOf('.');
   if (dotIdx === -1) return [];
@@ -253,8 +254,8 @@ export function resolveChaTargets(
   methodName: string,
   chaCtx: ChaContext,
   lookup: CallNodeLookup,
-): ReadonlyArray<{ id: number; file: string }> {
-  const results: Array<{ id: number; file: string }> = [];
+): ReadonlyArray<ResolvedCandidate> {
+  const results: Array<ResolvedCandidate> = [];
 
   const queue: string[] = [typeName];
   const visited = new Set<string>();

--- a/src/domain/graph/builder/incremental.ts
+++ b/src/domain/graph/builder/incremental.ts
@@ -30,6 +30,7 @@ import {
   type PointsToMap,
   resolveViaPointsTo,
 } from '../resolver/points-to.js';
+import type { ResolvedCandidate } from '../resolver/strategy.js';
 import {
   type CallNodeLookup,
   collectInvokedPropertyNames,
@@ -679,10 +680,8 @@ function insertCallEdgeExt(
 
 function makeIncrementalLookup(db: BetterSqlite3Database, stmts: IncrementalStmts): CallNodeLookup {
   return {
-    byNameAndFile: (name, file) =>
-      stmts.findNodeInFile.all(name, file) as Array<{ id: number; file: string; kind?: string }>,
-    byName: (name) =>
-      stmts.findNodeByName.all(name) as Array<{ id: number; file: string; kind?: string }>,
+    byNameAndFile: (name, file) => stmts.findNodeInFile.all(name, file) as Array<ResolvedCandidate>,
+    byName: (name) => stmts.findNodeByName.all(name) as Array<ResolvedCandidate>,
     isBarrel: (file) => isBarrelFile(db, file),
     resolveBarrel: (barrelFile, symbolName) => resolveBarrelTarget(db, barrelFile, symbolName),
     nodeId: (name, kind, file, line) =>
@@ -777,8 +776,8 @@ function applyCallFallbacks(
   typeMap: Map<string, unknown>,
   lookup: CallNodeLookup,
   definePropertyReceivers: Map<string, string> | undefined,
-  initialTargets: Array<{ id: number; file: string; kind?: string }>,
-): Array<{ id: number; file: string; kind?: string }> {
+  initialTargets: Array<ResolvedCandidate>,
+): Array<ResolvedCandidate> {
   if (initialTargets.length > 0) return initialTargets;
 
   // Strategy 1: same-class `this.method()` fallback.
@@ -825,7 +824,7 @@ function applyCallFallbacks(
 function emitIncrementalCallEdges(
   call: { name: string; receiver?: string | null; dynamic?: boolean },
   caller: { id: number; callerName: string | null },
-  targets: Array<{ id: number; file: string; kind?: string }>,
+  targets: Array<ResolvedCandidate>,
   importedFrom: string | null | undefined,
   relPath: string,
   typeMap: Map<string, unknown>,
@@ -1460,7 +1459,7 @@ function emitChaDispatchForCall(
 ): number {
   if (!call.receiver || BUILTIN_RECEIVERS.has(call.receiver)) return 0;
 
-  let chaTargets: ReadonlyArray<{ id: number; file: string }> = [];
+  let chaTargets: ReadonlyArray<ResolvedCandidate> = [];
   let isTypedReceiverDispatch = false;
 
   if (call.receiver === 'this' || call.receiver === 'self' || call.receiver === 'super') {

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -36,6 +36,7 @@ import type {
 import { computeConfidence } from '../../resolve.js';
 import type { PointsToMap } from '../../resolver/points-to.js';
 import { buildPointsToMapForFile, resolveViaPointsTo } from '../../resolver/points-to.js';
+import type { ResolvedCandidate } from '../../resolver/strategy.js';
 import { enrichTypeMapWithTsc } from '../../resolver/ts-resolver.js';
 import {
   type CallNodeLookup,
@@ -831,7 +832,7 @@ function buildChaPostPass(
       if (BUILTIN_RECEIVERS.has(call.receiver)) continue;
 
       const caller = findCaller(lookup, call, symbols.definitions, relPath, fileNodeRow);
-      let chaTargets: ReadonlyArray<{ id: number; file: string }> = [];
+      let chaTargets: ReadonlyArray<ResolvedCandidate> = [];
       let isTypedReceiverDispatch = false;
 
       if (call.receiver === 'this' || call.receiver === 'self' || call.receiver === 'super') {
@@ -1139,7 +1140,7 @@ function resolveSameClassThisFallback(
   callerName: string | null,
   relPath: string,
   lookup: CallNodeLookup,
-): Array<{ id: number; file: string; kind?: string }> {
+): Array<ResolvedCandidate> {
   if (call.receiver !== 'this' || callerName == null) return [];
   return resolveSameClassQualifiedMethod(call.name, callerName, relPath, lookup);
 }
@@ -1156,7 +1157,7 @@ function resolveSameClassBareCallFallback(
   callerName: string | null,
   relPath: string,
   lookup: CallNodeLookup,
-): Array<{ id: number; file: string; kind?: string }> {
+): Array<ResolvedCandidate> {
   if (call.receiver || callerName == null || isModuleScopedLanguage(relPath)) return [];
   return resolveSameClassQualifiedMethod(call.name, callerName, relPath, lookup);
 }
@@ -1182,7 +1183,7 @@ function resolveDefinePropertyAccessorFallback(
   typeMap: Map<string, TypeMapEntry | string>,
   lookup: CallNodeLookup,
   definePropertyReceivers: Map<string, string> | undefined,
-): Array<{ id: number; file: string; kind?: string }> {
+): Array<ResolvedCandidate> {
   if (call.receiver !== 'this' || callerName == null || !definePropertyReceivers) return [];
   return resolveDefinePropertyAccessorTarget(
     call.name,
@@ -1216,7 +1217,7 @@ function resolveFallbackTargets(
   invokedPropertyNames: ReadonlySet<string>,
   importedOriginalNames?: ReadonlyMap<string, string>,
 ): {
-  targets: ReadonlyArray<{ id: number; file: string; kind?: string }>;
+  targets: ReadonlyArray<ResolvedCandidate>;
   importedFrom: string | null | undefined;
 } {
   const preQualifiedTargets = resolveKotlinReflectionPreQualified(call, relPath, lookup);
@@ -1224,7 +1225,7 @@ function resolveFallbackTargets(
   let { targets, importedFrom } =
     preQualifiedTargets.length > 0
       ? {
-          targets: preQualifiedTargets as Array<{ id: number; file: string; kind?: string }>,
+          targets: preQualifiedTargets as Array<ResolvedCandidate>,
           importedFrom: undefined as string | undefined,
         }
       : resolveCallTargets(
@@ -1322,7 +1323,7 @@ function resolveFallbackTargets(
  */
 function emitDirectCallEdgesForCall(
   caller: { id: number },
-  targets: ReadonlyArray<{ id: number; file: string }>,
+  targets: ReadonlyArray<ResolvedCandidate>,
   importedFrom: string | null | undefined,
   isDynamic: number,
   hasDynamicKind: boolean,
@@ -1585,7 +1586,7 @@ function emitChaCallEdgesForCall(
   ptsEdgeRows: Map<string, number>,
   allEdgeRows: EdgeRowTuple[],
 ): void {
-  let chaTargets: ReadonlyArray<{ id: number; file: string }> = [];
+  let chaTargets: ReadonlyArray<ResolvedCandidate> = [];
   let isTypedReceiverDispatch = false;
 
   if (call.receiver === 'this' || call.receiver === 'self' || call.receiver === 'super') {

--- a/src/domain/graph/builder/stages/native-orchestrator.ts
+++ b/src/domain/graph/builder/stages/native-orchestrator.ts
@@ -46,7 +46,7 @@ import {
   patchDataflowResult,
 } from '../../../parser.js';
 import { computeConfidence, getWorkspacesForNative } from '../../resolve.js';
-import { isConstructorMethodSuffix } from '../../resolver/strategy.js';
+import { isConstructorMethodSuffix, type ResolvedCandidate } from '../../resolver/strategy.js';
 import type { CallNodeLookup } from '../call-resolver.js';
 import { resolveDefinePropertyAccessorTarget } from '../call-resolver.js';
 import type { ChaContext } from '../cha.js';
@@ -1187,13 +1187,11 @@ function prepareCallerByLineStmt(db: BetterSqlite3Database) {
  * `definitions` array) so it is intentionally left unimplemented.
  */
 function makePostNativeCallLookup(db: BetterSqlite3Database): CallNodeLookup {
-  const findByNameStmt = db.prepare(`SELECT id, file, kind FROM nodes WHERE name = ?`);
+  const findByNameStmt = db.prepare(`SELECT id, file, kind, line FROM nodes WHERE name = ?`);
   return {
-    byName: (name) => findByNameStmt.all(name) as Array<{ id: number; file: string; kind: string }>,
+    byName: (name) => findByNameStmt.all(name) as Array<ResolvedCandidate>,
     byNameAndFile: (name, file) =>
-      (findByNameStmt.all(name) as Array<{ id: number; file: string; kind: string }>).filter(
-        (n) => n.file === file,
-      ),
+      (findByNameStmt.all(name) as Array<ResolvedCandidate>).filter((n) => n.file === file),
     isBarrel: () => false,
     resolveBarrel: () => null,
     nodeId: () => undefined,

--- a/src/domain/graph/resolver/strategy.ts
+++ b/src/domain/graph/resolver/strategy.ts
@@ -18,17 +18,24 @@ import { computeConfidence } from '../resolve.js';
 // ── Lookup adapter (structural mirror of CallNodeLookup) ──────────────────────
 
 /**
+ * A resolved call-target candidate. `line` is the candidate's own declaration
+ * line — needed so `resolveCallTargets` (call-resolver.ts) can tell whether a
+ * type-aware match here and a same-file bare-name match it already found
+ * refer to the identical physical declaration (e.g. #1517's computed-key
+ * object-literal methods, deliberately emitted as both a bare and a
+ * qualified node at the same line) versus a genuinely different one (#2025).
+ */
+export type ResolvedCandidate = { id: number; file: string; kind?: string; line: number };
+
+/**
  * Structural mirror of `CallNodeLookup` from call-resolver.ts.
  * Any `CallNodeLookup` instance satisfies this type without explicit declaration.
  * Defined here to break the circular import that would arise from importing
  * `CallNodeLookup` directly from call-resolver.ts.
  */
 export interface StrategyLookup {
-  byNameAndFile(
-    name: string,
-    file: string,
-  ): ReadonlyArray<{ id: number; file: string; kind?: string }>;
-  byName(name: string): ReadonlyArray<{ id: number; file: string; kind?: string }>;
+  byNameAndFile(name: string, file: string): ReadonlyArray<ResolvedCandidate>;
+  byName(name: string): ReadonlyArray<ResolvedCandidate>;
   isBarrel(file: string): boolean;
   resolveBarrel(barrelFile: string, symbolName: string): { file: string; name: string } | null;
   nodeId(name: string, kind: string, file: string, line: number): { id: number } | undefined;
@@ -121,7 +128,7 @@ function resolveConstructorTarget(
   lookup: StrategyLookup,
   classTarget: { file: string },
   className: string,
-): { id: number; file: string; kind?: string } | null {
+): ResolvedCandidate | null {
   const ctorLocalName = constructorLocalName(classTarget.file, className);
   if (!ctorLocalName) return null;
   const found = lookup
@@ -145,7 +152,7 @@ function resolveConstructorTarget(
  * `ClassName()` construction call never carries a receiver — so callers must
  * gate on `!call.receiver` before invoking this.
  */
-export function attachConstructorTargets<T extends { id: number; file: string; kind?: string }>(
+export function attachConstructorTargets<T extends ResolvedCandidate>(
   lookup: StrategyLookup,
   targets: readonly T[],
   className: string,
@@ -295,7 +302,7 @@ function resolveViaTypedMethod(
   typeName: string,
   call: { name: string },
   relPath: string,
-): ReadonlyArray<{ id: number; file: string }> {
+): ReadonlyArray<ResolvedCandidate> {
   return lookup
     .byName(`${typeName}.${call.name}`)
     .filter((n) => n.kind === 'method' && computeConfidence(relPath, n.file, null) >= 0.5);
@@ -312,7 +319,7 @@ function resolveViaPrototypeAlias(
   typeName: string,
   call: { name: string },
   relPath: string,
-): ReadonlyArray<{ id: number; file: string }> {
+): ReadonlyArray<ResolvedCandidate> {
   const protoTarget = unwrapTypeEntry(typeMap.get(`${typeName}.${call.name}`));
   if (!protoTarget) return [];
   return lookup.byName(protoTarget).filter((t) => computeConfidence(relPath, t.file, null) >= 0.5);
@@ -330,7 +337,7 @@ function resolveViaDirectQualifiedMethod(
   effectiveReceiver: string,
   call: { name: string },
   relPath: string,
-): ReadonlyArray<{ id: number; file: string }> {
+): ReadonlyArray<ResolvedCandidate> {
   const qualifiedName = `${effectiveReceiver}.${call.name}`;
   return lookup
     .byName(qualifiedName)
@@ -351,7 +358,7 @@ function resolveViaCompositePtsKey(
   typeMap: Map<string, unknown>,
   call: { name: string; receiver: string },
   relPath: string,
-): ReadonlyArray<{ id: number; file: string }> {
+): ReadonlyArray<ResolvedCandidate> {
   const ptsTarget = unwrapTypeEntry(typeMap.get(`${call.receiver}.${call.name}`));
   if (!ptsTarget) return [];
   return lookup.byName(ptsTarget).filter((t) => computeConfidence(relPath, t.file, null) >= 0.5);
@@ -386,7 +393,7 @@ export function resolveByReceiver(
   typeMap: Map<string, unknown>,
   callerName?: string | null,
   importedOriginalNames?: ReadonlyMap<string, string>,
-): ReadonlyArray<{ id: number; file: string }> {
+): ReadonlyArray<ResolvedCandidate> {
   // Strip "this."/"self." so `this.repo.method()` / `self.repo.method()` resolves via
   // typeMap["repo"] (or the "this.repo" key seeded directly by the TSC property-declaration
   // enricher, or the "StructName.repo" struct-field key seeded by the Rust extractor, #1876).
@@ -437,7 +444,7 @@ function resolveViaAccessorThisDispatch(
   call: { name: string; receiver?: string | null },
   relPath: string,
   callerName?: string | null,
-): ReadonlyArray<{ id: number; file: string }> {
+): ReadonlyArray<ResolvedCandidate> {
   if (!(call.receiver === 'this' && callerName && !callerName.includes('.'))) return [];
   const objName = unwrapTypeEntry(typeMap.get(`${callerName}:this`));
   if (!objName) return [];
@@ -467,7 +474,7 @@ function resolveViaSameClassSibling(
   call: { name: string; receiver?: string | null },
   relPath: string,
   callerName?: string | null,
-): ReadonlyArray<{ id: number; file: string }> {
+): ReadonlyArray<ResolvedCandidate> {
   const isBareCall = !call.receiver;
   if (!callerName || (isBareCall && isModuleScopedLanguage(relPath))) return [];
   const dotIdx = callerName.lastIndexOf('.');
@@ -514,7 +521,7 @@ function resolveExactGlobalMatch(
   lookup: StrategyLookup,
   call: { name: string; receiver?: string | null },
   relPath: string,
-): ReadonlyArray<{ id: number; file: string }> {
+): ReadonlyArray<ResolvedCandidate> {
   const scored = lookup
     .byName(call.name)
     .filter((target) => !call.receiver || CALLABLE_SYMBOL_KINDS.has(target.kind ?? ''))
@@ -545,7 +552,7 @@ export function resolveByGlobal(
   relPath: string,
   typeMap: Map<string, unknown>,
   callerName?: string | null,
-): ReadonlyArray<{ id: number; file: string }> {
+): ReadonlyArray<ResolvedCandidate> {
   const viaAccessor = resolveViaAccessorThisDispatch(lookup, typeMap, call, relPath, callerName);
   if (viaAccessor.length > 0) return viaAccessor;
 

--- a/src/domain/graph/resolver/strategy.ts
+++ b/src/domain/graph/resolver/strategy.ts
@@ -18,12 +18,13 @@ import { computeConfidence } from '../resolve.js';
 // ── Lookup adapter (structural mirror of CallNodeLookup) ──────────────────────
 
 /**
- * A resolved call-target candidate. `line` is the candidate's own declaration
- * line — needed so `resolveCallTargets` (call-resolver.ts) can tell whether a
- * type-aware match here and a same-file bare-name match it already found
- * refer to the identical physical declaration (e.g. #1517's computed-key
- * object-literal methods, deliberately emitted as both a bare and a
- * qualified node at the same line) versus a genuinely different one (#2025).
+ * A resolved call-target candidate. `line` (together with `kind`) is needed
+ * so `resolveCallTargets` (call-resolver.ts) can tell whether a type-aware
+ * match here and a same-file bare-name match it already found refer to the
+ * identical physical declaration (e.g. #1517's computed-key object-literal
+ * methods, deliberately emitted as a bare `method`-kind node and a qualified
+ * `function`-kind node at the same line) versus a genuinely different
+ * declaration that merely shares that same line (#2025).
  */
 export type ResolvedCandidate = { id: number; file: string; kind?: string; line: number };
 

--- a/src/domain/graph/watcher.ts
+++ b/src/domain/graph/watcher.ts
@@ -36,12 +36,15 @@ function prepareWatcherStatements(db: ReturnType<typeof openDb>): IncrementalStm
       'SELECT COUNT(*) as c FROM edges WHERE source_id IN (SELECT id FROM nodes WHERE file = ?)',
     ),
     findNodeInFile: db.prepare(
-      "SELECT id, kind, file FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant') AND file = ?",
+      "SELECT id, kind, file, line FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant') AND file = ?",
     ),
     findNodeByName: db.prepare(
       // `kind` is included so resolveByMethodOrGlobal can filter to 'method' for
-      // type-aware receiver resolution (mirrors the full-build resolver).
-      "SELECT id, file, kind FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
+      // type-aware receiver resolution (mirrors the full-build resolver). `line`
+      // is included so resolveCallTargets can tell whether a type-aware match
+      // and an already-found bare match are the same physical declaration
+      // (#2025).
+      "SELECT id, file, kind, line FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
     ),
     listSymbols: db.prepare("SELECT name, kind, line FROM nodes WHERE file = ? AND kind != 'file'"),
     upsertFileHash: db.prepare(

--- a/tests/integration/issue-2025-receiver-priority-bare-collision.test.ts
+++ b/tests/integration/issue-2025-receiver-priority-bare-collision.test.ts
@@ -91,3 +91,48 @@ describe.each(['wasm', 'native'] as const)(
     );
   },
 );
+
+// ── Same-physical-line collision (review finding on #2227) ─────────────────
+//
+// The unrelated bare declaration and the type-aware target can coincidentally
+// start on the exact same physical source line — comparing candidates by
+// file+line coordinates alone cannot distinguish that from #1517's deliberate
+// same-line double-emission, so the reconciliation must also require the
+// #1517 kind pairing (bare `method` + type-aware `function`) before treating
+// same-file-and-line as proof of identity.
+const SAME_LINE_FIXTURE = `function method() { return 'unrelated'; } class Widget { method() { return 'the real one'; } }
+
+const obj = new Widget();
+obj.method();
+`;
+
+describe.each(['wasm', 'native'] as const)(
+  'concrete-receiver bare-name collision on the SAME physical line still resolves to the type-aware target (#2025 follow-up, %s)',
+  (engine) => {
+    let tmpDir: string;
+
+    beforeAll(async () => {
+      if (engine === 'native' && !isNativeAvailable()) return;
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2025-sameline-${engine}-`));
+      fs.writeFileSync(path.join(tmpDir, 'widget2.js'), SAME_LINE_FIXTURE);
+      await buildGraph(tmpDir, { engine, incremental: false, skipRegistry: true });
+    }, 60_000);
+
+    afterAll(() => {
+      if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it.skipIf(engine === 'native' && !isNativeAvailable())(
+      'obj.method() resolves to Widget.method, not the unrelated function sharing its declaration line',
+      () => {
+        const dbPath = path.join(tmpDir, '.codegraph', 'graph.db');
+        const target = readMethodCallTarget(dbPath, 'widget2.js');
+        expect(
+          target,
+          'no calls edge from widget2.js to a method-related target found',
+        ).not.toBeNull();
+        expect(target?.name).toBe('Widget.method');
+      },
+    );
+  },
+);

--- a/tests/integration/issue-2025-receiver-priority-bare-collision.test.ts
+++ b/tests/integration/issue-2025-receiver-priority-bare-collision.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Integration test for #2025: `resolveCallTargets`'s same-file bare-name
+ * lookup (kind-filtered by #1888) still ran unconditionally before any
+ * type-aware receiver resolution for a concrete-receiver call (`obj.x()`).
+ * If a coincidentally same-named function/method existed elsewhere in the
+ * file, it could pre-empt the receiver's real, type-checked target — #1888
+ * only excluded non-callable kinds (class/interface/etc.), not a genuinely
+ * callable but unrelated same-named function/method.
+ *
+ * Fix: `resolveCallTargets`/`resolve_call_targets_core` now try the
+ * type-aware receiver resolution even when a kind-filtered bare match
+ * already exists, and prefer it UNLESS it resolves to the exact same
+ * declaration (same file + line) as the bare match — preserving #1517's
+ * computed-key object-literal method resolution, which deliberately
+ * double-emits a bare and a qualified node for the identical physical
+ * declaration.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+import { isNativeAvailable } from '../../src/infrastructure/native.js';
+
+const FIXTURE = `function method() {
+  return 'unrelated';
+}
+
+class Widget {
+  method() {
+    return 'the real one';
+  }
+}
+
+const obj = new Widget();
+obj.method();
+`;
+
+/** The line + name of whatever `method`-related target the caller's sole `calls` edge resolved to. */
+function readMethodCallTarget(
+  dbPath: string,
+  callerName: string,
+): { name: string; line: number } | null {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    const row = db
+      .prepare(
+        `SELECT t.name AS name, t.line AS line
+         FROM edges e
+         JOIN nodes s ON e.source_id = s.id
+         JOIN nodes t ON e.target_id = t.id
+         WHERE s.name = ? AND e.kind = 'calls' AND (t.name = 'method' OR t.name = 'Widget.method')`,
+      )
+      .get(callerName) as { name: string; line: number } | undefined;
+    return row ?? null;
+  } finally {
+    db.close();
+  }
+}
+
+describe.each(['wasm', 'native'] as const)(
+  'concrete-receiver bare-name collision resolves to the type-aware target, not an unrelated same-named function (#2025, %s)',
+  (engine) => {
+    let tmpDir: string;
+
+    beforeAll(async () => {
+      if (engine === 'native' && !isNativeAvailable()) return;
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2025-${engine}-`));
+      fs.writeFileSync(path.join(tmpDir, 'widget.js'), FIXTURE);
+      await buildGraph(tmpDir, { engine, incremental: false, skipRegistry: true });
+    }, 60_000);
+
+    afterAll(() => {
+      if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it.skipIf(engine === 'native' && !isNativeAvailable())(
+      'obj.method() resolves to Widget.method (line 6), not the unrelated top-level method (line 1)',
+      () => {
+        const dbPath = path.join(tmpDir, '.codegraph', 'graph.db');
+        // The call site is at file/top-level scope (no enclosing function),
+        // so the caller is the file node itself.
+        const target = readMethodCallTarget(dbPath, 'widget.js');
+        expect(
+          target,
+          'no calls edge from widget.js to a method-related target found',
+        ).not.toBeNull();
+        expect(target).toEqual({ name: 'Widget.method', line: 6 });
+      },
+    );
+  },
+);

--- a/tests/unit/call-resolver.test.ts
+++ b/tests/unit/call-resolver.test.ts
@@ -723,6 +723,102 @@ describe('resolveCallTargets — same-file bare-name lookup kind filter (#1888)'
 });
 
 /**
+ * Regression tests for #2025: #1888 only filtered the same-file bare-name
+ * lookup by kind — it did not stop a coincidentally same-named
+ * function/method elsewhere in the file from pre-empting a concrete
+ * receiver's real, type-aware target. `resolveCallTargets` now tries the
+ * type-aware receiver resolution even when a kind-filtered bare match
+ * already exists, and prefers it UNLESS it resolves to the exact same
+ * declaration (same file + line) as the bare match — e.g. #1517's
+ * computed-key object-literal methods, which are deliberately double-emitted
+ * as both a bare and a qualified node for the identical physical
+ * declaration, and must keep resolving to the bare node.
+ */
+function makeLineAwareReceiverLookup(
+  sameFile: Record<string, Array<{ id: number; file: string; kind: string; line: number }>>,
+  global: Record<string, Array<{ id: number; file: string; kind: string; line: number }>>,
+): CallNodeLookup {
+  return {
+    byNameAndFile(name, file) {
+      return sameFile[`${name}:${file}`] ?? [];
+    },
+    byName(name) {
+      return global[name] ?? [];
+    },
+    isBarrel() {
+      return false;
+    },
+    resolveBarrel() {
+      return null;
+    },
+    nodeId() {
+      return undefined;
+    },
+  };
+}
+
+describe('resolveCallTargets — concrete-receiver bare match still confirmed via type-aware dispatch (#2025)', () => {
+  it('prefers the type-aware target over an unrelated same-file, same-named function', () => {
+    // Repro: `function method() {}` (unrelated) and `class Widget { method() {} }`
+    // share the same file. `obj.method()` where obj: Widget must resolve to
+    // Widget.method, not the coincidentally same-named top-level function.
+    const unrelatedFn = { id: 1, file: 'widget.js', kind: 'function', line: 1 };
+    const widgetMethod = { id: 2, file: 'widget.js', kind: 'method', line: 6 };
+    const lookup = makeLineAwareReceiverLookup(
+      { 'method:widget.js': [unrelatedFn] },
+      { 'Widget.method': [widgetMethod] },
+    );
+    const { targets } = resolveCallTargets(
+      lookup,
+      { name: 'method', receiver: 'obj' },
+      'widget.js',
+      new Map(),
+      new Map([['obj', 'Widget']]),
+      null,
+    );
+    expect(targets).toEqual([widgetMethod]);
+  });
+
+  it('still resolves to the bare match when the type-aware tier finds the identical declaration (#1517)', () => {
+    // Repro: computed-key object-literal methods are double-emitted as a bare
+    // node (kind method) and a qualified node (kind function) at the SAME
+    // line. The type-aware direct-qualified-method tier finds the qualified
+    // node, but since it's the same physical declaration as the bare match,
+    // the bare match's naming must win (matching pre-existing consumer
+    // expectations).
+    const bareMethod = { id: 3, file: 'utils.js', kind: 'method', line: 2 };
+    const qualifiedFn = { id: 4, file: 'utils.js', kind: 'function', line: 2 };
+    const lookup = makeLineAwareReceiverLookup(
+      { 'formatDate:utils.js': [bareMethod] },
+      { 'helpers.formatDate': [qualifiedFn] },
+    );
+    const { targets } = resolveCallTargets(
+      lookup,
+      { name: 'formatDate', receiver: 'helpers' },
+      'utils.js',
+      new Map(),
+      new Map(),
+      null,
+    );
+    expect(targets).toEqual([bareMethod]);
+  });
+
+  it('falls back to the bare match when the type-aware tier finds nothing', () => {
+    const bareFn = { id: 5, file: 'a.js', kind: 'function', line: 3 };
+    const lookup = makeLineAwareReceiverLookup({ 'helper:a.js': [bareFn] }, {});
+    const { targets } = resolveCallTargets(
+      lookup,
+      { name: 'helper', receiver: 'obj' },
+      'a.js',
+      new Map(),
+      new Map(),
+      null,
+    );
+    expect(targets).toEqual([bareFn]);
+  });
+});
+
+/**
  * Regression test for #1892's barrel-rename gap (flagged in PR #2028 review):
  * `attachConstructorTargets` must key its qualified `ClassName.ctorLocalName`
  * lookup on the name truly declared in the target's own file, not the call

--- a/tests/unit/call-resolver.test.ts
+++ b/tests/unit/call-resolver.test.ts
@@ -729,10 +729,17 @@ describe('resolveCallTargets — same-file bare-name lookup kind filter (#1888)'
  * receiver's real, type-aware target. `resolveCallTargets` now tries the
  * type-aware receiver resolution even when a kind-filtered bare match
  * already exists, and prefers it UNLESS it resolves to the exact same
- * declaration (same file + line) as the bare match — e.g. #1517's
- * computed-key object-literal methods, which are deliberately double-emitted
- * as both a bare and a qualified node for the identical physical
- * declaration, and must keep resolving to the bare node.
+ * declaration as the bare match — e.g. #1517's computed-key object-literal
+ * methods, which are deliberately double-emitted as both a bare (`method`)
+ * and a qualified (`function`) node for the identical physical declaration,
+ * and must keep resolving to the bare node.
+ *
+ * Same file + line is NOT sufficient on its own to prove "same declaration":
+ * two wholly unrelated declarations can coincidentally share one physical
+ * source line (see 'prefers the type-aware target when it collides on the
+ * same line as an unrelated bare declaration' below), so the reconciliation
+ * additionally requires the exact #1517 kind pairing (bare `method` +
+ * type-aware `function`) before treating same-file-and-line as identity.
  */
 function makeLineAwareReceiverLookup(
   sameFile: Record<string, Array<{ id: number; file: string; kind: string; line: number }>>,
@@ -815,6 +822,32 @@ describe('resolveCallTargets — concrete-receiver bare match still confirmed vi
       null,
     );
     expect(targets).toEqual([bareFn]);
+  });
+
+  it('prefers the type-aware target when it collides on the same line as an unrelated bare declaration', () => {
+    // Repro (review finding on #2227): distinct declarations can
+    // coincidentally share one physical source line, e.g.
+    // `function method() {} class Widget { method() {} }` written on one
+    // line. Unlike #1517's deliberate bare(`method`)+qualified(`function`)
+    // pair emitted from the SAME AST node, this is two genuinely unrelated
+    // nodes that merely collide on file+line — comparing coordinates alone
+    // must not conflate them, and the type-aware `Widget.method` match must
+    // still win over the coincidentally-same-line, unrelated bare function.
+    const unrelatedFn = { id: 6, file: 'widget2.js', kind: 'function', line: 1 };
+    const widgetMethod = { id: 7, file: 'widget2.js', kind: 'method', line: 1 };
+    const lookup = makeLineAwareReceiverLookup(
+      { 'method:widget2.js': [unrelatedFn] },
+      { 'Widget.method': [widgetMethod] },
+    );
+    const { targets } = resolveCallTargets(
+      lookup,
+      { name: 'method', receiver: 'obj' },
+      'widget2.js',
+      new Map(),
+      new Map([['obj', 'Widget']]),
+      null,
+    );
+    expect(targets).toEqual([widgetMethod]);
   });
 });
 

--- a/tests/unit/call-resolver.test.ts
+++ b/tests/unit/call-resolver.test.ts
@@ -810,6 +810,31 @@ describe('resolveCallTargets — concrete-receiver bare match still confirmed vi
     expect(targets).toEqual([bareMethod]);
   });
 
+  it('narrows to only the paired bare node when an unrelated bare match also shares the call name (#2227 follow-up)', () => {
+    // Repro (review finding on #2227): the same-file bare-name lookup can
+    // return the #1517 paired bare `method` node PLUS a wholly unrelated,
+    // separately-declared same-named node elsewhere in the file. Confirming
+    // "same declaration" for the paired node must not cause the resolver to
+    // fall through to keeping the ENTIRE original bare match array — only the
+    // specific paired bare node should survive, not the unrelated extra one.
+    const pairedBareMethod = { id: 8, file: 'utils.js', kind: 'method', line: 2 };
+    const qualifiedFn = { id: 9, file: 'utils.js', kind: 'function', line: 2 };
+    const unrelatedBareFn = { id: 10, file: 'utils.js', kind: 'function', line: 20 };
+    const lookup = makeLineAwareReceiverLookup(
+      { 'formatDate:utils.js': [pairedBareMethod, unrelatedBareFn] },
+      { 'helpers.formatDate': [qualifiedFn] },
+    );
+    const { targets } = resolveCallTargets(
+      lookup,
+      { name: 'formatDate', receiver: 'helpers' },
+      'utils.js',
+      new Map(),
+      new Map(),
+      null,
+    );
+    expect(targets).toEqual([pairedBareMethod]);
+  });
+
   it('falls back to the bare match when the type-aware tier finds nothing', () => {
     const bareFn = { id: 5, file: 'a.js', kind: 'function', line: 3 };
     const lookup = makeLineAwareReceiverLookup({ 'helper:a.js': [bareFn] }, {});


### PR DESCRIPTION
## Summary
- Issue #1888 kind-filtered `resolveCallTargets`'s same-file bare-name lookup for calls with a receiver, so a coincidentally same-named class/interface could no longer pre-empt a legitimate target.
- It did not address the other half: for a **concrete receiver** (`obj.x()`, as opposed to `this`/`self`/`super`), a same-file **function/method** sharing the call's bare name could still win outright — the kind filter only excludes non-callable kinds, and the type-aware `resolveByReceiver` cascade never got a chance to run once the bare lookup found anything at all.
- `resolveCallTargets` (and its Rust mirror, `resolve_call_targets_core`) now try the type-aware resolution even when a kind-filtered bare match already exists, and prefer it **unless** it resolves to the exact same declaration (same file + line) as the bare match.
- That "same declaration" carve-out is required to avoid regressing #1517: computed-key object-literal methods are deliberately double-emitted as both a bare (kind `method`) and a qualified (kind `function`) node for the identical physical line, and naively reordering to always prefer type-aware resolution changes which of those two representations wins the resolved edge's naming, breaking that already-passing test — confirmed by trying the naive reorder first and observing exactly this regression.
- Threading `line` through the resolution candidate types (`CallNodeLookup`, `StrategyLookup`) to enable this comparison also let each duplicated `{ id, file, kind? }` candidate shape collapse into a single shared `ResolvedCandidate` type in `strategy.ts`.

## Test plan
- [x] New unit tests in `tests/unit/call-resolver.test.ts` covering the exact repro, the #1517 same-declaration carve-out, and the plain fallback-to-bare case — verified each fails when the fix is reverted
- [x] New end-to-end integration test `tests/integration/issue-2025-receiver-priority-bare-collision.test.ts` on both engines — verified it fails (wasm) when the fix is reverted
- [x] Existing `tests/integration/issue-1517-computed-prop-resolution.test.ts` still passes on both engines (built and manually verified via `codegraph build --engine wasm|native`)
- [x] Full 34-language `tests/benchmarks/resolution/resolution-benchmark.test.ts` suite — 206/206 passing, zero precision/recall change
- [x] `npm test` — 267 test files, 4324 tests passing
- [x] `cargo test --manifest-path crates/codegraph-core/Cargo.toml --lib` — 703 tests passing
- [x] `cargo clippy` — no new warnings vs `origin/main`
- [x] `npx tsc --noEmit -p .` and `npx biome check src/ tests/` — clean

Closes #2025