### PR TITLE
feat: add complexity metrics for Objective-C (#1923)

### DIFF
--- a/crates/codegraph-core/src/ast_analysis/complexity.rs
+++ b/crates/codegraph-core/src/ast_analysis/complexity.rs
@@ -382,6 +382,36 @@ pub static CPP_RULES: LangRules = LangRules {
     switch_like_nodes: &["switch_statement"],
 };
 
+// tree-sitter-objc extends tree-sitter-c: if_statement/for_statement/
+// while_statement/do_statement/switch_statement/case_statement/
+// conditional_expression/binary_expression are byte-identical to plain C
+// (confirmed by parsing sample ObjC control flow and inspecting the
+// S-expression), including the same else_clause wrapper (Pattern A). Two
+// additions on top of C_RULES:
+//   - `method_definition` (the `-`/`+` method body) joins `function_definition`
+//     in function_nodes — its compound_statement body is a direct child
+//     (unlike tree-sitter-dart's function_signature/function_body sibling
+//     split, #2182), confirmed by parsing
+//     `@implementation Foo - (void)bar { .. } @end`.
+//   - `catch_clause` (from `@try`/`@catch`/`@finally`, which tree-sitter-objc
+//     also models as a dedicated try_statement/catch_clause/finally_clause
+//     shape) is a branch/nesting node, same treatment as CPP_RULES's
+//     catch_clause.
+pub static OBJC_RULES: LangRules = LangRules {
+    branch_nodes: &["if_statement", "else_clause", "for_statement", "while_statement", "do_statement", "case_statement", "conditional_expression", "catch_clause"],
+    case_nodes: &["case_statement"],
+    logical_operators: &["&&", "||"],
+    logical_node_types: &["binary_expression"],
+    optional_chain_type: None,
+    nesting_nodes: &["if_statement", "for_statement", "while_statement", "do_statement", "catch_clause", "conditional_expression"],
+    function_nodes: &["function_definition", "method_definition"],
+    if_node_type: Some("if_statement"),
+    else_node_type: Some("else_clause"),
+    elif_node_type: None,
+    else_via_alternative: false,
+    switch_like_nodes: &["switch_statement"],
+};
+
 pub static KOTLIN_RULES: LangRules = LangRules {
     branch_nodes: &["if_expression", "for_statement", "while_statement", "do_while_statement", "catch_block", "when_expression", "when_entry"],
     case_nodes: &["when_entry"],
@@ -498,6 +528,7 @@ pub fn lang_rules(lang_id: &str) -> Option<&'static LangRules> {
         "php" => Some(&PHP_RULES),
         "c" => Some(&C_RULES),
         "cpp" | "cuda" => Some(&CPP_RULES),
+        "objc" => Some(&OBJC_RULES),
         "kotlin" => Some(&KOTLIN_RULES),
         "swift" => Some(&SWIFT_RULES),
         "scala" => Some(&SCALA_RULES),
@@ -996,6 +1027,31 @@ pub static CPP_HALSTEAD: HalsteadRules = HalsteadRules {
     skip_types: &["template_argument_list", "template_parameter_list"],
 };
 
+// Extends C_HALSTEAD with ObjC's `@try`/`@catch`/`@finally`/`@throw`/
+// `@synchronized` keyword tokens (each its own anonymous leaf node in
+// tree-sitter-objc, confirmed by parsing) and treats `message_expression`
+// (`[receiver selector:arg]`) and `selector_expression` (`@selector(...)`) as
+// compound operators, the same way `call_expression` is already treated —
+// their leaf children (receiver/selector/argument identifiers) fall through
+// to the shared identifier operand rule below.
+pub static OBJC_HALSTEAD: HalsteadRules = HalsteadRules {
+    operator_leaf_types: &[
+        "+", "-", "*", "/", "%", "=", "+=", "-=", "*=", "/=", "%=", "&=", "|=", "^=", "<<=", ">>=",
+        "==", "!=", "<", ">", "<=", ">=", "&&", "||", "!",
+        "&", "|", "^", "~", "<<", ">>", "++", "--",
+        "sizeof", "if", "else", "for", "while", "do", "switch", "case",
+        "return", "break", "continue", "goto",
+        "@try", "@catch", "@finally", "@throw", "@synchronized",
+        ".", "->", ",", ";", ":", "?",
+    ],
+    operand_leaf_types: &[
+        "identifier", "type_identifier", "field_identifier", "number_literal", "string_literal",
+        "char_literal", "true", "false", "null",
+    ],
+    compound_operators: &["call_expression", "subscript_expression", "message_expression", "selector_expression"],
+    skip_types: &[],
+};
+
 pub static KOTLIN_HALSTEAD: HalsteadRules = HalsteadRules {
     operator_leaf_types: &[
         "+", "-", "*", "/", "%", "=", "+=", "-=", "*=", "/=", "%=",
@@ -1122,6 +1178,7 @@ pub fn halstead_rules(lang_id: &str) -> Option<&'static HalsteadRules> {
         "php" => Some(&PHP_HALSTEAD),
         "c" => Some(&C_HALSTEAD),
         "cpp" | "cuda" => Some(&CPP_HALSTEAD),
+        "objc" => Some(&OBJC_HALSTEAD),
         "kotlin" => Some(&KOTLIN_HALSTEAD),
         "swift" => Some(&SWIFT_HALSTEAD),
         "scala" => Some(&SCALA_HALSTEAD),
@@ -1139,7 +1196,7 @@ pub fn comment_prefixes(lang_id: &str) -> &'static [&'static str] {
         }
         "python" | "ruby" => &["#"],
         "php" => &["//", "#", "/*", "*", "*/"],
-        "c" | "cpp" | "cuda" => &["//", "/*"],
+        "c" | "cpp" | "cuda" | "objc" => &["//", "/*"],
         "kotlin" => &["//", "/*"],
         "swift" => &["//", "/*"],
         "scala" => &["//", "/*"],
@@ -1921,6 +1978,68 @@ mod tests {
             "__global__ void kernel(int *a, int n) {\n  for (int i = 0; i < n && a[i] > 0; i++) {\n    a[i]++;\n  }\n}",
         );
         assert_eq!(m.cyclomatic, 3);
+    }
+
+    // ─── ObjC tests (issue #1923) ────────────────────────────────────────────
+    //
+    // tree-sitter-objc extends tree-sitter-c: if/else/for/while/switch/case/
+    // logical-operator node kinds are identical to plain C (confirmed by
+    // parsing sample ObjC control flow), so OBJC_RULES reuses the same shapes
+    // as C_RULES, plus `method_definition` in function_nodes and
+    // `catch_clause` (from `@try`/`@catch`) as a branch/nesting node.
+
+    fn compute_objc(code: &str) -> ComplexityMetrics {
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_objc::LANGUAGE.into())
+            .unwrap();
+        let tree = parser.parse(code.as_bytes(), None).unwrap();
+        let root = tree.root_node();
+        let func = find_first_function(&root, &OBJC_RULES).expect("no function found");
+        compute_function_complexity(&func, &OBJC_RULES)
+    }
+
+    #[test]
+    fn objc_method_if_elseif_else() {
+        // method_definition's compound_statement body is a direct child
+        // (unlike tree-sitter-dart's function_signature/function_body
+        // sibling split, #2182) — confirmed by parsing this fixture.
+        let m = compute_objc(
+            "@implementation Calculator\n- (NSInteger)classify:(NSInteger)value {\n  if (value > 0) {\n    return 1;\n  } else if (value < 0) {\n    return -1;\n  } else {\n    return 0;\n  }\n}\n@end",
+        );
+        assert_eq!(m.cognitive, 3);
+        assert_eq!(m.cyclomatic, 3);
+        assert_eq!(m.max_nesting, 1);
+    }
+
+    #[test]
+    fn objc_method_logical_operators_and_for_loop() {
+        let m = compute_objc(
+            "@implementation Calculator\n- (NSInteger)sum:(NSInteger)n withFlag:(BOOL)flag {\n  NSInteger result = 0;\n  for (NSInteger i = 0; i < n && flag; i++) {\n    result += i;\n  }\n  return result;\n}\n@end",
+        );
+        assert_eq!(m.cyclomatic, 3);
+        assert_eq!(m.max_nesting, 1);
+    }
+
+    #[test]
+    fn objc_method_try_catch() {
+        let m = compute_objc(
+            "@implementation Calculator\n- (NSInteger)risky {\n  @try {\n    return 1;\n  } @catch (NSException *ex) {\n    return -1;\n  }\n}\n@end",
+        );
+        // catch_clause: +1 cog, +1 cyc (mirrors CPP_RULES's catch_clause treatment)
+        assert_eq!(m.cognitive, 1);
+        assert_eq!(m.cyclomatic, 2);
+    }
+
+    #[test]
+    fn objc_plain_c_function_still_works() {
+        // Plain C-style functions (not ObjC methods) inside an .m file still
+        // use function_definition, unchanged from C_RULES's shape.
+        let m = compute_objc(
+            "NSInteger plainFunction(NSInteger a, NSInteger b) {\n  if (a > b) {\n    return a;\n  }\n  return b;\n}",
+        );
+        assert_eq!(m.cognitive, 1);
+        assert_eq!(m.cyclomatic, 2);
     }
 
     // ─── Kotlin tests (issue #1923) ─────────────────────────────────────────

--- a/crates/codegraph-core/src/extractors/objc.rs
+++ b/crates/codegraph-core/src/extractors/objc.rs
@@ -174,16 +174,30 @@ fn handle_method(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     };
 
     let params = extract_method_params(node, source);
+    // `method_declaration` (an `@interface`/`@protocol` signature) never has a
+    // `compound_statement` body — only `method_definition` (inside
+    // `@implementation`) does, confirmed via tree-sitter-objc's node-types.json.
+    // Running complexity/CFG analysis on the bodyless signature node produced a
+    // spurious trivial entry (cognitive 0, cyclomatic 1) that duplicated the
+    // real `method_definition` entry under the same dotted name — a
+    // native/WASM divergence, since the WASM/TS side only attaches complexity
+    // to definitions matched by a real function-shaped node later in the
+    // pipeline. Gate both on body presence, mirroring the
+    // `bodyless: Some(child_by_field_name("body").is_none())` convention used
+    // by the C#/Java/Go/PHP/Rust extractors (which can't use that exact field
+    // lookup here since tree-sitter-objc exposes the method body as a
+    // positional child, not a named field).
+    let has_body = find_child(node, "compound_statement").is_some();
     symbols.definitions.push(Definition {
         name: full_name,
         kind: "method".to_string(),
         line: start_line(node),
         end_line: Some(end_line(node)),
         decorators: None,
-        complexity: compute_all_metrics(node, source, "objc"),
-        cfg: build_function_cfg(node, "objc", source),
+        complexity: if has_body { compute_all_metrics(node, source, "objc") } else { None },
+        cfg: if has_body { build_function_cfg(node, "objc", source) } else { None },
         children: opt_children(params),
-        bodyless: None,
+        bodyless: Some(!has_body),
         content_hash: None,
     });
 }

