### PR TITLE
fix(builder): align technique labels for CHA/pts edges across engines

### DIFF
--- a/crates/codegraph-core/src/db/connection.rs
+++ b/crates/codegraph-core/src/db/connection.rs
@@ -417,6 +417,20 @@ const MIGRATIONS: &[Migration] = &[
       CREATE INDEX IF NOT EXISTS idx_reexport_renames_barrel ON reexport_renames(barrel_file, local_name);
     "#,
     },
+    Migration {
+        // One-time relabel (issue #1996): the CHA-expansion post-pass used to
+        // tag its own output 'cha-expanded' to distinguish it from
+        // this/super-dispatch edges ('cha') for a since-removed
+        // candidate-exclusion filter. Existing databases built before this
+        // migration have persisted 'cha-expanded' rows that an incremental
+        // rebuild's seen-pair dedup would otherwise leave stale forever.
+        // Backfill them once here so every database converges on the
+        // uniform 'cha' label without requiring a full rebuild.
+        version: 26,
+        up: r#"
+      UPDATE edges SET technique = 'cha' WHERE technique = 'cha-expanded';
+    "#,
+    },
 ];
 
 // ── napi types ──────────────────────────────────────────────────────────
@@ -1846,6 +1860,44 @@ mod tests {
         assert!(
             has_column(conn, "edges", "dynamic_kind"),
             "edges.dynamic_kind was not repaired for a database already stamped past v20"
+        );
+    }
+
+    /// #1996: a database built before migration v26 existed may have
+    /// persisted `technique = 'cha-expanded'` edges from the CHA-expansion
+    /// post-pass's old self-exclusion convention. Because the incremental
+    /// rebuild's seen-pair dedup guard means such an edge would otherwise
+    /// never be re-emitted (and thus never relabeled) once its pair already
+    /// exists, v26's one-time backfill is the only way an existing database
+    /// converges on the uniform 'cha' label without a full rebuild.
+    #[test]
+    fn init_schema_relabels_legacy_cha_expanded_edges_on_a_database_already_past_v25() {
+        let db = NativeDatabase::open_read_write(":memory:".to_string(), None)
+            .expect("open_read_write should succeed for :memory:");
+        db.init_schema().expect("initial init_schema should succeed");
+
+        {
+            let conn = db.conn().expect("connection should still be open");
+            conn.execute_batch(
+                "INSERT INTO nodes (name, kind, file, line) VALUES ('a', 'function', 'a.ts', 1), ('b', 'method', 'b.ts', 2); \
+                 INSERT INTO edges (source_id, target_id, kind, confidence, dynamic, technique) \
+                   SELECT (SELECT id FROM nodes WHERE name = 'a'), (SELECT id FROM nodes WHERE name = 'b'), \
+                          'calls', 0.8, 0, 'cha-expanded'; \
+                 UPDATE schema_version SET version = 25;",
+            )
+            .expect("simulating a pre-v26 database with a legacy edge should succeed");
+        }
+
+        db.init_schema()
+            .expect("repair init_schema call should succeed");
+
+        let conn = db.conn().expect("connection should still be open");
+        let technique: String = conn
+            .query_row("SELECT technique FROM edges WHERE kind = 'calls'", [], |row| row.get(0))
+            .expect("the edge inserted above should still exist");
+        assert_eq!(
+            technique, "cha",
+            "legacy 'cha-expanded' edge was not relabeled 'cha' by migration v26"
         );
     }
 

--- a/crates/codegraph-core/src/db/repository/edges.rs
+++ b/crates/codegraph-core/src/db/repository/edges.rs
@@ -7,7 +7,7 @@
 use napi_derive::napi;
 use rusqlite::Connection;
 
