### PR TITLE
fix(watch): persist barrel rename pairs for incremental resolution

### DIFF
--- a/crates/codegraph-core/src/db/connection.rs
+++ b/crates/codegraph-core/src/db/connection.rs
@@ -394,6 +394,29 @@ const MIGRATIONS: &[Migration] = &[
       ALTER TABLE nodes ADD COLUMN content_hash TEXT;
     "#,
     },
+    Migration {
+        // Persist barrel re-export rename pairs (issue #1967): `export { X
+        // as Y } from '...'` records `{local: Y, imported: X}` alongside
+        // which file the rename's own source resolves to. Populated by the
+        // native orchestrator (import_edges::persist_reexport_renames) and
+        // the JS pipeline (resolve-imports.ts) whenever a barrel file is
+        // (re)parsed, so `codegraph watch`'s single-file incremental rebuild
+        // (resolveBarrelTarget, domain/graph/builder/incremental.ts, JS-only)
+        // can translate a consumer's requested external alias back to the
+        // name actually declared in the reexport source without needing to
+        // re-parse the barrel file itself in the same watch batch.
+        version: 25,
+        up: r#"
+      CREATE TABLE IF NOT EXISTS reexport_renames (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        barrel_file TEXT NOT NULL,
+        local_name TEXT NOT NULL,
+        imported_name TEXT NOT NULL,
+        source_file TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_reexport_renames_barrel ON reexport_renames(barrel_file, local_name);
+    "#,
+    },
 ];
 
 // ── napi types ──────────────────────────────────────────────────────────

--- a/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
@@ -685,6 +685,12 @@ pub fn run_pipeline(
     import_ctx.barrel_only_files =
         import_edges::detect_barrel_only_files(&import_ctx, &barrel_candidates_added);
 
+    // Persist barrel rename pairs so `codegraph watch`'s JS-only single-file
+    // rebuild (resolveBarrelTarget, incremental.ts) can resolve renamed
+    // barrel re-exports for repos built with the native engine too (#1967).
+    import_edges::persist_reexport_renames(conn, &import_ctx.reexport_map)
+        .map_err(|e| format!("reexport rename persistence failed: {e}"))?;
+
     // Build import edges. A write failure here (transaction-start, a
     // malformed chunk, or commit) propagates via `?` instead of being
     // discarded — the old `run_pipeline` had no way to know edges were

--- a/crates/codegraph-core/src/domain/graph/builder/stages/detect_changes.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/detect_changes.rs
@@ -1109,6 +1109,11 @@ pub fn purge_changed_files(
         ("DELETE FROM function_complexity WHERE node_id IN (SELECT id FROM nodes WHERE file = ?1)", false),
         ("DELETE FROM node_metrics WHERE node_id IN (SELECT id FROM nodes WHERE file = ?1)", false),
         ("DELETE FROM ast_nodes WHERE file = ?1", false),
+        // #1967: barrel rename pairs keyed by barrel file — cleared alongside
+        // the barrel's own outgoing edges so a deleted or no-longer-barrel
+        // file never leaves stale rows behind for the JS watch path's
+        // `resolveBarrelTarget` to read later.
+        ("DELETE FROM reexport_renames WHERE barrel_file = ?1", false),
         // Core tables (errors logged)
         ("DELETE FROM edges WHERE source_id IN (SELECT id FROM nodes WHERE file = ?1) OR target_id IN (SELECT id FROM nodes WHERE file = ?1)", true),
         ("DELETE FROM nodes WHERE file = ?1", true),
@@ -1155,7 +1160,7 @@ pub fn clear_all_graph_data(conn: &Connection, has_embeddings: bool) {
         "PRAGMA foreign_keys = OFF; \
          DELETE FROM cfg_edges; DELETE FROM cfg_blocks; DELETE FROM node_metrics; \
          DELETE FROM edges; DELETE FROM function_complexity; DELETE FROM dataflow; \
-         DELETE FROM ast_nodes; DELETE FROM nodes; DELETE FROM file_hashes;",
+         DELETE FROM ast_nodes; DELETE FROM reexport_renames; DELETE FROM nodes; DELETE FROM file_hashes;",
     );
     if has_embeddings {
         sql.push_str(" DELETE FROM embeddings;");

--- a/crates/codegraph-core/src/domain/graph/builder/stages/import_edges.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/import_edges.rs
@@ -224,6 +224,61 @@ pub fn build_reexport_map(ctx: &ImportEdgeContext) -> HashMap<String, Vec<Reexpo
     reexport_map
 }
 
+/// Persist barrel re-export rename pairs (`export { X as Y } from …`) from
+/// `reexport_map` into the `reexport_renames` table (#1967) — the native
+/// orchestrator's counterpart of `persistReexportRenames` in
+/// `resolve-imports.ts` (JS pipeline).
+///
+/// `codegraph watch`'s single-file incremental rebuild (JS-only —
+/// `resolveBarrelTarget` in `domain/graph/builder/incremental.ts`) resolves
+/// barrel chains purely from already-persisted `reexports` edges, which
+/// carry no rename metadata. Persisting the rename table here, once per
+/// native-orchestrated build (full or incremental), gives that JS-only watch
+/// path something durable to query even for repos built with the native
+/// engine.
+///
+/// Deletes and re-inserts per barrel file so a barrel whose renames changed
+/// (or were removed entirely) never leaves stale rows behind for that file.
+pub fn persist_reexport_renames(
+    conn: &Connection,
+    reexport_map: &HashMap<String, Vec<ReexportEntry>>,
+) -> Result<(), String> {
+    if reexport_map.is_empty() {
+        return Ok(());
+    }
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|e| format!("persist_reexport_renames: failed to start transaction: {e}"))?;
+    {
+        let mut delete_stmt = tx
+            .prepare("DELETE FROM reexport_renames WHERE barrel_file = ?1")
+            .map_err(|e| e.to_string())?;
+        let mut insert_stmt = tx
+            .prepare(
+                "INSERT INTO reexport_renames (barrel_file, local_name, imported_name, source_file)
+                 VALUES (?1, ?2, ?3, ?4)",
+            )
+            .map_err(|e| e.to_string())?;
+        for (barrel_file, entries) in reexport_map {
+            delete_stmt.execute([barrel_file]).map_err(|e| e.to_string())?;
+            for entry in entries {
+                for rename in &entry.renames {
+                    insert_stmt
+                        .execute(rusqlite::params![
+                            barrel_file,
+                            rename.local,
+                            rename.imported,
+                            entry.source
+                        ])
+                        .map_err(|e| e.to_string())?;
+                }
+            }
+        }
+    }
+    tx.commit().map_err(|e| format!("persist_reexport_renames: commit failed: {e}"))?;
+    Ok(())
+}
+
 /// Detect which of `candidate_paths` are barrel-only (reexport count >=
 /// definition count).
 ///

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -387,6 +387,28 @@ export const MIGRATIONS: Migration[] = [
       ALTER TABLE nodes ADD COLUMN content_hash TEXT;
     `,
   },
+  {
+    // Persist barrel re-export rename pairs (issue #1967): `export { X as Y }
+    // from '...'` records `{local: Y, imported: X}` alongside which file the
+    // rename's own source resolves to. Populated by the full-build pipeline
+    // (resolve-imports.ts) and both native paths whenever a barrel file is
+    // (re)parsed, so `codegraph watch`'s single-file incremental rebuild
+    // (resolveBarrelTarget, domain/graph/builder/incremental.ts) can
+    // translate a consumer's requested external alias back to the name
+    // actually declared in the reexport source without needing to re-parse
+    // the barrel file itself in the same watch batch.
+    version: 25,
+    up: `
+      CREATE TABLE IF NOT EXISTS reexport_renames (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        barrel_file TEXT NOT NULL,
+        local_name TEXT NOT NULL,
+        imported_name TEXT NOT NULL,
+        source_file TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_reexport_renames_barrel ON reexport_renames(barrel_file, local_name);
+    `,
+  },
 ];
 
 interface PragmaColumnInfo {

--- a/src/db/repository/build-stmts.ts
+++ b/src/db/repository/build-stmts.ts
@@ -15,6 +15,11 @@ interface PurgeStmts {
   edges: SqliteStatement;
   nodes: SqliteStatement;
   fileHashes: SqliteStatement | null;
+  /** #1967: barrel rename pairs keyed by barrel file — cleared alongside the
+   *  barrel's own outgoing edges so a deleted or no-longer-barrel file never
+   *  leaves stale rows behind for `resolveBarrelTarget` (incremental.ts) to
+   *  read later. */
+  reexportRenames: SqliteStatement | null;
 }
 
 interface PurgeOpts {
@@ -81,6 +86,7 @@ function preparePurgeStmts(db: BetterSqlite3Database): PurgeStmts {
     ),
     nodes: db.prepare('DELETE FROM nodes WHERE file = ?'),
     fileHashes: tryPrepare('DELETE FROM file_hashes WHERE file = ?'),
+    reexportRenames: tryPrepare('DELETE FROM reexport_renames WHERE barrel_file = ?'),
   };
 }
 