--- a/src/ast-analysis/metrics.ts
+++ b/src/ast-analysis/metrics.ts
@@ -60,7 +60,7 @@ export function computeHalsteadDerived(
 
 const C_STYLE_PREFIXES = ['//', '/*', '*', '*/'];
 
-// c/cpp/cuda/kotlin/swift/scala intentionally mirror the native `comment_prefixes()`
+// c/cpp/cuda/objc/kotlin/swift/scala intentionally mirror the native `comment_prefixes()`
 // 2-entry list (`//`, `/*`) rather than the 4-entry C_STYLE_PREFIXES used by
 // javascript/go/rust/java/csharp — see native `comment_prefixes()` in
 // crates/codegraph-core/src/ast_analysis/complexity.rs for the source of truth
@@ -82,6 +82,7 @@ const COMMENT_PREFIXES = new Map<string, string[]>([
   ['c', C_LIKE_PREFIXES],
   ['cpp', C_LIKE_PREFIXES],
   ['cuda', C_LIKE_PREFIXES],
+  ['objc', C_LIKE_PREFIXES],
   ['kotlin', C_LIKE_PREFIXES],
   ['swift', C_LIKE_PREFIXES],
   ['scala', C_LIKE_PREFIXES],

--- a/src/ast-analysis/rules/c.ts
+++ b/src/ast-analysis/rules/c.ts
@@ -241,6 +241,144 @@ export const halsteadCpp: HalsteadRules = {
   skipTypes: new Set(['template_argument_list', 'template_parameter_list']),
 };
 
+// ─── Objective-C Complexity ────────────────────────────────────────────────
+//
+// Mirrors the native `OBJC_RULES`. tree-sitter-objc extends tree-sitter-c:
+// if_statement/for_statement/while_statement/do_statement/switch_statement/
+// case_statement/conditional_expression/binary_expression are byte-identical
+// to plain C (confirmed by parsing sample ObjC control flow and inspecting
+// the S-expression), including the same else_clause wrapper (Pattern A).
+// Two additions on top of C_RULES:
+//   - `method_definition` (the `-`/`+` method body, e.g. `- (void)foo {..}`)
+//     is added to functionNodes alongside `function_definition` — its
+//     compound_statement body is a direct child (unlike tree-sitter-dart's
+//     function_signature/function_body sibling split, #2182), confirmed by
+//     parsing `@implementation Foo - (void)bar { .. } @end`.
+//   - `catch_clause` (from ObjC's `@try`/`@catch`/`@finally` exception
+//     handling, which tree-sitter-objc also models with a dedicated
+//     try_statement/catch_clause/finally_clause shape) is a branch/nesting
+//     node, same treatment as C++'s catch_clause.
+export const complexityObjC: ComplexityRules = {
+  branchNodes: new Set([
+    'if_statement',
+    'else_clause',
+    'for_statement',
+    'while_statement',
+    'do_statement',
+    'case_statement',
+    'conditional_expression',
+    'catch_clause',
+  ]),
+  caseNodes: new Set(['case_statement']),
+  logicalOperators: new Set(['&&', '||']),
+  logicalNodeTypes: new Set(['binary_expression']),
+  optionalChainType: null,
+  nestingNodes: new Set([
+    'if_statement',
+    'for_statement',
+    'while_statement',
+    'do_statement',
+    'catch_clause',
+    'conditional_expression',
+  ]),
+  functionNodes: new Set(['function_definition', 'method_definition']),
+  ifNodeType: 'if_statement',
+  elseNodeType: 'else_clause',
+  elifNodeType: null,
+  elseViaAlternative: false,
+  switchLikeNodes: new Set(['switch_statement']),
+};
+
+// ─── Objective-C Halstead ───────────────────────────────────────────────────
+//
+// Mirrors the native `OBJC_HALSTEAD`. Extends C's operator/operand leaf sets
+// with ObjC's `@try`/`@catch`/`@finally`/`@throw`/`@synchronized` keyword
+// tokens (each its own anonymous leaf node in tree-sitter-objc, confirmed by
+// parsing) and treats `message_expression` (`[receiver selector:arg]`) and
+// `selector_expression` (`@selector(...)`) as compound operators, the same
+// way `call_expression` is already treated — their leaf children (receiver/
+// selector/argument identifiers) fall through to the shared identifier
+// operand rule below.
+
+export const halsteadObjC: HalsteadRules = {
+  operatorLeafTypes: new Set([
+    '+',
+    '-',
+    '*',
+    '/',
+    '%',
+    '=',
+    '+=',
+    '-=',
+    '*=',
+    '/=',
+    '%=',
+    '&=',
+    '|=',
+    '^=',
+    '<<=',
+    '>>=',
+    '==',
+    '!=',
+    '<',
+    '>',
+    '<=',
+    '>=',
+    '&&',
+    '||',
+    '!',
+    '&',
+    '|',
+    '^',
+    '~',
+    '<<',
+    '>>',
+    '++',
+    '--',
+    'sizeof',
+    'if',
+    'else',
+    'for',
+    'while',
+    'do',
+    'switch',
+    'case',
+    'return',
+    'break',
+    'continue',
+    'goto',
+    '@try',
+    '@catch',
+    '@finally',
+    '@throw',
+    '@synchronized',
+    '.',
+    '->',
+    ',',
+    ';',
+    ':',
+    '?',
+  ]),
+  operandLeafTypes: new Set([
+    'identifier',
+    'type_identifier',
+    'field_identifier',
+    'number_literal',
+    'string_literal',
+    'char_literal',
+    'true',
+    'false',
+    'null',
+  ]),
+  compoundOperators: new Set([
+    'call_expression',
+    'subscript_expression',
+    'message_expression',
+    'selector_expression',
+  ]),
+  skipTypes: new Set([]),
+};
+
 // ─── C/C++ function-name extraction ──────────────────────────────────────────
 //
 // C/C++ function_definition nests the name inside declarators:

--- a/src/ast-analysis/rules/index.ts
+++ b/src/ast-analysis/rules/index.ts
@@ -37,6 +37,7 @@ export const COMPLEXITY_RULES: Map<string, ComplexityRules> = new Map([
   // if/else/for/while/switch/logical-operator node kinds are byte-identical
   // to C++'s, confirmed by parsing sample CUDA source with tree-sitter-cuda.
   ['cuda', c.complexityCpp],
+  ['objc', c.complexityObjC],
   ['kotlin', b2.complexityKotlin],
   ['swift', b2.complexitySwift],
   ['scala', b2.complexityScala],
@@ -60,6 +61,7 @@ export const HALSTEAD_RULES: Map<string, HalsteadRules> = new Map([
   ['c', c.halstead],
   ['cpp', c.halsteadCpp],
   ['cuda', c.halsteadCpp],
+  ['objc', c.halsteadObjC],
   ['kotlin', b2.halsteadKotlin],
   ['swift', b2.halsteadSwift],
   ['scala', b2.halsteadScala],

--- a/src/extractors/objc.ts
+++ b/src/extractors/objc.ts
@@ -204,12 +204,24 @@ function handleMethodDecl(node: TreeSitterNode, ctx: ExtractorOutput): void {
   const fullName = parentClass ? `${parentClass}.${selector}` : selector;
 
   const params = extractMethodParams(node);
+  // `method_declaration` (an `@interface`/`@protocol` signature) never has a
+  // `compound_statement` body — only `method_definition` (inside
+  // `@implementation`) does, confirmed via tree-sitter-objc's node-types.json.
+  // Set `bodyless` explicitly rather than relying solely on the endLine>line
+  // heuristic in `hasFuncBody` (apply-results.ts), which a multi-line
+  // signature-only declaration could otherwise slip past. Mirrors the fix to
+  // the native extractor (`crates/codegraph-core/src/extractors/objc.rs`),
+  // which was calling complexity/CFG analysis unconditionally on the bodyless
+  // node and producing a spurious trivial entry duplicating the real
+  // `method_definition` entry under the same dotted name.
+  const bodyless = !findChild(node, 'compound_statement');
   ctx.definitions.push({
     name: fullName,
     kind: 'method',
     line: node.startPosition.row + 1,
     endLine: nodeEndLine(node),
     children: params.length > 0 ? params : undefined,
+    bodyless,
   });
 }
 

--- a/tests/unit/complexity.test.ts
+++ b/tests/unit/complexity.test.ts
@@ -1177,6 +1177,60 @@ describe('CUDA complexity', () => {
   });
 });
 
+// ─── Objective-C (#1923) ──────────────────────────────────────────────────
+//
+// tree-sitter-objc extends tree-sitter-c: if/else/for/while/switch/case/
+// logical-operator node kinds are identical to plain C (confirmed by parsing
+// sample ObjC control flow and inspecting the S-expression), so complexityObjC
+// reuses the same shapes as C's rules, plus `method_definition` in
+// functionNodes and `catch_clause` (from `@try`/`@catch`) as a branch/nesting
+// node — mirroring how C++'s catch_clause is already treated.
+
+describe('ObjC complexity', () => {
+  const { analyze, halstead } = makeHelpers('objc', sharedParsers());
+
+  it('method with if/else-if/else chain', () => {
+    // method_definition's compound_statement body is a direct child (unlike
+    // tree-sitter-dart's function_signature/function_body sibling split,
+    // #2182) — confirmed by parsing this fixture.
+    const r = analyze(
+      '@implementation Calculator\n- (NSInteger)classify:(NSInteger)value {\n  if (value > 0) {\n    return 1;\n  } else if (value < 0) {\n    return -1;\n  } else {\n    return 0;\n  }\n}\n@end\n',
+    );
+    expect(r).toEqual({ cognitive: 3, cyclomatic: 3, maxNesting: 1 });
+  });
+
+  it('method with logical operators and for loop', () => {
+    const r = analyze(
+      '@implementation Calculator\n- (NSInteger)sum:(NSInteger)n withFlag:(BOOL)flag {\n  NSInteger result = 0;\n  for (NSInteger i = 0; i < n && flag; i++) {\n    result += i;\n  }\n  return result;\n}\n@end\n',
+    );
+    expect(r.cyclomatic).toBe(3);
+    expect(r.maxNesting).toBe(1);
+  });
+
+  it('method with @try/@catch', () => {
+    const r = analyze(
+      '@implementation Calculator\n- (NSInteger)risky {\n  @try {\n    return 1;\n  } @catch (NSException *ex) {\n    return -1;\n  }\n}\n@end\n',
+    );
+    // catch_clause: +1 cog, +1 cyc, +1 nesting (mirrors C++'s/JS's catch_clause treatment)
+    expect(r).toEqual({ cognitive: 1, cyclomatic: 2, maxNesting: 1 });
+  });
+
+  it('plain C-style function still works', () => {
+    const r = analyze(
+      'NSInteger plainFunction(NSInteger a, NSInteger b) {\n  if (a > b) {\n    return a;\n  }\n  return b;\n}\n',
+    );
+    expect(r).toEqual({ cognitive: 1, cyclomatic: 2, maxNesting: 1 });
+  });
+
+  it('halstead: message send and positive volume', () => {
+    const h = halstead(
+      '@implementation Calculator\n- (NSInteger)sum {\n  return [self compute];\n}\n@end\n',
+    );
+    expect(h).not.toBeNull();
+    expect(h.volume).toBeGreaterThan(0);
+  });
+});
+
 // ─── Kotlin (#1923) ───────────────────────────────────────────────────────
 
 describe('Kotlin complexity', () => {
@@ -1489,6 +1543,61 @@ describe('DFS vs visitor parity — Go (elseViaAlternative)', () => {
         return -2
       }
     `);
+    expect(visitor!.cognitive).toBe(dfs!.cognitive);
+    expect(visitor!.cyclomatic).toBe(dfs!.cyclomatic);
+    expect(visitor!.maxNesting).toBe(dfs!.maxNesting);
+  });
+});
+
+// computeFunctionComplexity is the standalone DFS reference (mirrors the
+// Rust walk); computeAllMetrics is the visitor-based path WASM builds
+// actually use. ObjC gets its own dedicated block (rather than folding into
+// the tier-1 dict below) because it introduces a genuinely new rule set
+// (method_definition in functionNodes, catch_clause as a branch/nesting
+// node) rather than reusing an existing one — both walk paths must agree on
+// method-body detection and @try/@catch handling.
+describe('DFS vs visitor parity — ObjC (#1923)', () => {
+  let objcParser: any;
+
+  beforeAll(async () => {
+    const parsers = await createParsers();
+    objcParser = parsers.get('objc');
+  });
+
+  function findObjCFunc(node: any): any {
+    const rules = COMPLEXITY_RULES.get('objc');
+    if (!rules) return null;
+    if (rules.functionNodes.has(node.type)) return node;
+    for (let i = 0; i < node.childCount; i++) {
+      const result = findObjCFunc(node.child(i));
+      if (result) return result;
+    }
+    return null;
+  }
+
+  function analyzeObjCBoth(code: string) {
+    if (!objcParser) throw new Error('ObjC parser not available');
+    const tree = objcParser.parse(code);
+    const funcNode = findObjCFunc(tree.rootNode);
+    if (!funcNode) throw new Error('No function found in ObjC snippet');
+    const dfs = computeFunctionComplexity(funcNode, 'objc');
+    const visitor = computeAllMetrics(funcNode, 'objc');
+    return { dfs, visitor };
+  }
+
+  it('method if/else-if/else chain — identical', () => {
+    const { dfs, visitor } = analyzeObjCBoth(
+      '@implementation Calculator\n- (NSInteger)classify:(NSInteger)value {\n  if (value > 0) {\n    return 1;\n  } else if (value < 0) {\n    return -1;\n  } else {\n    return 0;\n  }\n}\n@end\n',
+    );
+    expect(visitor!.cognitive).toBe(dfs!.cognitive);
+    expect(visitor!.cyclomatic).toBe(dfs!.cyclomatic);
+    expect(visitor!.maxNesting).toBe(dfs!.maxNesting);
+  });
+
+  it('method @try/@catch — identical', () => {
+    const { dfs, visitor } = analyzeObjCBoth(
+      '@implementation Calculator\n- (NSInteger)risky {\n  @try {\n    return 1;\n  } @catch (NSException *ex) {\n    return -1;\n  }\n}\n@end\n',
+    );
     expect(visitor!.cognitive).toBe(dfs!.cognitive);
     expect(visitor!.cyclomatic).toBe(dfs!.cyclomatic);
     expect(visitor!.maxNesting).toBe(dfs!.maxNesting);


### PR DESCRIPTION
## Summary

Progress on #1923 — adds `objc` complexity/Halstead support (tier 2).

tree-sitter-objc extends tree-sitter-c: if/else/for/while/switch/case/logical-operator/conditional-expression node kinds are byte-identical to plain C (confirmed by parsing sample ObjC control flow and inspecting the S-expression), including the same `else_clause` wrapper (Pattern A). Wires `COMPLEXITY_RULES`/`HALSTEAD_RULES` (TS) and `lang_rules()`/`halstead_rules()` (native) for `objc`, extending C's rule shape with:

- `method_definition` (the `-`/`+` method body) added to `functionNodes` alongside `function_definition`
- `catch_clause` (from `@try`/`@catch`/`@finally`) treated as a branch/nesting node, the same treatment C++'s `catch_clause` already gets
- `message_expression`/`selector_expression` treated as compound Halstead operators, mirroring `call_expression`

Also fixes a native/WASM divergence this surfaced: the native ObjC extractor's `handle_method` ran complexity/CFG analysis unconditionally on both `method_declaration` (an `@interface`/`@protocol` signature, which never has a body) and `method_definition`, producing a spurious trivial complexity entry (cognitive 0, cyclomatic 1) for every interface declaration that duplicated the real `method_definition` entry under the same dotted name. Gated both on actual body presence and set `bodyless` accordingly; ported the same explicit `bodyless` signal to the TS/WASM extractor for defense-in-depth (its `hasFuncBody` skip logic otherwise relies on an `endLine > line` heuristic that a multi-line bodyless signature could slip past).

## Verification

- `npm run lint` — clean
- `npm test` — 267/267 test files, 4335 passed, 30 skipped, 2 todo
- `cargo test --lib` (crates/codegraph-core) — 707/707 passed
- Native and WASM engines produce **byte-identical** `codegraph complexity --health --json` output on a hand-built fixture covering if/else-if/else, classic and fast-enumeration for loops, switch/case, `@try`/`@catch`/`@finally`, ternary, and message sends.

## Remaining scope on #1923

Tier 1 (c, cpp, kotlin, swift, scala, bash) and CUDA were already done. Dart is blocked on #2182 (grammar structural issue) — do not attempt until that's fixed. Remaining unattempted: zig, haskell, ocaml, ocaml-interface, fsharp, fsharp-signature, gleam, clojure, julia, r, erlang, solidity, groovy, verilog.

## Test plan

- [x] `npm run lint`
- [x] `npm test`
- [x] `cargo test --lib` in `crates/codegraph-core`
- [x] Native vs WASM diff on a hand-built ObjC fixture (identical output)