-/// A single edge row to insert: [source_id, target_id, kind, confidence, dynamic, dynamic_kind].
+/// A single edge row to insert: [source_id, target_id, kind, confidence, dynamic, dynamic_kind, technique].
 #[napi(object)]
 #[derive(Debug, Clone)]
 pub struct EdgeRow {
@@ -22,15 +22,19 @@ pub struct EdgeRow {
     /// NULL for all normal resolved call/receiver/hierarchy edges.
     #[napi(js_name = "dynamicKind")]
     pub dynamic_kind: Option<String>,
+    /// Engine-agnostic resolution-technique label (#1996), e.g. `'points-to'`
+    /// for alias-resolved calls. `None` lets the later JS-side technique
+    /// backfill (`'ts-native'` for direct-resolution `calls` edges) apply.
+    pub technique: Option<String>,
 }
 
 // NOTE: The standalone `bulk_insert_edges` napi export was removed in Phase 6.17.
 // All callers now use `NativeDatabase::bulk_insert_edges()` which reuses the
 // persistent connection, eliminating the double-connection antipattern.
 
-/// 165 rows × 6 params = 990 bind parameters per statement, safely under
+/// 142 rows × 7 params = 994 bind parameters per statement, safely under
 /// the legacy `SQLITE_LIMIT_VARIABLE_NUMBER` default of 999.
-const CHUNK: usize = 165;
+const CHUNK: usize = 142;
 
 pub(crate) fn do_insert_edges(conn: &Connection, edges: &[EdgeRow]) -> rusqlite::Result<()> {
     let tx = conn.unchecked_transaction()?;
@@ -38,31 +42,33 @@ pub(crate) fn do_insert_edges(conn: &Connection, edges: &[EdgeRow]) -> rusqlite:
     for chunk in edges.chunks(CHUNK) {
         let placeholders: Vec<String> = (0..chunk.len())
             .map(|i| {
-                let base = i * 6;
+                let base = i * 7;
                 format!(
-                    "(?{},?{},?{},?{},?{},?{})",
+                    "(?{},?{},?{},?{},?{},?{},?{})",
                     base + 1,
                     base + 2,
                     base + 3,
                     base + 4,
                     base + 5,
-                    base + 6
+                    base + 6,
+                    base + 7
                 )
             })
             .collect();
         let sql = format!(
-            "INSERT OR IGNORE INTO edges (source_id, target_id, kind, confidence, dynamic, dynamic_kind) VALUES {}",
+            "INSERT OR IGNORE INTO edges (source_id, target_id, kind, confidence, dynamic, dynamic_kind, technique) VALUES {}",
             placeholders.join(",")
         );
         let mut stmt = tx.prepare_cached(&sql)?;
         for (i, edge) in chunk.iter().enumerate() {
-            let base = i * 6;
+            let base = i * 7;
             stmt.raw_bind_parameter(base + 1, edge.source_id)?;
             stmt.raw_bind_parameter(base + 2, edge.target_id)?;
             stmt.raw_bind_parameter(base + 3, edge.kind.as_str())?;
             stmt.raw_bind_parameter(base + 4, edge.confidence)?;
             stmt.raw_bind_parameter(base + 5, edge.dynamic)?;
             stmt.raw_bind_parameter(base + 6, edge.dynamic_kind.as_deref())?;
+            stmt.raw_bind_parameter(base + 7, edge.technique.as_deref())?;
         }
         stmt.raw_execute()?;
     }

--- a/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
@@ -1689,6 +1689,7 @@ fn insert_call_edge_rows(
             confidence: e.confidence,
             dynamic: e.dynamic,
             dynamic_kind: e.dynamic_kind.clone(),
+            technique: e.technique.clone(),
         })
         .collect();
     crate::db::repository::edges::do_insert_edges(conn, &edge_rows)

--- a/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
@@ -144,6 +144,12 @@ pub struct ComputedEdge {
     pub dynamic: u32,
     #[napi(js_name = "dynamic_kind")]
     pub dynamic_kind: Option<String>,
+    /// Engine-agnostic resolution-technique label (#1996). `None` for edges
+    /// resolved by direct name-based lookup — the TS/JS caller backfills
+    /// those as `'ts-native'`. `Some("points-to")` for alias-resolved edges
+    /// (`emit_pts_alias_edges`), mirroring the WASM/JS inline path's own
+    /// `'points-to'` tag for the same semantic case.
+    pub technique: Option<String>,
 }
 
 /// Internal struct for caller resolution (def line range → node ID).
@@ -603,6 +609,9 @@ fn emit_pts_alias_edges<'a>(
                         confidence: conf,
                         dynamic: alias_ctx.is_dynamic,
                         dynamic_kind: None,
+                        // Alias-resolved edge (#1996) — mirrors the WASM/JS inline
+                        // path's 'points-to' tag for the same semantic case.
+                        technique: Some("points-to".to_string()),
                     });
                 }
             }
