### PR TITLE
chore(skills): housekeep after each batch, subagent-per-issue in /fixer

### DIFF
--- a/.claude/skills/fixer/SKILL.md
+++ b/.claude/skills/fixer/SKILL.md
@@ -442,7 +442,13 @@ case "$STATUS" in
         exit 1
       fi
       trap - EXIT
-      [ "$RECONCILE" = "parked" ] && printf '%s\n' "$EX_PR" >> .codegraph/fixer/parked.txt
+      # Guarded like the state.json/queue.json writes around it: if this append fails,
+      # state.json already says "parked" for a PR that parked.txt never learns about,
+      # so Phase: Drain Parked PRs would never see it — stop before the queue advances.
+      if [ "$RECONCILE" = "parked" ] && ! printf '%s\n' "$EX_PR" >> .codegraph/fixer/parked.txt; then
+        echo "ERROR: could not append PR #$EX_PR to parked.txt for issue #$ISSUE — state.json already recorded it as parked. Queue was NOT advanced."
+        exit 1
+      fi
       TMP_QUEUE=$(mktemp "${TMPDIR:-/tmp}/fixer-queue.XXXXXXXXXX")
       trap 'rm -f "$TMP_QUEUE"' EXIT
       if ! jq '.[1:]' .codegraph/fixer/queue.json > "$TMP_QUEUE"; then

--- a/.claude/skills/fixer/SKILL.md
+++ b/.claude/skills/fixer/SKILL.md
@@ -420,17 +420,29 @@ case "$STATUS" in
       echo "fixer: no usable PR found for issue #$ISSUE — will retry the full 2a-2g dispatch once"
     else
       # Apply the reconciliation directly — the only place besides 2g itself that writes
-      # a terminal state.json record, using the exact same append pattern.
+      # a terminal state.json record, using the exact same append pattern. The queue
+      # shift below must never run if this write failed — otherwise the issue drops out
+      # of queue.json with no state.json record at all, and (for RECONCILE=parked) a PR
+      # would be sitting in parked.txt with no matching state.json entry either.
       TMP_STATE=$(mktemp "${TMPDIR:-/tmp}/fixer-state.XXXXXXXXXX")
       trap 'rm -f "$TMP_STATE"' EXIT
-      jq --argjson issue "$ISSUE" --arg status "$RECONCILE" --argjson pr "$EX_PR" \
+      if ! jq --argjson issue "$ISSUE" --arg status "$RECONCILE" --argjson pr "$EX_PR" \
         '.issues += [{issue: $issue, status: $status, pr: $pr}]' \
-        .codegraph/fixer/state.json > "$TMP_STATE" && mv "$TMP_STATE" .codegraph/fixer/state.json
+        .codegraph/fixer/state.json > "$TMP_STATE"; then
+        echo "ERROR: could not write the reconciled record for issue #$ISSUE — state.json may be malformed."
+        echo "Restore from .codegraph/fixer/state.json.bak, then stop and report to the user. Queue was NOT advanced."
+        exit 1
+      fi
+      mv "$TMP_STATE" .codegraph/fixer/state.json
       trap - EXIT
       [ "$RECONCILE" = "parked" ] && printf '%s\n' "$EX_PR" >> .codegraph/fixer/parked.txt
       TMP_QUEUE=$(mktemp "${TMPDIR:-/tmp}/fixer-queue.XXXXXXXXXX")
       trap 'rm -f "$TMP_QUEUE"' EXIT
-      jq '.[1:]' .codegraph/fixer/queue.json > "$TMP_QUEUE" && mv "$TMP_QUEUE" .codegraph/fixer/queue.json
+      if ! jq '.[1:]' .codegraph/fixer/queue.json > "$TMP_QUEUE"; then
+        echo "ERROR: could not shift queue.json after recording issue #$ISSUE as $RECONCILE — state.json already has the record, but the queue was NOT advanced. Investigate queue.json before re-running, or this issue will be reprocessed."
+        exit 1
+      fi
+      mv "$TMP_QUEUE" .codegraph/fixer/queue.json
       trap - EXIT
       echo "fixer: reconciled issue #$ISSUE as $RECONCILE without retrying — advancing to the next issue"
     fi

