### PR TITLE
fix(js): sort query-path definitions by line to match walk/native order

### DIFF
--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -425,6 +425,19 @@ function extractSymbolsQuery(tree: TreeSitterTree, query: TreeSitterQuery): Extr
   // regardless of match order.
   const callbackParamShapes = collectCallbackParamShapes(tree.rootNode);
 
+  // Extract top-level constants via targeted walk (query patterns don't cover
+  // these). Deliberately run BEFORE the query-match dispatch loop below
+  // (#1961): this pass only ever pushes to `definitions` (never reads it
+  // back), so the two passes have no content/ordering dependency on each
+  // other — but a same-line tie between one of this pass's object-literal
+  // method entries (e.g. `obj.m`) and a class-qualified duplicate emitted by
+  // dispatchQueryMatch's generic method handler (e.g. `Foo.m`, via
+  // findParentClass — see isObjectLiteralDeclaratorMethod's doc comment)
+  // must resolve with this pass's entry first, matching the walk/native
+  // path's single source-ordered DFS, which visits the declarator-qualified
+  // name before the class-qualified duplicate at that same node.
+  extractConstantsWalk(tree.rootNode, definitions);
+
   for (const match of matches) {
     // Build capture lookup for this match (1-3 captures each, very fast)
     const c: Record<string, TreeSitterNode> = Object.create(null);
@@ -440,9 +453,6 @@ function extractSymbolsQuery(tree: TreeSitterTree, query: TreeSitterQuery): Extr
       arrayElemBindings,
     );
   }
-
-  // Extract top-level constants via targeted walk (query patterns don't cover these)
-  extractConstantsWalk(tree.rootNode, definitions);
 
   // Phase 8.2: Extract function return types first — runContextCollectorWalk's
   // declarator handler reads the *complete* per-file map for inter-procedural
@@ -494,6 +504,19 @@ function extractSymbolsQuery(tree: TreeSitterTree, query: TreeSitterQuery): Extr
     thisCallBindings,
     classMemberDefs: definitions,
   });
+
+  // #1961: the passes above each append their own findings to `definitions`
+  // in *pass* order, not source-position order (e.g. dispatchQueryMatch's
+  // class/method captures land before extractConstantsWalk's top-level
+  // constants, before runCollectorWalk's class fields/static blocks —
+  // regardless of those definitions' actual relative line numbers). The walk
+  // path (extractSymbolsWalk) and native both do a single source-ordered
+  // DFS, so they naturally agree with each other; sort here so the query
+  // path's returned order matches them too. `Array.prototype.sort` is
+  // spec-guaranteed stable, so definitions sharing the same line keep their
+  // original push order as the tiebreak — content (the definition set) is
+  // unaffected, only array order changes.
+  definitions.sort((a, b) => a.line - b.line);
 
   return {
     definitions,


### PR DESCRIPTION
## Summary

`extractSymbolsQuery` (the WASM query path used in production when native is unavailable) is not a single source-ordered traversal — it runs a sequence of independent passes (query-match dispatch, top-level constants, destructured bindings, class-member collector), each appending its own findings to the shared `definitions` array in *pass* order rather than *source-position* order. Native and the WASM walk path both do a single recursive source-ordered DFS, so they agree with each other but the WASM query path's `definitions` array order could diverge from both whenever a later pass's definitions were lexically earlier in the source than an earlier pass's.

Content (the set of `{name, kind, line, endLine}` tuples) was always identical — only array order differed. `tests/engines/query-walk-parity.test.ts` already sorts before comparing, so this was never a tested invariant, but downstream consumers that build on array order (e.g. DB insertion order → node id assignment, used for deterministic `ORDER BY id` iteration in community detection) benefit from all three paths agreeing.

## Fix

- Sort `definitions` by `line` ascending at the end of `extractSymbolsQuery`. `Array.prototype.sort` is spec-guaranteed stable (and this repo requires Node >= 22.12, well past the stability guarantee), so same-line entries keep their original push order as the tiebreak.
- Move the `extractConstantsWalk` call to run *before* the query-match dispatch loop. Neither pass reads `definitions` back (both are write-only into it — verified via grep, no reads of `definitions` anywhere in `javascript.ts`), so this is a pure reordering with no content risk. It's needed to resolve a same-line tie: an object-literal method nested in a class `static {}` block gets both a declarator-qualified entry (`obj.m`, from `extractConstantsWalk`) and a class-qualified duplicate (`Foo.m`, from the generic method handler via `findParentClass` — see `isObjectLiteralDeclaratorMethod`'s doc comment) on the same line; native/walk's single DFS visits the declarator-qualified entry first, so the query path now does too.

## Verification

Repro from #1961:
```js
class Foo {
  static {
    const obj = { m() {} };
  }
}
```
- Before: `['Foo', 'Foo.m', 'obj', 'obj.m', 'Foo.<static:L:C>']`
- After: `['Foo', 'Foo.<static:L:C>', 'obj', 'obj.m', 'Foo.m']` — now matches native/walk exactly.

Checked whether anything depends on the *current* (pass-order) ordering before changing it:
- No consumer reads `definitions` by array index/position for correctness — `insert-nodes.ts`, `build-edges.ts`, `resolve-imports.ts`, `points-to.ts`, `call-resolver.ts`'s `findCaller`/`findEnclosingCallable` all look up by `(name, kind, line)` key or scan the full array for a widest/narrowest span, independent of array order.
- `mergeDefinitionAnalysis` in `parser.ts` (worker complexity/cfg backfill) matches by `(kind, name, line)` key, not index.
- `buildDefinitionParamsMap`'s "keep first entry on duplicate name" tiebreak now resolves by source position instead of arbitrary pass order — strictly more correct, not a behavior regression.
- DB reads that need iteration determinism already impose their own explicit `ORDER BY id`/`ORDER BY line` (see `graph-read.ts`, `nodes.ts`) rather than relying on extractor array order.

Full verification run:
- `npm test` — all 267 test files / 4335 tests pass.
- `npm run lint` — clean.
- `node scripts/parity-compare.mjs` (all 34 language fixtures + variants) — one pre-existing divergence on `jelly-micro` (spurious cross-file `super()` edges, unrelated to this change — confirmed present on `origin/main` before this fix by temporarily reverting just this file and rebuilding). Filed as #2238.
- `node dist/cli.js diff-impact --staged -T` — 1 function changed (`extractSymbolsQuery`), 1 transitive caller affected, as expected for a change scoped to this one function.

Closes #1961