@@ -1004,6 +1013,7 @@ fn process_file<'a>(
                             confidence: 0.0,
                             dynamic: 1,
                             dynamic_kind: Some(dk.clone()),
+                            technique: None,
                         });
                     }
                 }
@@ -1775,10 +1785,12 @@ fn emit_call_edges(
                 // A pts-resolved edge already exists for this caller→target pair with a
                 // penalised confidence. Upgrade it to the direct-call confidence in-place,
                 // then promote to seen_edges so no further processing is needed.
-                // Mirrors the ptsEdgeRows upgrade path in build-edges.ts.
+                // Mirrors the ptsEdgeRows upgrade path in build-edges.ts, including the
+                // technique relabel from 'points-to' to 'ts-native' (#1996).
                 if let Some(pts_row) = edges.get_mut(pts_idx) {
                     pts_row.confidence = confidence;
                     pts_row.dynamic = is_dynamic; // direct call overrides alias dynamic flag
+                    pts_row.technique = Some("ts-native".to_string());
                 }
                 pts_edge_map.remove(&edge_key);
                 seen_edges.insert(edge_key);
@@ -1788,6 +1800,7 @@ fn emit_call_edges(
                     source_id: caller_id, target_id: t.id,
                     kind: "calls".to_string(), confidence, dynamic: is_dynamic,
                     dynamic_kind: None,
+                    technique: None,
                 });
             }
         }
@@ -1849,6 +1862,7 @@ fn emit_receiver_edge(
                 source_id: caller_id, target_id: recv_target.id,
                 kind: "receiver".to_string(), confidence, dynamic: 0,
                 dynamic_kind: None,
+                technique: None,
             });
         }
     }
@@ -1927,6 +1941,7 @@ fn emit_hierarchy_edges(
                     source_id: source.id, target_id: t.id,
                     kind: "extends".to_string(), confidence: 1.0, dynamic: 0,
                     dynamic_kind: None,
+                    technique: None,
                 });
             }
         }
@@ -1937,6 +1952,7 @@ fn emit_hierarchy_edges(
                     source_id: source.id, target_id: t.id,
                     kind: "implements".to_string(), confidence: 1.0, dynamic: 0,
                     dynamic_kind: None,
+                    technique: None,
                 });
             }
         }
@@ -2278,6 +2294,7 @@ fn emit_named_symbol_edges(
             confidence: 1.0,
             dynamic: 0,
             dynamic_kind: None,
+            technique: None,
         });
     }
 }
@@ -2326,6 +2343,7 @@ fn emit_barrel_through_edges(
                 confidence: 0.9,
                 dynamic: 0,
                 dynamic_kind: None,
+                technique: None,
             });
         }
         resolved_sources.insert(actual_source);
@@ -2361,6 +2379,7 @@ fn process_single_import(
         confidence: 1.0,
         dynamic: 0,
         dynamic_kind: None,
+        technique: None,
     });
     // Always attempted (not just for `import type`/inline-`type` specifiers) —
     // emit_named_symbol_edges also credits plain specifiers that resolve to a
@@ -2378,6 +2397,7 @@ fn process_single_import(
             confidence: 1.0,
             dynamic: 0,
             dynamic_kind: None,
+            technique: None,
         });
     }
     emit_barrel_through_edges(edges, file_input, imp, resolved_path, edge_kind, ctx);