--- a/.claude/skills/fixer/SKILL.md
+++ b/.claude/skills/fixer/SKILL.md
@@ -355,7 +355,49 @@ case "$STATUS" in
 esac
 ```
 
-If validation fails, retry the dispatch **once** for the same issue — 2a's own crash-safety (clearing stale `outcome`/`round`/`current-pr`/`gate-fail`/stall/signature scratch files left by an interrupted attempt) and the dedup loop above already make a retry safe even if the first sub-agent got partway through. If the retry also fails validation, **stop the run and report to the user** — never guess at the outcome or silently mark the issue as anything.
+**Before retrying, check GitHub for what actually happened — never assume nothing landed.** A sub-agent can crash after `gh pr merge` in 2f but before 2g ever writes `state.json` (or after `gh pr create` in 2e but before merging). Blindly retrying the full 2a–2g cycle in either case would cut a *second* branch and open a *second* PR for an issue whose original PR already merged, or already exists and is mid-review — silently duplicating or orphaning real work. 2a's branch name is deterministic (`fix/issue-$ISSUE`), so query it directly instead of guessing from `state.json` alone:
+
+```bash
+mkdir -p .codegraph/fixer
+REPO=$(cat .codegraph/fixer/repo)
+# ISSUE is the same number captured before dispatch, per the comment above
+EXISTING=$(gh pr list --repo "$REPO" --head "fix/issue-$ISSUE" --state all --json number,state,url)
+EXISTING_COUNT=$(printf '%s' "$EXISTING" | jq 'length')
+if [ "$EXISTING_COUNT" -eq 0 ]; then
+  echo "fixer: no PR exists for fix/issue-$ISSUE — the crash happened before 2e ever opened one. Safe to retry the full 2a-2g dispatch."
+  RECONCILE=retry
+else
+  EX_STATE=$(printf '%s' "$EXISTING" | jq -r '.[0].state')
+  EX_PR=$(printf '%s' "$EXISTING" | jq -r '.[0].number')
+  case "$EX_STATE" in
+    MERGED) echo "fixer: PR #$EX_PR for issue #$ISSUE is already merged — the crash was between 2f's merge and 2g's write. Reconciling state.json directly, no retry."; RECONCILE=merged ;;
+    OPEN) echo "fixer: PR #$EX_PR for issue #$ISSUE is already open — the crash was mid-2f. Recording it as parked so Phase: Drain Parked PRs converges it, rather than opening a duplicate PR."; RECONCILE=parked ;;
+    CLOSED) echo "fixer: PR #$EX_PR for issue #$ISSUE exists but was closed without merging — nothing to reconcile from it. Safe to retry the full 2a-2g dispatch."; RECONCILE=retry ;;
+  esac
+fi
+```
+
+Apply the reconciliation directly — this is the only place besides 2g itself that writes a terminal `state.json` record, and it uses the exact same append pattern:
+
+```bash
+mkdir -p .codegraph/fixer
+if [ "$RECONCILE" != "retry" ]; then
+  TMP_STATE=$(mktemp "${TMPDIR:-/tmp}/fixer-state.XXXXXXXXXX")
+  trap 'rm -f "$TMP_STATE"' EXIT
+  jq --argjson issue "$ISSUE" --arg status "$RECONCILE" --argjson pr "$EX_PR" \
+    '.issues += [{issue: $issue, status: $status, pr: $pr}]' \
+    .codegraph/fixer/state.json > "$TMP_STATE" && mv "$TMP_STATE" .codegraph/fixer/state.json
+  trap - EXIT
+  [ "$RECONCILE" = "parked" ] && printf '%s\n' "$EX_PR" >> .codegraph/fixer/parked.txt
+  TMP_QUEUE=$(mktemp "${TMPDIR:-/tmp}/fixer-queue.XXXXXXXXXX")
+  trap 'rm -f "$TMP_QUEUE"' EXIT
+  jq '.[1:]' .codegraph/fixer/queue.json > "$TMP_QUEUE" && mv "$TMP_QUEUE" .codegraph/fixer/queue.json
+  trap - EXIT
+  echo "fixer: reconciled issue #$ISSUE as $RECONCILE without retrying — advancing to the next issue"
+fi
+```
+
+Only when `RECONCILE=retry` does a second dispatch happen, and only **once** — 2a's own crash-safety (clearing stale `outcome`/`round`/`current-pr`/`gate-fail`/stall/signature scratch files left by an interrupted attempt) and the dedup loop above already make that retry safe. If the retry also fails validation, or the GitHub lookup itself is ambiguous or fails, **stop the run and report to the user** — never guess at the outcome or silently mark the issue as anything.
 
 Nothing about 2a–2g's content changes because of this dispatch — every check, gate, and invariant below still applies exactly as written. A sub-agent is simply the thing now applying them, one issue at a time, in a clean context each time.
 
@@ -882,9 +924,11 @@ echo "fixer: batch complete — running housekeeping before deciding on the next
 
 Invoke the `housekeep` skill: `/housekeep --dry-run` if `DRY_RUN` is `true` (fixer's own dry-run must not let a nested skill mutate anything either), otherwise plain `/housekeep`.
 
-`/housekeep` asks for confirmation before deleting a stale worktree or a merged branch — it never deletes unattended. Answer those prompts with the same judgment /fixer already exercises unattended for PR merges elsewhere in this skill, never an `AskUserQuestion`, with one hard exception:
+`/housekeep` asks for confirmation before deleting a stale worktree or a merged branch — it never deletes unattended, and /fixer must not blanket-approve on its behalf just because it is running unattended. /fixer only has firsthand knowledge of its own work, so its autonomy here is deliberately narrow — never an `AskUserQuestion` either way, but the default is to decline, not confirm:
 
-- **Never confirm removal of the worktree this run is executing in.** Compare the path housekeep lists against `git rev-parse --show-toplevel`. This run's own worktree can legitimately look stale to housekeep — its currently checked-out branch is whichever issue branch merged most recently, which by definition has no commits ahead of `main` — but removing it out from under this run kills the batch loop mid-run. Decline that one specific removal; everything else housekeep proposes (other sessions' stale worktrees, this run's own already-merged local branch refs, dirt files) is fair game to confirm.
+- **Confirm deletion only for local branches this run itself recorded as `merged` in `state.json`.** /fixer knows these are safe because it merged them itself moments ago, and `--delete-branch` (I1) already removed them on the remote — housekeep is only pruning the leftover local ref.
+- **Decline every worktree-removal prompt, with no exception — including this run's own worktree.** Housekeep's stale-worktree criteria (branch merged, no commits ahead of `main`, no uncommitted changes) cannot distinguish "abandoned" from "another session is actively using it between commits," which is exactly why housekeep gates worktree removal behind confirmation in the first place; /fixer has no additional information that would make it safe to override that gate. This run's own worktree is doubly out of bounds — its currently checked-out branch is whichever issue branch merged most recently, which by definition looks stale by every one of those criteria, and removing it out from under this run would kill the batch loop mid-run.
+- **Decline everything else** (branches this run did not itself merge, large untracked files, anything not self-evidently this run's own completed work). Report it in the final summary and move on — the same posture /fixer already takes toward genuinely ambiguous merge conflicts, which it hands to `/resolve` rather than guessing at.
 
 Housekeep's own scope is strictly local (no pushes, no PR activity), so it never conflicts with the merge machinery in Phase 2 or Phase: Drain Parked PRs.
 
@@ -1229,8 +1273,8 @@ All state is under `.codegraph/fixer/`:
 
 - **One branch per issue, always cut from a freshly fetched `origin/main` (I1).** Never reuse a branch across issues. Never stack a branch on another issue's branch — `deleteBranchOnMerge` is enabled, so merging a base PR closes its stacked PRs.
 - **Merge the current PR before cutting the next branch (I2, I3).** Never open the next issue's PR while the previous one is still open and mergeable. Only a parked PR may remain open.
-- **Every issue's 2a–2g runs in a freshly dispatched sub-agent, never inline (I7).** Snapshot `state.json` before each dispatch, validate the sub-agent's result against `state.json` afterward, and retry once on validation failure before stopping the run.
-- **Run `/housekeep` once per completed batch (Phase 3), including the last one.** Never let it confirm removal of the worktree this run is executing in — check the path first.
+- **Every issue's 2a–2g runs in a freshly dispatched sub-agent, never inline (I7).** Snapshot `state.json` before each dispatch and validate the sub-agent's result against `state.json` afterward. On validation failure, check GitHub for an existing `fix/issue-$ISSUE` PR before retrying — reconcile a merged or open PR directly into `state.json`/`parked.txt` instead of re-dispatching, since a blind retry can duplicate already-merged work or orphan an in-flight PR. Only retry the full 2a-2g cycle, once, when no such PR exists or it was closed unmerged.
+- **Run `/housekeep` once per completed batch (Phase 3), including the last one.** /fixer's autonomy to confirm housekeep's deletion prompts is narrow: only local branches this run itself just merged. Decline every worktree-removal prompt unconditionally — including this run's own worktree — since housekeep cannot distinguish "abandoned" from "another session mid-use," and /fixer has no basis to override that.
 - **Never rebase (I5).** Always `git merge origin/main`. The ruleset forbids non-fast-forward pushes to `main` and the repo disables rebase-merge.
 - **Never push a catch-up merge without a passing I4 integrity check.** Every line the PR authored must still exist, or its absence must be individually documented. A clean merge with no conflict markers is not evidence that nothing was lost.
 - **Never `git stash`.** The stash stack is shared with the main checkout and every other worktree. Use commits.

--- a/.claude/skills/fixer/SKILL.md
+++ b/.claude/skills/fixer/SKILL.md
@@ -378,13 +378,24 @@ if [ "$NEEDS_RECONCILE" = "true" ]; then
     echo "fixer: no PR exists for fix/issue-$ISSUE — the crash happened before 2e ever opened one. Safe to retry the full 2a-2g dispatch."
     RECONCILE=retry
   else
-    [ "$EXISTING_COUNT" -gt 1 ] && echo "WARN: $EXISTING_COUNT PRs found for fix/issue-$ISSUE — using the most recent by PR number"
-    EX_STATE=$(printf '%s' "$EXISTING" | jq -r 'sort_by(.number) | last | .state')
-    EX_PR=$(printf '%s' "$EXISTING" | jq -r 'sort_by(.number) | last | .number')
+    # Priority MERGED > OPEN > CLOSED, never "most recent by number". A branch name is
+    # reused across attempts (a merged PR deletes its branch via --delete-branch, and a
+    # later retry can recreate the same fix/issue-$ISSUE name), so --state all can return
+    # an OLDER merged PR alongside a NEWER closed-unmerged one. Picking by recency would
+    # find the newer CLOSED PR, decide RECONCILE=retry, and re-dispatch work that the
+    # older MERGED PR already completed — a merged result must win regardless of number.
+    [ "$EXISTING_COUNT" -gt 1 ] && echo "WARN: $EXISTING_COUNT PRs found for fix/issue-$ISSUE — prioritizing any merged result over recency"
+    EX_PR=$(printf '%s' "$EXISTING" | jq -r '[.[] | select(.state=="MERGED")] | .[0].number // empty')
+    if [ -n "$EX_PR" ]; then
+      EX_STATE=MERGED
+    else
+      EX_PR=$(printf '%s' "$EXISTING" | jq -r '[.[] | select(.state=="OPEN")] | .[0].number // empty')
+      [ -n "$EX_PR" ] && EX_STATE=OPEN || EX_STATE=CLOSED
+    fi
     case "$EX_STATE" in
       MERGED) echo "fixer: PR #$EX_PR for issue #$ISSUE is already merged — the crash was between 2f's merge and 2g's write. Reconciling state.json directly, no retry."; RECONCILE=merged ;;
       OPEN) echo "fixer: PR #$EX_PR for issue #$ISSUE is already open — the crash was mid-2f. Recording it as parked so Phase: Drain Parked PRs converges it, rather than opening a duplicate PR."; RECONCILE=parked ;;
-      CLOSED) echo "fixer: PR #$EX_PR for issue #$ISSUE exists but was closed without merging — nothing to reconcile from it. Safe to retry the full 2a-2g dispatch."; RECONCILE=retry ;;
+      CLOSED) echo "fixer: every PR for fix/issue-$ISSUE is closed without merging — nothing to reconcile from. Safe to retry the full 2a-2g dispatch."; RECONCILE=retry ;;
     esac
   fi
 fi

--- a/.claude/skills/fixer/SKILL.md
+++ b/.claude/skills/fixer/SKILL.md
@@ -433,7 +433,11 @@ case "$STATUS" in
         echo "Restore from .codegraph/fixer/state.json.bak, then stop and report to the user. Queue was NOT advanced."
         exit 1
       fi
-      mv "$TMP_STATE" .codegraph/fixer/state.json
+      if ! mv "$TMP_STATE" .codegraph/fixer/state.json; then
+        echo "ERROR: could not replace state.json with the reconciled record for issue #$ISSUE (mv failed)."
+        echo "Restore from .codegraph/fixer/state.json.bak if needed, then stop and report to the user. Queue was NOT advanced."
+        exit 1
+      fi
       trap - EXIT
       [ "$RECONCILE" = "parked" ] && printf '%s\n' "$EX_PR" >> .codegraph/fixer/parked.txt
       TMP_QUEUE=$(mktemp "${TMPDIR:-/tmp}/fixer-queue.XXXXXXXXXX")
@@ -442,7 +446,10 @@ case "$STATUS" in
         echo "ERROR: could not shift queue.json after recording issue #$ISSUE as $RECONCILE — state.json already has the record, but the queue was NOT advanced. Investigate queue.json before re-running, or this issue will be reprocessed."
         exit 1
       fi
-      mv "$TMP_QUEUE" .codegraph/fixer/queue.json
+      if ! mv "$TMP_QUEUE" .codegraph/fixer/queue.json; then
+        echo "ERROR: could not replace queue.json after recording issue #$ISSUE as $RECONCILE (mv failed) — state.json already has the record. Investigate queue.json before re-running, or this issue will be reprocessed."
+        exit 1
+      fi
       trap - EXIT
       echo "fixer: reconciled issue #$ISSUE as $RECONCILE without retrying — advancing to the next issue"
     fi

--- a/.claude/skills/fixer/SKILL.md
+++ b/.claude/skills/fixer/SKILL.md
@@ -30,6 +30,7 @@ A previous batch run on this repo collapsed under compounding merge conflicts �
 - **I4 — Never re-solve solved work.** Only parked PRs ever need a catch-up merge. Every such merge must pass the diff-integrity check in Phase: Drain Parked PRs, which mechanically verifies that every line the PR authored still survives.
 - **I5 — Never rebase; always `git merge origin/main`.** The ruleset forbids non-fast-forward pushes to `main` and the repo disables rebase-merge.
 - **I6 — A parked PR never blocks the next issue.** Parking is the escape hatch that keeps the batch moving; Phase: Drain Parked PRs cleans up.
+- **I7 — Every issue's work happens in a freshly dispatched sub-agent, never inline in the orchestrating session.** The orchestrator only reads state back off disk between dispatches, the same disk state a resumed run already relies on. This keeps a multi-batch run's context from growing without bound and gives each issue a genuinely clean slate.
 
 ---
 
@@ -252,7 +253,7 @@ jq -r '.[] | "  #\(.issue)  \(.title)"' .codegraph/fixer/queue.json
 
 ## Phase 2 — Solve and Merge Loop
 
-Process queue entries **strictly in ascending issue order, one at a time**. Do not start the next issue until the current one is either merged or parked — that serialisation is what enforces I2 and I3.
+Process queue entries **strictly in ascending issue order, one at a time**. Do not start the next issue until the current one is either merged or parked — that serialisation is what enforces I2 and I3. **This session never executes 2a–2g itself** — each issue is dispatched to a fresh sub-agent (invariant I7, below) and the result is validated off disk before the next dispatch.
 
 Emit progress at the top of every iteration so a long batch is never silent (Pattern 11):
 
@@ -264,7 +265,7 @@ echo "fixer: progress $DONE/$TOTAL issues resolved"
 jq -r '.[] | "  #\(.issue)  \(.title)"' .codegraph/fixer/queue.json | head -"$TOTAL"
 ```
 