@@ -113,6 +119,7 @@ function runPurge(stmts: PurgeStmts, file: string, opts: PurgeOpts = {}): void {
   stmts.complexity?.run(file);
   stmts.nodeMetrics?.run(file);
   stmts.astNodes?.run(file);
+  stmts.reexportRenames?.run(file);
 
   // Core tables
   stmts.edges.run({ f: file });

--- a/src/domain/graph/builder/incremental.ts
+++ b/src/domain/graph/builder/incremental.ts
@@ -56,6 +56,7 @@ import {
   CHA_TYPED_DISPATCH_CONFIDENCE,
   fileHash,
   fileStat,
+  loadPathAliases,
   readFileSafe,
 } from './helpers.js';
 import { importNamePairs } from './import-utils.js';
@@ -372,6 +373,19 @@ function isBarrelFile(db: BetterSqlite3Database, relPath: string): boolean {
  * barrel's rename table stays current whenever *it* is reparsed, regardless
  * of which file triggered this rebuild.
  */
+// Lazily-cached tsconfig/jsconfig path aliases, keyed by rootDir (avoid a
+// disk read + JSON parse on every single-file rebuild — #1967 review).
+let _aliasesRootDir: string | null = null;
+let _aliasesCache: PathAliases | null = null;
+
+function getCachedPathAliases(rootDir: string): PathAliases {
+  if (_aliasesRootDir !== rootDir) {
+    _aliasesRootDir = rootDir;
+    _aliasesCache = loadPathAliases(rootDir);
+  }
+  return _aliasesCache!;
+}
+
 function persistReexportRenamesForFile(
   db: BetterSqlite3Database,
   relPath: string,
@@ -384,7 +398,12 @@ function persistReexportRenamesForFile(
   const reexports = symbols.imports.filter((imp) => imp.reexport);
   if (reexports.length === 0) return;
 
-  const aliases: PathAliases = { baseUrl: null, paths: {} };
+  // Real tsconfig/jsconfig aliases (#1967 review) — using an empty aliases
+  // object here would resolve an alias-based reexport source (e.g.
+  // `@utils/foo`) to a bogus non-file specifier, overwriting a correct
+  // full-build row with one `resolveBarrelTarget` can never match to a
+  // graph node.
+  const aliases = getCachedPathAliases(rootDir);
   for (const imp of reexports) {
     if (!imp.renamedImports?.length) continue;
     const source = resolveImportPath(path.join(rootDir, relPath), imp.source, rootDir, aliases);

--- a/src/domain/graph/builder/incremental.ts
+++ b/src/domain/graph/builder/incremental.ts
@@ -235,6 +235,10 @@ function rebuildReverseDepEdges(
   const fileNodeRow = stmts.getNodeId.get(depRelPath, 'file', depRelPath, 0);
   if (!fileNodeRow) return 0;
 
+  // #1967: keep this reverse-dep's persisted barrel rename table current if
+  // it's itself a barrel — independent of the edges rebuilt below.
+  persistReexportRenamesForFile(db, depRelPath, symbols, rootDir);
+
   const aliases: PathAliases = { baseUrl: null, paths: {} };
   let edgesAdded = buildContainmentEdges(db, stmts, depRelPath, symbols);
   // Don't rebuild dir->file containment for reverse-deps (it was never deleted)
@@ -299,11 +303,17 @@ let _barrelDb: BetterSqlite3Database | null = null;
 let _isBarrelStmt: SqliteStatement | null = null;
 let _reexportTargetsStmt: SqliteStatement | null = null;
 let _hasDefStmt: SqliteStatement | null = null;
+let _renameLookupStmt: SqliteStatement | null = null;
+let _renameDeleteStmt: SqliteStatement | null = null;
+let _renameInsertStmt: SqliteStatement | null = null;
 
 function getBarrelStmts(db: BetterSqlite3Database): {
   isBarrelStmt: SqliteStatement;
   reexportTargetsStmt: SqliteStatement;
   hasDefStmt: SqliteStatement;
+  renameLookupStmt: SqliteStatement;
+  renameDeleteStmt: SqliteStatement;
+  renameInsertStmt: SqliteStatement;
 } {
   if (_barrelDb !== db) {
     _barrelDb = db;
@@ -321,11 +331,25 @@ function getBarrelStmts(db: BetterSqlite3Database): {
     _hasDefStmt = db.prepare(
       `SELECT 1 FROM nodes WHERE name = ? AND file = ? AND kind != 'file' AND kind != 'directory' LIMIT 1`,
     );
+    // #1967: persisted barrel rename pairs — see `resolveBarrelTarget` and
+    // `persistReexportRenamesForFile` below.
+    _renameLookupStmt = db.prepare(
+      `SELECT imported_name, source_file FROM reexport_renames
+       WHERE barrel_file = ? AND local_name = ? LIMIT 1`,
+    );
+    _renameDeleteStmt = db.prepare('DELETE FROM reexport_renames WHERE barrel_file = ?');
+    _renameInsertStmt = db.prepare(
+      `INSERT INTO reexport_renames (barrel_file, local_name, imported_name, source_file)
+       VALUES (?, ?, ?, ?)`,
+    );
   }
   return {
     isBarrelStmt: _isBarrelStmt!,
     reexportTargetsStmt: _reexportTargetsStmt!,
     hasDefStmt: _hasDefStmt!,
+    renameLookupStmt: _renameLookupStmt!,
+    renameDeleteStmt: _renameDeleteStmt!,
+    renameInsertStmt: _renameInsertStmt!,
   };
 }
 
@@ -336,17 +360,69 @@ function isBarrelFile(db: BetterSqlite3Database, relPath: string): boolean {
 }
 
 /**
- * KNOWN LIMITATION, tracked separately in #1967: this is `codegraph watch`'s
- * single-file rebuild path (see `watcher.ts`) — unlike the `codegraph build`
- * resolver (`resolveBarrelExport` in resolve-imports.ts, fixed for #1823),
- * this has no way to recover a barrel's `export { X as Y } from …` rename
- * table when the barrel file itself isn't part of the current watch batch —
- * that mapping only exists in the barrel's freshly-parsed `Import.renamedImports`,
- * which isn't persisted to the DB and this function has no reparse access to.
- * It therefore still resolves purely by direct name match — renamed barrel
- * re-exports are not resolved when only a consumer file changes under watch.
+ * Persist this file's barrel re-export rename pairs (`export { X as Y } from
+ * …`) into `reexport_renames` (#1967) — the durable counterpart of
+ * `persistReexportRenames` in `resolve-imports.ts` (full-build path), needed
+ * here because `codegraph watch`'s single-file rebuild never goes through
+ * that stage. Always deletes this file's existing rows first (even when it
+ * has no reexports left) so a barrel that drops all its renames — or stops
+ * being a barrel entirely — never leaves stale rows behind.
+ *
+ * Called for both the primary rebuilt file and each reverse-dep, so a
+ * barrel's rename table stays current whenever *it* is reparsed, regardless
+ * of which file triggered this rebuild.
+ */
+function persistReexportRenamesForFile(
+  db: BetterSqlite3Database,
+  relPath: string,
+  symbols: ExtractorOutput,
+  rootDir: string,
+): void {
+  const { renameDeleteStmt, renameInsertStmt } = getBarrelStmts(db);
+  renameDeleteStmt.run(relPath);
+
+  const reexports = symbols.imports.filter((imp) => imp.reexport);
+  if (reexports.length === 0) return;
+
+  const aliases: PathAliases = { baseUrl: null, paths: {} };
+  for (const imp of reexports) {
+    if (!imp.renamedImports?.length) continue;
+    const source = resolveImportPath(path.join(rootDir, relPath), imp.source, rootDir, aliases);
+    for (const rename of imp.renamedImports) {
+      renameInsertStmt.run(relPath, rename.local, rename.imported, source);
+    }
+  }
+}
+
+/**
+ * Resolve a symbol through a barrel's re-export chain, consulting persisted
+ * rename pairs (`reexport_renames`, #1967) before falling back to a direct
+ * name match against the barrel's `reexports` edge targets.
+ *
+ * This is `codegraph watch`'s single-file rebuild path (see `watcher.ts`) —
+ * unlike the `codegraph build` resolver (`resolveBarrelExport` in
+ * resolve-imports.ts, fixed for #1823), it cannot re-parse the barrel file
+ * itself when it isn't part of the current watch batch. Previously this
+ * meant a renamed barrel re-export (`export { X as Y } from …`) could never
+ * resolve unless the barrel itself was reparsed in the same batch — the
+ * `{ local: Y, imported: X }` mapping only existed in the barrel's
+ * freshly-parsed `Import.renamedImports`, which was never persisted.
+ * `persistReexportRenamesForFile` (this file) and `persistReexportRenames`
+ * (resolve-imports.ts) now write that mapping to `reexport_renames` whenever
+ * the barrel itself is parsed (full build, incremental build, or a watch
+ * rebuild that happens to touch the barrel directly), so a later watch cycle
+ * that only touches a *consumer* can still look up the translation here.
+ *
+ * If a rename row matches but doesn't resolve (a stale mapping — the target
+ * no longer defines that symbol, and it isn't a further barrel hop), this
+ * deliberately falls through to the untranslated search below rather than
+ * committing to a possibly-wrong answer: unlike `resolveBarrelExport`'s
+ * in-memory `reexportMap` (always fresh within a single build), this
+ * persisted table can go stale between builds when only a consumer changes.
+ *
  * `name` in the result mirrors the shared `CallNodeLookup.resolveBarrel`
- * shape but is always just the input `symbolName` unchanged.
+ * shape — the actual declared name in `file`, which differs from the input
+ * `symbolName` exactly when a rename translation was applied.
  */
 function resolveBarrelTarget(
   db: BetterSqlite3Database,
@@ -357,7 +433,20 @@ function resolveBarrelTarget(
   if (visited.has(barrelPath)) return null;
   visited.add(barrelPath);
 
-  const { reexportTargetsStmt, hasDefStmt } = getBarrelStmts(db);
+  const { reexportTargetsStmt, hasDefStmt, renameLookupStmt } = getBarrelStmts(db);
+
+  const renameRow = renameLookupStmt.get(barrelPath, symbolName) as
+    | { imported_name: string; source_file: string }
+    | undefined;
+  if (renameRow) {
+    const { imported_name: importedName, source_file: sourceFile } = renameRow;
+    if (hasDefStmt.get(importedName, sourceFile)) return { file: sourceFile, name: importedName };
+    if (isBarrelFile(db, sourceFile)) {
+      const deeper = resolveBarrelTarget(db, sourceFile, importedName, visited);
+      if (deeper) return deeper;
+    }
+    // Stale rename mapping — fall through to the untranslated search below.
+  }
 
   // Find re-export targets from this barrel
   const reexportTargets = reexportTargetsStmt.all(barrelPath) as Array<{ file: string }>;
@@ -1287,6 +1376,10 @@ function rebuildEdgesForTargetFile(
   fileNodeRow: { id: number },
   rootDir: string,
 ): number {
+  // #1967: keep this file's persisted barrel rename table current if it's
+  // itself a barrel — independent of the edges rebuilt below.
+  persistReexportRenamesForFile(db, relPath, symbols, rootDir);
+
   const aliases: PathAliases = { baseUrl: null, paths: {} };
   let edgesAdded = buildContainmentEdges(db, stmts, relPath, symbols);
   edgesAdded += rebuildDirContainment(db, stmts, relPath);

--- a/src/domain/graph/builder/incremental.ts
+++ b/src/domain/graph/builder/incremental.ts
@@ -373,19 +373,6 @@ function isBarrelFile(db: BetterSqlite3Database, relPath: string): boolean {
  * barrel's rename table stays current whenever *it* is reparsed, regardless
  * of which file triggered this rebuild.
  */
-// Lazily-cached tsconfig/jsconfig path aliases, keyed by rootDir (avoid a
-// disk read + JSON parse on every single-file rebuild — #1967 review).
-let _aliasesRootDir: string | null = null;
-let _aliasesCache: PathAliases | null = null;
-
-function getCachedPathAliases(rootDir: string): PathAliases {
-  if (_aliasesRootDir !== rootDir) {
-    _aliasesRootDir = rootDir;
-    _aliasesCache = loadPathAliases(rootDir);
-  }
-  return _aliasesCache!;
-}
-
 function persistReexportRenamesForFile(
   db: BetterSqlite3Database,
   relPath: string,
@@ -402,8 +389,13 @@ function persistReexportRenamesForFile(
   // object here would resolve an alias-based reexport source (e.g.
   // `@utils/foo`) to a bogus non-file specifier, overwriting a correct
   // full-build row with one `resolveBarrelTarget` can never match to a
-  // graph node.
-  const aliases = getCachedPathAliases(rootDir);
+  // graph node. Loaded fresh (not cached) on every call: this branch only
+  // runs for files that are actually barrels with renamed specifiers — rare
+  // enough that the disk read is negligible — and a stale cache could
+  // otherwise persist a wrong `source_file` for the rest of a long-running
+  // `codegraph watch` session after a mid-session tsconfig/jsconfig edit
+  // (#1967 review).
+  const aliases = loadPathAliases(rootDir);
   for (const imp of reexports) {
     if (!imp.renamedImports?.length) continue;
     const source = resolveImportPath(path.join(rootDir, relPath), imp.source, rootDir, aliases);

--- a/src/domain/graph/builder/stages/detect-changes.ts
+++ b/src/domain/graph/builder/stages/detect-changes.ts
@@ -633,7 +633,7 @@ function handleFullBuild(ctx: PipelineContext): void {
   const hasEmbeddings = detectHasEmbeddings(db, ctx.nativeDb);
   ctx.hasEmbeddings = hasEmbeddings;
   const deletions =
-    'PRAGMA foreign_keys = OFF; DELETE FROM cfg_edges; DELETE FROM cfg_blocks; DELETE FROM node_metrics; DELETE FROM edges; DELETE FROM function_complexity; DELETE FROM dataflow; DELETE FROM ast_nodes; DELETE FROM nodes; DELETE FROM file_hashes; PRAGMA foreign_keys = ON;';
+    'PRAGMA foreign_keys = OFF; DELETE FROM cfg_edges; DELETE FROM cfg_blocks; DELETE FROM node_metrics; DELETE FROM edges; DELETE FROM function_complexity; DELETE FROM dataflow; DELETE FROM ast_nodes; DELETE FROM reexport_renames; DELETE FROM nodes; DELETE FROM file_hashes; PRAGMA foreign_keys = ON;';
   db.exec(
     hasEmbeddings
       ? `${deletions.replace('PRAGMA foreign_keys = ON;', '')} DELETE FROM embeddings; PRAGMA foreign_keys = ON;`

--- a/src/domain/graph/builder/stages/resolve-imports.ts
+++ b/src/domain/graph/builder/stages/resolve-imports.ts
@@ -205,6 +205,47 @@ export function resolveBarrelExportCached(
   return result;
 }
 
+/**
+ * Persist barrel re-export rename pairs (`export { X as Y } from …`) from
+ * `ctx.reexportMap` into the `reexport_renames` table (#1967).
+ *
+ * `codegraph watch`'s single-file incremental rebuild (`resolveBarrelTarget`
+ * in `domain/graph/builder/incremental.ts`) resolves barrel chains purely
+ * from already-persisted `reexports` edges, which carry no rename metadata —
+ * when a watch cycle only touches a *consumer* of a barrel (not the barrel
+ * itself), there is no in-memory `reexportMap` available to translate a
+ * requested external alias (Y) back to the name actually declared in the
+ * reexport source (X). Persisting the rename table here, once per full or
+ * incremental `codegraph build` (both engines' JS-pipeline path — the native
+ * orchestrator mirrors this via `import_edges::persist_reexport_renames` in
+ * Rust), gives the watch path something durable to query.
+ *
+ * Deletes and re-inserts per barrel file so a barrel whose renames changed
+ * (or were removed entirely) never leaves stale rows behind for that file.
+ */
+function persistReexportRenames(ctx: PipelineContext): void {
+  const { db, reexportMap } = ctx;
+  if (!reexportMap || reexportMap.size === 0) return;
+
+  const deleteStmt = db.prepare('DELETE FROM reexport_renames WHERE barrel_file = ?');
+  const insertStmt = db.prepare(
+    `INSERT INTO reexport_renames (barrel_file, local_name, imported_name, source_file)
+     VALUES (?, ?, ?, ?)`,
+  );
+
+  const tx = db.transaction(() => {
+    for (const [barrelFile, entries] of reexportMap) {
+      deleteStmt.run(barrelFile);
+      for (const re of entries as ReexportEntry[]) {
+        for (const rename of re.renames) {
+          insertStmt.run(barrelFile, rename.local, rename.imported, re.source);
+        }
+      }
+    }
+  });
+  tx();
+}
+
 export async function resolveImports(ctx: PipelineContext): Promise<void> {
   const { fileSymbols, rootDir, aliases, allFiles, isFullBuild } = ctx;
   const t0 = performance.now();
@@ -250,6 +291,8 @@ export async function resolveImports(ctx: PipelineContext): Promise<void> {
       firstPass = false;
     }
   }
+
+  persistReexportRenames(ctx);
 }
 
 export function getResolved(ctx: PipelineContext, absFile: string, importSource: string): string {

--- a/tests/integration/issue-1967-watch-barrel-rename.test.ts
+++ b/tests/integration/issue-1967-watch-barrel-rename.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Regression test for #1967: `codegraph watch` does not resolve barrel
+ * re-export renames (`export { X as Y } from '...'`) on incremental rebuild
+ * when only a *consumer* of the barrel changes and the barrel itself is not
+ * part of the same watch batch.
+ *
+ * `codegraph build` (both full and hash-based incremental) already resolves
+ * this correctly (#1823) via `resolveBarrelExport` in resolve-imports.ts,
+ * which works from a freshly-parsed, in-memory `reexportMap`. `codegraph
+ * watch` uses a separate, DB-only single-file rebuild path
+ * (`rebuildFile`/`resolveBarrelTarget` in `domain/graph/builder/incremental.ts`)
+ * that, before this fix, had no way to recover the barrel's rename table
+ * when the barrel itself wasn't reparsed in the same watch cycle.
+ *
+ * The fix persists barrel rename pairs to a `reexport_renames` table
+ * whenever a barrel file is parsed (full build, incremental build, or a
+ * watch rebuild that happens to touch the barrel directly), so a later
+ * watch cycle that only touches a *consumer* can still translate the
+ * requested external alias back to the name actually declared in the
+ * reexport source.
+ *
+ * Fixture (mirrors #1823's):
+ *   underlying.ts — `export function realName() {}`
+ *   barrel.ts     — `export { realName as friendlyName } from './underlying.js';`
+ *   consumer.ts   — `import { friendlyName } from './barrel.js';` calls
+ *                   `friendlyName()` inside an exported function.
+ *
+ * Parametrized on the *initial full build's* engine to exercise both
+ * population paths: the JS pipeline (`persistReexportRenames` in
+ * resolve-imports.ts) and the native orchestrator
+ * (`import_edges::persist_reexport_renames` in Rust). The watch-mode
+ * `rebuildFile` call itself is always JS — `codegraph watch` has no native
+ * single-file rebuild path.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { getNodeId as getNodeIdQuery, initSchema, openDb } from '../../src/db/index.js';
+import { rebuildFile } from '../../src/domain/graph/builder/incremental.js';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+import type { EngineMode } from '../../src/types.js';
+
+const FILES: Record<string, string> = {
+  'underlying.ts': `
+export function realName(): string {
+  return 'real';
+}
+`,
+  'barrel.ts': `
+// Barrel re-export with rename — the external name (friendlyName) differs
+// from the underlying declaration (realName).
+export { realName as friendlyName } from './underlying.js';
+`,
+  'consumer.ts': `
+import { friendlyName } from './barrel.js';
+
+export function useIt(): string {
+  return friendlyName();
+}
+`,
+};
+
+function writeFixture(dir: string) {
+  for (const [rel, content] of Object.entries(FILES)) {
+    const abs = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, content);
+  }
+}
+
+function readCallEdges(dbPath: string) {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return db
+      .prepare(
+        `SELECT n1.name AS src, n1.file AS src_file, n2.name AS tgt, n2.file AS tgt_file
+         FROM edges e
+         JOIN nodes n1 ON e.source_id = n1.id
+         JOIN nodes n2 ON e.target_id = n2.id
+         WHERE e.kind = 'calls'
+         ORDER BY n1.name, n2.name`,
+      )
+      .all() as Array<{ src: string; src_file: string; tgt: string; tgt_file: string }>;
+  } finally {
+    db.close();
+  }
+}
+
+function readReexportRenames(dbPath: string) {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return db
+      .prepare(
+        `SELECT barrel_file, local_name, imported_name, source_file
+         FROM reexport_renames ORDER BY barrel_file, local_name`,
+      )
+      .all() as Array<{
+      barrel_file: string;
+      local_name: string;
+      imported_name: string;
+      source_file: string;
+    }>;
+  } finally {
+    db.close();
+  }
+}
+
+function makeStmts(db: ReturnType<typeof openDb>) {
+  return {
+    insertNode: db.prepare(
+      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line) VALUES (?, ?, ?, ?, ?)',
+    ),
+    getNodeId: {
+      get: (name: string, kind: string, file: string, line: number) => {
+        const id = getNodeIdQuery(db, name, kind, file, line);
+        return id != null ? { id } : undefined;
+      },
+    },
+    insertEdge: db.prepare(
+      'INSERT INTO edges (source_id, target_id, kind, confidence, dynamic) VALUES (?, ?, ?, ?, ?)',
+    ),
+    countNodes: db.prepare('SELECT COUNT(*) as c FROM nodes WHERE file = ?'),
+    countEdges: db.prepare(
+      'SELECT COUNT(*) as c FROM edges WHERE source_id IN (SELECT id FROM nodes WHERE file = ?)',
+    ),
+    findNodeInFile: db.prepare(
+      "SELECT id, kind, file FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant') AND file = ?",
+    ),
+    findNodeByName: db.prepare(
+      "SELECT id, file, kind FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
+    ),
+    listSymbols: db.prepare("SELECT name, kind, line FROM nodes WHERE file = ? AND kind != 'file'"),
+    upsertFileHash: db.prepare(
+      'INSERT OR REPLACE INTO file_hashes (file, hash, mtime, size) VALUES (?, ?, ?, ?)',
+    ),
+    deleteFileHash: db.prepare('DELETE FROM file_hashes WHERE file = ?'),
+  };
+}
+
+const ENGINES: EngineMode[] = ['wasm', 'native'];
+
+describe.each(ENGINES)(
+  'codegraph watch resolves barrel rename on consumer-only rebuild (#1967) — initial build: %s',
+  (engine) => {
+    let watchDir: string;
+    let dbPath: string;
+
+    beforeAll(async () => {
+      watchDir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-1967-${engine}-`));
+      writeFixture(watchDir);
+
+      // Initial full build — populates `reexport_renames` for barrel.ts via
+      // either the JS pipeline or the native orchestrator, depending on `engine`.
+      await buildGraph(watchDir, { incremental: false, skipRegistry: true, engine });
+      dbPath = path.join(watchDir, '.codegraph', 'graph.db');
+
+      // Sanity check: the initial full build actually persisted the rename.
+      const renamesAfterFullBuild = readReexportRenames(dbPath);
+      expect(renamesAfterFullBuild).toEqual([
+        {
+          barrel_file: 'barrel.ts',
+          local_name: 'friendlyName',
+          imported_name: 'realName',
+          source_file: 'underlying.ts',
+        },
+      ]);
+
+      // Touch ONLY consumer.ts — the barrel itself is untouched, matching the
+      // issue's exact reproduction ("a consumer of that barrel is edited in a
+      // watch cycle where the barrel itself isn't reparsed").
+      const consumerFile = path.join(watchDir, 'consumer.ts');
+      fs.appendFileSync(consumerFile, '\n// touch\n');
+
+      // Run the watch-mode single-file rebuild path directly.
+      const db = openDb(dbPath);
+      initSchema(db);
+      await rebuildFile(db, watchDir, consumerFile, makeStmts(db), { engine }, null);
+      db.close();
+    }, 60_000);
+
+    afterAll(() => {
+      try {
+        if (watchDir) fs.rmSync(watchDir, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+    });
+
+    it('useIt -> realName calls edge survives the consumer-only watch rebuild', () => {
+      const edges = readCallEdges(dbPath);
+      const edge = edges.find((e) => e.src === 'useIt' && e.tgt === 'realName');
+      expect(
+        edge,
+        `Expected useIt -> realName call edge, resolved through barrel.ts's rename table\nActual call edges:\n${JSON.stringify(edges, null, 2)}`,
+      ).toBeDefined();
+      expect(edge?.tgt_file).toBe('underlying.ts');
+    });
+
+    it('no spurious edge is created against a nonexistent "friendlyName" symbol', () => {
+      const edges = readCallEdges(dbPath);
+      expect(edges.find((e) => e.tgt === 'friendlyName')).toBeUndefined();
+    });
+
+    it("barrel.ts's rename row survives the consumer-only rebuild unchanged", () => {
+      // The barrel itself was never touched, so its own persisted rename row
+      // must still be exactly what the initial full build wrote.
+      expect(readReexportRenames(dbPath)).toEqual([
+        {
+          barrel_file: 'barrel.ts',
+          local_name: 'friendlyName',
+          imported_name: 'realName',
+          source_file: 'underlying.ts',
+        },
+      ]);
+    });
+  },
+);

--- a/tests/integration/issue-1967-watch-barrel-rename.test.ts
+++ b/tests/integration/issue-1967-watch-barrel-rename.test.ts
@@ -218,3 +218,160 @@ describe.each(ENGINES)(
     });
   },
 );
+
+/**
+ * Regression coverage for a review finding on this same fix: the barrel's
+ * reexport *source* can itself be a tsconfig/jsconfig path alias (e.g.
+ * `@utils/foo`), not just a relative specifier. `persistReexportRenamesForFile`
+ * (the watch-mode write path, `incremental.ts`) must resolve that alias using
+ * the project's real tsconfig aliases — not an empty `PathAliases` object —
+ * or reparsing the barrel under watch (for any reason, not necessarily a
+ * rename change) would overwrite a correct full-build row with one pointing
+ * at an unresolved, non-file specifier that `resolveBarrelTarget` can never
+ * match to a graph node.
+ */
+const ALIAS_TSCONFIG = JSON.stringify({
+  compilerOptions: {
+    baseUrl: '.',
+    paths: { '@utils/*': ['utils/*'] },
+  },
+});
+
+const ALIAS_FILES: Record<string, string> = {
+  'tsconfig.json': ALIAS_TSCONFIG,
+  'utils/foo.ts': `
+export function realName(): string {
+  return 'real';
+}
+`,
+  'barrel.ts': `
+// Reexport source is a tsconfig path alias, not a relative specifier.
+export { realName as friendlyName } from '@utils/foo';
+`,
+  'consumer.ts': `
+import { friendlyName } from './barrel.js';
+
+export function useIt(): string {
+  return friendlyName();
+}
+`,
+};
+
+function writeAliasFixture(dir: string) {
+  for (const [rel, content] of Object.entries(ALIAS_FILES)) {
+    const abs = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, content);
+  }
+}
+
+describe.each(ENGINES)(
+  'codegraph watch preserves alias-resolved barrel renames (#1967 review) — initial build: %s',
+  (engine) => {
+    let watchDir: string;
+    let dbPath: string;
+
+    beforeAll(async () => {
+      watchDir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-1967-alias-${engine}-`));
+      writeAliasFixture(watchDir);
+
+      await buildGraph(watchDir, { incremental: false, skipRegistry: true, engine });
+      dbPath = path.join(watchDir, '.codegraph', 'graph.db');
+
+      // Sanity check: the full build resolved the alias to the real file.
+      expect(readReexportRenames(dbPath)).toEqual([
+        {
+          barrel_file: 'barrel.ts',
+          local_name: 'friendlyName',
+          imported_name: 'realName',
+          source_file: 'utils/foo.ts',
+        },
+      ]);
+
+      // Touch the BARREL itself (not the consumer) — this is the case the
+      // review flagged: reparsing an alias-based barrel under watch must not
+      // corrupt its own rename row.
+      const barrelFile = path.join(watchDir, 'barrel.ts');
+      fs.appendFileSync(barrelFile, '\n// touch\n');
+
+      const db = openDb(dbPath);
+      initSchema(db);
+      await rebuildFile(db, watchDir, barrelFile, makeStmts(db), { engine }, null);
+      db.close();
+    }, 60_000);
+
+    afterAll(() => {
+      try {
+        if (watchDir) fs.rmSync(watchDir, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+    });
+
+    it('the rename row still resolves to the real aliased file after the barrel is reparsed', () => {
+      // Deliberately scoped to the row itself, not the barrel's own `calls`/
+      // `imports` edges: incremental.ts's edge-building functions
+      // (buildImportEdges, buildImportedNamesMap, etc.) hardcode an *empty*
+      // PathAliases object for every import resolution — a separate,
+      // pre-existing limitation of the whole file (not introduced by this
+      // fix, and not scoped to reexports/renames) that also breaks the
+      // barrel's own alias-resolved edges when it's reparsed under watch.
+      // Filed as a follow-up (issue link in the PR description) rather than
+      // fixed here — it affects every edge kind under watch for alias-based
+      // projects, well beyond this fix's scope.
+      expect(readReexportRenames(dbPath)).toEqual([
+        {
+          barrel_file: 'barrel.ts',
+          local_name: 'friendlyName',
+          imported_name: 'realName',
+          source_file: 'utils/foo.ts',
+        },
+      ]);
+    });
+  },
+);
+
+describe.each(ENGINES)(
+  'codegraph watch resolves alias-based barrel rename on consumer-only rebuild (#1967 review) — initial build: %s',
+  (engine) => {
+    let watchDir: string;
+    let dbPath: string;
+
+    beforeAll(async () => {
+      watchDir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-1967-alias-consumer-${engine}-`));
+      writeAliasFixture(watchDir);
+
+      await buildGraph(watchDir, { incremental: false, skipRegistry: true, engine });
+      dbPath = path.join(watchDir, '.codegraph', 'graph.db');
+
+      // Touch ONLY consumer.ts — the alias-based barrel is untouched, so its
+      // own (correctly alias-resolved) edges and rename row from the full
+      // build are never re-derived by this rebuild.
+      const consumerFile = path.join(watchDir, 'consumer.ts');
+      fs.appendFileSync(consumerFile, '\n// touch\n');
+
+      const db = openDb(dbPath);
+      initSchema(db);
+      await rebuildFile(db, watchDir, consumerFile, makeStmts(db), { engine }, null);
+      db.close();
+    }, 60_000);
+
+    afterAll(() => {
+      try {
+        if (watchDir) fs.rmSync(watchDir, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+    });
+
+    it('useIt -> realName resolves through the alias-based barrel rename', () => {
+      const edges = readCallEdges(dbPath);
+      const edge = edges.find((e) => e.src === 'useIt' && e.tgt === 'realName');
+      expect(
+        edge,
+        `Expected useIt -> realName call edge via alias-resolved barrel\nActual call edges:\n${JSON.stringify(edges, null, 2)}`,
+      ).toBeDefined();
+      expect(edge?.tgt_file).toBe('utils/foo.ts');
+    });
+  },
+);


### PR DESCRIPTION
## Summary

`codegraph watch`'s single-file rebuild (`resolveBarrelTarget` in `domain/graph/builder/incremental.ts`) resolves barrel re-export chains purely from already-persisted `reexports` edges, which carry no rename metadata for `export { X as Y } from '...'`. When a watch cycle only touches a *consumer* of a renamed barrel re-export (not the barrel itself), there was no way to translate the requested external alias (`Y`) back to the name actually declared in the reexport source (`X`) — the call/import edge was silently dropped.

This had been assessed twice before (see issue comments) and deferred both times: option 2 (re-parse the barrel synchronously) was correctly identified as high-risk due to `resolveBarrelTarget`'s sync/recursive shared interface. Option 1 (persist rename pairs) was only *estimated* as carrying "schema migration + dual-engine mirroring" cost and never actually attempted. This PR attempts option 1 and it turned out clean and tractable.

## Fix

- New `reexport_renames` table (migration v25, mirrored in both `src/db/migrations.ts` and `crates/codegraph-core/src/db/connection.rs`) storing `{barrel_file, local_name, imported_name, source_file}` rows.
- Populated whenever a barrel file is parsed:
  - Full-build JS pipeline: `persistReexportRenames` in `resolve-imports.ts`, called once `ctx.reexportMap` is fully resolved.
  - Native orchestrator: `import_edges::persist_reexport_renames` in Rust, called right after `build_reexport_map`.
  - Watch-mode single-file rebuild: `persistReexportRenamesForFile` in `incremental.ts`, called for both the primary rebuilt file and each reverse-dep, so a barrel's rename table stays current whenever *it* happens to be reparsed.
- Cleaned up alongside a file's other graph data whenever purged (`purgeFileData`/`build-stmts.ts`, the full-build wholesale wipe in both `detect-changes.ts` and `detect_changes.rs`), so a deleted or no-longer-barrel file never leaves stale rows behind.
- `resolveBarrelTarget` now consults `reexport_renames` first — translating the requested alias via a persisted row — before falling back to the existing untranslated search. If a rename row matches but doesn't actually resolve (a stale mapping), it deliberately falls through rather than committing to a possibly-wrong answer, since this persisted data (unlike the full-build's in-memory `reexportMap`) can go stale between builds.

No FFI/shared-interface changes were needed — `resolveBarrelTarget`'s 5 call sites, including the synchronous `CallNodeLookup.resolveBarrel` shape consumed by `call-resolver.ts`, are all untouched. The new table is queried via a plain synchronous prepared statement, sidestepping the sync/async problem that blocked option 2.

## Testing

- New regression test: `tests/integration/issue-1967-watch-barrel-rename.test.ts` — full build (parametrized on engine, exercising both the JS pipeline and native-orchestrator population paths), then a watch-mode `rebuildFile` on the *consumer* only (barrel untouched), asserting the call edge through the rename survives.
- Manually verified the test fails (proving it's a meaningful regression guard) when the new rename lookup is disabled, then confirmed it passes again with the fix restored.
- Full suite: `npm test` (4341 tests, all passing), `npm run lint` (clean), `cargo test --lib` (711 tests, all passing).
- `codegraph diff-impact --staged -T`: 11 functions changed, 31 affected callers — no cycles or dead-export warnings.

## Out of scope

While investigating, found and filed a separate, unrelated dual-engine bug: #2240 (native-engine `forceFullRebuild` fallback path drops barrel rename data via a different, narrower FFI call — `buildNativeReexports` in `build-edges.ts`). Confirmed reproducible; not fixed here as it's outside this issue's scope (`codegraph build`, not `codegraph watch`).

Closes #1967