### PR TITLE
fix(builder): resolve same-line decorator upgrade gap in call dedup

### DIFF
--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -1317,12 +1317,12 @@ function resolveFallbackTargets(
  *   - If a pts edge already exists for this pair, upgrades it in-place to
  *     direct-call confidence and promotes to seenCallEdges.
  *   - If a dyn=0 edge already exists and the incoming call has an explicit
- *     dynamicKind AND textually precedes the recorded dyn=0 call (e.g. a bare
- *     decorator `@Log` reordered after `@Log()` by the query path's
- *     query-then-walk collection — see buildFileCallEdges), upgrades the
- *     existing row to dyn=1 in-place so the earlier-in-source classification
- *     wins, matching what native's single-pass source-order walk produces
- *     natively.
+ *     dynamicKind AND (textually precedes the recorded dyn=0 call, OR shares
+ *     its line and is confirmed `outOfOrder` — e.g. a bare decorator `@Log`
+ *     reordered after `@Log()` by the query path's query-then-walk collection,
+ *     see buildFileCallEdges), upgrades the existing row to dyn=1 in-place so
+ *     the earlier-in-source classification wins, matching what native's
+ *     single-pass source-order walk produces natively.
  *   - Otherwise records a new `calls` edge with `ts-native` technique.
  */
 function emitDirectCallEdgesForCall(
@@ -1337,6 +1337,7 @@ function emitDirectCallEdgesForCall(
   ptsEdgeRows: Map<string, number>,
   allEdgeRows: EdgeRowTuple[],
   dynZeroEdgeRows?: Map<string, DynZeroEdgeEntry>,
+  outOfOrder?: boolean,
 ): void {
   // Sort targets by confidence descending before emitting edges.
   // For multi-target calls with duplicate (source_id, target_id) pairs the
@@ -1379,9 +1380,23 @@ function emitDirectCallEdgesForCall(
       // dynamic-flavored call's line is LATER than the recorded dyn=0 call, it
       // is genuinely a second, later reference to the same target — native's
       // dedup (first-recorded-wins, no upgrade) drops it, so WASM must too.
+      //
+      // `line` alone can't distinguish a same-line bare decorator that's
+      // genuinely EARLIER in source (`@Log @Log()`, should upgrade) from one
+      // that's genuinely LATER (`@Log() @Log`, should not — first-recorded-wins
+      // already got it right) — both collide on the same `callLine ===
+      // dynZeroEntry.line`. `outOfOrder` (set by the extractor from direct AST
+      // sibling-position comparison, see decoratorPrecedesCallSibling in
+      // javascript.ts) resolves that collision per-entry, so the guard only
+      // loosens to `<=` for the entries where it's actually been confirmed safe
+      // (#2029) — every other dynamicKind (`.call`/`.apply`/`.bind` included)
+      // keeps the strict `<` that #1687 depends on.
       if (isDynamic === 1 && hasDynamicKind && dynZeroEdgeRows) {
         const dynZeroEntry = dynZeroEdgeRows.get(edgeKey);
-        if (dynZeroEntry !== undefined && callLine < dynZeroEntry.line) {
+        if (
+          dynZeroEntry !== undefined &&
+          (callLine < dynZeroEntry.line || (outOfOrder && callLine === dynZeroEntry.line))
+        ) {
           const row = allEdgeRows[dynZeroEntry.idx];
           if (row) row[4] = 1;
           dynZeroEdgeRows.delete(edgeKey);
@@ -1719,6 +1734,7 @@ function buildFileCallEdges(
       ptsEdgeRows,
       allEdgeRows,
       dynZeroEdgeRows,
+      call.outOfOrder,
     );
 
     // Step 3: Phase 8.3/8.3c pts fallback for unresolved no-receiver calls.

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -1793,6 +1793,58 @@ function handleNewExpr(node: TreeSitterNode, ctx: ExtractorOutput): void {
 }
 
 /**
+ * The logical callee name of a decorator's call-expression form (`@Foo()` →
+ * `Foo`, `@Ns.Foo()` → `Foo`), or null if `decoratorNode` doesn't wrap a
+ * call_expression. Used by `decoratorPrecedesCallSibling` to confirm a
+ * sibling decorator actually targets the same name before trusting its
+ * position for the `outOfOrder` determination.
+ */
+function decoratorCallExprName(decoratorNode: TreeSitterNode): string | null {
+  for (let i = 0; i < decoratorNode.childCount; i++) {
+    const child = decoratorNode.child(i);
+    if (!child || child.type === '@') continue;
+    if (child.type !== 'call_expression') return null;
+    const fn = child.childForFieldName('function');
+    if (fn?.type === 'identifier') return fn.text;
+    if (fn?.type === 'member_expression') {
+      const prop = fn.childForFieldName('property');
+      return prop?.text ?? null;
+    }
+    return null;
+  }
+  return null;
+}
+
+/**
+ * True when `decoratorNode` (a bare-identifier/member-expression decorator,
+ * e.g. `@Log`) has a LATER sibling decorator in the same decorator list
+ * (e.g. class_declaration's `@Log()`) that wraps a call_expression targeting
+ * the same callee name.
+ *
+ * Decorators are always direct, contiguous siblings of one another and of
+ * the node they decorate (confirmed via AST dump: `@Log @Log() class Foo {}`
+ * parses as two sibling `decorator` nodes under `class_declaration`), so
+ * walking `nextSibling` gives the true relative source order directly from
+ * the AST — independent of which pass (query-match loop vs supplementary
+ * walk, see runCollectorWalk) happens to visit this node, and independent of
+ * both nodes sharing the same `line`.
+ *
+ * This is what lets `outOfOrder` be correct for BOTH textual orderings of a
+ * stacked bare/call decorator pair sharing a callee name: `@Log @Log()` (bare
+ * genuinely first — flag true, upgrade is safe) and `@Log() @Log` (bare
+ * genuinely second — flag false, no upgrade, matching native's
+ * first-recorded-wins result for that ordering) (#2029).
+ */
+function decoratorPrecedesCallSibling(decoratorNode: TreeSitterNode, name: string): boolean {
+  let sib = decoratorNode.nextSibling;
+  while (sib?.type === 'decorator') {
+    if (decoratorCallExprName(sib) === name) return true;
+    sib = sib.nextSibling;
+  }
+  return false;
+}
+
+/**
  * Handle a TypeScript/JS decorator node.
  *
  * Only handles bare-identifier and bare-member-expression decorators
@@ -1812,11 +1864,19 @@ function handleDecorator(node: TreeSitterNode, calls: Call[]): void {
         line: nodeStartLine(node),
         dynamic: true,
         dynamicKind: 'reflection',
+        outOfOrder: decoratorPrecedesCallSibling(node, child.text),
       });
     } else if (t === 'member_expression') {
       // @Foo.bar — emit as reflection; always mark dynamic since it's decorator dispatch
       const callInfo = extractCallInfo(child, node);
-      if (callInfo) calls.push({ ...callInfo, dynamic: true, dynamicKind: 'reflection' });
+      if (callInfo) {
+        calls.push({
+          ...callInfo,
+          dynamic: true,
+          dynamicKind: 'reflection',
+          outOfOrder: decoratorPrecedesCallSibling(node, callInfo.name),
+        });
+      }
     }
     // call_expression / other — handled by the recursive walker automatically
     break;

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -1792,23 +1792,38 @@ function handleNewExpr(node: TreeSitterNode, ctx: ExtractorOutput): void {
   }
 }
 
+/** The callee `{ name, receiver }` a decorator/call resolves to — see `decoratorCallExprIdentity`. */
+interface DecoratorCalleeIdentity {
+  name: string;
+  receiver: string | undefined;
+}
+
 /**
- * The logical callee name of a decorator's call-expression form (`@Foo()` →
- * `Foo`, `@Ns.Foo()` → `Foo`), or null if `decoratorNode` doesn't wrap a
+ * The logical callee identity of a decorator's call-expression form
+ * (`@Foo()` → `{name: 'Foo', receiver: undefined}`, `@Ns.Foo()` →
+ * `{name: 'Foo', receiver: 'Ns'}`), or null if `decoratorNode` doesn't wrap a
  * call_expression. Used by `decoratorPrecedesCallSibling` to confirm a
- * sibling decorator actually targets the same name before trusting its
- * position for the `outOfOrder` determination.
+ * sibling decorator actually targets the same callee — name AND receiver —
+ * before trusting its position for the `outOfOrder` determination.
+ *
+ * Comparing the receiver too (not just the terminal property name) matters:
+ * in a mixed qualified list like `@B.Log() @A.Log @C.Log()`, `@B.Log()` and
+ * `@C.Log()` share the tail name "Log" but are different callees (different
+ * receivers) — matching on name alone would wrongly treat `@C.Log()` as proof
+ * that the middle `@A.Log` is out of order, when `@A.Log`'s real callee
+ * (receiver `A`) has no call-expression sibling at all.
  */
-function decoratorCallExprName(decoratorNode: TreeSitterNode): string | null {
+function decoratorCallExprIdentity(decoratorNode: TreeSitterNode): DecoratorCalleeIdentity | null {
   for (let i = 0; i < decoratorNode.childCount; i++) {
     const child = decoratorNode.child(i);
     if (!child || child.type === '@') continue;
     if (child.type !== 'call_expression') return null;
     const fn = child.childForFieldName('function');
-    if (fn?.type === 'identifier') return fn.text;
+    if (fn?.type === 'identifier') return { name: fn.text, receiver: undefined };
     if (fn?.type === 'member_expression') {
       const prop = fn.childForFieldName('property');
-      return prop?.text ?? null;
+      if (!prop) return null;
+      return { name: prop.text, receiver: extractReceiverName(fn.childForFieldName('object')) };
     }
     return null;
   }
@@ -1817,9 +1832,11 @@ function decoratorCallExprName(decoratorNode: TreeSitterNode): string | null {
 
 /**
  * True when `decoratorNode` (a bare-identifier/member-expression decorator,
- * e.g. `@Log`) has a LATER sibling decorator in the same decorator list
- * (e.g. class_declaration's `@Log()`) that wraps a call_expression targeting
- * the same callee name.
+ * e.g. `@Log`, resolving to callee identity `{name, receiver}`) has a LATER
+ * sibling decorator in the same decorator list (e.g. class_declaration's
+ * `@Log()`) that wraps a call_expression targeting that SAME callee — both
+ * name and receiver, not merely the tail name (see `decoratorCallExprIdentity`
+ * for why the receiver check matters).
  *
  * Decorators are always direct, contiguous siblings of one another and of
  * the node they decorate (confirmed via AST dump: `@Log @Log() class Foo {}`
@@ -1830,15 +1847,20 @@ function decoratorCallExprName(decoratorNode: TreeSitterNode): string | null {
  * both nodes sharing the same `line`.
  *
  * This is what lets `outOfOrder` be correct for BOTH textual orderings of a
- * stacked bare/call decorator pair sharing a callee name: `@Log @Log()` (bare
+ * stacked bare/call decorator pair sharing a callee: `@Log @Log()` (bare
  * genuinely first — flag true, upgrade is safe) and `@Log() @Log` (bare
  * genuinely second — flag false, no upgrade, matching native's
  * first-recorded-wins result for that ordering) (#2029).
  */
-function decoratorPrecedesCallSibling(decoratorNode: TreeSitterNode, name: string): boolean {
+function decoratorPrecedesCallSibling(
+  decoratorNode: TreeSitterNode,
+  name: string,
+  receiver: string | undefined,
+): boolean {
   let sib = decoratorNode.nextSibling;
   while (sib?.type === 'decorator') {
-    if (decoratorCallExprName(sib) === name) return true;
+    const identity = decoratorCallExprIdentity(sib);
+    if (identity && identity.name === name && identity.receiver === receiver) return true;
     sib = sib.nextSibling;
   }
   return false;
@@ -1864,7 +1886,7 @@ function handleDecorator(node: TreeSitterNode, calls: Call[]): void {
         line: nodeStartLine(node),
         dynamic: true,
         dynamicKind: 'reflection',
-        outOfOrder: decoratorPrecedesCallSibling(node, child.text),
+        outOfOrder: decoratorPrecedesCallSibling(node, child.text, undefined),
       });
     } else if (t === 'member_expression') {
       // @Foo.bar — emit as reflection; always mark dynamic since it's decorator dispatch
@@ -1874,7 +1896,7 @@ function handleDecorator(node: TreeSitterNode, calls: Call[]): void {
           ...callInfo,
           dynamic: true,
           dynamicKind: 'reflection',
-          outOfOrder: decoratorPrecedesCallSibling(node, callInfo.name),
+          outOfOrder: decoratorPrecedesCallSibling(node, callInfo.name, callInfo.receiver),
         });
       }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -560,6 +560,30 @@ export interface Call {
   dynamicKind?: DynamicKind;
   /** Raw key/arg text — used for diagnostics and future RES-1 const-string resolution. */
   keyExpr?: string;
+  /**
+   * True when this entry's true source position is known to be EARLIER than a
+   * sibling call this extractor already recorded for the same target — even
+   * though `line` collides with (or, on the query path, this entry was
+   * appended to `calls` after) that sibling's entry, so array order alone
+   * doesn't reflect that.
+   *
+   * Only set by the JS/TS extractor's bare-decorator handling
+   * (`handleDecorator`): a bare decorator (`@Log`) and its call-expression
+   * sibling (`@Log()`) share one `line`, and on the query path
+   * (`extractSymbolsQuery`) the bare form is always collected by a
+   * supplementary walk pass that runs after — and therefore appends after —
+   * the main query-match loop that collects call expressions, regardless of
+   * which one is textually first (#1683). This flag is computed directly from
+   * sibling AST position at extraction time (see `decoratorPrecedesCallSibling`)
+   * so it is accurate for both textual orderings (`@Log @Log()` vs
+   * `@Log() @Log`), not merely "collected in the walk pass".
+   *
+   * Consumed by `emitDirectCallEdgesForCall` (build-edges.ts) to loosen its
+   * dyn=0→dyn=1 upgrade guard from strict `<` to `<=` only for entries that
+   * carry this flag — keeping strict `<` for ordinary query-phase entries
+   * (`.call`/`.apply`/`.bind`) so #1687 stays fixed (#2029).
+   */
+  outOfOrder?: boolean;
 }
 
 /** An import statement detected by an extractor. */

--- a/tests/integration/issue-2029-same-line-decorator-upgrade.test.ts
+++ b/tests/integration/issue-2029-same-line-decorator-upgrade.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Engine-parity tests for the same-line decorator upgrade gap in
+ * `emitDirectCallEdgesForCall`'s dyn=0 → dyn=1 dedup (#2029).
+ *
+ * BACKGROUND
+ * ──────────
+ * #1778 fixed the dedup-collision upgrade path to compare source lines
+ * (`callLine < dynZeroEntry.line`) rather than upgrading unconditionally —
+ * see issue-1778-reflection-dynamic-kind-parity.test.ts. That comparison is
+ * strict, so it only helps when the two calls land on DIFFERENT lines. When a
+ * bare decorator and its call-expression sibling share the exact same line
+ * (`@Log @Log() class Foo {}`), the query path's two-phase collection still
+ * records `@Log()` (dyn=0) before the bare `@Log` (dyn=1) — `line < line` is
+ * false, so the upgrade never fires and WASM keeps dyn=0 where native (a
+ * single source-order pass) keeps dyn=1.
+ *
+ * FIX (#2029)
+ * ───────────
+ * The extractor now tags each bare-decorator Call with `outOfOrder` — computed
+ * directly from AST sibling position (`decoratorPrecedesCallSibling` in
+ * javascript.ts), not merely "collected by the walk pass" — so it is correct
+ * for BOTH textual orderings of a stacked bare/call decorator pair.
+ * `emitDirectCallEdgesForCall` only loosens its guard to `<=` when that flag
+ * is set, leaving every other dynamicKind (`.call`/`.apply`/`.bind`) on the
+ * strict `<` that #1687 depends on — including the same-line variant of that
+ * bug, which must still collapse to dyn=0.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterEach, describe, expect, it } from 'vitest';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+
+const ENGINES = ['wasm', 'native'] as const;
+
+interface CallEdgeRow {
+  source: string;
+  target: string;
+  confidence: number;
+  dynamic: number;
+}
+
+function writeFixture(baseDir: string, files: Record<string, string>): void {
+  for (const [rel, content] of Object.entries(files)) {
+    const fullPath = path.join(baseDir, rel);
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+    fs.writeFileSync(fullPath, content);
+  }
+}
+
+function readCallEdgesTo(dbPath: string, targetName: string): CallEdgeRow[] {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return db
+      .prepare(
+        `SELECT n1.name AS source, n2.name AS target, e.confidence, e.dynamic
+         FROM edges e
+         JOIN nodes n1 ON e.source_id = n1.id
+         JOIN nodes n2 ON e.target_id = n2.id
+         WHERE e.kind = 'calls' AND n2.name = ?
+         ORDER BY n1.name`,
+      )
+      .all(targetName) as CallEdgeRow[];
+  } finally {
+    db.close();
+  }
+}
+
+let tmpDirs: string[] = [];
+afterEach(() => {
+  for (const d of tmpDirs) {
+    try {
+      fs.rmSync(d, { recursive: true, force: true });
+    } catch {
+      /* ignore cleanup races */
+    }
+  }
+  tmpDirs = [];
+});
+
+async function buildAndReadEdgesTo(
+  files: Record<string, string>,
+  engine: 'wasm' | 'native',
+  targetName: string,
+): Promise<CallEdgeRow[]> {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2029-${engine}-`));
+  tmpDirs.push(tmpDir);
+  writeFixture(tmpDir, files);
+  await buildGraph(tmpDir, { engine, incremental: false, skipRegistry: true });
+  return readCallEdgesTo(path.join(tmpDir, '.codegraph', 'graph.db'), targetName);
+}
+
+describe('#2029: same-line decorator upgrade gap — engine parity', () => {
+  it.each(ENGINES)(
+    '%s: bare decorator immediately followed by its call-expression form on the SAME line upgrades to dyn=1',
+    async (engine) => {
+      // True source order: bare `@Log` (dyn=1) genuinely precedes `@Log()`
+      // (dyn=0) — native keeps dyn=1 via first-recorded-wins. WASM's query
+      // path collects `@Log()` first regardless (phase separation), so the
+      // upgrade must fire even though both share line 3.
+      const edges = await buildAndReadEdgesTo(
+        {
+          'index.ts': [
+            'export function Log(target: unknown): void {}',
+            '',
+            '@Log @Log() class Foo {}',
+            '',
+          ].join('\n'),
+        },
+        engine,
+        'Log',
+      );
+      expect(edges).toHaveLength(1);
+      expect(edges[0].dynamic).toBe(1);
+    },
+  );
+
+  it.each(ENGINES)(
+    '%s: call-expression decorator immediately followed by its bare form on the SAME line stays dyn=0',
+    async (engine) => {
+      // Mirror of the case above with the two decorators swapped: true source
+      // order now has `@Log()` (dyn=0) genuinely FIRST and the bare `@Log`
+      // (dyn=1) genuinely SECOND — native's first-recorded-wins keeps dyn=0,
+      // and the fix's AST-sibling-position check must recognize this ordering
+      // and NOT upgrade, even though both still share one line.
+      const edges = await buildAndReadEdgesTo(
+        {
+          'index.ts': [
+            'export function Log(target: unknown): void {}',
+            '',
+            '@Log() @Log class Foo {}',
+            '',
+          ].join('\n'),
+        },
+        engine,
+        'Log',
+      );
+      expect(edges).toHaveLength(1);
+      expect(edges[0].dynamic).toBe(0);
+    },
+  );
+
+  it.each(ENGINES)(
+    '%s: direct f() followed by f.call({}) on the SAME line still dedups to a single dyn=0 edge (#1687 same-line variant)',
+    async (engine) => {
+      // The same-line variant of #1687's regression guard: f() and f.call({})
+      // are ordinary call_expressions collected in the same query phase, so
+      // true source order is already preserved — the later reflection-style
+      // reference to the same target must not flip the edge to dyn=1.
+      const edges = await buildAndReadEdgesTo(
+        { 'index.js': ['function f() {}', 'f(); f.call({});', ''].join('\n') },
+        engine,
+        'f',
+      );
+      expect(edges).toHaveLength(1);
+      expect(edges[0].dynamic).toBe(0);
+    },
+  );
+});

--- a/tests/integration/issue-2029-same-line-decorator-upgrade.test.ts
+++ b/tests/integration/issue-2029-same-line-decorator-upgrade.test.ts
@@ -24,14 +24,22 @@
  * is set, leaving every other dynamicKind (`.call`/`.apply`/`.bind`) on the
  * strict `<` that #1687 depends on — including the same-line variant of that
  * bug, which must still collapse to dyn=0.
+ *
+ * REVIEW FOLLOW-UP: `decoratorPrecedesCallSibling` must compare a sibling's
+ * FULL callee identity (name AND receiver), not just the tail property name —
+ * otherwise an unrelated qualified decorator sharing only a tail name (e.g.
+ * `@B.Log()` vs `@C.Log()`) could be mistaken for the same callee as a middle
+ * bare decorator (`@A.Log`), wrongly marking it out of order. See the
+ * `decoratorCallExprIdentity` unit tests below.
  */
 
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import Database from 'better-sqlite3';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { buildGraph } from '../../src/domain/graph/builder.js';
+import { createParsers, extractSymbols } from '../../src/domain/parser.js';
 
 const ENGINES = ['wasm', 'native'] as const;
 
@@ -158,4 +166,45 @@ describe('#2029: same-line decorator upgrade gap — engine parity', () => {
       expect(edges[0].dynamic).toBe(0);
     },
   );
+});
+
+describe('#2029: decoratorPrecedesCallSibling — receiver-aware sibling matching', () => {
+  let parsers: any;
+
+  beforeAll(async () => {
+    parsers = await createParsers();
+  });
+
+  function parseTS(code: string) {
+    const parser = parsers.get('typescript');
+    const tree = parser.parse(code);
+    return extractSymbols(tree, 'test.ts');
+  }
+
+  it('does not mark a bare decorator out of order because of an unrelated later decorator sharing only its tail name', () => {
+    // `@B.Log() @A.Log @C.Log() class Foo {}` — three qualified decorators
+    // sharing the tail name "Log" but with three DIFFERENT receivers (A, B,
+    // C). The middle bare `@A.Log`'s real callee is `{name: 'Log', receiver:
+    // 'A'}` — neither `@B.Log()` (receiver B, precedes it) nor `@C.Log()`
+    // (receiver C, follows it) targets that callee. Matching on the tail name
+    // "Log" alone would wrongly treat the later `@C.Log()` as proof `@A.Log`
+    // is out of order.
+    const symbols = parseTS(['@B.Log() @A.Log @C.Log() class Foo {}', ''].join('\n'));
+    const bareA = symbols.calls.find(
+      (c) => c.name === 'Log' && c.receiver === 'A' && c.dynamicKind === 'reflection',
+    );
+    expect(bareA).toBeDefined();
+    expect(bareA?.outOfOrder).toBe(false);
+  });
+
+  it('still marks a qualified bare decorator out of order when a later sibling targets the exact same callee (name AND receiver)', () => {
+    // `@A.Log @A.Log() class Foo {}` — the genuine #2029 scenario through a
+    // qualified (member-expression) decorator: same receiver AND name.
+    const symbols = parseTS(['@A.Log @A.Log() class Foo {}', ''].join('\n'));
+    const bareA = symbols.calls.find(
+      (c) => c.name === 'Log' && c.receiver === 'A' && c.dynamicKind === 'reflection',
+    );
+    expect(bareA).toBeDefined();
+    expect(bareA?.outOfOrder).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

Closes #2029.

`emitDirectCallEdgesForCall` (build-edges.ts) gates the dyn=0→dyn=1 upgrade for a dynamicKind-tagged call referring to an already-recorded target on `callLine < dynZeroEntry.line` — the incoming call must be strictly *earlier* than the recorded one. When a bare decorator and its call-expression sibling share the exact same line (`@Log @Log() class Foo {}`), the query path collects `@Log()` first (dyn=0) and the bare `@Log` afterward (dyn=1, dynamicKind='reflection') — both on line N, so `N < N` is false and the upgrade never fires, diverging from native's single-pass source-order walk (which correctly keeps dyn=1).

A naive `<=` fix would reintroduce #1687 for the symmetric same-line case `f(); f.call({});`, since `.call/.apply/.bind` are collected in the *same* query phase as the direct call (unlike decorators) — a later-or-equal-line reflection call there is a genuinely separate reference and must stay dyn=0.

## Fix

- Added `Call.outOfOrder` (`src/types.ts`) — an optional flag meaning "this entry's true source position is confirmed earlier than a sibling call already recorded for the same target, even though `line` collides or array order says otherwise."
- The JS/TS extractor's `handleDecorator` now computes this flag via a new `decoratorPrecedesCallSibling` helper, which walks `nextSibling` from the bare decorator node to check whether a *later* sibling decorator wraps a call_expression targeting the same callee name — a direct AST-position check, not merely "collected in the walk pass."
- `emitDirectCallEdgesForCall` loosens its guard to `<=` only when `outOfOrder` is set on the incoming call, keeping strict `<` for every other dynamicKind (`.call`/`.apply`/`.bind` included).

This is more precise than a blanket "collected in walk-phase → use `<=`" tag: that naive version would fix `@Log @Log()` but *regress* the reversed ordering `@Log() @Log` (call genuinely first, bare genuinely second) — verified locally by temporarily reverting to the blanket approach and watching that exact test fail. The AST-sibling check distinguishes both orderings correctly because it reads true source position directly, not inferred from processing order.

## Native engine

No changes needed. `handle_decorator` in `crates/codegraph-core/src/extractors/javascript.rs` is dispatched from the same single-pass `match_js_node` walk as `call_expression`, so native calls are always collected in true source order — the whole two-phase-collection artifact this issue describes is WASM/query-path-specific. `emit_call_edges` in `build_edges.rs` has no upgrade path at all (plain first-recorded-wins), confirming native was never affected.

## Testing

- New `tests/integration/issue-2029-same-line-decorator-upgrade.test.ts` (engine-parity, wasm+native):
  - `@Log @Log() class Foo {}` → upgrades to dyn=1 (matches native).
  - `@Log() @Log class Foo {}` (reversed) → stays dyn=0 (matches native; regression guard for the naive-fix failure mode above).
  - `f(); f.call({});` on one line → stays dyn=0 (#1687 same-line variant, not regressed).
- Full suite: `npm run lint`, `npm test` (270 files / 4358 tests passing), `cargo test --lib` (714 passing).
- `node scripts/parity-compare.mjs --hybrid` across javascript/typescript/tsx/pts-javascript/dynamic-javascript/dynamic-typescript fixtures: all engines identical.
- Resolution-benchmark suite (`tests/benchmarks/resolution/`): 317 tests passing, no precision/recall regressions.

## Test plan

- [x] `npm run lint`
- [x] `npm test`
- [x] `cargo test --lib`
- [x] `node scripts/parity-compare.mjs --hybrid`
- [x] `codegraph diff-impact --staged -T`