-For each issue `ISSUE` in the queue whose recorded status is not `merged`, `parked`, or `abandoned`, run steps 2a–2g.
+For each issue `ISSUE` in the queue whose recorded status is not `merged`, `parked`, or `abandoned`, **dispatch one fresh sub-agent to run steps 2a–2g for that issue alone**, then validate its result before advancing (see "Dispatching each issue to a sub-agent" below).
 
 `state.json` and `queue.json` are updated by two separate writes in step 2g (Pattern 1 — bash blocks do not share variables, so the outcome is appended in one `jq`/`mv` and the queue is shifted in another). If a run stops between those two writes, `queue.json[0]` is still the issue that `state.json` already recorded as resolved. Filter it out before ever reading the queue head, so a resumed run never re-branches or re-PRs completed work:
 
@@ -298,6 +299,65 @@ while true; do
   trap - EXIT
 done
 ```
+
+### Dispatching each issue to a sub-agent (invariant I7)
+
+Steps 2a–2g below are never executed inline in this session. An issue's full cycle — reading it, building codegraph context, editing, verifying, opening a PR, waiting on CI and Greptile, converging, merging — generates a lot of transcript, and ten issues' worth of that compounding in one session is exactly the kind of unbounded growth this skill should not depend on tolerating for a normal run (as opposed to surviving as an *interruption*, which is what the disk-based state in Pattern 1 exists for). So each issue gets a genuinely clean context: this session only ever dispatches a sub-agent to run 2a–2g and then reads the outcome back off disk — the same disk state a resumed run already reads.
+
+Snapshot `state.json` immediately before every dispatch, so a corrupted write is recoverable — this mirrors the state backup `/titan-run` takes ahead of its own sub-agent dispatches:
+
+```bash
+mkdir -p .codegraph/fixer
+cp .codegraph/fixer/state.json .codegraph/fixer/state.json.bak 2>/dev/null || true
+```
+
+Use the **Agent tool** in the foreground (`run_in_background: false` — I2/I3 require the next issue to wait for this one to fully land) and with **no `isolation` parameter** — this run already has its one dedicated worktree from Phase 0, and spawning another would violate I1's single-worktree-per-run design:
+
+```
+Agent({
+  description: "Solve issue #<ISSUE> end-to-end",
+  run_in_background: false,
+  prompt: |
+    You are executing exactly ONE issue for an in-progress /fixer run in <REPO>.
+    Read .claude/skills/fixer/SKILL.md and follow Phase 2, steps 2a through 2g,
+    EXACTLY and IN FULL, for issue #<ISSUE> only.
+
+    You are already inside the correct worktree, on the correct starting point.
+    Do not run /worktree, do not create a new worktree, do not touch any other
+    queue entry. Arguments (count, author, start-from, once, dry-run) are already
+    parsed and persisted under .codegraph/fixer/ — read them from there, do not
+    reparse $ARGUMENTS.
+
+    Stop as soon as steps 2a-2g reach a terminal outcome for this issue (merged,
+    parked, or abandoned) — do not continue to the next queue entry, that is the
+    orchestrating run's job. Return a short summary: the outcome, the PR number
+    if one was opened, and anything unusual.
+})
+```
+
+After the sub-agent returns, validate before trusting it — a sub-agent's own summary describes what it intended to do, not necessarily what actually landed on disk, the same caution this skill already applies to `/sweep` and `/resolve`:
+
+```bash
+mkdir -p .codegraph/fixer
+# ISSUE must be the number captured from queue.json's head BEFORE dispatch — by the
+# time the sub-agent's 2g has run, queue.json has already shifted (on success), so it
+# can no longer be re-derived by reading queue.json here the way earlier steps do.
+RECORDED=$(jq --argjson issue "$ISSUE" '[.issues[] | select(.issue == $issue)] | length' .codegraph/fixer/state.json)
+if [ "$RECORDED" -ne 1 ]; then
+  echo "ERROR: sub-agent for issue #$ISSUE left $RECORDED state.json record(s), expected exactly 1."
+  echo "Compare against .codegraph/fixer/state.json.bak; if state.json is corrupted, restore the backup, then retry issue #$ISSUE once."
+  exit 1
+fi
+STATUS=$(jq -r --argjson issue "$ISSUE" '[.issues[] | select(.issue == $issue)][0].status' .codegraph/fixer/state.json)
+case "$STATUS" in
+  merged|parked|abandoned) echo "fixer: sub-agent recorded issue #$ISSUE as $STATUS" ;;
+  *) echo "ERROR: issue #$ISSUE recorded with invalid status '$STATUS'"; exit 1 ;;
+esac
+```
+
+If validation fails, retry the dispatch **once** for the same issue — 2a's own crash-safety (clearing stale `outcome`/`round`/`current-pr`/`gate-fail`/stall/signature scratch files left by an interrupted attempt) and the dedup loop above already make a retry safe even if the first sub-agent got partway through. If the retry also fails validation, **stop the run and report to the user** — never guess at the outcome or silently mark the issue as anything.
+
+Nothing about 2a–2g's content changes because of this dispatch — every check, gate, and invariant below still applies exactly as written. A sub-agent is simply the thing now applying them, one issue at a time, in a clean context each time.
 
 ### 2a. Cut a fresh branch from `origin/main` (invariant I1)
 
@@ -802,13 +862,31 @@ echo "fixer: issue #$ISSUE recorded as $STATUS; $(jq 'length' .codegraph/fixer/q
 
 Loop back to step 2a for the next queue entry. **Only after the current PR is merged or parked** — that ordering is I2.
 
-**Exit condition:** Every queue entry has a `state.json` record with status `merged`, `parked`, or `abandoned`; `queue.json` is an empty array. Every merged PR satisfied all five gate conditions. No branch was reused and no branch was stacked on another issue's branch.
+**Exit condition:** Every queue entry has a `state.json` record with status `merged`, `parked`, or `abandoned`; `queue.json` is an empty array. Every merged PR satisfied all five gate conditions. No branch was reused and no branch was stacked on another issue's branch. Every issue's 2a–2g ran inside its own dispatched sub-agent, validated against `state.json` before the next dispatch — never inline in this session.
 
 ---
 
 ## Phase 3 — Continue the Batch Loop, or Proceed to Drain
 
 Phase 1 and Phase 2 together process exactly one batch of up to `COUNT` issues. **The run's objective is the whole qualifying backlog, not one batch** — this phase decides whether more work remains before moving on to drain and report.
+
+### 3a. Housekeep the worktree
+
+Every batch cuts and merges several branches inside the one worktree serving this run (Phase 0), leaving local branch refs behind even though `--delete-branch` already removed them on the remote. Run `/housekeep` once per completed batch — including the last one — rather than letting that cleanup accumulate for a human to notice later:
+
+```bash
+mkdir -p .codegraph/fixer
+DRY_RUN=$(cat .codegraph/fixer/dry-run)
+echo "fixer: batch complete — running housekeeping before deciding on the next step"
+```
+
+Invoke the `housekeep` skill: `/housekeep --dry-run` if `DRY_RUN` is `true` (fixer's own dry-run must not let a nested skill mutate anything either), otherwise plain `/housekeep`.
+
+`/housekeep` asks for confirmation before deleting a stale worktree or a merged branch — it never deletes unattended. Answer those prompts with the same judgment /fixer already exercises unattended for PR merges elsewhere in this skill, never an `AskUserQuestion`, with one hard exception:
+
+- **Never confirm removal of the worktree this run is executing in.** Compare the path housekeep lists against `git rev-parse --show-toplevel`. This run's own worktree can legitimately look stale to housekeep — its currently checked-out branch is whichever issue branch merged most recently, which by definition has no commits ahead of `main` — but removing it out from under this run kills the batch loop mid-run. Decline that one specific removal; everything else housekeep proposes (other sessions' stale worktrees, this run's own already-merged local branch refs, dirt files) is fair game to confirm.
+
+Housekeep's own scope is strictly local (no pushes, no PR activity), so it never conflicts with the merge machinery in Phase 2 or Phase: Drain Parked PRs.
 
 Stop looping and go straight to Phase: Drain Parked PRs if `ONCE` or `DRY_RUN` is `true` — a single batch is the entire run in either case:
 
@@ -870,7 +948,7 @@ fi
 
 If `.codegraph/fixer/loop-decision` is `loop`, go back to Phase 1 and process another batch — do **not** re-run Phase 0 (the repo slug, test/lint commands, and `state.json` are already established for this run, and re-running Phase 0's resume-detection would misread the mid-run `state.json` as a crash to resume from). If it is `stop`, proceed to Phase: Drain Parked PRs.
 
-**Exit condition:** `.codegraph/fixer/loop-decision` is `loop` (with a fresh `start-from` persisted and per-batch scratch state cleared) or `stop`. Every batch processed this run is recorded cumulatively in `state.json` — nothing from an earlier batch is lost or overwritten by a later one.
+**Exit condition:** `/housekeep` has run for this batch (3a). `.codegraph/fixer/loop-decision` is `loop` (with a fresh `start-from` persisted and per-batch scratch state cleared) or `stop`. Every batch processed this run is recorded cumulatively in `state.json` — nothing from an earlier batch is lost or overwritten by a later one.
 
 ---
 
@@ -1120,6 +1198,7 @@ All state is under `.codegraph/fixer/`:
 | `test-cmd`, `lint-cmd` | text | detected package-manager commands |
 | `queue.json` | JSON array of `{issue, title}` | current batch's remaining work, ascending; entries are shifted off as they complete. **A present-but-empty `queue.json` means the batch loop fully completed** — Phase 0 uses this, together with `parked.txt` and `run-complete`, to decide fresh-run vs. resume |
 | `state.json` | `{"issues":[{issue, status, pr}]}` | per-issue outcome, accumulated across every batch this run has processed; reset to empty whenever Phase 0 detects a fresh run |
+| `state.json.bak` | JSON | snapshot taken immediately before each issue's sub-agent dispatch (I7); restore from this if a dispatch corrupts `state.json` |
 | `parked.txt` | newline-separated PR numbers | accumulated across every batch; input to Phase: Drain Parked PRs; a merged PR's number is removed from this file the moment it merges. **Only ever emptied, never deleted, by a fully-merged drain** — Phase 0 treats a non-empty `parked.txt` as evidence of a resumable (mid-drain) run only if `run-complete` is absent; once Phase: Final Report has actually run and written it, the remaining entries are a closed, already-reported matter, not a resume signal |
 | `run-complete` | empty marker file | touched by Phase: Final Report as its last action, strictly after the report has been produced — the sole authoritative "this run's outcome was reported" signal Phase 0 checks, deliberately decoupled from `drain-stall`/`drain-pass` (which get written mid-Phase-4 and would otherwise race against the report actually happening); reset (removed) whenever Phase 0 starts a genuinely fresh run |
 | `batches-done` | text | count of batches completed this run; read by Phase 3 and the final report; reset on a fresh run |
@@ -1150,6 +1229,8 @@ All state is under `.codegraph/fixer/`:
 
 - **One branch per issue, always cut from a freshly fetched `origin/main` (I1).** Never reuse a branch across issues. Never stack a branch on another issue's branch — `deleteBranchOnMerge` is enabled, so merging a base PR closes its stacked PRs.
 - **Merge the current PR before cutting the next branch (I2, I3).** Never open the next issue's PR while the previous one is still open and mergeable. Only a parked PR may remain open.
+- **Every issue's 2a–2g runs in a freshly dispatched sub-agent, never inline (I7).** Snapshot `state.json` before each dispatch, validate the sub-agent's result against `state.json` afterward, and retry once on validation failure before stopping the run.
+- **Run `/housekeep` once per completed batch (Phase 3), including the last one.** Never let it confirm removal of the worktree this run is executing in — check the path first.
 - **Never rebase (I5).** Always `git merge origin/main`. The ruleset forbids non-fast-forward pushes to `main` and the repo disables rebase-merge.
 - **Never push a catch-up merge without a passing I4 integrity check.** Every line the PR authored must still exist, or its absence must be individually documented. A clean merge with no conflict markers is not evidence that nothing was lost.
 - **Never `git stash`.** The stash stack is shared with the main checkout and every other worktree. Use commits.

--- a/.claude/skills/fixer/SKILL.md
+++ b/.claude/skills/fixer/SKILL.md
@@ -433,7 +433,14 @@ case "$STATUS" in
         echo "Restore from .codegraph/fixer/state.json.bak, then stop and report to the user. Queue was NOT advanced."
         exit 1
       fi
-      mv "$TMP_STATE" .codegraph/fixer/state.json
+      # mv is checked too, not just the jq that preceded it — a failed rename (e.g. a
+      # cross-device TMPDIR, disk full, or permissions) must stop here exactly like a
+      # failed jq does, otherwise the queue below still shifts past a state.json that
+      # was never actually replaced.
+      if ! mv "$TMP_STATE" .codegraph/fixer/state.json; then
+        echo "ERROR: could not replace state.json with the reconciled record for issue #$ISSUE. Queue was NOT advanced."
+        exit 1
+      fi
       trap - EXIT
       [ "$RECONCILE" = "parked" ] && printf '%s\n' "$EX_PR" >> .codegraph/fixer/parked.txt
       TMP_QUEUE=$(mktemp "${TMPDIR:-/tmp}/fixer-queue.XXXXXXXXXX")
@@ -442,7 +449,10 @@ case "$STATUS" in
         echo "ERROR: could not shift queue.json after recording issue #$ISSUE as $RECONCILE — state.json already has the record, but the queue was NOT advanced. Investigate queue.json before re-running, or this issue will be reprocessed."
         exit 1
       fi
-      mv "$TMP_QUEUE" .codegraph/fixer/queue.json
+      if ! mv "$TMP_QUEUE" .codegraph/fixer/queue.json; then
+        echo "ERROR: could not replace queue.json after recording issue #$ISSUE as $RECONCILE — state.json already has the record, but the queue was NOT advanced. Investigate queue.json before re-running, or this issue will be reprocessed."
+        exit 1
+      fi
       trap - EXIT
       echo "fixer: reconciled issue #$ISSUE as $RECONCILE without retrying — advancing to the next issue"
     fi

--- a/.claude/skills/fixer/SKILL.md
+++ b/.claude/skills/fixer/SKILL.md
@@ -410,6 +410,12 @@ case "$STATUS" in
     fi
 
     if [ "$RECONCILE" = "retry" ]; then
+      # A closed-without-merging PR's branch is NOT deleted automatically — this repo's
+      # --delete-branch only runs on merge (I1), so a stale fix/issue-$ISSUE can still be
+      # on the remote here. Since we already established above that no useful work lives
+      # on it (not merged, not open), delete it now so the retry's 2e can push cleanly
+      # instead of hitting a non-fast-forward rejection — never force-push (Rules).
+      git push origin --delete "fix/issue-$ISSUE" 2>/dev/null || true
       printf '%s\n' "retry" > .codegraph/fixer/dispatch-retry-needed
       echo "fixer: no usable PR found for issue #$ISSUE — will retry the full 2a-2g dispatch once"
     else

--- a/.claude/skills/fixer/SKILL.md
+++ b/.claude/skills/fixer/SKILL.md
@@ -335,7 +335,7 @@ Agent({
 })
 ```
 