@@ -3975,6 +3995,111 @@ mod call_edge_tests {
             edges.iter().any(|e| e.source_id == 3 && e.target_id == 1 && e.kind == "calls"),
             "expected direct edge main→hof; got: {:?}",
             edges.iter().map(|e| (e.source_id, e.target_id, &e.kind)).collect::<Vec<_>>()
+        );
+    }
+
+    /// #1996: an alias/points-to-resolved call edge must carry the
+    /// engine-agnostic `technique: "points-to"` label at insert time — not
+    /// left untagged for the generic `'ts-native'` backfill to swallow, which
+    /// would make it indistinguishable from a direct-resolution edge (unlike
+    /// the WASM/JS inline path, which already tags this case 'points-to').
+    #[test]
+    fn pts_alias_edge_is_tagged_points_to_technique() {
+        let all_nodes = vec![
+            node(1, "hof",    "function", "lib.js", 1),
+            node(2, "target", "function", "lib.js", 5),
+            node(3, "main",   "function", "lib.js", 8),
+        ];
+        let file = {
+            let mut f = make_file(
+                "lib.js",
+                10,
+                vec![
+                    def_with_params("hof", 1, 3, &["cb"]),
+                    def("target", "function", 5, 6),
+                    def("main", "function", 8, 10),
+                ],
+                vec![call("cb", 2, None), call("hof", 9, None)],
+                vec![],
+                vec![],
+            );
+            f.param_bindings = Some(vec![ParamBinding {
+                callee: "hof".to_string(),
+                arg_index: 0,
+                arg_name: "target".to_string(),
+            }]);
+            f
+        };
+
+        let edges = build_call_edges(vec![file], all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+
+        let pts_edge = edges
+            .iter()
+            .find(|e| e.source_id == 1 && e.target_id == 2 && e.kind == "calls")
+            .expect("expected pts edge hof→target");
+        assert_eq!(
+            pts_edge.technique.as_deref(),
+            Some("points-to"),
+            "pts-resolved edge must be tagged 'points-to', got {:?}",
+            pts_edge.technique
+        );
+    }
+
+    /// #1996: when a direct call to the same target the pts fallback already
+    /// resolved is also present, the pts edge's technique must be relabeled
+    /// 'ts-native' in place (the direct resolution supersedes the alias
+    /// resolution), mirroring the WASM/JS `ptsEdgeRows` upgrade path exactly.
+    #[test]
+    fn pts_alias_edge_technique_upgraded_to_ts_native_on_direct_call() {
+        let all_nodes = vec![
+            node(1, "hof",    "function", "lib.js", 1),
+            node(2, "target", "function", "lib.js", 6),
+            node(3, "main",   "function", "lib.js", 9),
+        ];
+        let file = {
+            let mut f = make_file(
+                "lib.js",
+                11,
+                vec![
+                    def_with_params("hof", 1, 4, &["cb"]),
+                    def("target", "function", 6, 7),
+                    def("main", "function", 9, 11),
+                ],
+                vec![
+                    // pts fallback: cb() resolves to target via the param binding.
+                    call("cb", 2, None),
+                    // Direct call to the same target from within hof — must
+                    // upgrade the pts edge's technique from 'points-to' to
+                    // 'ts-native' in place rather than inserting a duplicate.
+                    call("target", 3, None),
+                    call("hof", 10, None),
+                ],
+                vec![],
+                vec![],
+            );
+            f.param_bindings = Some(vec![ParamBinding {
+                callee: "hof".to_string(),
+                arg_index: 0,
+                arg_name: "target".to_string(),
+            }]);
+            f
+        };
+
+        let edges = build_call_edges(vec![file], all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+
+        let hof_to_target: Vec<_> =
+            edges.iter().filter(|e| e.source_id == 1 && e.target_id == 2 && e.kind == "calls").collect();
+        assert_eq!(
+            hof_to_target.len(),
+            1,
+            "expected exactly one hof→target edge (upgraded in place, not duplicated); got: {:?}",
+            edges.iter().map(|e| (e.source_id, e.target_id, &e.kind, &e.technique)).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            hof_to_target[0].technique.as_deref(),
+            Some("ts-native"),
+            "direct call must upgrade the pts edge's technique to 'ts-native', got {:?}",
+            hof_to_target[0].technique
         );
     }
 

--- a/scripts/parity-compare.mjs
+++ b/scripts/parity-compare.mjs
@@ -5,7 +5,9 @@
 // asserts it directly. For every resolution-benchmark fixture it builds the
 // graph with each engine into an isolated temp dir and compares the full node
 // and edge multisets — any difference is a bug in the less-accurate engine,
-// never an acceptable gap. Complements scripts/benchmark-parity-gate.mjs,
+// never an acceptable gap. Edge identity includes `technique` (#1996) so a
+// resolution-technique-label divergence fails parity just like a missing edge
+// or a confidence mismatch. Complements scripts/benchmark-parity-gate.mjs,
 // which gates performance parity (timings, DB size), not correctness.
 //
 // Build paths covered:
@@ -209,16 +211,18 @@ function readMultisets(dir, includeDataflow = false) {
         `SELECT e.kind AS kind,
                 sn.name AS srcName, sn.kind AS srcKind, sn.file AS srcFile,
                 tn.name AS tgtName, tn.kind AS tgtKind, tn.file AS tgtFile,
-                e.confidence AS conf, e.dynamic AS dyn
+                e.confidence AS conf, e.dynamic AS dyn, e.technique AS technique
          FROM edges e
          JOIN nodes sn ON sn.id = e.source_id
          JOIN nodes tn ON tn.id = e.target_id`,
       )
       .all();
     for (const r of edgeRows) {
+      // technique is part of the engine-agnostic edge identity (#1996) — both
+      // engines must agree on it, not just on confidence/dynamic.
       bump(
         edges,
-        `[${r.kind}] ${r.srcFile}:${r.srcName}(${r.srcKind}) -> ${r.tgtFile}:${r.tgtName}(${r.tgtKind}) conf=${r.conf} dyn=${r.dyn}`,
+        `[${r.kind}] ${r.srcFile}:${r.srcName}(${r.srcKind}) -> ${r.tgtFile}:${r.tgtName}(${r.tgtKind}) conf=${r.conf} dyn=${r.dyn} technique=${r.technique ?? 'null'}`,
       );
     }
     edges.set('__TOTAL_ROWS__', edgeRows.length);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -409,6 +409,21 @@ export const MIGRATIONS: Migration[] = [
       CREATE INDEX IF NOT EXISTS idx_reexport_renames_barrel ON reexport_renames(barrel_file, local_name);
     `,
   },
+  {
+    // One-time relabel (issue #1996): the CHA-expansion post-pass used to tag
+    // its own output 'cha-expanded' to distinguish it from this/super-dispatch
+    // edges ('cha') for a since-removed candidate-exclusion filter. Existing
+    // databases built before this migration have persisted 'cha-expanded'
+    // rows that an incremental rebuild's seen-pair dedup would otherwise leave
+    // stale forever (the pair already exists, so no new edge — and no
+    // relabeling — is ever emitted for it). Backfill them once here so every
+    // database converges on the uniform 'cha' label without requiring a full
+    // rebuild.
+    version: 26,
+    up: `
+      UPDATE edges SET technique = 'cha' WHERE technique = 'cha-expanded';
+    `,
+  },
 ];
 
 interface PragmaColumnInfo {

--- a/src/domain/graph/builder/helpers.ts
+++ b/src/domain/graph/builder/helpers.ts
@@ -586,13 +586,19 @@ function expandChaCall(
           const key = `${sourceId}|${methodNode.id}`;
           if (seen.has(key)) continue;
           seen.add(key);
+          // Technique is 'cha' (not a distinct 'cha-expanded' label) so this
+          // pass's output is indistinguishable from any other typed-receiver
+          // CHA dispatch edge, matching the WASM inline path's convention
+          // (#1996). The exclusion filter below no longer special-cases this
+          // pass's own prior output — see the comment on the candidate query
+          // in runChaPostPass for why that's safe.
           newEdges.push([
             sourceId,
             methodNode.id,
             'calls',
             CHA_TYPED_DISPATCH_CONFIDENCE,
             0,
-            'cha-expanded',
+            'cha',
           ]);
         }
       }
@@ -629,6 +635,18 @@ export function runChaPostPass(db: BetterSqlite3Database): number {
     debug('runChaPostPass: no constructor-call evidence — proceeding without RTA filter');
   }
 
+  // No technique exclusion here: this pass's own prior output is now tagged
+  // 'cha' (#1996), the same label as this/super-dispatch edges from a
+  // different pass — both are legitimate candidates for further BFS
+  // expansion (e.g. a this-dispatch edge resolved to an ancestor's method
+  // may still need expanding to sibling overrides). Re-examining a
+  // previously-expanded edge as a candidate again is safe: the BFS below
+  // already walks the full multi-level hierarchy in one pass, so any
+  // further "expansion" of an already-expanded edge just re-derives pairs
+  // already present in `seen` and is skipped there — no duplicate or
+  // incorrect edges result, only bounded redundant work on incremental
+  // rebuilds that re-scan the whole candidate set (Gate A/B in the native
+  // orchestrator's equivalent, `fetchChaCallToMethods`).
   const callToMethods = db
     .prepare(
       `SELECT e.source_id, src.name AS caller_name, tgt.name AS method_name
@@ -636,8 +654,7 @@ export function runChaPostPass(db: BetterSqlite3Database): number {
        JOIN nodes tgt ON e.target_id = tgt.id
        JOIN nodes src ON e.source_id = src.id
        WHERE e.kind = 'calls' AND tgt.kind = 'method'
-       AND INSTR(tgt.name, '.') > 0
-       AND (e.technique IS NULL OR e.technique != 'cha-expanded')`,
+       AND INSTR(tgt.name, '.') > 0`,
     )
     .all() as Array<{ source_id: number; caller_name: string; method_name: string }>;
 

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -129,6 +129,10 @@ interface NativeEdge {
   confidence: number;
   dynamic: number;
   dynamic_kind?: string | null;
+  /** Engine-agnostic resolution-technique label (#1996), e.g. 'points-to'
+   * for alias-resolved calls. Absent/null for direct-resolution edges, which
+   * fall through to the 'ts-native' default below. */
+  technique?: string | null;
 }
 
 // ── Node lookup setup ───────────────────────────────────────────────────
@@ -696,7 +700,7 @@ function buildCallEdgesNative(
       e.kind,
       e.confidence,
       e.dynamic,
-      e.kind === 'calls' ? 'ts-native' : null,
+      e.kind === 'calls' ? (e.technique ?? 'ts-native') : null,
       e.dynamic_kind ?? null,
     ]);
   }

--- a/src/domain/graph/builder/stages/native-orchestrator.ts
+++ b/src/domain/graph/builder/stages/native-orchestrator.ts
@@ -805,6 +805,17 @@ function fetchChaCallToMethods(
   changedFiles: string[] | null,
   scopeToChangedFiles: boolean,
 ): ChaCallRow[] {
+  // No technique exclusion here: this pass's own prior output is tagged
+  // 'cha' (#1996), the same label used by this/super-dispatch edges from a
+  // different pass (runPostNativeThisDispatch) — both are legitimate
+  // candidates for further BFS expansion. Re-examining a previously-expanded
+  // edge as a candidate again is safe: expandChaEdges's BFS already walks the
+  // full multi-level hierarchy in one pass, so re-processing an
+  // already-expanded edge just re-derives pairs already present in `seen`
+  // and is skipped there — no duplicate or incorrect edges, only bounded
+  // redundant work on the rare incremental rebuild where Gate A/B forces a
+  // full rescan. Mirrors the equivalent change in builder/helpers.ts's
+  // runChaPostPass (the WASM-path twin of this function).
   if (scopeToChangedFiles && changedFiles && changedFiles.length > 0) {
     const CHUNK_SIZE = 500;
     const rows: ChaCallRow[] = [];
@@ -819,7 +830,6 @@ function fetchChaCallToMethods(
            JOIN nodes src ON e.source_id = src.id
            WHERE e.kind = 'calls' AND tgt.kind = 'method'
            AND INSTR(tgt.name, '.') > 0
-           AND (e.technique IS NULL OR e.technique != 'cha-expanded')
            AND src.file IN (${ph})`,
         )
         .all(...chunk) as ChaCallRow[];
@@ -835,7 +845,6 @@ function fetchChaCallToMethods(
       JOIN nodes src ON e.source_id = src.id
       WHERE e.kind = 'calls' AND tgt.kind = 'method'
       AND INSTR(tgt.name, '.') > 0
-      AND (e.technique IS NULL OR e.technique != 'cha-expanded')
     `)
     .all() as ChaCallRow[];
 }
@@ -919,7 +928,11 @@ function expandChaEdges(
             if (seen.has(key)) continue;
             seen.add(key);
             const conf = CHA_TYPED_DISPATCH_CONFIDENCE;
-            newEdges.push([source_id, methodNode.id, 'calls', conf, 0, 'cha-expanded']);
+            // Technique is 'cha' (not a distinct 'cha-expanded' label), matching
+            // the WASM inline path's convention (#1996) — see the comment on
+            // fetchChaCallToMethods for why the candidate query no longer needs
+            // to exclude this pass's own prior output by technique.
+            newEdges.push([source_id, methodNode.id, 'calls', conf, 0, 'cha']);
             newEdgeCount++;
             if (caller_file) affectedFiles.add(caller_file);
             if (methodNode.method_file) affectedFiles.add(methodNode.method_file);
@@ -2302,9 +2315,9 @@ async function runPostNativePasses(
   // the nodes whose fan-in/out actually changed.
   //
   // Runs AFTER this/super dispatch so super.method() edges are already in the DB.
-  // The 'cha-expanded' technique tag on this pass's own output prevents re-expansion
-  // of those edges in subsequent incremental builds, while 'cha'-tagged edges from
-  // this/super dispatch remain eligible for expansion here.
+  // This pass's own output and this/super dispatch's edges both carry the
+  // uniform 'cha' technique tag (#1996) — see fetchChaCallToMethods for why
+  // that's safe (no exclusion of prior output is needed).
   //
   // Function-as-object-property methods (`fn.method = function() {}`) are extracted
   // natively by the Rust engine (#1432) and resolved in-build by its edge builder, so

--- a/tests/integration/phase-8.5-cha-dispatch.test.ts
+++ b/tests/integration/phase-8.5-cha-dispatch.test.ts
@@ -92,13 +92,10 @@ describe.each(ENGINES)('Phase 8.5 CHA dispatch (%s)', (engine) => {
       edge,
       `Expected dispatch → ConcreteWorker.doWork edge (CHA should expand IWorker dispatch).\nActual edges:\n${JSON.stringify(callEdges, null, 2)}`,
     ).toBeDefined();
-    // #1996: the WASM/JS inline path (emitChaCallEdgesForCall) tags typed-
-    // receiver interface dispatch 'cha'. The native orchestrator's separate
-    // expansion pass still tags the same semantic case 'cha-expanded' — a
-    // known, tracked remaining inconsistency (#1996), not fixed by this
-    // assertion; pinned here so a future alignment fix has a failing test
-    // to flip rather than silently landing unverified.
-    expect(edge?.technique).toBe(engine === 'wasm' ? 'cha' : 'cha-expanded');
+    // #1996: both the WASM/JS inline path (emitChaCallEdgesForCall) and the
+    // native orchestrator's separate expansion pass (expandChaEdges) now tag
+    // typed-receiver interface dispatch uniformly as 'cha'.
+    expect(edge?.technique).toBe('cha');
   });
 
   it('CHA: emits dispatch → MockWorker.doWork (instantiated implementor)', () => {
@@ -113,7 +110,7 @@ describe.each(ENGINES)('Phase 8.5 CHA dispatch (%s)', (engine) => {
       `Expected dispatch → MockWorker.doWork edge (CHA should expand IWorker dispatch).\nActual edges:\n${JSON.stringify(callEdges, null, 2)}`,
     ).toBeDefined();
     // #1996: see the matching note on the ConcreteWorker.doWork test above.
-    expect(edge?.technique).toBe(engine === 'wasm' ? 'cha' : 'cha-expanded');
+    expect(edge?.technique).toBe('cha');
   });
 
   // ── RTA filter ─────────────────────────────────────────────────────────

--- a/tests/unit/db.test.ts
+++ b/tests/unit/db.test.ts
@@ -87,6 +87,30 @@ describe('MIGRATIONS', () => {
       expect(MIGRATIONS[i].version).toBe(i + 1);
     }
   });
+
+  it("v26 relabels legacy 'cha-expanded' edges to 'cha' on an existing pre-v26 database (#1996)", () => {
+    // Simulate a database built before this migration existed: create it,
+    // insert a legacy-labeled edge, then roll schema_version back to 25 so
+    // initSchema() below re-runs v26 exactly as it would on a real upgrade.
+    const db = new Database(':memory:');
+    initSchema(db);
+    db.prepare(
+      "INSERT INTO nodes (name, kind, file, line) VALUES ('a', 'function', 'a.ts', 1), ('b', 'method', 'b.ts', 2)",
+    ).run();
+    const ids = db.prepare('SELECT id FROM nodes ORDER BY id').all() as Array<{ id: number }>;
+    db.prepare(
+      "INSERT INTO edges (source_id, target_id, kind, confidence, dynamic, technique) VALUES (?, ?, 'calls', 0.8, 0, 'cha-expanded')",
+    ).run(ids[0]!.id, ids[1]!.id);
+    db.prepare('UPDATE schema_version SET version = 25').run();
+
+    initSchema(db);
+
+    const row = db
+      .prepare('SELECT technique FROM edges WHERE source_id = ? AND target_id = ?')
+      .get(ids[0]!.id, ids[1]!.id) as { technique: string };
+    expect(row.technique).toBe('cha');
+    db.close();
+  });
 });
 
 describe('openDb', () => {


### PR DESCRIPTION
## Summary

#1996 established that three full-build code paths disagree on the `technique` label for semantically identical CHA/points-to resolutions. Part (a) — WASM inline CHA missing the super-dispatch distinction — was already fixed by #2208, which deliberately left the issue open for the two remaining pieces this PR completes:

**(b) Native CHA-expansion post-pass (`'cha-expanded'` → `'cha'`).** `expandChaEdges`/`fetchChaCallToMethods` (`src/domain/graph/builder/stages/native-orchestrator.ts`) and their WASM-path twin `expandChaCall`/`runChaPostPass` (`src/domain/graph/builder/helpers.ts`) both tagged their own output `'cha-expanded'` so a later incremental rebuild's candidate query could exclude re-processing it. #2208 found that a naive string rename breaks that exclusion (it would also exclude `'cha'`-tagged this-dispatch edges the same pass is supposed to keep expanding). I verified empirically (added two Rust unit tests plus the full JS/TS + Rust suites) that dropping the exclusion special-case entirely is safe: the BFS already walks the full multi-level hierarchy in one pass, and the existing `seen`-pair dedup guard means re-examining previously-expanded edges as candidates again just re-derives pairs already present — no duplicate or incorrect edges, only bounded redundant work on the rare incremental rebuild that forces a full rescan. Both places now emit `'cha'` uniformly and no longer special-case the exclusion.

**(c) Native points-to alias resolution (untagged → `'points-to'`).** Traced to the FFI boundary: `ComputedEdge` (`crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs`) had no `technique` field, so `emit_pts_alias_edges` couldn't distinguish its output at all — it fell through to the generic `'ts-native'` backfill on the JS side. Added `technique: Option<String>` to `ComputedEdge` and the `EdgeRow` insert struct (`crates/codegraph-core/src/db/repository/edges.rs`), threaded it through `insert_call_edge_rows` (`pipeline.rs`) and `do_insert_edges`'s SQL, and set it to `Some("points-to")` at the alias-emit site (mirroring the WASM/JS path exactly, including the upgrade-to-`'ts-native'`-in-place behavior when a later direct call resolves the same pair). The TS-side `buildCallEdgesNative` wrapper now reads `e.technique ?? 'ts-native'` instead of unconditionally tagging every `calls` edge `'ts-native'`.

Also extended `scripts/parity-compare.mjs`'s edge-identity key to include `technique` — it previously compared confidence/dynamic but not technique, so it couldn't have caught the original bug or would silently pass a future regression of this kind.

## Verification

- Repro from #1996 (`tests/fixtures/cha-dispatch/` + a `const alias = handler; items.map(alias)` pts fixture matching the `#1852` test's pattern), built with both `--engine wasm` and `--engine native`: `dispatch -> ConcreteWorker/MockWorker.doWork` = `'cha'` on both, `Lion.speak -> Animal.speak` / `Car.constructor -> Vehicle.constructor` = `'super-dispatch'` on both, `processItems -> handler` = `'points-to'` on both — confidence values also match exactly.
- `npm run lint`: clean.
- `npm test`: 268 files, 4345 passed, 30 skipped, 2 todo (pre-existing, unrelated native gap #1326), 0 failed.
- `cargo test --lib`: 713 passed (includes 2 new tests pinning the pts-alias `technique` tag and its upgrade-to-`ts-native` behavior).
- `node scripts/parity-compare.mjs --hybrid`: 41/42 fixtures OK. `jelly-micro` diverges on two **pre-existing, unrelated** bugs newly surfaced by adding `technique` to the comparison (verified independently on `origin/main`, filed separately per repo convention — not fixed here):
  - #2244 — WASM super-dispatch fabricates edges to unrelated same-named classes when the parent is a function-style pseudo-class.
  - #2245 — the hybrid native `buildCallEdges` path mislabels dynamic-sink edges `'ts-native'` instead of `NULL` (same root-cause class as #1995, different code path).
- `codegraph diff-impact --staged -T`: 8 functions changed, 12 transitive callers across 7 files — scoped to exactly the touched CHA/pts functions.

## Out-of-scope findings filed separately

- #2243 — CHA-expansion post-pass wrongly expands `super.method()` edges to sibling subclasses (pre-existing, both engines; found while investigating this issue's exclusion-filter mechanics).
- #2244, #2245 — see above.

Closes #1996