-After the sub-agent returns, validate before trusting it — a sub-agent's own summary describes what it intended to do, not necessarily what actually landed on disk, the same caution this skill already applies to `/sweep` and `/resolve`:
+After the sub-agent returns, validate before trusting it — a sub-agent's own summary describes what it intended to do, not necessarily what actually landed on disk, the same caution this skill already applies to `/sweep` and `/resolve`. **A validation failure must never `exit` directly** — it must fall through to the GitHub reconciliation check below, since the whole point of that check is to handle exactly the crash this validation is built to detect:
 
 ```bash
 mkdir -p .codegraph/fixer
@@ -343,37 +343,50 @@ mkdir -p .codegraph/fixer
 # time the sub-agent's 2g has run, queue.json has already shifted (on success), so it
 # can no longer be re-derived by reading queue.json here the way earlier steps do.
 RECORDED=$(jq --argjson issue "$ISSUE" '[.issues[] | select(.issue == $issue)] | length' .codegraph/fixer/state.json)
-if [ "$RECORDED" -ne 1 ]; then
-  echo "ERROR: sub-agent for issue #$ISSUE left $RECORDED state.json record(s), expected exactly 1."
-  echo "Compare against .codegraph/fixer/state.json.bak; if state.json is corrupted, restore the backup, then retry issue #$ISSUE once."
-  exit 1
+STATUS=""
+if [ "$RECORDED" -eq 1 ]; then
+  STATUS=$(jq -r --argjson issue "$ISSUE" '[.issues[] | select(.issue == $issue)][0].status' .codegraph/fixer/state.json)
 fi
-STATUS=$(jq -r --argjson issue "$ISSUE" '[.issues[] | select(.issue == $issue)][0].status' .codegraph/fixer/state.json)
 case "$STATUS" in
-  merged|parked|abandoned) echo "fixer: sub-agent recorded issue #$ISSUE as $STATUS" ;;
-  *) echo "ERROR: issue #$ISSUE recorded with invalid status '$STATUS'"; exit 1 ;;
+  merged|parked|abandoned)
+    echo "fixer: sub-agent recorded issue #$ISSUE as $STATUS"
+    NEEDS_RECONCILE=false
+    ;;
+  *)
+    echo "fixer: issue #$ISSUE has no valid terminal state.json record ($RECORDED record(s), status='${STATUS:-none}') — checking GitHub before deciding what to do, not exiting blind"
+    NEEDS_RECONCILE=true
+    ;;
 esac
 ```
 
-**Before retrying, check GitHub for what actually happened — never assume nothing landed.** A sub-agent can crash after `gh pr merge` in 2f but before 2g ever writes `state.json` (or after `gh pr create` in 2e but before merging). Blindly retrying the full 2a–2g cycle in either case would cut a *second* branch and open a *second* PR for an issue whose original PR already merged, or already exists and is mid-review — silently duplicating or orphaning real work. 2a's branch name is deterministic (`fix/issue-$ISSUE`), so query it directly instead of guessing from `state.json` alone:
+**If `$NEEDS_RECONCILE` is `true`, check GitHub for what actually happened before retrying — never assume nothing landed.** A sub-agent can crash after `gh pr merge` in 2f but before 2g ever writes `state.json` (or after `gh pr create` in 2e but before merging). Blindly retrying the full 2a–2g cycle in either case would cut a *second* branch and open a *second* PR for an issue whose original PR already merged, or already exists and is mid-review — silently duplicating or orphaning real work. 2a's branch name is deterministic (`fix/issue-$ISSUE`), so query it directly instead of guessing from `state.json` alone. **Treat a failed lookup as unknown, never as "no PR exists"** — a `gh pr list` failure (auth, network, rate limit) must stop the run, not silently fall through to a retry that could duplicate an already-merged PR:
 
 ```bash
 mkdir -p .codegraph/fixer
-REPO=$(cat .codegraph/fixer/repo)
-# ISSUE is the same number captured before dispatch, per the comment above
-EXISTING=$(gh pr list --repo "$REPO" --head "fix/issue-$ISSUE" --state all --json number,state,url)
-EXISTING_COUNT=$(printf '%s' "$EXISTING" | jq 'length')
-if [ "$EXISTING_COUNT" -eq 0 ]; then
-  echo "fixer: no PR exists for fix/issue-$ISSUE — the crash happened before 2e ever opened one. Safe to retry the full 2a-2g dispatch."
-  RECONCILE=retry
-else
-  EX_STATE=$(printf '%s' "$EXISTING" | jq -r '.[0].state')
-  EX_PR=$(printf '%s' "$EXISTING" | jq -r '.[0].number')
-  case "$EX_STATE" in
-    MERGED) echo "fixer: PR #$EX_PR for issue #$ISSUE is already merged — the crash was between 2f's merge and 2g's write. Reconciling state.json directly, no retry."; RECONCILE=merged ;;
-    OPEN) echo "fixer: PR #$EX_PR for issue #$ISSUE is already open — the crash was mid-2f. Recording it as parked so Phase: Drain Parked PRs converges it, rather than opening a duplicate PR."; RECONCILE=parked ;;
-    CLOSED) echo "fixer: PR #$EX_PR for issue #$ISSUE exists but was closed without merging — nothing to reconcile from it. Safe to retry the full 2a-2g dispatch."; RECONCILE=retry ;;
-  esac
+if [ "$NEEDS_RECONCILE" = "true" ]; then
+  REPO=$(cat .codegraph/fixer/repo)
+  if ! EXISTING=$(gh pr list --repo "$REPO" --head "fix/issue-$ISSUE" --state all --json number,state,url 2>&1); then
+    echo "ERROR: 'gh pr list' failed while reconciling issue #$ISSUE — cannot tell whether a PR already exists: $EXISTING"
+    echo "Do not retry blind. Compare state.json against .codegraph/fixer/state.json.bak, then stop and report to the user."
+    exit 1
+  fi
+  if ! EXISTING_COUNT=$(printf '%s' "$EXISTING" | jq 'length' 2>&1); then
+    echo "ERROR: could not parse 'gh pr list' output while reconciling issue #$ISSUE: $EXISTING_COUNT"
+    exit 1
+  fi
+  if [ "$EXISTING_COUNT" -eq 0 ]; then
+    echo "fixer: no PR exists for fix/issue-$ISSUE — the crash happened before 2e ever opened one. Safe to retry the full 2a-2g dispatch."
+    RECONCILE=retry
+  else
+    [ "$EXISTING_COUNT" -gt 1 ] && echo "WARN: $EXISTING_COUNT PRs found for fix/issue-$ISSUE — using the most recent by PR number"
+    EX_STATE=$(printf '%s' "$EXISTING" | jq -r 'sort_by(.number) | last | .state')
+    EX_PR=$(printf '%s' "$EXISTING" | jq -r 'sort_by(.number) | last | .number')
+    case "$EX_STATE" in
+      MERGED) echo "fixer: PR #$EX_PR for issue #$ISSUE is already merged — the crash was between 2f's merge and 2g's write. Reconciling state.json directly, no retry."; RECONCILE=merged ;;
+      OPEN) echo "fixer: PR #$EX_PR for issue #$ISSUE is already open — the crash was mid-2f. Recording it as parked so Phase: Drain Parked PRs converges it, rather than opening a duplicate PR."; RECONCILE=parked ;;
+      CLOSED) echo "fixer: PR #$EX_PR for issue #$ISSUE exists but was closed without merging — nothing to reconcile from it. Safe to retry the full 2a-2g dispatch."; RECONCILE=retry ;;
+    esac
+  fi
 fi
 ```
 
@@ -381,7 +394,7 @@ Apply the reconciliation directly — this is the only place besides 2g itself t
 
 ```bash
 mkdir -p .codegraph/fixer
-if [ "$RECONCILE" != "retry" ]; then
+if [ "$NEEDS_RECONCILE" = "true" ] && [ "$RECONCILE" != "retry" ]; then
   TMP_STATE=$(mktemp "${TMPDIR:-/tmp}/fixer-state.XXXXXXXXXX")
   trap 'rm -f "$TMP_STATE"' EXIT
   jq --argjson issue "$ISSUE" --arg status "$RECONCILE" --argjson pr "$EX_PR" \
@@ -397,7 +410,7 @@ if [ "$RECONCILE" != "retry" ]; then
 fi
 ```
 
-Only when `RECONCILE=retry` does a second dispatch happen, and only **once** — 2a's own crash-safety (clearing stale `outcome`/`round`/`current-pr`/`gate-fail`/stall/signature scratch files left by an interrupted attempt) and the dedup loop above already make that retry safe. If the retry also fails validation, or the GitHub lookup itself is ambiguous or fails, **stop the run and report to the user** — never guess at the outcome or silently mark the issue as anything.
+Only when `NEEDS_RECONCILE=true` and `RECONCILE=retry` does a second dispatch happen, and only **once** — 2a's own crash-safety (clearing stale `outcome`/`round`/`current-pr`/`gate-fail`/stall/signature scratch files left by an interrupted attempt) and the dedup loop above already make that retry safe. If the retry also fails validation, **stop the run and report to the user** — never guess at the outcome or silently mark the issue as anything.
 
 Nothing about 2a–2g's content changes because of this dispatch — every check, gate, and invariant below still applies exactly as written. A sub-agent is simply the thing now applying them, one issue at a time, in a clean context each time.
 

--- a/.claude/skills/fixer/SKILL.md
+++ b/.claude/skills/fixer/SKILL.md
@@ -184,7 +184,8 @@ else
         .codegraph/fixer/outcome .codegraph/fixer/round .codegraph/fixer/current-pr .codegraph/fixer/gate-fail \
         .codegraph/fixer/stall-count .codegraph/fixer/gate-signature .codegraph/fixer/prev-gate-signature \
         .codegraph/fixer/drain-pass .codegraph/fixer/drain-stall .codegraph/fixer/drain-parked-count \
-        .codegraph/fixer/run-complete
+        .codegraph/fixer/run-complete .codegraph/fixer/state.json.bak .codegraph/fixer/dispatching-issue \
+        .codegraph/fixer/dispatch-retry-needed
 fi
 ```
 
@@ -304,6 +305,16 @@ done
 
 Steps 2a–2g below are never executed inline in this session. An issue's full cycle — reading it, building codegraph context, editing, verifying, opening a PR, waiting on CI and Greptile, converging, merging — generates a lot of transcript, and ten issues' worth of that compounding in one session is exactly the kind of unbounded growth this skill should not depend on tolerating for a normal run (as opposed to surviving as an *interruption*, which is what the disk-based state in Pattern 1 exists for). So each issue gets a genuinely clean context: this session only ever dispatches a sub-agent to run 2a–2g and then reads the outcome back off disk — the same disk state a resumed run already reads.
 
+**Capture and persist the issue number before doing anything else.** Every step below — the dispatch prompt, validation, and reconciliation — needs the same `ISSUE` value, but they are separate bash invocations (Pattern 1: bash blocks do not share variables) and, unlike 2a-2g's own steps, cannot simply re-read `queue.json`'s head after dispatch, since 2g may have already shifted it by then. Write it to disk once, here, and every later step in this subsection reads it back from that file rather than assuming a shell variable survived:
+
+```bash
+mkdir -p .codegraph/fixer
+ISSUE=$(jq -r '.[0].issue' .codegraph/fixer/queue.json)
+printf '%s\n' "$ISSUE" > .codegraph/fixer/dispatching-issue
+REPO=$(cat .codegraph/fixer/repo)
+echo "fixer: dispatching issue #$ISSUE"
+```
+
 Snapshot `state.json` immediately before every dispatch, so a corrupted write is recoverable — this mirrors the state backup `/titan-run` takes ahead of its own sub-agent dispatches:
 
 ```bash
@@ -311,7 +322,7 @@ mkdir -p .codegraph/fixer
 cp .codegraph/fixer/state.json .codegraph/fixer/state.json.bak 2>/dev/null || true
 ```
 
-Use the **Agent tool** in the foreground (`run_in_background: false` — I2/I3 require the next issue to wait for this one to fully land) and with **no `isolation` parameter** — this run already has its one dedicated worktree from Phase 0, and spawning another would violate I1's single-worktree-per-run design:
+Use the **Agent tool** in the foreground (`run_in_background: false` — I2/I3 require the next issue to wait for this one to fully land) and with **no `isolation` parameter** — this run already has its one dedicated worktree from Phase 0, and spawning another would violate I1's single-worktree-per-run design. Substitute `<ISSUE>` and `<REPO>` below with the exact values just captured and persisted above:
 
 ```
 Agent({
@@ -335,93 +346,93 @@ Agent({
 })
 ```
 
-After the sub-agent returns, validate before trusting it — a sub-agent's own summary describes what it intended to do, not necessarily what actually landed on disk, the same caution this skill already applies to `/sweep` and `/resolve`. **A validation failure must never `exit` directly** — it must fall through to the GitHub reconciliation check below, since the whole point of that check is to handle exactly the crash this validation is built to detect:
+After the sub-agent returns, validate before trusting it — a sub-agent's own summary describes what it intended to do, not necessarily what actually landed on disk, the same caution this skill already applies to `/sweep` and `/resolve`. If validation fails, check GitHub for what actually happened before retrying — never assume nothing landed. A sub-agent can crash after `gh pr merge` in 2f but before 2g ever writes `state.json` (or after `gh pr create` in 2e but before merging); blindly retrying the full 2a–2g cycle in either case would cut a *second* branch and open a *second* PR for an issue whose original PR already merged, or already exists and is mid-review — silently duplicating or orphaning real work. 2a's branch name is deterministic (`fix/issue-$ISSUE`), so query it directly instead of guessing from `state.json` alone.
+
+**Validation and reconciliation run as a single bash invocation, not several.** Every value below — `ISSUE`, whether reconciliation is even needed, the reconciliation verdict, which PR it found — is produced and consumed within this one continuous decision. Splitting it across separate bash blocks (Pattern 1: bash blocks do not share variables) would silently lose every one of them the moment a later block tried to read what an earlier one computed:
 
 ```bash
 mkdir -p .codegraph/fixer
-# ISSUE must be the number captured from queue.json's head BEFORE dispatch — by the
-# time the sub-agent's 2g has run, queue.json has already shifted (on success), so it
-# can no longer be re-derived by reading queue.json here the way earlier steps do.
+rm -f .codegraph/fixer/dispatch-retry-needed
+# Read back the value captured before dispatch — by now queue.json has already shifted
+# (on success), so ISSUE can no longer be re-derived by reading queue.json here.
+ISSUE=$(cat .codegraph/fixer/dispatching-issue)
+REPO=$(cat .codegraph/fixer/repo)
+
 RECORDED=$(jq --argjson issue "$ISSUE" '[.issues[] | select(.issue == $issue)] | length' .codegraph/fixer/state.json)
 STATUS=""
 if [ "$RECORDED" -eq 1 ]; then
   STATUS=$(jq -r --argjson issue "$ISSUE" '[.issues[] | select(.issue == $issue)][0].status' .codegraph/fixer/state.json)
 fi
+
 case "$STATUS" in
   merged|parked|abandoned)
     echo "fixer: sub-agent recorded issue #$ISSUE as $STATUS"
-    NEEDS_RECONCILE=false
     ;;
   *)
     echo "fixer: issue #$ISSUE has no valid terminal state.json record ($RECORDED record(s), status='${STATUS:-none}') — checking GitHub before deciding what to do, not exiting blind"
-    NEEDS_RECONCILE=true
+
+    # Treat a failed lookup as unknown, never as "no PR exists" — a gh pr list failure
+    # (auth, network, rate limit) must stop the run, not silently fall through to a
+    # retry that could duplicate an already-merged PR.
+    if ! EXISTING=$(gh pr list --repo "$REPO" --head "fix/issue-$ISSUE" --state all --json number,state,url 2>&1); then
+      echo "ERROR: 'gh pr list' failed while reconciling issue #$ISSUE — cannot tell whether a PR already exists: $EXISTING"
+      echo "Do not retry blind. Compare state.json against .codegraph/fixer/state.json.bak, then stop and report to the user."
+      exit 1
+    fi
+    if ! EXISTING_COUNT=$(printf '%s' "$EXISTING" | jq 'length' 2>&1); then
+      echo "ERROR: could not parse 'gh pr list' output while reconciling issue #$ISSUE: $EXISTING_COUNT"
+      exit 1
+    fi
+
+    if [ "$EXISTING_COUNT" -eq 0 ]; then
+      echo "fixer: no PR exists for fix/issue-$ISSUE — the crash happened before 2e ever opened one. Safe to retry the full 2a-2g dispatch."
+      RECONCILE=retry
+    else
+      # Priority MERGED > OPEN > CLOSED, never "most recent by number". A branch name is
+      # reused across attempts (a merged PR deletes its branch via --delete-branch, and a
+      # later retry can recreate the same fix/issue-$ISSUE name), so --state all can
+      # return an OLDER merged PR alongside a NEWER closed-unmerged one. Picking by
+      # recency would find the newer CLOSED PR, decide RECONCILE=retry, and re-dispatch
+      # work the older MERGED PR already completed — merged must win regardless of number.
+      [ "$EXISTING_COUNT" -gt 1 ] && echo "WARN: $EXISTING_COUNT PRs found for fix/issue-$ISSUE — prioritizing any merged result over recency"
+      EX_PR=$(printf '%s' "$EXISTING" | jq -r '[.[] | select(.state=="MERGED")] | .[0].number // empty')
+      if [ -n "$EX_PR" ]; then
+        EX_STATE=MERGED
+      else
+        EX_PR=$(printf '%s' "$EXISTING" | jq -r '[.[] | select(.state=="OPEN")] | .[0].number // empty')
+        [ -n "$EX_PR" ] && EX_STATE=OPEN || EX_STATE=CLOSED
+      fi
+      case "$EX_STATE" in
+        MERGED) echo "fixer: PR #$EX_PR for issue #$ISSUE is already merged — the crash was between 2f's merge and 2g's write. Reconciling state.json directly, no retry."; RECONCILE=merged ;;
+        OPEN) echo "fixer: PR #$EX_PR for issue #$ISSUE is already open — the crash was mid-2f. Recording it as parked so Phase: Drain Parked PRs converges it, rather than opening a duplicate PR."; RECONCILE=parked ;;
+        CLOSED) echo "fixer: every PR for fix/issue-$ISSUE is closed without merging — nothing to reconcile from. Safe to retry the full 2a-2g dispatch."; RECONCILE=retry ;;
+      esac
+    fi
+
+    if [ "$RECONCILE" = "retry" ]; then
+      printf '%s\n' "retry" > .codegraph/fixer/dispatch-retry-needed
+      echo "fixer: no usable PR found for issue #$ISSUE — will retry the full 2a-2g dispatch once"
+    else
+      # Apply the reconciliation directly — the only place besides 2g itself that writes
+      # a terminal state.json record, using the exact same append pattern.
+      TMP_STATE=$(mktemp "${TMPDIR:-/tmp}/fixer-state.XXXXXXXXXX")
+      trap 'rm -f "$TMP_STATE"' EXIT
+      jq --argjson issue "$ISSUE" --arg status "$RECONCILE" --argjson pr "$EX_PR" \
+        '.issues += [{issue: $issue, status: $status, pr: $pr}]' \
+        .codegraph/fixer/state.json > "$TMP_STATE" && mv "$TMP_STATE" .codegraph/fixer/state.json
+      trap - EXIT
+      [ "$RECONCILE" = "parked" ] && printf '%s\n' "$EX_PR" >> .codegraph/fixer/parked.txt
+      TMP_QUEUE=$(mktemp "${TMPDIR:-/tmp}/fixer-queue.XXXXXXXXXX")
+      trap 'rm -f "$TMP_QUEUE"' EXIT
+      jq '.[1:]' .codegraph/fixer/queue.json > "$TMP_QUEUE" && mv "$TMP_QUEUE" .codegraph/fixer/queue.json
+      trap - EXIT
+      echo "fixer: reconciled issue #$ISSUE as $RECONCILE without retrying — advancing to the next issue"
+    fi
     ;;
 esac
 ```
 
-**If `$NEEDS_RECONCILE` is `true`, check GitHub for what actually happened before retrying — never assume nothing landed.** A sub-agent can crash after `gh pr merge` in 2f but before 2g ever writes `state.json` (or after `gh pr create` in 2e but before merging). Blindly retrying the full 2a–2g cycle in either case would cut a *second* branch and open a *second* PR for an issue whose original PR already merged, or already exists and is mid-review — silently duplicating or orphaning real work. 2a's branch name is deterministic (`fix/issue-$ISSUE`), so query it directly instead of guessing from `state.json` alone. **Treat a failed lookup as unknown, never as "no PR exists"** — a `gh pr list` failure (auth, network, rate limit) must stop the run, not silently fall through to a retry that could duplicate an already-merged PR:
-
-```bash
-mkdir -p .codegraph/fixer
-if [ "$NEEDS_RECONCILE" = "true" ]; then
-  REPO=$(cat .codegraph/fixer/repo)
-  if ! EXISTING=$(gh pr list --repo "$REPO" --head "fix/issue-$ISSUE" --state all --json number,state,url 2>&1); then
-    echo "ERROR: 'gh pr list' failed while reconciling issue #$ISSUE — cannot tell whether a PR already exists: $EXISTING"
-    echo "Do not retry blind. Compare state.json against .codegraph/fixer/state.json.bak, then stop and report to the user."
-    exit 1
-  fi
-  if ! EXISTING_COUNT=$(printf '%s' "$EXISTING" | jq 'length' 2>&1); then
-    echo "ERROR: could not parse 'gh pr list' output while reconciling issue #$ISSUE: $EXISTING_COUNT"
-    exit 1
-  fi
-  if [ "$EXISTING_COUNT" -eq 0 ]; then
-    echo "fixer: no PR exists for fix/issue-$ISSUE — the crash happened before 2e ever opened one. Safe to retry the full 2a-2g dispatch."
-    RECONCILE=retry
-  else
-    # Priority MERGED > OPEN > CLOSED, never "most recent by number". A branch name is
-    # reused across attempts (a merged PR deletes its branch via --delete-branch, and a
-    # later retry can recreate the same fix/issue-$ISSUE name), so --state all can return
-    # an OLDER merged PR alongside a NEWER closed-unmerged one. Picking by recency would
-    # find the newer CLOSED PR, decide RECONCILE=retry, and re-dispatch work that the
-    # older MERGED PR already completed — a merged result must win regardless of number.
-    [ "$EXISTING_COUNT" -gt 1 ] && echo "WARN: $EXISTING_COUNT PRs found for fix/issue-$ISSUE — prioritizing any merged result over recency"
-    EX_PR=$(printf '%s' "$EXISTING" | jq -r '[.[] | select(.state=="MERGED")] | .[0].number // empty')
-    if [ -n "$EX_PR" ]; then
-      EX_STATE=MERGED
-    else
-      EX_PR=$(printf '%s' "$EXISTING" | jq -r '[.[] | select(.state=="OPEN")] | .[0].number // empty')
-      [ -n "$EX_PR" ] && EX_STATE=OPEN || EX_STATE=CLOSED
-    fi
-    case "$EX_STATE" in
-      MERGED) echo "fixer: PR #$EX_PR for issue #$ISSUE is already merged — the crash was between 2f's merge and 2g's write. Reconciling state.json directly, no retry."; RECONCILE=merged ;;
-      OPEN) echo "fixer: PR #$EX_PR for issue #$ISSUE is already open — the crash was mid-2f. Recording it as parked so Phase: Drain Parked PRs converges it, rather than opening a duplicate PR."; RECONCILE=parked ;;
-      CLOSED) echo "fixer: every PR for fix/issue-$ISSUE is closed without merging — nothing to reconcile from. Safe to retry the full 2a-2g dispatch."; RECONCILE=retry ;;
-    esac
-  fi
-fi
-```
-
-Apply the reconciliation directly — this is the only place besides 2g itself that writes a terminal `state.json` record, and it uses the exact same append pattern:
-
-```bash
-mkdir -p .codegraph/fixer
-if [ "$NEEDS_RECONCILE" = "true" ] && [ "$RECONCILE" != "retry" ]; then
-  TMP_STATE=$(mktemp "${TMPDIR:-/tmp}/fixer-state.XXXXXXXXXX")
-  trap 'rm -f "$TMP_STATE"' EXIT
-  jq --argjson issue "$ISSUE" --arg status "$RECONCILE" --argjson pr "$EX_PR" \
-    '.issues += [{issue: $issue, status: $status, pr: $pr}]' \
-    .codegraph/fixer/state.json > "$TMP_STATE" && mv "$TMP_STATE" .codegraph/fixer/state.json
-  trap - EXIT
-  [ "$RECONCILE" = "parked" ] && printf '%s\n' "$EX_PR" >> .codegraph/fixer/parked.txt
-  TMP_QUEUE=$(mktemp "${TMPDIR:-/tmp}/fixer-queue.XXXXXXXXXX")
-  trap 'rm -f "$TMP_QUEUE"' EXIT
-  jq '.[1:]' .codegraph/fixer/queue.json > "$TMP_QUEUE" && mv "$TMP_QUEUE" .codegraph/fixer/queue.json
-  trap - EXIT
-  echo "fixer: reconciled issue #$ISSUE as $RECONCILE without retrying — advancing to the next issue"
-fi
-```
-
-Only when `NEEDS_RECONCILE=true` and `RECONCILE=retry` does a second dispatch happen, and only **once** — 2a's own crash-safety (clearing stale `outcome`/`round`/`current-pr`/`gate-fail`/stall/signature scratch files left by an interrupted attempt) and the dedup loop above already make that retry safe. If the retry also fails validation, **stop the run and report to the user** — never guess at the outcome or silently mark the issue as anything.
+Only when `.codegraph/fixer/dispatch-retry-needed` was written does a second dispatch happen — re-invoke the same `Agent()` call above for the same issue (`cat .codegraph/fixer/dispatching-issue`), then re-run this whole validation-and-reconciliation block once more, only **once** — 2a's own crash-safety (clearing stale `outcome`/`round`/`current-pr`/`gate-fail`/stall/signature scratch files left by an interrupted attempt) and the dedup loop above already make that retry safe. If the retry also fails validation, **stop the run and report to the user** — never guess at the outcome or silently mark the issue as anything.
 
 Nothing about 2a–2g's content changes because of this dispatch — every check, gate, and invariant below still applies exactly as written. A sub-agent is simply the thing now applying them, one issue at a time, in a clean context each time.
 
@@ -1267,6 +1278,8 @@ All state is under `.codegraph/fixer/`:
 | `queue.json` | JSON array of `{issue, title}` | current batch's remaining work, ascending; entries are shifted off as they complete. **A present-but-empty `queue.json` means the batch loop fully completed** — Phase 0 uses this, together with `parked.txt` and `run-complete`, to decide fresh-run vs. resume |
 | `state.json` | `{"issues":[{issue, status, pr}]}` | per-issue outcome, accumulated across every batch this run has processed; reset to empty whenever Phase 0 detects a fresh run |
 | `state.json.bak` | JSON | snapshot taken immediately before each issue's sub-agent dispatch (I7); restore from this if a dispatch corrupts `state.json` |
+| `dispatching-issue` | text | the issue number captured before the current dispatch; read back by the validation/reconciliation block and by a retry dispatch, since queue.json's head is no longer reliable once 2g has shifted it |
+| `dispatch-retry-needed` | marker file | written only when reconciliation determines a second 2a-2g dispatch is needed for the same issue; cleared at the top of every validation-and-reconciliation run |
 | `parked.txt` | newline-separated PR numbers | accumulated across every batch; input to Phase: Drain Parked PRs; a merged PR's number is removed from this file the moment it merges. **Only ever emptied, never deleted, by a fully-merged drain** — Phase 0 treats a non-empty `parked.txt` as evidence of a resumable (mid-drain) run only if `run-complete` is absent; once Phase: Final Report has actually run and written it, the remaining entries are a closed, already-reported matter, not a resume signal |
 | `run-complete` | empty marker file | touched by Phase: Final Report as its last action, strictly after the report has been produced — the sole authoritative "this run's outcome was reported" signal Phase 0 checks, deliberately decoupled from `drain-stall`/`drain-pass` (which get written mid-Phase-4 and would otherwise race against the report actually happening); reset (removed) whenever Phase 0 starts a genuinely fresh run |
 | `batches-done` | text | count of batches completed this run; read by Phase 3 and the final report; reset on a fresh run |


### PR DESCRIPTION
## Summary
- Run `/housekeep` once per completed batch (including the final one) in `/fixer`'s Phase 3, so local branch refs left behind by `--delete-branch` merges and other worktree bloat get cleaned up during a long run instead of accumulating unnoticed. Added a hard guard: never confirm removal of the worktree the run is currently executing in, since its just-merged branch can legitimately look "stale" to housekeep's own criteria.
- There is no mechanism for a skill to clear its own hosting session's context (`/clear` is a REPL-only command, not something exposed to running code). As the documented equivalent already used by `/titan-run` in this repo, each issue's full solve-to-merge cycle (steps 2a-2g: branch, implement, verify, PR, converge, merge) is now dispatched to a fresh sub-agent via the Agent tool instead of running inline, so every PR gets a genuinely clean context. The orchestrating session only reads/writes the existing disk state (`state.json`, `queue.json`) between dispatches — the same state a resumed run already relies on — plus a `state.json.bak` snapshot before each dispatch and validate-or-retry-once handling afterward, since a sub-agent's own summary isn't proof of what actually landed on disk.
- Documented both as new invariants/rules (I7 for sub-agent dispatch) alongside the existing I1-I6 list, consistent with how the rest of the skill is structured.

## Verification
- lint: pass (`npm run lint`)
- No src/tests changes — this is a `.claude/skills/fixer/SKILL.md` documentation/procedure change only, so the test suite is not applicable.