### PR TITLE
fix(extractors): recognize cross-file ES6 getter/setter accessor reads

### DIFF
--- a/crates/codegraph-core/src/db/connection.rs
+++ b/crates/codegraph-core/src/db/connection.rs
@@ -431,6 +431,16 @@ const MIGRATIONS: &[Migration] = &[
       UPDATE edges SET technique = 'cha' WHERE technique = 'cha-expanded';
     "#,
     },
+    Migration {
+        // Cross-file ES6 getter/setter accessor recognition (issue #2030,
+        // follow-up to #1893). Mirrors src/db/migrations.ts v27 — see that
+        // migration's comment for the rationale.
+        version: 27,
+        up: r#"
+      ALTER TABLE nodes ADD COLUMN accessor_kind TEXT;
+      CREATE INDEX IF NOT EXISTS idx_nodes_accessor_kind ON nodes(accessor_kind) WHERE accessor_kind IS NOT NULL;
+    "#,
+    },
 ];
 
 // ── napi types ──────────────────────────────────────────────────────────
@@ -788,6 +798,9 @@ impl NativeDatabase {
                             "legacy repair: add nodes.content_hash failed: {e}"
                         ))
                     })?;
+            }
+            if !has_column(conn, "nodes", "accessor_kind") {
+                let _ = conn.execute_batch("ALTER TABLE nodes ADD COLUMN accessor_kind TEXT");
             }
             let _ = conn.execute_batch(
                 "UPDATE nodes SET qualified_name = name WHERE qualified_name IS NULL",
@@ -1886,6 +1899,21 @@ mod tests {
                  UPDATE schema_version SET version = 25;",
             )
             .expect("simulating a pre-v26 database with a legacy edge should succeed");
+            // #2030 added migration v27 (a non-idempotent `ALTER TABLE ... ADD
+            // COLUMN`) after this test was written. Stamping schema_version
+            // back to 25 below replays every migration after it — including
+            // v27 — on the SECOND init_schema() call; the first call above
+            // already added `accessor_kind` once, so replaying v27 without
+            // also undoing it would hit "duplicate column name" (exactly the
+            // staleness failure mode the dynamic_kind/content_hash repair
+            // tests' doc comments already warn about). Drop it back out here,
+            // mirroring how those tests drop their own non-idempotent column
+            // before re-stamping.
+            conn.execute_batch(
+                "DROP INDEX IF EXISTS idx_nodes_accessor_kind; \
+                 ALTER TABLE nodes DROP COLUMN accessor_kind;",
+            )
+            .expect("simulating the pre-v27 state should succeed");
         }
 
         db.init_schema()

--- a/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
@@ -1209,6 +1209,7 @@ fn build_insert_batches(
                         end_line: d.end_line,
                         visibility: None,
                         content_hash: d.content_hash.clone(),
+                        accessor_kind: d.accessor_kind.clone(),
                         children: d
                             .children
                             .as_ref()
@@ -1409,7 +1410,7 @@ fn load_edge_node_set(
     }
 
     let sql = format!(
-        "SELECT n.id, n.name, n.kind, n.file, n.line FROM nodes n \
+        "SELECT n.id, n.name, n.kind, n.file, n.line, n.accessor_kind FROM nodes n \
          INNER JOIN temp._edge_files ef ON n.file = ef.file \
          WHERE n.{EDGE_NODE_KIND_FILTER}",
     );
@@ -1427,7 +1428,7 @@ fn load_edge_node_set(
 /// Load every candidate edge node from the DB (full-build path).
 fn load_all_edge_nodes(conn: &Connection) -> Vec<crate::domain::graph::builder::stages::build_edges::NodeInfo> {
     let sql = format!(
-        "SELECT id, name, kind, file, line FROM nodes WHERE {EDGE_NODE_KIND_FILTER}",
+        "SELECT id, name, kind, file, line, accessor_kind FROM nodes WHERE {EDGE_NODE_KIND_FILTER}",
     );
     match conn.prepare(&sql) {
         Ok(mut stmt) => stmt
@@ -1447,6 +1448,7 @@ fn read_edge_node_info(row: &rusqlite::Row) -> rusqlite::Result<crate::domain::g
         kind: row.get(2)?,
         file: row.get(3)?,
         line: row.get::<_, i64>(4)? as u32,
+        accessor_kind: row.get(5)?,
     })
 }
 
@@ -1778,6 +1780,7 @@ fn build_and_insert_call_edges(
                     receiver: c.receiver.clone(),
                     dynamic_kind: c.dynamic_kind.clone(),
                     key_expr: c.key_expr.clone(),
+                    accessor_read: c.accessor_read.clone(),
                 })
                 .collect(),
             imported_names,

--- a/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
@@ -605,7 +605,7 @@ fn emit_pts_alias_edges<'a>(
         let mut alias_confidence_override: Option<f64> = None;
         let mut alias_targets = resolve_call_targets(
             ctx, &alias_call, alias_ctx.rel_path, alias_imported_from, alias_ctx.type_map, alias_ctx.caller_name,
-            alias_ctx.imported_original_names, &mut alias_confidence_override,
+            alias_ctx.imported_names, alias_ctx.imported_original_names, &mut alias_confidence_override,
         );
         sort_targets_by_confidence(&mut alias_targets, alias_ctx.rel_path, alias_imported_from, alias_confidence_override);
         for t in &alias_targets {
@@ -966,8 +966,8 @@ fn process_file<'a>(
         // interface lookup missed — see `resolve_call_targets` doc comment.
         let mut confidence_override: Option<f64> = None;
         let mut targets = resolve_call_targets(
-            ctx, call, fc.rel_path, imported_from, &fc.type_map, caller_name, &fc.imported_original_names,
-            &mut confidence_override,
+            ctx, call, fc.rel_path, imported_from, &fc.type_map, caller_name, &fc.imported_names,
+            &fc.imported_original_names, &mut confidence_override,
         );
         // #1771/#1784: value-ref references (object-literal property values,
         // Lua builtin reassignment, `instanceof ClassName`) resolve against
@@ -1267,12 +1267,13 @@ fn resolve_call_targets<'a>(
     imported_from: Option<&str>,
     type_map: &HashMap<&str, (&str, f64)>,
     caller_name: &str,
+    imported_names: &HashMap<&str, &str>,
     imported_original_names: &HashMap<&str, &str>,
     confidence_override: &mut Option<f64>,
 ) -> Vec<&'a NodeInfo> {
     let targets = resolve_call_targets_core(
-        ctx, call, rel_path, imported_from, type_map, caller_name, imported_original_names,
-        confidence_override,
+        ctx, call, rel_path, imported_from, type_map, caller_name, imported_names,
+        imported_original_names, confidence_override,
     );
     if call.receiver.is_some() {
         return targets;
@@ -1293,6 +1294,7 @@ fn resolve_call_targets_core<'a>(
     imported_from: Option<&str>,
     type_map: &HashMap<&str, (&str, f64)>,
     caller_name: &str,
+    imported_names: &HashMap<&str, &str>,
     imported_original_names: &HashMap<&str, &str>,
     confidence_override: &mut Option<f64>,
 ) -> Vec<&'a NodeInfo> {
@@ -1319,7 +1321,34 @@ fn resolve_call_targets_core<'a>(
     // to prevent. Mirrors resolveCallTargets in call-resolver.ts.
     if let Some(ref needed_kind) = call.accessor_read {
         let Some(receiver) = call.receiver.as_deref() else { return vec![] };
-        let qualified = format!("{}.{}", receiver, call.name);
+        // The resolved class name can itself be a renamed import binding
+        // (`import { Original as Alias }` — the extractor's type_map only
+        // knows the local alias), so de-alias before building the qualified
+        // lookup key exactly like the general cascade below does (#1730).
+        let dealiased_class_name = imported_original_names.get(receiver).copied().unwrap_or(receiver);
+        let qualified = format!("{}.{}", dealiased_class_name, call.name);
+        // When the class is a known import, commit to the specific file it
+        // resolves to rather than falling through to the unscoped global
+        // lookup below — otherwise an unrelated same-qualified-name accessor
+        // in a completely different file could "confirm" a read it has
+        // nothing to do with, whenever two files coincidentally declare the
+        // same class+property name pair. This scoped result is authoritative:
+        // an empty (or wrong-kind) match here means "no", not "keep looking
+        // elsewhere" — the unscoped global fallback below is reserved for
+        // when the class isn't a known import in this file at all (e.g. an
+        // ambient/global type).
+        if let Some(accessor_imported_from) = imported_names.get(dealiased_class_name) {
+            return ctx
+                .nodes_by_name_and_file
+                .get(&(qualified.as_str(), *accessor_imported_from))
+                .map(|v| {
+                    v.iter()
+                        .filter(|n| n.accessor_kind.as_deref() == Some(needed_kind.as_str()))
+                        .copied()
+                        .collect()
+                })
+                .unwrap_or_default();
+        }
         return ctx
             .nodes_by_name
             .get(qualified.as_str())
@@ -3486,6 +3515,115 @@ mod call_edge_tests {
             edges.iter().map(|e| (&e.kind, e.source_id, e.target_id)).collect::<Vec<_>>()
         );
         assert_eq!(call_edges[0].target_id, 3, "expected the setter (id=3), not the getter");
+    }
+
+    /// Regression for #2030's Greptile review finding: the resolved class
+    /// name on an accessor-read-tagged call can itself be a renamed import
+    /// binding (`import { SqliteRepository as SR } from './sqlite-repository.js'`),
+    /// so `call.receiver` is the local alias 'SR' — the accessor is
+    /// persisted under the real declared name. Must de-alias before the
+    /// qualified lookup, mirroring #1730's general-cascade de-aliasing.
+    #[test]
+    fn cross_file_accessor_read_dealiases_renamed_import_binding() {
+        let all_nodes = vec![
+            node(1, "useRepo", "function", "consumer.js", 1),
+            accessor_node(2, "SqliteRepository.db", "method", "sqlite-repository.js", 3, "get"),
+        ];
+        let mut file = make_file(
+            "consumer.js",
+            10,
+            vec![def("useRepo", "function", 1, 3)],
+            vec![accessor_call("db", 2, "SR", "get")],
+            vec![],
+            vec![],
+        );
+        file.imported_names = vec![ImportedName {
+            name: "SR".to_string(),
+            file: "sqlite-repository.js".to_string(),
+            imported: Some("SqliteRepository".to_string()),
+        }];
+
+        let edges = build_call_edges(vec![file], all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+
+        let call_edge = edges.iter().find(|e| e.kind == "calls");
+        assert!(
+            call_edge.is_some(),
+            "expected the renamed-import alias to resolve to the real accessor; got: {:?}",
+            edges.iter().map(|e| (&e.kind, e.source_id, e.target_id)).collect::<Vec<_>>()
+        );
+        assert_eq!(call_edge.unwrap().target_id, 2);
+    }
+
+    /// Regression for #2030's Greptile review finding: when the resolved
+    /// class name is a known import, resolution must commit to that specific
+    /// file rather than falling through to the unscoped global name map —
+    /// otherwise an unrelated file that happens to declare the same
+    /// `ClassName.prop` accessor (same kind) would also match.
+    #[test]
+    fn cross_file_accessor_read_prefers_imported_file_over_unrelated_same_named_global_match() {
+        let all_nodes = vec![
+            node(1, "useRepo", "function", "consumer.js", 1),
+            accessor_node(2, "SqliteRepository.db", "method", "sqlite-repository.js", 3, "get"),
+            accessor_node(3, "SqliteRepository.db", "method", "unrelated-other-file.js", 9, "get"),
+        ];
+        let mut file = make_file(
+            "consumer.js",
+            10,
+            vec![def("useRepo", "function", 1, 3)],
+            vec![accessor_call("db", 2, "SqliteRepository", "get")],
+            vec![],
+            vec![],
+        );
+        file.imported_names = vec![ImportedName {
+            name: "SqliteRepository".to_string(),
+            file: "sqlite-repository.js".to_string(),
+            imported: None,
+        }];
+
+        let edges = build_call_edges(vec![file], all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+
+        let call_edges: Vec<_> = edges.iter().filter(|e| e.kind == "calls").collect();
+        assert_eq!(
+            call_edges.len(),
+            1,
+            "expected exactly one calls edge (to the imported file's accessor only); got: {:?}",
+            edges.iter().map(|e| (&e.kind, e.source_id, e.target_id)).collect::<Vec<_>>()
+        );
+        assert_eq!(call_edges[0].target_id, 2, "expected the imported file's node (id=2), not the unrelated one (id=3)");
+    }
+
+    /// Companion to the above: when the imported file's own accessor doesn't
+    /// match the needed kind, the call must be dropped outright — never fall
+    /// back to an unrelated global match of the right kind in a different
+    /// file, even though one exists.
+    #[test]
+    fn cross_file_accessor_read_drops_when_imported_file_kind_mismatches_without_global_fallback() {
+        let all_nodes = vec![
+            node(1, "useRepo", "function", "consumer.js", 1),
+            accessor_node(2, "SqliteRepository.db", "method", "sqlite-repository.js", 3, "set"),
+            accessor_node(3, "SqliteRepository.db", "method", "unrelated-other-file.js", 9, "get"),
+        ];
+        let mut file = make_file(
+            "consumer.js",
+            10,
+            vec![def("useRepo", "function", 1, 3)],
+            vec![accessor_call("db", 2, "SqliteRepository", "get")],
+            vec![],
+            vec![],
+        );
+        file.imported_names = vec![ImportedName {
+            name: "SqliteRepository".to_string(),
+            file: "sqlite-repository.js".to_string(),
+            imported: None,
+        }];
+
+        let edges = build_call_edges(vec![file], all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+
+        assert!(
+            !edges.iter().any(|e| e.kind == "calls"),
+            "expected no calls edge — the imported file has only a setter, and the unrelated global getter must not be used as a fallback; got: {:?}",
+            edges.iter().map(|e| (&e.kind, e.source_id, e.target_id)).collect::<Vec<_>>()
+        );
     }
 
     /// Issue #1895: an object-literal-property value-ref call whose property

--- a/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
@@ -1337,7 +1337,14 @@ fn resolve_call_targets_core<'a>(
         // elsewhere" — the unscoped global fallback below is reserved for
         // when the class isn't a known import in this file at all (e.g. an
         // ambient/global type).
-        if let Some(accessor_imported_from) = imported_names.get(dealiased_class_name) {
+        //
+        // `imported_names` is keyed by the *local* binding as written in this
+        // file's own import statement (`receiver` — e.g. "Alias" for
+        // `import { Original as Alias }`), not the de-aliased original name —
+        // looking it up under `dealiased_class_name` would always miss for a
+        // renamed import and silently fall through to the unscoped lookup
+        // this whole branch exists to avoid.
+        if let Some(accessor_imported_from) = imported_names.get(receiver) {
             return ctx
                 .nodes_by_name_and_file
                 .get(&(qualified.as_str(), *accessor_imported_from))
@@ -3525,9 +3532,17 @@ mod call_edge_tests {
     /// qualified lookup, mirroring #1730's general-cascade de-aliasing.
     #[test]
     fn cross_file_accessor_read_dealiases_renamed_import_binding() {
+        // A competing unrelated node with the identical qualified name in a
+        // different file is included deliberately: `imported_names` is keyed
+        // by the *local alias* ('SR'), not the de-aliased original
+        // ('SqliteRepository') — an earlier version of this fix looked it up
+        // under the de-aliased name, always missed, and silently fell through
+        // to the unscoped global lookup, which would have returned this
+        // unrelated node too (masked in a single-candidate test).
         let all_nodes = vec![
             node(1, "useRepo", "function", "consumer.js", 1),
             accessor_node(2, "SqliteRepository.db", "method", "sqlite-repository.js", 3, "get"),
+            accessor_node(3, "SqliteRepository.db", "method", "unrelated-other-file.js", 9, "get"),
         ];
         let mut file = make_file(
             "consumer.js",
@@ -3545,13 +3560,17 @@ mod call_edge_tests {
 
         let edges = build_call_edges(vec![file], all_nodes, vec![], MAX_SOLVER_ITERATIONS);
 
-        let call_edge = edges.iter().find(|e| e.kind == "calls");
-        assert!(
-            call_edge.is_some(),
-            "expected the renamed-import alias to resolve to the real accessor; got: {:?}",
+        let call_edges: Vec<_> = edges.iter().filter(|e| e.kind == "calls").collect();
+        assert_eq!(
+            call_edges.len(),
+            1,
+            "expected exactly one calls edge (to the aliased import's own file); got: {:?}",
             edges.iter().map(|e| (&e.kind, e.source_id, e.target_id)).collect::<Vec<_>>()
         );
-        assert_eq!(call_edge.unwrap().target_id, 2);
+        assert_eq!(
+            call_edges[0].target_id, 2,
+            "expected the imported file's node (id=2), not the unrelated one (id=3)"
+        );
     }
 
     /// Regression for #2030's Greptile review finding: when the resolved

--- a/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
@@ -38,6 +38,13 @@ pub struct NodeInfo {
     pub kind: String,
     pub file: String,
     pub line: u32,
+    /// `get`/`set` when this `method`-kind node is an ES6 accessor
+    /// declaration, `None` otherwise (issue #2030). Populated from the DB
+    /// `accessor_kind` column — see `loadNodes` in `build-edges.ts` (JS path)
+    /// and `load_all_edge_nodes`/`load_edge_node_set` in `pipeline.rs`
+    /// (native path) for the two SELECTs that populate this field.
+    #[napi(js_name = "accessorKind")]
+    pub accessor_kind: Option<String>,
 }
 
 #[napi(object)]
@@ -50,6 +57,11 @@ pub struct CallInfo {
     pub dynamic_kind: Option<String>,
     #[napi(js_name = "keyExpr")]
     pub key_expr: Option<String>,
+    /// Set on a synthetic property-read call to the accessor kind the read
+    /// requires — mirrors TS `Call.accessorRead` (issue #2030). See that
+    /// field's doc comment for the full rationale.
+    #[napi(js_name = "accessorRead")]
+    pub accessor_read: Option<String>,
 }
 
 #[napi(object)]
@@ -584,6 +596,7 @@ fn emit_pts_alias_edges<'a>(
             receiver: None,
             dynamic_kind: None,
             key_expr: None,
+            accessor_read: None,
         };
         // The CHA typed-dispatch fallback (#1949) only fires for a genuine
         // receiver; `alias_call` is always receiver-less (an alias name
@@ -1287,6 +1300,36 @@ fn resolve_call_targets_core<'a>(
     // so they never accidentally match a real symbol via name lookup.
     if call.name.starts_with("<dynamic:") {
         return vec![];
+    }
+
+    // #2030: a property-read call tagged with the accessor kind it needs
+    // carries its *resolved class name* as `receiver` (see
+    // handle_accessor_property_read in extractors/javascript.rs) — resolve
+    // directly against the qualified `receiver.name`, filtered to the DB's
+    // `accessor_kind` column. Deliberately bypasses the rest of this
+    // function's directory-proximity confidence scoring: kind-plus-exact-
+    // qualified-name match is a strictly stronger disambiguator than
+    // proximity (proximity exists only to arbitrate when nothing stronger is
+    // available — see resolve_exact_global_match for that precedent), and a
+    // real cross-file accessor can legitimately live many directories away
+    // from the read site. An unconfirmed candidate is dropped outright —
+    // never falls through to the general cascade below, which could
+    // otherwise resolve to an unrelated same-named non-accessor method/field,
+    // the exact false-positive class #1893's same-file registry was designed
+    // to prevent. Mirrors resolveCallTargets in call-resolver.ts.
+    if let Some(ref needed_kind) = call.accessor_read {
+        let Some(receiver) = call.receiver.as_deref() else { return vec![] };
+        let qualified = format!("{}.{}", receiver, call.name);
+        return ctx
+            .nodes_by_name
+            .get(qualified.as_str())
+            .map(|v| {
+                v.iter()
+                    .filter(|n| n.accessor_kind.as_deref() == Some(needed_kind.as_str()))
+                    .copied()
+                    .collect()
+            })
+            .unwrap_or_default();
     }
 
     // When the call site uses a renamed import binding (`import { X as Y }`),
@@ -3211,7 +3254,33 @@ mod call_edge_tests {
     use super::*;
 
     fn node(id: u32, name: &str, kind: &str, file: &str, line: u32) -> NodeInfo {
-        NodeInfo { id, name: name.to_string(), kind: kind.to_string(), file: file.to_string(), line }
+        NodeInfo {
+            id,
+            name: name.to_string(),
+            kind: kind.to_string(),
+            file: file.to_string(),
+            line,
+            accessor_kind: None,
+        }
+    }
+
+    /// Like [`node`], but with an explicit `accessor_kind` — for #2030 tests.
+    fn accessor_node(
+        id: u32,
+        name: &str,
+        kind: &str,
+        file: &str,
+        line: u32,
+        accessor_kind: &str,
+    ) -> NodeInfo {
+        NodeInfo {
+            id,
+            name: name.to_string(),
+            kind: kind.to_string(),
+            file: file.to_string(),
+            line,
+            accessor_kind: Some(accessor_kind.to_string()),
+        }
     }
 
     fn def(name: &str, kind: &str, line: u32, end_line: u32) -> DefInfo {
@@ -3232,6 +3301,20 @@ mod call_edge_tests {
             receiver: receiver.map(|s| s.to_string()),
             dynamic_kind: None,
             key_expr: None,
+            accessor_read: None,
+        }
+    }
+
+    /// Like [`call`], but tagged with `accessor_read` — for #2030 tests.
+    fn accessor_call(name: &str, line: u32, receiver: &str, accessor_read: &str) -> CallInfo {
+        CallInfo {
+            name: name.to_string(),
+            line,
+            dynamic: None,
+            receiver: Some(receiver.to_string()),
+            dynamic_kind: None,
+            key_expr: None,
+            accessor_read: Some(accessor_read.to_string()),
         }
     }
 
@@ -3306,6 +3389,103 @@ mod call_edge_tests {
         let re = receiver_edge.unwrap();
         assert_eq!(re.source_id, 1, "receiver edge source should be main (id=1)");
         assert_eq!(re.target_id, 2, "receiver edge target should be Calculator (id=2)");
+    }
+
+    // ── Cross-file ES6 accessor property-read resolution (#2030) ───────────
+
+    /// The issue's own repro shape: a property-read call tagged
+    /// `accessor_read: "get"` with `receiver` set to the *resolved class
+    /// name* (not a variable) must resolve to the matching accessor node
+    /// even when it lives many directories away from the caller — the
+    /// directory-proximity confidence gate the rest of the cascade relies on
+    /// must NOT apply here.
+    #[test]
+    fn cross_file_accessor_read_resolves_across_distant_directories() {
+        let all_nodes = vec![
+            node(1, "useRepo", "function", "src/features/sequence.js", 1),
+            accessor_node(2, "SqliteRepository.db", "method", "src/db/repository/sqlite.js", 3, "get"),
+        ];
+        let files = vec![make_file(
+            "src/features/sequence.js",
+            10,
+            vec![def("useRepo", "function", 1, 3)],
+            vec![accessor_call("db", 2, "SqliteRepository", "get")],
+            vec![],
+            vec![],
+        )];
+
+        let edges = build_call_edges(files, all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+
+        let call_edge = edges.iter().find(|e| e.kind == "calls");
+        assert!(
+            call_edge.is_some(),
+            "expected a calls edge to the cross-file accessor; got: {:?}",
+            edges.iter().map(|e| (&e.kind, e.source_id, e.target_id)).collect::<Vec<_>>()
+        );
+        let ce = call_edge.unwrap();
+        assert_eq!(ce.source_id, 1);
+        assert_eq!(ce.target_id, 2);
+    }
+
+    /// A plain (non-accessor) method sharing the exact qualified name must
+    /// NOT be matched by an `accessor_read`-tagged call — the whole point of
+    /// #2030's DB `accessor_kind` column is to rule this false positive out,
+    /// which #1893's same-file-only registry couldn't do across files.
+    #[test]
+    fn cross_file_accessor_read_does_not_match_plain_method_of_same_name() {
+        let all_nodes = vec![
+            node(1, "useThing", "function", "consumer.js", 1),
+            node(2, "Thing.value", "method", "thing.js", 3), // plain method, accessor_kind = None
+        ];
+        let files = vec![make_file(
+            "consumer.js",
+            10,
+            vec![def("useThing", "function", 1, 3)],
+            vec![accessor_call("value", 2, "Thing", "get")],
+            vec![],
+            vec![],
+        )];
+
+        let edges = build_call_edges(files, all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+
+        assert!(
+            !edges.iter().any(|e| e.kind == "calls"),
+            "an accessor-read call must never resolve to a plain (non-accessor) method; got: {:?}",
+            edges.iter().map(|e| (&e.kind, e.source_id, e.target_id)).collect::<Vec<_>>()
+        );
+    }
+
+    /// When a property declares both a getter and setter (two distinct
+    /// nodes sharing the same qualified name, one accessor_kind="get" and
+    /// the other "set"), an accessor_read-tagged call must resolve to
+    /// exactly the one matching its own needed kind — never both, never the
+    /// wrong one.
+    #[test]
+    fn cross_file_accessor_read_disambiguates_get_and_set_pair() {
+        let all_nodes = vec![
+            node(1, "useToggle", "function", "consumer.js", 1),
+            accessor_node(2, "Toggle.flag", "method", "toggle.js", 3, "get"),
+            accessor_node(3, "Toggle.flag", "method", "toggle.js", 6, "set"),
+        ];
+        let files = vec![make_file(
+            "consumer.js",
+            10,
+            vec![def("useToggle", "function", 1, 3)],
+            vec![accessor_call("flag", 2, "Toggle", "set")],
+            vec![],
+            vec![],
+        )];
+
+        let edges = build_call_edges(files, all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+
+        let call_edges: Vec<_> = edges.iter().filter(|e| e.kind == "calls").collect();
+        assert_eq!(
+            call_edges.len(),
+            1,
+            "expected exactly one calls edge (to the setter only); got: {:?}",
+            edges.iter().map(|e| (&e.kind, e.source_id, e.target_id)).collect::<Vec<_>>()
+        );
+        assert_eq!(call_edges[0].target_id, 3, "expected the setter (id=3), not the getter");
     }
 
     /// Issue #1895: an object-literal-property value-ref call whose property
@@ -4124,7 +4304,7 @@ mod call_edge_tests {
                 // this() inside invoker
                 call("this", 2, None),
                 // invoker.call(handler, 10) — extractor emits dynamic call to invoker
-                CallInfo { name: "invoker".to_string(), line: 9, dynamic: Some(true), receiver: None, dynamic_kind: None, key_expr: None },
+                CallInfo { name: "invoker".to_string(), line: 9, dynamic: Some(true), receiver: None, dynamic_kind: None, key_expr: None, accessor_read: None },
             ],
             vec![],
             vec![],
@@ -4207,7 +4387,7 @@ mod call_edge_tests {
             vec![def("f3", "function", 1, 3), def("main", "function", 8, 10)],
             vec![
                 // eerest.e4() inside f3
-                CallInfo { name: "e4".to_string(), line: 2, dynamic: None, receiver: Some("eerest".to_string()), dynamic_kind: None, key_expr: None },
+                CallInfo { name: "e4".to_string(), line: 2, dynamic: None, receiver: Some("eerest".to_string()), dynamic_kind: None, key_expr: None, accessor_read: None },
                 call("f3", 9, None),
             ],
             vec![],

--- a/crates/codegraph-core/src/domain/graph/builder/stages/import_edges.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/import_edges.rs
@@ -826,6 +826,7 @@ mod tests {
                     children: None,
                     bodyless: None,
                     content_hash: None,
+                    accessor_kind: None,
                 })
                 .collect(),
             imports,

--- a/crates/codegraph-core/src/domain/graph/builder/stages/insert_nodes.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/insert_nodes.rs
@@ -40,6 +40,11 @@ pub struct InsertNodesDefinition {
     pub visibility: Option<String>,
     #[serde(default, rename = "contentHash")]
     pub content_hash: Option<String>,
+    /// `get`/`set` when this `method`-kind definition is an ES6 accessor
+    /// (issue #2030, follow-up to #1893) — mirrors TS
+    /// `InsertNodesBatch.definitions[].accessorKind`.
+    #[serde(default, rename = "accessorKind")]
+    pub accessor_kind: Option<String>,
     #[serde(default)]
     pub children: Vec<InsertNodesChild>,
 }
@@ -146,8 +151,8 @@ fn insert_file_nodes(
 ) -> rusqlite::Result<()> {
     let mut stmt = tx.prepare_cached(
         "INSERT OR IGNORE INTO nodes \
-         (name, kind, file, line, end_line, parent_id, qualified_name, scope, visibility, content_hash) \
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+         (name, kind, file, line, end_line, parent_id, qualified_name, scope, visibility, content_hash, accessor_kind) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
     )?;
 
     for batch in batches {
@@ -162,6 +167,7 @@ fn insert_file_nodes(
             None::<&str>,
             None::<&str>,
             None::<&str>,
+            None::<&str>,
             None::<&str>
         ])?;
 
@@ -172,6 +178,7 @@ fn insert_file_nodes(
             // serialises None as SQL NULL unambiguously (#709).
             let vis = def.visibility.as_deref();
             let content_hash = def.content_hash.as_deref();
+            let accessor_kind = def.accessor_kind.as_deref();
             stmt.execute(params![
                 &def.name,
                 &def.kind,
@@ -182,7 +189,8 @@ fn insert_file_nodes(
                 &def.name,
                 scope,
                 vis,
-                content_hash
+                content_hash,
+                accessor_kind
             ])?;
         }
 
@@ -196,6 +204,7 @@ fn insert_file_nodes(
                 None::<u32>,
                 None::<i64>,
                 &exp.name,
+                None::<&str>,
                 None::<&str>,
                 None::<&str>,
                 None::<&str>
@@ -234,8 +243,8 @@ fn insert_symbol_nodes(
             tx.prepare_cached("SELECT id, name, kind, line FROM nodes WHERE file = ?1")?;
         let mut child_stmt = tx.prepare_cached(
             "INSERT OR IGNORE INTO nodes \
-             (name, kind, file, line, end_line, parent_id, qualified_name, scope, visibility, content_hash) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+             (name, kind, file, line, end_line, parent_id, qualified_name, scope, visibility, content_hash, accessor_kind) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
         )?;
 
         for batch in batches {
@@ -270,7 +279,8 @@ fn insert_symbol_nodes(
                         &qname,
                         &def.name,
                         child_vis,
-                        child_content_hash
+                        child_content_hash,
+                        None::<&str>
                     ])?;
                 }
             }

--- a/crates/codegraph-core/src/domain/parallel.rs
+++ b/crates/codegraph-core/src/domain/parallel.rs
@@ -161,6 +161,7 @@ mod tests {
             children: None,
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         }
     }
 

--- a/crates/codegraph-core/src/extractors/bash.rs
+++ b/crates/codegraph-core/src/extractors/bash.rs
@@ -32,6 +32,7 @@ fn match_bash_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth
                     children: None,
                     bodyless: None,
                     content_hash: None,
+                    accessor_kind: None,
                 });
             }
         }

--- a/crates/codegraph-core/src/extractors/c.rs
+++ b/crates/codegraph-core/src/extractors/c.rs
@@ -195,6 +195,7 @@ fn match_c_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: u
                     children: opt_children(children),
                     bodyless: None,
                     content_hash: None,
+                    accessor_kind: None,
                 });
             }
         }
@@ -216,6 +217,7 @@ fn match_c_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: u
                     children: opt_children(children),
                     bodyless: None,
                     content_hash: None,
+                    accessor_kind: None,
                 });
             }
         }
@@ -236,6 +238,7 @@ fn match_c_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: u
                     children: opt_children(children),
                     bodyless: None,
                     content_hash: None,
+                    accessor_kind: None,
                 });
             }
         }
@@ -254,6 +257,7 @@ fn match_c_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: u
                     children: opt_children(children),
                     bodyless: None,
                     content_hash: None,
+                    accessor_kind: None,
                 });
             }
         }
@@ -284,6 +288,7 @@ fn match_c_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: u
                     children: None,
                     bodyless: None,
                     content_hash: None,
+                    accessor_kind: None,
                 });
             }
         }

--- a/crates/codegraph-core/src/extractors/clojure.rs
+++ b/crates/codegraph-core/src/extractors/clojure.rs
@@ -192,6 +192,7 @@ fn handle_ns_form(node: &Node, source: &[u8], symbols: &mut FileSymbols) -> Opti
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 
     // Scan for nested `(:require ...)`, `(:import ...)`, `(:use ...)` forms.
@@ -273,6 +274,7 @@ fn handle_def_form(
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -308,6 +310,7 @@ fn handle_defn_form(
         children: opt_children(params),
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -359,6 +362,7 @@ fn handle_defprotocol(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -378,6 +382,7 @@ fn handle_defrecord(node: &Node, source: &[u8], symbols: &mut FileSymbols, kind:
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 

--- a/crates/codegraph-core/src/extractors/cpp.rs
+++ b/crates/codegraph-core/src/extractors/cpp.rs
@@ -205,6 +205,7 @@ fn handle_cpp_function_definition(node: &Node, source: &[u8], symbols: &mut File
             children: opt_children(children),
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }
@@ -226,6 +227,7 @@ fn handle_cpp_class_specifier(node: &Node, source: &[u8], symbols: &mut FileSymb
             children: opt_children(children),
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
         extract_cpp_base_classes(node, source, &class_name, symbols);
     }
@@ -248,6 +250,7 @@ fn handle_cpp_struct_specifier(node: &Node, source: &[u8], symbols: &mut FileSym
             children: opt_children(children),
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
         extract_cpp_base_classes(node, source, &struct_name, symbols);
     }
@@ -267,6 +270,7 @@ fn handle_cpp_enum_specifier(node: &Node, source: &[u8], symbols: &mut FileSymbo
             children: opt_children(children),
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }
@@ -284,6 +288,7 @@ fn handle_cpp_namespace_definition(node: &Node, source: &[u8], symbols: &mut Fil
             children: None,
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }
@@ -313,6 +318,7 @@ fn handle_cpp_type_definition(node: &Node, source: &[u8], symbols: &mut FileSymb
             children: None,
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }

--- a/crates/codegraph-core/src/extractors/csharp.rs
+++ b/crates/codegraph-core/src/extractors/csharp.rs
@@ -63,6 +63,7 @@ fn handle_class_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: opt_children(children),
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
     extract_csharp_base_types(node, &class_name, source, symbols);
 }
@@ -81,6 +82,7 @@ fn handle_struct_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
     extract_csharp_base_types(node, &name, source, symbols);
 }
@@ -99,6 +101,7 @@ fn handle_record_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
     extract_csharp_base_types(node, &name, source, symbols);
 }
@@ -117,6 +120,7 @@ fn handle_interface_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
     if let Some(body) = node.child_by_field_name("body") {
         for i in 0..body.child_count() {
@@ -137,6 +141,7 @@ fn handle_interface_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
                     children: None,
                     bodyless: Some(child.child_by_field_name("body").is_none()),
                     content_hash: None,
+                    accessor_kind: None,
                 });
             }
         }
@@ -158,6 +163,7 @@ fn handle_enum_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             children: opt_children(children),
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }
@@ -182,6 +188,7 @@ fn handle_method_or_ctor(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
         children: opt_children(children),
         bodyless: Some(node.child_by_field_name("body").is_none()),
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -220,6 +227,7 @@ fn handle_property_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 

--- a/crates/codegraph-core/src/extractors/cuda.rs
+++ b/crates/codegraph-core/src/extractors/cuda.rs
@@ -364,6 +364,7 @@ fn handle_cuda_function_definition(node: &Node, source: &[u8], symbols: &mut Fil
             children: opt_children(children),
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }
@@ -386,6 +387,7 @@ fn handle_cuda_class_specifier(node: &Node, source: &[u8], symbols: &mut FileSym
             children: opt_children(children),
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
         extract_cuda_base_classes(node, source, &class_name, symbols);
     }
@@ -409,6 +411,7 @@ fn handle_cuda_struct_specifier(node: &Node, source: &[u8], symbols: &mut FileSy
             children: opt_children(children),
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }
@@ -427,6 +430,7 @@ fn handle_cuda_enum_specifier(node: &Node, source: &[u8], symbols: &mut FileSymb
             children: opt_children(children),
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }
@@ -444,6 +448,7 @@ fn handle_cuda_namespace_definition(node: &Node, source: &[u8], symbols: &mut Fi
             children: None,
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }
@@ -476,6 +481,7 @@ fn handle_cuda_type_definition(node: &Node, source: &[u8], symbols: &mut FileSym
             children: None,
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }

--- a/crates/codegraph-core/src/extractors/dart.rs
+++ b/crates/codegraph-core/src/extractors/dart.rs
@@ -94,6 +94,7 @@ fn handle_dart_class(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -152,6 +153,7 @@ fn extract_dart_class_methods(body: &Node, class_name: &str, source: &[u8], symb
                             children: None,
                             bodyless: None,
                             content_hash: None,
+                            accessor_kind: None,
                         });
                     }
                 }
@@ -208,6 +210,7 @@ fn handle_dart_enum(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -228,6 +231,7 @@ fn handle_dart_mixin(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -248,6 +252,7 @@ fn handle_dart_extension(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -268,6 +273,7 @@ fn handle_dart_function_sig(node: &Node, source: &[u8], symbols: &mut FileSymbol
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -331,6 +337,7 @@ fn handle_dart_type_alias(node: &Node, source: &[u8], symbols: &mut FileSymbols)
             children: None,
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }

--- a/crates/codegraph-core/src/extractors/elixir.rs
+++ b/crates/codegraph-core/src/extractors/elixir.rs
@@ -75,6 +75,7 @@ fn handle_defmodule(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: opt_children(children),
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -146,6 +147,7 @@ fn handle_def_function(node: &Node, source: &[u8], symbols: &mut FileSymbols, _k
         children: opt_children(params),
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -331,6 +333,7 @@ fn handle_defprotocol(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -355,6 +358,7 @@ fn handle_defimpl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 

--- a/crates/codegraph-core/src/extractors/erlang.rs
+++ b/crates/codegraph-core/src/extractors/erlang.rs
@@ -58,6 +58,7 @@ fn handle_module_attr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -101,6 +102,7 @@ fn handle_record_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: opt_children(children),
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -129,6 +131,7 @@ fn handle_type_alias(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -183,6 +186,7 @@ fn handle_function_clause(node: &Node, source: &[u8], symbols: &mut FileSymbols)
         children: opt_children(params),
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -254,6 +258,7 @@ fn handle_define(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 

--- a/crates/codegraph-core/src/extractors/fsharp.rs
+++ b/crates/codegraph-core/src/extractors/fsharp.rs
@@ -82,6 +82,7 @@ fn handle_named_module(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -114,6 +115,7 @@ fn handle_module_defn(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -163,6 +165,7 @@ fn handle_function_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: opt_children(params),
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -234,6 +237,7 @@ fn handle_type_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             children: opt_children(children),
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }
@@ -416,6 +420,7 @@ fn handle_value_definition(node: &Node, source: &[u8], symbols: &mut FileSymbols
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 

--- a/crates/codegraph-core/src/extractors/gleam.rs
+++ b/crates/codegraph-core/src/extractors/gleam.rs
@@ -51,6 +51,7 @@ fn handle_function(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: opt_children(params),
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -76,6 +77,7 @@ fn handle_external_function(node: &Node, source: &[u8], symbols: &mut FileSymbol
         children: opt_children(params),
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -145,6 +147,7 @@ fn handle_type_definition(node: &Node, source: &[u8], symbols: &mut FileSymbols)
         children: opt_children(children),
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -168,6 +171,7 @@ fn handle_type_alias(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -191,6 +195,7 @@ fn handle_constant(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 

--- a/crates/codegraph-core/src/extractors/go.rs
+++ b/crates/codegraph-core/src/extractors/go.rs
@@ -46,6 +46,7 @@ fn handle_function_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             children: opt_children(children),
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }
@@ -70,6 +71,7 @@ fn handle_method_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: opt_children(children),
         bodyless: Some(node.child_by_field_name("body").is_none()),
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -111,6 +113,7 @@ fn handle_type_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                     children: opt_children(children),
                     bodyless: None,
                     content_hash: None,
+                    accessor_kind: None,
                 });
             }
             "interface_type" => {
@@ -125,6 +128,7 @@ fn handle_type_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                     children: None,
                     bodyless: None,
                     content_hash: None,
+                    accessor_kind: None,
                 });
                 extract_go_interface_methods(&type_node, &name, source, symbols);
             }
@@ -140,6 +144,7 @@ fn handle_type_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                     children: None,
                     bodyless: None,
                     content_hash: None,
+                    accessor_kind: None,
                 });
             }
         }
@@ -162,6 +167,7 @@ fn extract_go_interface_methods(type_node: &Node, iface_name: &str, source: &[u8
                 children: None,
                 bodyless: Some(member.child_by_field_name("body").is_none()),
                 content_hash: None,
+                accessor_kind: None,
             });
         }
     }
@@ -183,6 +189,7 @@ fn handle_const_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                 children: None,
                 bodyless: None,
                 content_hash: None,
+                accessor_kind: None,
             });
         }
     }

--- a/crates/codegraph-core/src/extractors/groovy.rs
+++ b/crates/codegraph-core/src/extractors/groovy.rs
@@ -85,6 +85,7 @@ fn handle_class_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: opt_children(children),
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 
     // Superclass: `superclass` field wraps a `_type` child (type_identifier /
@@ -172,6 +173,7 @@ fn handle_interface_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 
     // `interface X extends Y, Z` — tree-sitter-groovy 0.1.x exposes parent
@@ -218,6 +220,7 @@ fn handle_enum_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: opt_children(members),
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -243,6 +246,7 @@ fn handle_method_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: opt_children(params),
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -266,6 +270,7 @@ fn handle_constructor_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols
         children: opt_children(params),
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -284,6 +289,7 @@ fn handle_function_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: opt_children(params),
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 

--- a/crates/codegraph-core/src/extractors/haskell.rs
+++ b/crates/codegraph-core/src/extractors/haskell.rs
@@ -50,6 +50,7 @@ fn handle_haskell_function(node: &Node, source: &[u8], symbols: &mut FileSymbols
         children: opt_children(params),
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -140,6 +141,7 @@ fn handle_haskell_bind(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -180,6 +182,7 @@ fn handle_haskell_data_type(node: &Node, source: &[u8], symbols: &mut FileSymbol
         children: opt_children(children),
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -200,6 +203,7 @@ fn handle_haskell_newtype(node: &Node, source: &[u8], symbols: &mut FileSymbols)
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -220,6 +224,7 @@ fn handle_haskell_type_synonym(node: &Node, source: &[u8], symbols: &mut FileSym
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -240,6 +245,7 @@ fn handle_haskell_class(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -260,6 +266,7 @@ fn handle_haskell_instance(node: &Node, source: &[u8], symbols: &mut FileSymbols
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 

--- a/crates/codegraph-core/src/extractors/hcl.rs
+++ b/crates/codegraph-core/src/extractors/hcl.rs
@@ -71,6 +71,7 @@ fn extract_block_attributes(node: &Node, source: &[u8]) -> Vec<Definition> {
                 children: None,
                 bodyless: None,
                 content_hash: None,
+                accessor_kind: None,
             });
         }
     }
@@ -128,6 +129,7 @@ fn match_hcl_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth:
                     children,
                     bodyless: None,
                     content_hash: None,
+                    accessor_kind: None,
                 });
                 if block_type == "module" {
                     extract_module_source(node, source, symbols);

--- a/crates/codegraph-core/src/extractors/helpers.rs
+++ b/crates/codegraph-core/src/extractors/helpers.rs
@@ -27,6 +27,7 @@ pub fn child_def(name: String, kind: &str, line: u32) -> Definition {
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     }
 }
 

--- a/crates/codegraph-core/src/extractors/java.rs
+++ b/crates/codegraph-core/src/extractors/java.rs
@@ -103,6 +103,7 @@ fn handle_class_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: opt_children(children),
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 
     // Superclass
@@ -159,6 +160,7 @@ fn handle_interface_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
     if let Some(body) = node.child_by_field_name("body") {
         for i in 0..body.child_count() {
@@ -176,6 +178,7 @@ fn handle_interface_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
                     children: None,
                     bodyless: Some(child.child_by_field_name("body").is_none()),
                     content_hash: None,
+                    accessor_kind: None,
                 });
             }
         }
@@ -197,6 +200,7 @@ fn handle_enum_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             children: opt_children(children),
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }
@@ -231,6 +235,7 @@ fn handle_method_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             children: opt_children(children),
             bodyless: Some(node.child_by_field_name("body").is_none()),
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }
@@ -255,6 +260,7 @@ fn handle_constructor_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols
             children: opt_children(children),
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }

--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -577,6 +577,7 @@ fn extract_object_literal_functions(
                             children: None,
                             bodyless: None,
                             content_hash: None,
+                            accessor_kind: None,
                         });
                         // Store qualified name as value so resolver looks up the qualified def.
                         symbols.type_map.push(TypeMapEntry {
@@ -626,6 +627,7 @@ fn extract_object_literal_functions(
                         children: opt_children(children),
                         bodyless: None,
                         content_hash: None,
+                        accessor_kind: None,
                     });
                 }
                 let body = child.child_by_field_name("body");
@@ -640,6 +642,7 @@ fn extract_object_literal_functions(
                     children: None,
                     bodyless: None,
                     content_hash: None,
+                    accessor_kind: None,
                 });
             }
             _ => {}
@@ -903,6 +906,7 @@ fn handle_js_prototype_assignment(lhs: &Node, rhs: &Node, source: &[u8], symbols
             children: opt_children(children),
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }
@@ -926,6 +930,7 @@ fn emit_js_prototype_method(class_name: &str, method_name: &str, rhs: &Node, sou
                 children: opt_children(children),
                 bodyless: None,
                 content_hash: None,
+                accessor_kind: None,
             });
         }
         "identifier" => {
@@ -959,6 +964,7 @@ fn extract_js_prototype_object_literal(class_name: &str, obj_node: &Node, source
                     children: opt_children(children),
                     bodyless: None,
                     content_hash: None,
+                    accessor_kind: None,
                 });
             }
             "shorthand_property_identifier" => {
@@ -1080,6 +1086,7 @@ fn handle_function_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             children: opt_children(children),
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }
@@ -1099,6 +1106,7 @@ fn handle_class_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: opt_children(children),
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 
     // Heritage: extends + implements
@@ -1193,6 +1201,11 @@ fn handle_method_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             None => method_name.to_string(),
         };
         let children = extract_js_parameters(node, source);
+        // #2030: persist which ES6 accessor kind (if any) this method is, so
+        // a global (whole-build) accessor registry can confirm cross-file
+        // property reads at resolution time — see
+        // handle_accessor_property_read below.
+        let accessor_kind = get_method_accessor_kind(node).map(|k| k.to_string());
         symbols.definitions.push(Definition {
             name: full_name,
             kind: "method".to_string(),
@@ -1204,11 +1217,12 @@ fn handle_method_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             children: opt_children(children),
             bodyless: None,
             content_hash: None,
+            accessor_kind,
         });
     }
 }
 
-// ── ES6 getter/setter property-read call attribution (#1893) ────────────────
+// ── ES6 getter/setter property-read call attribution (#1893, #2030) ────────
 //
 // A bare (non-call) property read/write on an ES6 `get`/`set` class accessor
 // (`obj.isReady`, no call parens) invokes the accessor function just as surely
@@ -1217,11 +1231,13 @@ fn handle_method_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 // callee, so accessor reads/writes never produced a `calls` edge at all.
 // Mirrors `collectAccessorPropertyRead` in `src/extractors/javascript.ts`.
 //
-// Scoped to the *same-file* case: `this.prop` inside one of the accessor's own
-// class's methods, or `varName.prop` where `varName`'s type (from this file's
-// own type_map) is a class also declared in this file. Cross-file accessor
-// reads (the accessor's class declared in a different file than the read
-// site) are not yet covered — see #2030.
+// Two confirmation tiers — see `handle_accessor_property_read`'s doc comment:
+//   1. Same-file (#1893): `this.prop`, or `varName.prop` where `varName`'s
+//      type is a class also declared in this file — confirmed directly via
+//      this file's own `local_accessors` registry below.
+//   2. Cross-file (#2030): `varName.prop` where the type isn't declared in
+//      this file — emitted as a tagged candidate for the resolver's global
+//      accessor-kind filter to confirm once every file's accessors are known.
 
 /// Per-property record of which accessor kinds a same-file class declares.
 #[derive(Default, Clone, Copy)]
@@ -1291,19 +1307,115 @@ fn collect_local_accessors(root: &Node, source: &[u8]) -> LocalAccessorRegistry 
     registry
 }
 
+/// #2030: within the truthy branch of `if (var_name instanceof ClassName) { ... }`
+/// (including `&&`-chained conditions), `var_name`'s narrowed runtime type is
+/// `ClassName` for the rest of that branch — more specific than whatever this
+/// file's type_map otherwise knows about `var_name` (e.g. a base-class
+/// parameter annotation). Lets a cross-file accessor declared only on the
+/// narrowed (concrete) subclass, not the wider declared type, still be
+/// recognized as the property read's target. Mirrors
+/// `findNarrowedInstanceofType` in `src/extractors/javascript.ts` — see that
+/// function's doc comment for the full rationale and scope limits.
+fn find_narrowed_instanceof_type(node: &Node, var_name: &str, source: &[u8]) -> Option<String> {
+    let mut current = *node;
+    let mut depth = 0;
+    while depth < MAX_WALK_DEPTH {
+        let parent = current.parent()?;
+        if parent.kind() == "if_statement" {
+            if let Some(consequence) = parent.child_by_field_name("consequence") {
+                if consequence.id() == current.id() {
+                    if let Some(condition) = parent.child_by_field_name("condition") {
+                        if let Some(narrowed) =
+                            find_instanceof_operand(&condition, var_name, source, 0)
+                        {
+                            return Some(narrowed);
+                        }
+                    }
+                }
+            }
+        }
+        current = parent;
+        depth += 1;
+    }
+    None
+}
+
+/// Search `node` (an `if_statement`'s condition) for an `instanceof` check on
+/// `var_name`, recursing through `&&` chains only — any other operator
+/// (`||`, `===`, ...) does not guarantee the instanceof check held, so
+/// narrowing stops there rather than risk a false positive. Mirrors
+/// `findInstanceofOperand` in `src/extractors/javascript.ts`.
+fn find_instanceof_operand(
+    node: &Node,
+    var_name: &str,
+    source: &[u8],
+    depth: usize,
+) -> Option<String> {
+    if depth >= MAX_WALK_DEPTH {
+        return None;
+    }
+    if node.kind() == "parenthesized_expression" {
+        let inner = node.named_child(0)?;
+        return find_instanceof_operand(&inner, var_name, source, depth + 1);
+    }
+    if node.kind() != "binary_expression" {
+        return None;
+    }
+    let operator_n = node.child_by_field_name("operator")?;
+    let operator = node_text(&operator_n, source);
+    let left = node.child_by_field_name("left");
+    let right = node.child_by_field_name("right");
+    if operator == "instanceof" {
+        let (Some(left), Some(right)) = (&left, &right) else { return None };
+        if left.kind() == "identifier"
+            && node_text(left, source) == var_name
+            && right.kind() == "identifier"
+        {
+            return Some(node_text(right, source).to_string());
+        }
+        return None;
+    }
+    if operator == "&&" {
+        if let Some(left) = &left {
+            if let Some(found) = find_instanceof_operand(left, var_name, source, depth + 1) {
+                return Some(found);
+            }
+        }
+        if let Some(right) = &right {
+            if let Some(found) = find_instanceof_operand(right, var_name, source, depth + 1) {
+                return Some(found);
+            }
+        }
+    }
+    None
+}
+
 /// Detect a bare (non-call) `this.prop` / `varName.prop` member-expression
-/// that reads or writes a same-file accessor property, and record it as an
+/// that reads or writes an ES6 accessor property, and record it as an
 /// ordinary `Call` — indistinguishable from a real
 /// `this.prop()`/`varName.prop()` call site, so it flows through the existing
 /// (unchanged) call-resolution cascade.
 ///
 /// A plain assignment (`obj.prop = value`) invokes the setter; every other
 /// bare usage (reads, compound-assignment targets, etc.) invokes the getter.
-/// When a property declares *both* a getter and a setter, the two accessors
-/// share the same qualified name and resolution has no way to tell them
-/// apart — rather than risk an edge to the wrong one, that case is skipped
-/// entirely (mirrors the "ambiguous → drop rather than fan out" precedent
-/// used elsewhere in call resolution).
+///
+/// Two confirmation tiers — mirrors `collectAccessorPropertyRead` in
+/// `src/extractors/javascript.ts`:
+///   1. Same-file (#1893): `class_name` is declared in this file, so
+///      `local_accessors` can confirm (or rule out) the accessor directly.
+///      A property declaring *both* a getter and a setter is skipped
+///      entirely here (mirrors the "ambiguous → drop rather than fan out"
+///      precedent used elsewhere in call resolution).
+///   2. Cross-file (#2030): `class_name` isn't declared in this file (a
+///      `this` receiver's class always is, so this tier only ever applies to
+///      a `var_name.prop` identifier receiver) — emitted anyway, tagged with
+///      `accessor_read`, deferring confirmation to the resolver's global
+///      accessor-kind filter. `receiver` carries the *resolved class name*
+///      here (not the read site's variable text) for the same reason given
+///      in the TS mirror: resolution must look up the qualified
+///      `class_name.prop_name` directly, since re-deriving the type from
+///      type_map would only recover the wider declared type for a narrowed
+///      variable, never the narrowed one.
 fn handle_accessor_property_read(
     node: &Node,
     source: &[u8],
@@ -1330,27 +1442,6 @@ fn handle_accessor_property_read(
     }
     let prop_name = node_text(&prop_node, source);
 
-    let (receiver, class_name): (String, Option<String>) = match obj.kind() {
-        "this" => ("this".to_string(), find_parent_class(node, source)),
-        "identifier" => {
-            let obj_name = node_text(&obj, source).to_string();
-            let type_name = symbols
-                .type_map
-                .iter()
-                .find(|e| e.name == obj_name)
-                .map(|e| e.type_name.clone());
-            (obj_name, type_name)
-        }
-        _ => return,
-    };
-    let Some(class_name) = class_name else { return };
-
-    let key = format!("{}.{}", class_name, prop_name);
-    let Some(accessor_info) = local_accessors.get(&key) else { return };
-    if accessor_info.get && accessor_info.set {
-        return;
-    }
-
     let is_plain_assign_target = node
         .parent()
         .filter(|p| p.kind() == "assignment_expression")
@@ -1358,17 +1449,71 @@ fn handle_accessor_property_read(
         .map(|l| l.id())
         == Some(node.id());
     let needed_get = !is_plain_assign_target;
-    if needed_get && !accessor_info.get {
-        return;
-    }
-    if !needed_get && !accessor_info.set {
+
+    if obj.kind() == "this" {
+        // `this`'s enclosing class is always declared in this same file —
+        // the #1893 same-file registry is authoritative, so keep its exact
+        // semantics (including the ambiguous get+set skip) unchanged.
+        let Some(class_name) = find_parent_class(node, source) else { return };
+        let key = format!("{}.{}", class_name, prop_name);
+        let Some(accessor_info) = local_accessors.get(&key) else { return };
+        if accessor_info.get && accessor_info.set {
+            return;
+        }
+        if needed_get && !accessor_info.get {
+            return;
+        }
+        if !needed_get && !accessor_info.set {
+            return;
+        }
+        symbols.calls.push(Call {
+            name: prop_name.to_string(),
+            line: start_line(node),
+            receiver: Some("this".to_string()),
+            ..Default::default()
+        });
         return;
     }
 
+    if obj.kind() != "identifier" {
+        return;
+    }
+    let receiver = node_text(&obj, source).to_string();
+    let narrowed_type = find_narrowed_instanceof_type(node, &receiver, source);
+    let class_name = narrowed_type.or_else(|| {
+        symbols.type_map.iter().find(|e| e.name == receiver).map(|e| e.type_name.clone())
+    });
+    let Some(class_name) = class_name else { return };
+
+    let key = format!("{}.{}", class_name, prop_name);
+    if let Some(accessor_info) = local_accessors.get(&key) {
+        // #1893: same-file confirmation available — unchanged semantics.
+        if accessor_info.get && accessor_info.set {
+            return;
+        }
+        if needed_get && !accessor_info.get {
+            return;
+        }
+        if !needed_get && !accessor_info.set {
+            return;
+        }
+        symbols.calls.push(Call {
+            name: prop_name.to_string(),
+            line: start_line(node),
+            receiver: Some(receiver),
+            ..Default::default()
+        });
+        return;
+    }
+
+    // #2030: `class_name` isn't declared in this file — nothing to confirm
+    // against locally. Emit a tagged candidate for the resolver's global
+    // accessor-kind filter to confirm or discard.
     symbols.calls.push(Call {
         name: prop_name.to_string(),
         line: start_line(node),
-        receiver: Some(receiver),
+        receiver: Some(class_name),
+        accessor_read: Some(if needed_get { "get".to_string() } else { "set".to_string() }),
         ..Default::default()
     });
 }
@@ -1395,6 +1540,7 @@ fn handle_static_block(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -1435,6 +1581,7 @@ fn handle_field_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -1452,6 +1599,7 @@ fn handle_interface_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
     // Extract interface methods
     let body = node
@@ -1476,6 +1624,7 @@ fn handle_type_alias(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             children: None,
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }
@@ -1495,6 +1644,7 @@ fn handle_enum_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             children: opt_children(children),
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }
@@ -1533,6 +1683,7 @@ fn handle_var_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                 children: opt_children(children),
                 bodyless: None,
                 content_hash: None,
+                accessor_kind: None,
             });
         } else if is_const && name_n.kind() == "object_pattern" && !in_function_scope {
             // Parity with TS query path (extractDestructuredBindingsWalk):
@@ -1586,6 +1737,7 @@ fn handle_var_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                 children: None,
                 bodyless: None,
                 content_hash: None,
+                accessor_kind: None,
             });
             // Phase 8.3f: extract function/arrow properties from object literals and seed
             // typeMap composite keys so that this.method() inside Object.defineProperty
@@ -2449,6 +2601,7 @@ fn extract_interface_methods(
                         children: None,
                         bodyless: Some(child.child_by_field_name("body").is_none()),
                         content_hash: None,
+                        accessor_kind: None,
                     });
                 }
             }
@@ -3108,6 +3261,7 @@ fn extract_destructured_bindings(
                     children: None,
                     bodyless: None,
                     content_hash: None,
+                    accessor_kind: None,
                 });
             }
             "pair_pattern" | "pair" => {
@@ -3126,6 +3280,7 @@ fn extract_destructured_bindings(
                             children: None,
                             bodyless: None,
                             content_hash: None,
+                            accessor_kind: None,
                         });
                     }
                 }
@@ -3165,6 +3320,7 @@ fn extract_array_pattern_bindings(
                     children: None,
                     bodyless: None,
                     content_hash: None,
+                    accessor_kind: None,
                 });
             }
             "assignment_pattern" => {
@@ -3181,6 +3337,7 @@ fn extract_array_pattern_bindings(
                             children: None,
                             bodyless: None,
                             content_hash: None,
+                            accessor_kind: None,
                         });
                     }
                 }
@@ -3209,6 +3366,7 @@ fn extract_array_pattern_bindings(
                                 children: None,
                                 bodyless: None,
                                 content_hash: None,
+                                accessor_kind: None,
                             });
                             break;
                         }
@@ -3617,6 +3775,7 @@ fn extract_callback_definition(call_node: &Node, source: &[u8]) -> Option<Defini
             children: None,
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 
@@ -3638,6 +3797,7 @@ fn extract_callback_definition(call_node: &Node, source: &[u8]) -> Option<Defini
             children: None,
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 
@@ -3656,6 +3816,7 @@ fn extract_callback_definition(call_node: &Node, source: &[u8]) -> Option<Defini
             children: None,
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 
@@ -7458,6 +7619,149 @@ mod tests {
         assert!(
             s.calls.iter().any(|c| c.name == "version" && c.receiver.as_deref() == Some("this")),
             "expected a call to version via this; got: {:?}",
+            s.calls
+        );
+    }
+
+    // ── ES6 getter/setter cross-file property-read call attribution (#2030) ──
+
+    #[test]
+    fn tags_cross_file_property_read_with_get_and_resolved_class_name() {
+        let s = parse_ts(
+            "function useRepo(repo: SqliteRepository) {\n\
+               return repo.db;\n\
+             }",
+        );
+        let call = s
+            .calls
+            .iter()
+            .find(|c| c.name == "db" && c.receiver.as_deref() == Some("SqliteRepository"));
+        assert!(
+            call.is_some(),
+            "expected a tagged accessor-read call to SqliteRepository.db; got: {:?}",
+            s.calls
+        );
+        assert_eq!(call.unwrap().accessor_read.as_deref(), Some("get"));
+    }
+
+    #[test]
+    fn tags_cross_file_property_write_with_set() {
+        let s = parse_ts(
+            "function useRepo(repo: SqliteRepository) {\n\
+               repo.db = null;\n\
+             }",
+        );
+        let call = s
+            .calls
+            .iter()
+            .find(|c| c.name == "db" && c.receiver.as_deref() == Some("SqliteRepository"));
+        assert_eq!(
+            call.expect("expected a tagged accessor-read call").accessor_read.as_deref(),
+            Some("set")
+        );
+    }
+
+    #[test]
+    fn same_file_confirmed_accessor_call_is_not_tagged() {
+        let s = parse_ts(
+            "class Repo {\n\
+               get db() { return this._db; }\n\
+             }\n\
+             function useRepo(repo: Repo) {\n\
+               return repo.db;\n\
+             }",
+        );
+        let call = s.calls.iter().find(|c| c.name == "db" && c.receiver.as_deref() == Some("repo"));
+        assert_eq!(
+            call.expect("expected same-file accessor call").accessor_read,
+            None,
+            "same-file confirmed accessor calls must not carry accessor_read"
+        );
+    }
+
+    #[test]
+    fn narrows_instanceof_type_for_cross_file_accessor_read() {
+        let s = parse_js(
+            "function useRepo(repo) {\n\
+               if (repo instanceof SqliteRepository) {\n\
+                 return repo.db;\n\
+               }\n\
+             }",
+        );
+        let call = s
+            .calls
+            .iter()
+            .find(|c| c.name == "db" && c.receiver.as_deref() == Some("SqliteRepository"));
+        assert!(
+            call.is_some(),
+            "expected instanceof-narrowed type to produce a tagged accessor-read call; got: {:?}",
+            s.calls
+        );
+    }
+
+    #[test]
+    fn narrows_instanceof_type_across_logical_and_chain() {
+        let s = parse_js(
+            "function useRepo(x, repo) {\n\
+               if (x && repo instanceof SqliteRepository) {\n\
+                 return repo.db;\n\
+               }\n\
+             }",
+        );
+        let call = s.calls.iter().find(|c| c.name == "db");
+        assert_eq!(
+            call.expect("expected a call to db").receiver.as_deref(),
+            Some("SqliteRepository")
+        );
+    }
+
+    #[test]
+    fn does_not_narrow_instanceof_type_across_logical_or() {
+        let s = parse_ts(
+            "function useRepo(repo: Repository) {\n\
+               if (repo instanceof SqliteRepository || true) {\n\
+                 return repo.db;\n\
+               }\n\
+             }",
+        );
+        // `||` never guarantees the instanceof check held — must fall back to
+        // the declared type (Repository), not the unsafe narrowed one.
+        let call = s.calls.iter().find(|c| c.name == "db");
+        assert_eq!(
+            call.expect("expected a call to db").receiver.as_deref(),
+            Some("Repository")
+        );
+    }
+
+    #[test]
+    fn does_not_narrow_instanceof_type_in_else_branch() {
+        let s = parse_ts(
+            "function useRepo(repo: Repository) {\n\
+               if (repo instanceof SqliteRepository) {\n\
+                 return 1;\n\
+               } else {\n\
+                 return repo.db;\n\
+               }\n\
+             }",
+        );
+        let call = s.calls.iter().find(|c| c.name == "db");
+        assert_eq!(
+            call.expect("expected a call to db").receiver.as_deref(),
+            Some("Repository"),
+            "the else branch must not inherit the if-branch's instanceof narrowing"
+        );
+    }
+
+    #[test]
+    fn does_not_tag_plain_this_field_read_even_when_not_locally_confirmed() {
+        let s = parse_js(
+            "class Widget {\n\
+               useOther() { return this.unknownProp; }\n\
+             }",
+        );
+        assert!(
+            !s.calls.iter().any(|c| c.name == "unknownProp"),
+            "a plain (non-accessor) this.field read must never produce a call, tagged or not; got: {:?}",
             s.calls
         );
     }

--- a/crates/codegraph-core/src/extractors/julia.rs
+++ b/crates/codegraph-core/src/extractors/julia.rs
@@ -69,6 +69,7 @@ fn handle_module_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) -> O
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 
     Some(name)
@@ -122,6 +123,7 @@ fn handle_function_def(
                 children: opt_children(params),
                 bodyless: None,
                 content_hash: None,
+                accessor_kind: None,
             });
             return;
         }
@@ -151,6 +153,7 @@ fn handle_function_def(
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -193,6 +196,7 @@ fn handle_assignment(
         children: opt_children(params),
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -276,6 +280,7 @@ fn handle_struct_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: opt_children(children),
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -310,6 +315,7 @@ fn handle_abstract_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -390,6 +396,7 @@ fn handle_macro_def(
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 

--- a/crates/codegraph-core/src/extractors/kotlin.rs
+++ b/crates/codegraph-core/src/extractors/kotlin.rs
@@ -227,6 +227,7 @@ fn match_kotlin_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
                         children: None,
                         bodyless: None,
                         content_hash: None,
+                        accessor_kind: None,
                     });
                 } else if is_kotlin_enum(node) {
                     let children = extract_kotlin_enum_entries(node, source);
@@ -241,6 +242,7 @@ fn match_kotlin_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
                         children: opt_children(children),
                         bodyless: None,
                         content_hash: None,
+                        accessor_kind: None,
                     });
                 } else {
                     let children = extract_kotlin_class_properties(node, source);
@@ -255,6 +257,7 @@ fn match_kotlin_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
                         children: opt_children(children),
                         bodyless: None,
                         content_hash: None,
+                        accessor_kind: None,
                     });
                 }
 
@@ -277,6 +280,7 @@ fn match_kotlin_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
                     children: opt_children(children),
                     bodyless: None,
                     content_hash: None,
+                    accessor_kind: None,
                 });
                 extract_kotlin_delegation_specifiers(node, source, &obj_name, symbols);
             }
@@ -303,6 +307,7 @@ fn match_kotlin_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
                     children: opt_children(children),
                     bodyless: None,
                     content_hash: None,
+                    accessor_kind: None,
                 });
             }
         }

--- a/crates/codegraph-core/src/extractors/lua.rs
+++ b/crates/codegraph-core/src/extractors/lua.rs
@@ -85,6 +85,7 @@ fn handle_lua_function_decl(node: &Node, source: &[u8], symbols: &mut FileSymbol
         children: opt_children(params),
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 

--- a/crates/codegraph-core/src/extractors/objc.rs
+++ b/crates/codegraph-core/src/extractors/objc.rs
@@ -74,6 +74,7 @@ fn handle_class_interface(node: &Node, source: &[u8], symbols: &mut FileSymbols)
         children: opt_children(members),
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 
     // Superclass — use the bare class name (categories already recorded above)
@@ -137,6 +138,7 @@ fn handle_class_implementation(node: &Node, source: &[u8], symbols: &mut FileSym
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -157,6 +159,7 @@ fn handle_protocol_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -199,6 +202,7 @@ fn handle_method(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: opt_children(params),
         bodyless: Some(!has_body),
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -219,6 +223,7 @@ fn handle_function_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: opt_children(params),
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -269,6 +274,7 @@ fn handle_struct_specifier(node: &Node, source: &[u8], symbols: &mut FileSymbols
             children: None,
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }
@@ -286,6 +292,7 @@ fn handle_enum_specifier(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
             children: None,
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }
@@ -315,6 +322,7 @@ fn handle_typedef(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             children: None,
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }

--- a/crates/codegraph-core/src/extractors/ocaml.rs
+++ b/crates/codegraph-core/src/extractors/ocaml.rs
@@ -69,6 +69,7 @@ fn handle_ocaml_let_binding(node: &Node, source: &[u8], symbols: &mut FileSymbol
             children: None,
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     } else {
         symbols.definitions.push(Definition {
@@ -82,6 +83,7 @@ fn handle_ocaml_let_binding(node: &Node, source: &[u8], symbols: &mut FileSymbol
             children: None,
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }
@@ -130,6 +132,7 @@ fn handle_ocaml_module_def(node: &Node, source: &[u8], symbols: &mut FileSymbols
             children: None,
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }
@@ -159,6 +162,7 @@ fn handle_ocaml_type_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
                     children: opt_children(children),
                     bodyless: None,
                     content_hash: None,
+                    accessor_kind: None,
                 });
             }
         }
@@ -203,6 +207,7 @@ fn handle_ocaml_class_def(node: &Node, source: &[u8], symbols: &mut FileSymbols)
             children: None,
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }
@@ -247,6 +252,7 @@ fn handle_ocaml_value_spec(node: &Node, source: &[u8], symbols: &mut FileSymbols
             children: None,
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }
@@ -267,6 +273,7 @@ fn handle_ocaml_external(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
             children: None,
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }
@@ -286,6 +293,7 @@ fn handle_ocaml_module_type_def(node: &Node, source: &[u8], symbols: &mut FileSy
             children: None,
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }
@@ -312,6 +320,7 @@ fn handle_ocaml_exception_def(node: &Node, source: &[u8], symbols: &mut FileSymb
             children: None,
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }

--- a/crates/codegraph-core/src/extractors/php.rs
+++ b/crates/codegraph-core/src/extractors/php.rs
@@ -57,6 +57,7 @@ fn handle_function_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             children: opt_children(children),
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }
@@ -76,6 +77,7 @@ fn handle_class_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: opt_children(children),
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 
     // Extends
@@ -130,6 +132,7 @@ fn handle_interface_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
     if let Some(body) = node.child_by_field_name("body") {
         for i in 0..body.child_count() {
@@ -147,6 +150,7 @@ fn handle_interface_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
                     children: None,
                     bodyless: Some(child.child_by_field_name("body").is_none()),
                     content_hash: None,
+                    accessor_kind: None,
                 });
             }
         }
@@ -166,6 +170,7 @@ fn handle_trait_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             children: None,
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }
@@ -185,6 +190,7 @@ fn handle_enum_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             children: opt_children(children),
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }
@@ -209,6 +215,7 @@ fn handle_method_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             children: opt_children(children),
             bodyless: Some(node.child_by_field_name("body").is_none()),
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }

--- a/crates/codegraph-core/src/extractors/python.rs
+++ b/crates/codegraph-core/src/extractors/python.rs
@@ -58,6 +58,7 @@ fn handle_function_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: opt_children(children),
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -76,6 +77,7 @@ fn handle_class_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: opt_children(children),
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
     let superclasses = node
         .child_by_field_name("superclasses")
@@ -115,6 +117,7 @@ fn handle_expr_stmt(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 

--- a/crates/codegraph-core/src/extractors/r_lang.rs
+++ b/crates/codegraph-core/src/extractors/r_lang.rs
@@ -72,6 +72,7 @@ fn handle_binary_op(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             children: opt_children(params),
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     } else if is_program_level(node) {
         // Only record top-level variable assignments (matches JS extractor).
@@ -86,6 +87,7 @@ fn handle_binary_op(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             children: None,
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }
@@ -305,6 +307,7 @@ fn handle_set_class(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             children: None,
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }
@@ -322,6 +325,7 @@ fn handle_set_generic(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             children: None,
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }

--- a/crates/codegraph-core/src/extractors/ruby.rs
+++ b/crates/codegraph-core/src/extractors/ruby.rs
@@ -57,6 +57,7 @@ fn handle_assignment(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -77,6 +78,7 @@ fn handle_class(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: opt_children(children),
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
     if let Some(superclass) = node.child_by_field_name("superclass") {
         extract_ruby_superclass(&superclass, &class_name, node, source, symbols);
@@ -96,6 +98,7 @@ fn handle_module(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             children: None,
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }
@@ -120,6 +123,7 @@ fn handle_method(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: opt_children(children),
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -143,6 +147,7 @@ fn handle_singleton_method(node: &Node, source: &[u8], symbols: &mut FileSymbols
         children: opt_children(children),
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 

--- a/crates/codegraph-core/src/extractors/rust_lang.rs
+++ b/crates/codegraph-core/src/extractors/rust_lang.rs
@@ -79,6 +79,7 @@ fn handle_function_item(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: opt_children(children),
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -97,6 +98,7 @@ fn handle_struct_item(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             children: opt_children(children),
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
         seed_rust_struct_field_types(node, &struct_name, source, symbols);
     }
@@ -136,6 +138,7 @@ fn handle_enum_item(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             children: opt_children(children),
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }
@@ -153,6 +156,7 @@ fn handle_const_item(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             children: None,
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }
@@ -171,6 +175,7 @@ fn handle_trait_item(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
     if let Some(body) = node.child_by_field_name("body") {
         for i in 0..body.child_count() {
@@ -190,6 +195,7 @@ fn handle_trait_item(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                     children: None,
                     bodyless: Some(child.kind() == "function_signature_item"),
                     content_hash: None,
+                    accessor_kind: None,
                 });
             }
         }

--- a/crates/codegraph-core/src/extractors/scala.rs
+++ b/crates/codegraph-core/src/extractors/scala.rs
@@ -215,6 +215,7 @@ fn handle_scala_class_definition(node: &Node, source: &[u8], symbols: &mut FileS
             children: opt_children(children),
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
         extract_scala_extends(node, source, &class_name, symbols);
     }
@@ -236,6 +237,7 @@ fn handle_scala_trait_definition(node: &Node, source: &[u8], symbols: &mut FileS
             children: None,
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
         extract_scala_extends(node, source, &trait_name, symbols);
     }
@@ -258,6 +260,7 @@ fn handle_scala_object_definition(node: &Node, source: &[u8], symbols: &mut File
             children: opt_children(children),
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
         extract_scala_extends(node, source, &obj_name, symbols);
     }
@@ -286,6 +289,7 @@ fn handle_scala_function_definition(node: &Node, source: &[u8], symbols: &mut Fi
             children: opt_children(children),
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
     }
 }

--- a/crates/codegraph-core/src/extractors/solidity.rs
+++ b/crates/codegraph-core/src/extractors/solidity.rs
@@ -81,6 +81,7 @@ fn handle_contract_decl(
         children: opt_children(members),
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 
     extract_inheritance(node, &name, source, symbols);
@@ -132,6 +133,7 @@ fn extract_contract_member(child: &Node, source: &[u8]) -> Option<Definition> {
                 children: None,
                 bodyless: None,
                 content_hash: None,
+                accessor_kind: None,
             })
         }
         "error_declaration" => {
@@ -147,6 +149,7 @@ fn extract_contract_member(child: &Node, source: &[u8]) -> Option<Definition> {
                 children: None,
                 bodyless: None,
                 content_hash: None,
+                accessor_kind: None,
             })
         }
         "modifier_definition" => {
@@ -162,6 +165,7 @@ fn extract_contract_member(child: &Node, source: &[u8]) -> Option<Definition> {
                 children: None,
                 bodyless: None,
                 content_hash: None,
+                accessor_kind: None,
             })
         }
         _ => None,
@@ -241,6 +245,7 @@ fn handle_struct_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: opt_children(members),
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -282,6 +287,7 @@ fn handle_enum_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: opt_children(members),
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -310,6 +316,7 @@ fn handle_function_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: opt_children(params),
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -334,6 +341,7 @@ fn handle_modifier_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -358,6 +366,7 @@ fn handle_event_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -382,6 +391,7 @@ fn handle_error_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -406,6 +416,7 @@ fn handle_state_var_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 

--- a/crates/codegraph-core/src/extractors/swift.rs
+++ b/crates/codegraph-core/src/extractors/swift.rs
@@ -245,6 +245,7 @@ fn match_swift_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dept
                             children: opt_children(children),
                             bodyless: None,
                             content_hash: None,
+                            accessor_kind: None,
                         });
                     }
                     _ => {
@@ -260,6 +261,7 @@ fn match_swift_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dept
                             children: opt_children(children),
                             bodyless: None,
                             content_hash: None,
+                            accessor_kind: None,
                         });
                     }
                 }
@@ -284,6 +286,7 @@ fn match_swift_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dept
                     children: None,
                     bodyless: None,
                     content_hash: None,
+                    accessor_kind: None,
                 });
                 // Protocol can also have inheritance
                 extract_swift_inheritance(node, source, &proto_name, symbols);
@@ -313,6 +316,7 @@ fn match_swift_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dept
                     children: opt_children(children),
                     bodyless: None,
                     content_hash: None,
+                    accessor_kind: None,
                 });
             }
         }

--- a/crates/codegraph-core/src/extractors/verilog.rs
+++ b/crates/codegraph-core/src/extractors/verilog.rs
@@ -71,6 +71,7 @@ fn handle_module_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: opt_children(ports),
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -90,6 +91,7 @@ fn handle_interface_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -109,6 +111,7 @@ fn handle_package_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -136,6 +139,7 @@ fn handle_class_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 
     if let Some(superclass) = find_class_superclass(node, source) {
@@ -203,6 +207,7 @@ fn handle_function_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -227,6 +232,7 @@ fn handle_task_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 

--- a/crates/codegraph-core/src/extractors/zig.rs
+++ b/crates/codegraph-core/src/extractors/zig.rs
@@ -52,6 +52,7 @@ fn handle_zig_function(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: opt_children(params),
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -102,6 +103,7 @@ fn handle_zig_variable(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 
@@ -125,6 +127,7 @@ fn try_handle_zig_type_def(node: &Node, source: &[u8], symbols: &mut FileSymbols
             children,
             bodyless: None,
             content_hash: None,
+            accessor_kind: None,
         });
         return true;
     }
@@ -267,6 +270,7 @@ fn handle_zig_test(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         children: None,
         bodyless: None,
         content_hash: None,
+        accessor_kind: None,
     });
 }
 

--- a/crates/codegraph-core/src/types.rs
+++ b/crates/codegraph-core/src/types.rs
@@ -116,6 +116,11 @@ pub struct Definition {
     /// `end_line` is unavailable.
     #[napi(js_name = "contentHash")]
     pub content_hash: Option<String>,
+    /// Set when this `method`-kind definition is an ES6 `get`/`set` class
+    /// accessor declaration (issue #2030, follow-up to #1893) — mirrors the
+    /// `accessor_kind` DB column and TS `Definition.accessorKind`.
+    #[napi(js_name = "accessorKind")]
+    pub accessor_kind: Option<String>,
 }
 
 #[napi(object)]
@@ -129,6 +134,12 @@ pub struct Call {
     pub dynamic_kind: Option<String>,
     #[napi(js_name = "keyExpr")]
     pub key_expr: Option<String>,
+    /// Set on a synthetic property-read call (bare `varName.prop`/`this.prop`,
+    /// no call parens, on an ES6 get/set accessor) to the accessor kind the
+    /// read requires — mirrors TS `Call.accessorRead` (issue #2030). See that
+    /// field's doc comment for the full rationale.
+    #[napi(js_name = "accessorRead")]
+    pub accessor_read: Option<String>,
 }
 
 /// `import { X as Y }`: the local binding name (Y) paired with the original

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -424,6 +424,24 @@ export const MIGRATIONS: Migration[] = [
       UPDATE edges SET technique = 'cha' WHERE technique = 'cha-expanded';
     `,
   },
+  {
+    // Cross-file ES6 getter/setter accessor recognition (issue #2030, follow-up
+    // to #1893). #1893's same-file accessor registry could confirm a bare
+    // property read (`obj.prop`, no call parens) really targets a `get`/`set`
+    // accessor — not a plain method/field sharing the name — using only
+    // in-file knowledge, so it needed no DB column. Recognizing the same
+    // pattern when the accessor's class is declared in a *different* file
+    // requires a global (whole-build) accessor registry, which in turn needs
+    // each accessor's kind persisted on its own node so resolution can filter
+    // candidates by exact kind match rather than guessing. Set only on
+    // `method`-kind nodes that are ES6 get/set accessors; NULL for everything
+    // else. Mirrored in crates/codegraph-core/src/db/connection.rs.
+    version: 27,
+    up: `
+      ALTER TABLE nodes ADD COLUMN accessor_kind TEXT;
+      CREATE INDEX IF NOT EXISTS idx_nodes_accessor_kind ON nodes(accessor_kind) WHERE accessor_kind IS NOT NULL;
+    `,
+  },
 ];
 
 interface PragmaColumnInfo {
@@ -516,6 +534,7 @@ function ensureNodeColumns(db: BetterSqlite3Database): void {
   if (missing('scope')) db.exec('ALTER TABLE nodes ADD COLUMN scope TEXT');
   if (missing('visibility')) db.exec('ALTER TABLE nodes ADD COLUMN visibility TEXT');
   if (missing('content_hash')) db.exec('ALTER TABLE nodes ADD COLUMN content_hash TEXT');
+  if (missing('accessor_kind')) db.exec('ALTER TABLE nodes ADD COLUMN accessor_kind TEXT');
   db.exec('UPDATE nodes SET qualified_name = name WHERE qualified_name IS NULL');
   db.exec('CREATE INDEX IF NOT EXISTS idx_nodes_qualified_name ON nodes(qualified_name)');
   db.exec('CREATE INDEX IF NOT EXISTS idx_nodes_scope ON nodes(scope)');

--- a/src/domain/graph/builder/call-resolver.ts
+++ b/src/domain/graph/builder/call-resolver.ts
@@ -384,7 +384,7 @@ export function resolveByMethodOrGlobal(
 
 export function resolveCallTargets(
   lookup: CallNodeLookup,
-  call: { name: string; receiver?: string | null },
+  call: { name: string; receiver?: string | null; accessorRead?: 'get' | 'set' },
   relPath: string,
   importedNames: Map<string, string>,
   typeMap: Map<string, unknown>,
@@ -398,6 +398,30 @@ export function resolveCallTargets(
   // so they never accidentally match a real symbol via lookup.byName.
   if (call.name.startsWith('<dynamic:')) {
     return { targets: [], importedFrom: undefined };
+  }
+
+  // #2030: a property-read call tagged with the accessor kind it needs
+  // carries its *resolved class name* as `receiver` (see
+  // collectAccessorPropertyRead in extractors/javascript.ts, and the native
+  // mirror handle_accessor_property_read) — resolve directly against the
+  // qualified `receiver.name`, filtered to the DB's `accessor_kind` column.
+  // This deliberately bypasses the rest of this function's directory-
+  // proximity confidence scoring: kind-plus-exact-qualified-name match is a
+  // strictly stronger disambiguator than proximity (proximity exists only to
+  // arbitrate when nothing stronger is available — see resolveExactGlobalMatch
+  // in resolver/strategy.ts for that precedent), and a real cross-file
+  // accessor can legitimately live many directories away from the read site
+  // (the #2030 repro itself: src/features/sequence.ts ↔
+  // src/db/repository/sqlite-repository.ts). An unconfirmed candidate is
+  // dropped outright — never falls through to the general cascade below,
+  // which could otherwise resolve to an unrelated same-named non-accessor
+  // method/field, the exact false-positive class #1893's same-file registry
+  // was designed to prevent.
+  if (call.accessorRead && call.receiver) {
+    const targets = lookup
+      .byName(`${call.receiver}.${call.name}`)
+      .filter((n) => n.accessorKind === call.accessorRead);
+    return { targets: [...targets], importedFrom: undefined };
   }
 
   const importedFrom = importedNames.get(call.name);

--- a/src/domain/graph/builder/call-resolver.ts
+++ b/src/domain/graph/builder/call-resolver.ts
@@ -418,9 +418,29 @@ export function resolveCallTargets(
   // method/field, the exact false-positive class #1893's same-file registry
   // was designed to prevent.
   if (call.accessorRead && call.receiver) {
-    const targets = lookup
-      .byName(`${call.receiver}.${call.name}`)
-      .filter((n) => n.accessorKind === call.accessorRead);
+    // The resolved class name can itself be a renamed import binding
+    // (`import { Original as Alias }` — the extractor's typeMap only knows
+    // the local alias), so de-alias before building the qualified lookup key
+    // exactly like the general cascade below does (#1825).
+    const dealiasedClassName = importedOriginalNames?.get(call.receiver) ?? call.receiver;
+    const qualified = `${dealiasedClassName}.${call.name}`;
+    // When the class is a known import, commit to the specific file it
+    // resolves to rather than falling through to the unscoped global lookup
+    // below — otherwise an unrelated same-qualified-name accessor in a
+    // completely different file could "confirm" a read it has nothing to do
+    // with, whenever two files coincidentally declare the same class+property
+    // name pair. This scoped result is authoritative: an empty (or
+    // wrong-kind) match here means "no", not "keep looking elsewhere" — the
+    // unscoped global fallback below is reserved for when the class isn't a
+    // known import in this file at all (e.g. an ambient/global type).
+    const accessorImportedFrom = importedNames.get(dealiasedClassName);
+    if (accessorImportedFrom) {
+      const scoped = lookup
+        .byNameAndFile(qualified, accessorImportedFrom)
+        .filter((n) => n.accessorKind === call.accessorRead);
+      return { targets: [...scoped], importedFrom: undefined };
+    }
+    const targets = lookup.byName(qualified).filter((n) => n.accessorKind === call.accessorRead);
     return { targets: [...targets], importedFrom: undefined };
   }
 

--- a/src/domain/graph/builder/call-resolver.ts
+++ b/src/domain/graph/builder/call-resolver.ts
@@ -433,7 +433,14 @@ export function resolveCallTargets(
     // wrong-kind) match here means "no", not "keep looking elsewhere" — the
     // unscoped global fallback below is reserved for when the class isn't a
     // known import in this file at all (e.g. an ambient/global type).
-    const accessorImportedFrom = importedNames.get(dealiasedClassName);
+    //
+    // `importedNames` is keyed by the *local* binding as written in this
+    // file's own import statement (`call.receiver` — e.g. 'Alias' for
+    // `import { Original as Alias }`), not the de-aliased original name —
+    // looking it up under `dealiasedClassName` would always miss for a
+    // renamed import and silently fall through to the unscoped lookup this
+    // whole branch exists to avoid.
+    const accessorImportedFrom = importedNames.get(call.receiver);
     if (accessorImportedFrom) {
       const scoped = lookup
         .byNameAndFile(qualified, accessorImportedFrom)

--- a/src/domain/graph/builder/helpers.ts
+++ b/src/domain/graph/builder/helpers.ts
@@ -361,9 +361,9 @@ const edgeStmtCache = new WeakMap<BetterSqlite3Database, Map<number, SqliteState
 
 function getNodeStmt(db: BetterSqlite3Database, chunkSize: number): SqliteStatement {
   return getOrCreatePerDbChunkStmt(nodeStmtCache, db, chunkSize, (n) => {
-    const ph = '(?,?,?,?,?,?,?,?,?,?)';
+    const ph = '(?,?,?,?,?,?,?,?,?,?,?)';
     return (
-      'INSERT OR IGNORE INTO nodes (name,kind,file,line,end_line,parent_id,qualified_name,scope,visibility,content_hash) VALUES ' +
+      'INSERT OR IGNORE INTO nodes (name,kind,file,line,end_line,parent_id,qualified_name,scope,visibility,content_hash,accessor_kind) VALUES ' +
       Array.from({ length: n }, () => ph).join(',')
     );
   });
@@ -411,7 +411,7 @@ function runBatchInsert(
  */
 export function batchInsertNodes(db: BetterSqlite3Database, rows: unknown[][]): void {
   runBatchInsert(db, rows, getNodeStmt, (r, vals) => {
-    vals.push(r[0], r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8], r[9] ?? null);
+    vals.push(r[0], r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8], r[9] ?? null, r[10] ?? null);
   });
 }
 

--- a/src/domain/graph/builder/incremental.ts
+++ b/src/domain/graph/builder/incremental.ts
@@ -98,17 +98,31 @@ interface RebuildResult {
 // ── Node insertion ──────────────────────────────────────────────────────
 
 function insertFileNodes(stmts: IncrementalStmts, relPath: string, symbols: ExtractorOutput): void {
-  stmts.insertNode.run(relPath, 'file', relPath, 0, null);
+  stmts.insertNode.run(relPath, 'file', relPath, 0, null, null);
   for (const def of symbols.definitions) {
-    stmts.insertNode.run(def.name, def.kind, relPath, def.line, def.endLine || null);
+    stmts.insertNode.run(
+      def.name,
+      def.kind,
+      relPath,
+      def.line,
+      def.endLine || null,
+      def.accessorKind ?? null,
+    );
     if (def.children?.length) {
       for (const child of def.children) {
-        stmts.insertNode.run(child.name, child.kind, relPath, child.line, child.endLine || null);
+        stmts.insertNode.run(
+          child.name,
+          child.kind,
+          relPath,
+          child.line,
+          child.endLine || null,
+          null,
+        );
       }
     }
   }
   for (const exp of symbols.exports) {
-    stmts.insertNode.run(exp.name, exp.kind, relPath, exp.line, null);
+    stmts.insertNode.run(exp.name, exp.kind, relPath, exp.line, null, null);
   }
 }
 

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -92,6 +92,8 @@ interface QueryNodeRow {
   kind: string;
   file: string;
   line: number;
+  /** `get`/`set` for an ES6 accessor node, `null` otherwise (issue #2030). */
+  accessorKind?: string | null;
 }
 
 /** Shape fed to the native buildCallEdges FFI. */
@@ -687,9 +689,19 @@ function buildCallEdgesNative(
     nativeFiles.push(buildNativeFileEntry(ctx, relPath, fileNodeRow.id, symbols, rootDir));
   }
 
+  // #2030: napi's Option<String> conversion for NodeInfo.accessorKind expects
+  // the field to be absent (undefined) for None, not explicitly `null` — the
+  // shape better-sqlite3 returns for a NULL column. Normalize before crossing
+  // the FFI boundary; the in-memory nodesByName/nodesByNameAndFile maps used
+  // by the JS/WASM resolution path are unaffected (built from these same rows
+  // but compared with `=== call.accessorRead`, where `null` and `undefined`
+  // are equally non-matching).
+  const nativeNodes = allNodes.map((n) =>
+    n.accessorKind == null ? { ...n, accessorKind: undefined } : n,
+  );
   const nativeEdges = native.buildCallEdges(
     nativeFiles,
-    allNodes,
+    nativeNodes,
     [...BUILTIN_RECEIVERS],
     ctx.config.analysis.pointsToMaxIterations,
   ) as NativeEdge[];
@@ -2307,7 +2319,7 @@ function loadNodes(ctx: PipelineContext): { rows: QueryNodeRow[]; scoped: boolea
       const placeholders = [...relevantFiles].map(() => '?').join(',');
       const rows = db
         .prepare(
-          `SELECT id, name, kind, file, line FROM nodes WHERE ${nodeKindFilter} AND file IN (${placeholders})`,
+          `SELECT id, name, kind, file, line, accessor_kind AS accessorKind FROM nodes WHERE ${nodeKindFilter} AND file IN (${placeholders})`,
         )
         .all(...relevantFiles) as QueryNodeRow[];
       return { rows, scoped: true };
@@ -2315,7 +2327,9 @@ function loadNodes(ctx: PipelineContext): { rows: QueryNodeRow[]; scoped: boolea
   }
 
   const rows = db
-    .prepare(`SELECT id, name, kind, file, line FROM nodes WHERE ${nodeKindFilter}`)
+    .prepare(
+      `SELECT id, name, kind, file, line, accessor_kind AS accessorKind FROM nodes WHERE ${nodeKindFilter}`,
+    )
     .all() as QueryNodeRow[];
   return { rows, scoped: false };
 }
@@ -2334,7 +2348,7 @@ function addLazyFallback(ctx: PipelineContext, scopedLoad: boolean): void {
   // with the same name>` (#1174 follow-up). Calls only ever target the
   // definition kinds, so the fallback's filter must agree with `loadNodes`.
   const fallbackStmt = db.prepare(
-    `SELECT id, name, kind, file, line FROM nodes WHERE name = ? AND ${NODE_KIND_FILTER_SQL}`,
+    `SELECT id, name, kind, file, line, accessor_kind AS accessorKind FROM nodes WHERE name = ? AND ${NODE_KIND_FILTER_SQL}`,
   );
   const originalGet = ctx.nodesByName.get.bind(ctx.nodesByName);
   ctx.nodesByName.get = (name: string) => {

--- a/src/domain/graph/builder/stages/insert-nodes.ts
+++ b/src/domain/graph/builder/stages/insert-nodes.ts
@@ -57,6 +57,7 @@ interface InsertNodesBatch {
     endLine?: number;
     visibility?: string;
     contentHash?: string;
+    accessorKind?: string;
     children: Array<{
       name: string;
       kind: string;
@@ -82,6 +83,7 @@ function marshalSymbolBatches(allSymbols: Map<string, ExtractorOutput>): InsertN
         endLine: def.endLine ?? undefined,
         visibility: def.visibility ?? undefined,
         contentHash: def.contentHash ?? undefined,
+        accessorKind: def.accessorKind ?? undefined,
         children: (def.children ?? []).map((c) => ({
           name: c.name,
           kind: c.kind,
@@ -268,7 +270,7 @@ function insertDefinitionsAndExports(
   const phase1Rows: unknown[][] = [];
   const exportKeys: unknown[][] = [];
   for (const [relPath, symbols] of allSymbols) {
-    phase1Rows.push([relPath, 'file', relPath, 0, null, null, null, null, null, null]);
+    phase1Rows.push([relPath, 'file', relPath, 0, null, null, null, null, null, null, null]);
     for (const def of symbols.definitions) {
       const dotIdx = def.name.lastIndexOf('.');
       const scope = dotIdx !== -1 ? def.name.slice(0, dotIdx) : null;
@@ -283,6 +285,7 @@ function insertDefinitionsAndExports(
         scope,
         def.visibility || null,
         def.contentHash || null,
+        def.accessorKind || null,
       ]);
     }
     for (const exp of symbols.exports) {
@@ -294,6 +297,7 @@ function insertDefinitionsAndExports(
         null,
         null,
         exp.name,
+        null,
         null,
         null,
         null,
@@ -350,6 +354,7 @@ function collectChildRowsAndFileEdges(
           def.name,
           child.visibility || null,
           child.contentHash || null,
+          null,
         ]);
       }
     }

--- a/src/domain/graph/resolver/strategy.ts
+++ b/src/domain/graph/resolver/strategy.ts
@@ -26,7 +26,20 @@ import { computeConfidence } from '../resolve.js';
  * `function`-kind node at the same line) versus a genuinely different
  * declaration that merely shares that same line (#2025).
  */
-export type ResolvedCandidate = { id: number; file: string; kind?: string; line: number };
+export type ResolvedCandidate = {
+  id: number;
+  file: string;
+  kind?: string;
+  line: number;
+  /**
+   * `get`/`set` when this node is an ES6 accessor declaration, `null`/absent
+   * otherwise (issue #2030). Populated from the DB `accessor_kind` column by
+   * every `CallNodeLookup` implementation's underlying query. Consulted by
+   * `resolveCallTargets` (call-resolver.ts) to filter candidates for a call
+   * tagged `accessorRead`.
+   */
+  accessorKind?: string | null;
+};
 
 /**
  * Structural mirror of `CallNodeLookup` from call-resolver.ts.

--- a/src/domain/graph/watcher.ts
+++ b/src/domain/graph/watcher.ts
@@ -19,7 +19,7 @@ function shouldIgnorePath(filePath: string, ignoreSet: ReadonlySet<string>): boo
 function prepareWatcherStatements(db: ReturnType<typeof openDb>): IncrementalStmts {
   return {
     insertNode: db.prepare(
-      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line) VALUES (?, ?, ?, ?, ?)',
+      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
     ),
     getNodeId: {
       get: (...params: unknown[]) => {
@@ -36,15 +36,19 @@ function prepareWatcherStatements(db: ReturnType<typeof openDb>): IncrementalStm
       'SELECT COUNT(*) as c FROM edges WHERE source_id IN (SELECT id FROM nodes WHERE file = ?)',
     ),
     findNodeInFile: db.prepare(
-      "SELECT id, kind, file, line FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant') AND file = ?",
+      // `accessor_kind` (aliased to `accessorKind`) is included so
+      // resolveCallTargets can filter a #2030 accessorRead-tagged call to a
+      // matching accessor node.
+      "SELECT id, kind, file, line, accessor_kind AS accessorKind FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant') AND file = ?",
     ),
     findNodeByName: db.prepare(
       // `kind` is included so resolveByMethodOrGlobal can filter to 'method' for
       // type-aware receiver resolution (mirrors the full-build resolver). `line`
       // is included so resolveCallTargets can tell whether a type-aware match
       // and an already-found bare match are the same physical declaration
-      // (#2025).
-      "SELECT id, file, kind, line FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
+      // (#2025). `accessor_kind` (aliased to `accessorKind`) is included for
+      // the same #2030 reason as findNodeInFile above.
+      "SELECT id, file, kind, line, accessor_kind AS accessorKind FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
     ),
     listSymbols: db.prepare("SELECT name, kind, line FROM nodes WHERE file = ? AND kind != 'file'"),
     upsertFileHash: db.prepare(

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -607,6 +607,10 @@ function isObjectLiteralDeclaratorMethod(methNode: TreeSitterNode): boolean {
 function buildMethodDefinition(node: TreeSitterNode, name: string): Definition {
   const methChildren = extractParameters(node);
   const methVis = extractVisibility(node);
+  // #2030: persist which ES6 accessor kind (if any) this method is, so a
+  // global (whole-build) accessor registry can confirm cross-file property
+  // reads at resolution time — see collectAccessorPropertyRead below.
+  const accessorKind = getMethodAccessorKind(node) ?? undefined;
   return {
     name,
     kind: 'method',
@@ -614,6 +618,7 @@ function buildMethodDefinition(node: TreeSitterNode, name: string): Definition {
     endLine: nodeEndLine(node),
     children: methChildren.length > 0 ? methChildren : undefined,
     visibility: methVis,
+    accessorKind,
   };
 }
 
@@ -701,18 +706,115 @@ function localTypeMapTypeName(typeMap: Map<string, TypeMapEntry>, varName: strin
 }
 
 /**
+ * #2030: within the truthy branch of `if (varName instanceof ClassName) { ... }`
+ * (including `&&`-chained conditions, e.g. `if (x && varName instanceof
+ * ClassName)`), `varName`'s narrowed runtime type is `ClassName` for the rest
+ * of that branch — more specific than whatever this file's typeMap otherwise
+ * knows about `varName` (e.g. a base-class parameter annotation). This lets a
+ * cross-file accessor declared only on the narrowed (concrete) subclass, not
+ * on the wider declared type, still be recognized as the property read's
+ * target — the exact shape of the issue's own repro (`repo.db` narrowed from
+ * `Repository` to `SqliteRepository`).
+ *
+ * Deliberately narrow: only the single-level `if (... instanceof ...) { <here> }`
+ * consequence-branch shape is recognized — no general control-flow/negation
+ * analysis (e.g. an early-return guard `if (!(x instanceof Y)) return;`).
+ * Missing the narrower type here just falls through to the file's ordinary
+ * typeMap type (or finds nothing) — never a *wrong* one, since a non-`&&`
+ * operator (`||`, comparisons, ...) is never treated as a guarantee.
+ */
+function findNarrowedInstanceofType(node: TreeSitterNode, varName: string): string | null {
+  let current: TreeSitterNode = node;
+  let depth = 0;
+  while (depth < MAX_WALK_DEPTH) {
+    const parent = current.parent;
+    if (!parent) return null;
+    if (parent.type === 'if_statement') {
+      const consequence = parent.childForFieldName('consequence');
+      // `current` must be exactly the consequence branch itself (reached by
+      // walking straight up from `node`) — not the condition, and not an
+      // `else` alternative — for this if's narrowing to apply.
+      if (consequence && consequence.id === current.id) {
+        const condition = parent.childForFieldName('condition');
+        const narrowed = condition ? findInstanceofOperand(condition, varName, 0) : null;
+        if (narrowed) return narrowed;
+      }
+      // Not the consequence branch — keep walking up in case an outer if
+      // narrows the same variable.
+    }
+    current = parent;
+    depth++;
+  }
+  return null;
+}
+
+/**
+ * Search `node` (an `if_statement`'s condition, always wrapped in a
+ * `parenthesized_expression`) for an `instanceof` check on `varName`,
+ * recursing through `&&` chains only — any other operator (`||`, `===`, ...)
+ * does not guarantee the instanceof check held, so narrowing stops there
+ * rather than risk a false positive.
+ */
+function findInstanceofOperand(
+  node: TreeSitterNode,
+  varName: string,
+  depth: number,
+): string | null {
+  if (depth >= MAX_WALK_DEPTH) return null;
+  if (node.type === 'parenthesized_expression') {
+    const inner = node.namedChild(0);
+    return inner ? findInstanceofOperand(inner, varName, depth + 1) : null;
+  }
+  if (node.type !== 'binary_expression') return null;
+  const operator = node.childForFieldName('operator')?.text;
+  const left = node.childForFieldName('left');
+  const right = node.childForFieldName('right');
+  if (operator === 'instanceof') {
+    if (left?.type === 'identifier' && left.text === varName && right?.type === 'identifier') {
+      return right.text;
+    }
+    return null;
+  }
+  if (operator === '&&') {
+    return (
+      (left && findInstanceofOperand(left, varName, depth + 1)) ||
+      (right && findInstanceofOperand(right, varName, depth + 1)) ||
+      null
+    );
+  }
+  return null;
+}
+
+/**
  * Detect a bare (non-call) `this.prop` / `varName.prop` member-expression that
- * reads or writes a same-file accessor property, and record it as an ordinary
+ * reads or writes an ES6 accessor property, and record it as an ordinary
  * `Call` — indistinguishable from a real `this.prop()`/`varName.prop()` call
  * site, so it flows through the existing (unchanged) call-resolution cascade.
  *
  * A plain assignment (`obj.prop = value`) invokes the setter; every other bare
- * usage (reads, compound-assignment targets, etc.) invokes the getter. When a
- * property declares *both* a getter and a setter, the two accessors share the
- * same qualified name and resolution has no way to tell them apart — rather
- * than risk an edge to the wrong one, that case is skipped entirely (mirrors
- * resolveExactGlobalMatch's "ambiguous → drop rather than fan out" precedent
- * in resolver/strategy.ts).
+ * usage (reads, compound-assignment targets, etc.) invokes the getter.
+ *
+ * Two confirmation tiers:
+ *   1. Same-file (#1893): `className` is declared in this file, so this
+ *      file's own `localAccessors` registry can confirm (or rule out) the
+ *      accessor directly. When a property declares *both* a getter and a
+ *      setter, the two accessors share the same qualified name and this
+ *      file's registry alone can't tell them apart — rather than risk an
+ *      edge to the wrong one, that case is skipped entirely here (mirrors
+ *      resolveExactGlobalMatch's "ambiguous → drop rather than fan out"
+ *      precedent in resolver/strategy.ts).
+ *   2. Cross-file (#2030): `className` isn't declared in this file (a `this`
+ *      receiver's class always is, so this tier only ever applies to a
+ *      `varName.prop` identifier receiver) — this file has no way to confirm
+ *      the accessor itself, so the call is emitted anyway, tagged with
+ *      `accessorRead`, deferring confirmation to the resolver's global
+ *      accessor-kind filter (`resolveCallTargets` in call-resolver.ts) once
+ *      every file's own accessor declarations are known. `receiver` carries
+ *      the *resolved class name* here (not the read site's variable text) so
+ *      that filter can look up the qualified `className.propName` directly —
+ *      required for the narrowed-instanceof case, where re-deriving the type
+ *      from typeMap at resolution time would only recover the wider declared
+ *      type, never the narrowed one.
  */
 function collectAccessorPropertyRead(
   node: TreeSitterNode,
@@ -736,28 +838,50 @@ function collectAccessorPropertyRead(
   if (!obj || !propNode || propNode.type !== 'property_identifier') return;
   const propName = propNode.text;
 
-  let receiver: string;
-  let className: string | null;
-  if (obj.type === 'this') {
-    receiver = 'this';
-    className = findParentClass(node);
-  } else if (obj.type === 'identifier') {
-    receiver = obj.text;
-    className = localTypeMapTypeName(typeMap, obj.text);
-  } else {
-    return;
-  }
-  if (!className) return;
-
-  const accessorInfo = localAccessors.get(`${className}.${propName}`);
-  if (!accessorInfo || (accessorInfo.get && accessorInfo.set)) return;
-
   const isPlainAssignTarget =
     parent?.type === 'assignment_expression' && parent.childForFieldName('left')?.id === node.id;
   const neededKind = isPlainAssignTarget ? 'set' : 'get';
-  if (!accessorInfo[neededKind]) return;
 
-  valueRefCalls.push({ name: propName, receiver, line: nodeStartLine(node) });
+  if (obj.type === 'this') {
+    // `this`'s enclosing class is always declared in this same file — the
+    // #1893 same-file registry is authoritative, so keep its exact semantics
+    // (including the ambiguous get+set skip) unchanged. A #2030 cross-file
+    // fallback would never have anything to add for `this`, and tagging
+    // every plain `this.field` read would add unbounded extraction volume
+    // for zero benefit.
+    const className = findParentClass(node);
+    if (!className) return;
+    const accessorInfo = localAccessors.get(`${className}.${propName}`);
+    if (!accessorInfo || (accessorInfo.get && accessorInfo.set) || !accessorInfo[neededKind]) {
+      return;
+    }
+    valueRefCalls.push({ name: propName, receiver: 'this', line: nodeStartLine(node) });
+    return;
+  }
+
+  if (obj.type !== 'identifier') return;
+  const receiver = obj.text;
+  const narrowedType = findNarrowedInstanceofType(node, receiver);
+  const className = narrowedType ?? localTypeMapTypeName(typeMap, receiver);
+  if (!className) return;
+
+  const accessorInfo = localAccessors.get(`${className}.${propName}`);
+  if (accessorInfo) {
+    // #1893: same-file confirmation available — unchanged semantics.
+    if ((accessorInfo.get && accessorInfo.set) || !accessorInfo[neededKind]) return;
+    valueRefCalls.push({ name: propName, receiver, line: nodeStartLine(node) });
+    return;
+  }
+
+  // #2030: `className` isn't declared in this file — nothing to confirm
+  // against locally. Emit a tagged candidate for the resolver's global
+  // accessor-kind filter to confirm or discard.
+  valueRefCalls.push({
+    name: propName,
+    receiver: className,
+    line: nodeStartLine(node),
+    accessorRead: neededKind,
+  });
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -141,6 +141,12 @@ export interface NodeRow {
   scope: string | null;
   visibility: 'public' | 'private' | 'protected' | null;
   role: Role | null;
+  /**
+   * `get`/`set` when this `method`-kind node is an ES6 accessor declaration,
+   * `null` otherwise (issue #2030). Optional so existing call sites that
+   * construct/cast a narrower column set don't need updating.
+   */
+  accessor_kind?: 'get' | 'set' | null;
 }
 
 /** A node row augmented with fan-in count (from findNodesWithFanIn). */
@@ -488,6 +494,17 @@ export interface Definition {
    * when `endLine` is unavailable (no reliable body range to hash).
    */
   contentHash?: string;
+  /**
+   * Set when this `method`-kind definition is an ES6 `get`/`set` class
+   * accessor declaration (issue #2030, follow-up to #1893) — mirrors the
+   * `accessor_kind` DB column. Persisted so a global (whole-build) accessor
+   * registry can confirm, at resolution time, whether a bare property read
+   * on a *cross-file* receiver type genuinely targets an accessor (as
+   * opposed to an unrelated same-named plain method/field) — the same
+   * confirmation #1893's same-file-only registry already does for a
+   * same-file receiver, without needing this field at all.
+   */
+  accessorKind?: 'get' | 'set';
 }
 
 /** Sub-declaration (child) within a definition. */
@@ -584,6 +601,29 @@ export interface Call {
    * (`.call`/`.apply`/`.bind`) so #1687 stays fixed (#2029).
    */
   outOfOrder?: boolean;
+  /**
+   * Set on a synthetic property-read `Call` (a bare `varName.prop`/`this.prop`
+   * member-expression, no call parens, recognized as invoking an ES6 `get`/
+   * `set` class accessor — see `collectAccessorPropertyRead` in
+   * extractors/javascript.ts) to the accessor kind the read requires: `'get'`
+   * for an ordinary read, `'set'` for a plain-assignment write.
+   *
+   * Only set for the *cross-file* case (issue #2030) — when the accessor's
+   * declaring class isn't known to be declared in the reading file, so
+   * extraction cannot itself confirm the target is really an accessor (the
+   * same-file case stays either confirmed-and-emitted-plain or dropped, per
+   * #1893, since a same-file registry can already rule out false matches
+   * without this field). When set, `receiver` carries the *resolved class
+   * name* (not the read site's variable/`this` text) so resolution can look
+   * up the qualified `receiver.name` directly. `resolveCallTargets`
+   * (call-resolver.ts) short-circuits on this field: it resolves only
+   * against a candidate whose DB `accessor_kind` column matches exactly,
+   * dropping the call entirely rather than falling through to an unrelated
+   * same-named non-accessor method/field — the false-positive class #1893's
+   * same-file registry was designed to rule out, now enforced by the
+   * resolver instead of by an extraction-time gate.
+   */
+  accessorRead?: 'get' | 'set';
 }
 
 /** An import statement detected by an extractor. */

--- a/tests/integration/issue-1259-watch-call-resolution.test.ts
+++ b/tests/integration/issue-1259-watch-call-resolution.test.ts
@@ -76,7 +76,7 @@ function readEdges(dbPath: string) {
 function makeStmts(db: ReturnType<typeof openDb>) {
   return {
     insertNode: db.prepare(
-      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line) VALUES (?, ?, ?, ?, ?)',
+      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
     ),
     getNodeId: {
       get: (name: string, kind: string, file: string, line: number) => {

--- a/tests/integration/issue-1370-incremental-caller-name.test.ts
+++ b/tests/integration/issue-1370-incremental-caller-name.test.ts
@@ -73,7 +73,7 @@ function readCallEdges(dbPath: string) {
 function makeStmts(db: ReturnType<typeof openDb>) {
   return {
     insertNode: db.prepare(
-      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line) VALUES (?, ?, ?, ?, ?)',
+      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
     ),
     getNodeId: {
       get: (name: string, kind: string, file: string, line: number) => {

--- a/tests/integration/issue-1731-hash-edge-coupling.test.ts
+++ b/tests/integration/issue-1731-hash-edge-coupling.test.ts
@@ -163,7 +163,7 @@ describe('Issue #1731: file_hashes/edges coupling survives a mid-build failure',
 function makeStmts(db: ReturnType<typeof openDb>) {
   return {
     insertNode: db.prepare(
-      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line) VALUES (?, ?, ?, ?, ?)',
+      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
     ),
     getNodeId: {
       get: (name: string, kind: string, file: string, line: number) => {

--- a/tests/integration/issue-1744-incremental-edge-technique.test.ts
+++ b/tests/integration/issue-1744-incremental-edge-technique.test.ts
@@ -97,7 +97,7 @@ function readCallEdges(dbPath: string): CallEdgeRow[] {
 function makeStmts(db: ReturnType<typeof openDb>) {
   return {
     insertNode: db.prepare(
-      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line) VALUES (?, ?, ?, ?, ?)',
+      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
     ),
     getNodeId: {
       get: (name: string, kind: string, file: string, line: number) => {

--- a/tests/integration/issue-1765-incremental-same-class-barecall.test.ts
+++ b/tests/integration/issue-1765-incremental-same-class-barecall.test.ts
@@ -75,7 +75,7 @@ function readCallEdges(dbPath: string): CallEdgeRow[] {
 function makeStmts(db: ReturnType<typeof openDb>) {
   return {
     insertNode: db.prepare(
-      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line) VALUES (?, ?, ?, ?, ?)',
+      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
     ),
     getNodeId: {
       get: (name: string, kind: string, file: string, line: number) => {

--- a/tests/integration/issue-1766-defineproperty-kind-filter-parity.test.ts
+++ b/tests/integration/issue-1766-defineproperty-kind-filter-parity.test.ts
@@ -102,7 +102,7 @@ function readCallEdges(dbPath: string): CallEdgeRow[] {
 function makeStmts(db: ReturnType<typeof openDb>) {
   return {
     insertNode: db.prepare(
-      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line) VALUES (?, ?, ?, ?, ?)',
+      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
     ),
     getNodeId: {
       get: (name: string, kind: string, file: string, line: number) => {

--- a/tests/integration/issue-1852-watch-cha-pts-dynamic-sink.test.ts
+++ b/tests/integration/issue-1852-watch-cha-pts-dynamic-sink.test.ts
@@ -93,7 +93,7 @@ function withoutTechnique(edges: CallEdgeRow[]): Array<Omit<CallEdgeRow, 'techni
 function makeStmts(db: ReturnType<typeof openDb>) {
   return {
     insertNode: db.prepare(
-      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line) VALUES (?, ?, ?, ?, ?)',
+      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
     ),
     getNodeId: {
       get: (name: string, kind: string, file: string, line: number) => {

--- a/tests/integration/issue-1893-getter-setter-property-read.test.ts
+++ b/tests/integration/issue-1893-getter-setter-property-read.test.ts
@@ -147,7 +147,7 @@ describe.skipIf(!isNativeAvailable())('native engine coverage', () => {
 function makeStmts(db: ReturnType<typeof openDb>) {
   return {
     insertNode: db.prepare(
-      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line) VALUES (?, ?, ?, ?, ?)',
+      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
     ),
     getNodeId: {
       get: (name: string, kind: string, file: string, line: number) => {

--- a/tests/integration/issue-1967-watch-barrel-rename.test.ts
+++ b/tests/integration/issue-1967-watch-barrel-rename.test.ts
@@ -111,7 +111,7 @@ function readReexportRenames(dbPath: string) {
 function makeStmts(db: ReturnType<typeof openDb>) {
   return {
     insertNode: db.prepare(
-      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line) VALUES (?, ?, ?, ?, ?)',
+      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
     ),
     getNodeId: {
       get: (name: string, kind: string, file: string, line: number) => {

--- a/tests/integration/issue-2030-cross-file-accessor-recognition.test.ts
+++ b/tests/integration/issue-2030-cross-file-accessor-recognition.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Regression test for #2030 (follow-up to #1893): a bare (non-call) property
+ * read/write on an ES6 `get`/`set` class accessor never produced a `calls`
+ * edge when the accessor's declaring class lives in a *different* file than
+ * the read site — #1893 only covered the same-file case.
+ *
+ * Fixture mirrors the issue's own real-world repro:
+ *   `SqliteRepository.db` read from `src/features/sequence.ts` after
+ *   `instanceof SqliteRepository` narrowing (see `annotateDataflow` in
+ *   src/features/sequence.ts). Verifies:
+ *   - the cross-file getter-read edge appears in a full build, tagged with
+ *     the correct `accessor_kind` on the target node
+ *   - both engines (wasm/native) produce identical edges
+ *   - full build and an incremental single-file rebuild agree
+ *   - a same-file accessor (#1893) still resolves correctly alongside the
+ *     cross-file one — no regression
+ *   - a plain (non-accessor) cross-file method sharing the property name is
+ *     never matched (false-positive guard)
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { initSchema, openDb } from '../../src/db/index.js';
+import { rebuildFile } from '../../src/domain/graph/builder/incremental.js';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+import { isNativeAvailable } from '../../src/infrastructure/native.js';
+import type { EngineMode } from '../../src/types.js';
+
+function writeFixture(dir: string): void {
+  fs.mkdirSync(dir, { recursive: true });
+  // The accessor's class lives in its own file...
+  fs.writeFileSync(
+    path.join(dir, 'sqlite-repository.ts'),
+    `export class Repository {
+  hasDataflowTable(): boolean {
+    return false;
+  }
+}
+
+export class SqliteRepository extends Repository {
+  #db: unknown;
+
+  constructor(db: unknown) {
+    super();
+    this.#db = db;
+  }
+
+  get db(): unknown {
+    return this.#db;
+  }
+}
+
+export class OtherRepo {
+  // A plain (non-accessor) method sharing the property name "db" — must
+  // never be matched by the cross-file accessor-read call below.
+  db(): unknown {
+    return null;
+  }
+}
+`,
+  );
+  // ...and the bare property read happens in a completely different file,
+  // after an \`instanceof\` narrowing check — mirroring the real repro in
+  // src/features/sequence.ts's annotateDataflow.
+  fs.writeFileSync(
+    path.join(dir, 'sequence.ts'),
+    `import { Repository, SqliteRepository } from './sqlite-repository.js';
+
+export function annotateDataflow(repo: Repository): unknown {
+  if (repo instanceof SqliteRepository) {
+    return repo.db;
+  }
+  return null;
+}
+`,
+  );
+}
+
+interface CallEdgeRow {
+  src: string;
+  srcKind: string;
+  tgt: string;
+  tgtKind: string;
+  kind: string;
+}
+
+function readCallEdges(dbPath: string): CallEdgeRow[] {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return db
+      .prepare(
+        `SELECT n1.name AS src, n1.kind AS srcKind, n2.name AS tgt, n2.kind AS tgtKind, e.kind
+         FROM edges e
+         JOIN nodes n1 ON e.source_id = n1.id
+         JOIN nodes n2 ON e.target_id = n2.id
+         WHERE e.kind = 'calls'
+         ORDER BY n1.name, n2.name, n1.kind`,
+      )
+      .all() as CallEdgeRow[];
+  } finally {
+    db.close();
+  }
+}
+
+function readAccessorKind(dbPath: string, name: string): string | null {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    const row = db.prepare(`SELECT accessor_kind FROM nodes WHERE name = ?`).get(name) as
+      | { accessor_kind: string | null }
+      | undefined;
+    return row?.accessor_kind ?? null;
+  } finally {
+    db.close();
+  }
+}
+
+function runScenario(engine: EngineMode): void {
+  describe(`ES6 getter/setter cross-file property-read attribution (#2030) — ${engine}`, () => {
+    let projDir: string;
+
+    beforeAll(async () => {
+      projDir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2030-${engine}-`));
+      writeFixture(projDir);
+      await buildGraph(projDir, { engine, incremental: false, skipRegistry: true });
+    }, 60_000);
+
+    afterAll(() => {
+      fs.rmSync(projDir, { recursive: true, force: true });
+    });
+
+    it('attributes the cross-file `repo.db` read (after instanceof narrowing) to SqliteRepository.db', () => {
+      const dbPath = path.join(projDir, '.codegraph', 'graph.db');
+      const edges = readCallEdges(dbPath);
+      expect(edges).toContainEqual({
+        src: 'annotateDataflow',
+        srcKind: 'function',
+        tgt: 'SqliteRepository.db',
+        tgtKind: 'method',
+        kind: 'calls',
+      });
+    });
+
+    it('persists accessor_kind = "get" on the SqliteRepository.db node', () => {
+      const dbPath = path.join(projDir, '.codegraph', 'graph.db');
+      expect(readAccessorKind(dbPath, 'SqliteRepository.db')).toBe('get');
+    });
+
+    it('never attributes the read to the plain (non-accessor) OtherRepo.db method', () => {
+      const dbPath = path.join(projDir, '.codegraph', 'graph.db');
+      const edges = readCallEdges(dbPath);
+      expect(edges).not.toContainEqual(
+        expect.objectContaining({ src: 'annotateDataflow', tgt: 'OtherRepo.db' }),
+      );
+      expect(readAccessorKind(dbPath, 'OtherRepo.db')).toBeNull();
+    });
+  });
+}
+
+runScenario('wasm');
+describe.skipIf(!isNativeAvailable())('native engine coverage', () => {
+  runScenario('native');
+});
+
+function makeStmts(db: ReturnType<typeof openDb>) {
+  return {
+    insertNode: db.prepare(
+      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
+    ),
+    getNodeId: {
+      get: (name: string, kind: string, file: string, line: number) => {
+        const row = db
+          .prepare('SELECT id FROM nodes WHERE name = ? AND kind = ? AND file = ? AND line = ?')
+          .get(name, kind, file, line) as { id: number } | undefined;
+        return row ? { id: row.id } : undefined;
+      },
+    },
+    insertEdge: db.prepare(
+      'INSERT INTO edges (source_id, target_id, kind, confidence, dynamic) VALUES (?, ?, ?, ?, ?)',
+    ),
+    countNodes: db.prepare('SELECT COUNT(*) as c FROM nodes WHERE file = ?'),
+    countEdges: db.prepare(
+      'SELECT COUNT(*) as c FROM edges WHERE source_id IN (SELECT id FROM nodes WHERE file = ?)',
+    ),
+    findNodeInFile: db.prepare(
+      "SELECT id, kind, file, line, accessor_kind AS accessorKind FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant') AND file = ?",
+    ),
+    findNodeByName: db.prepare(
+      "SELECT id, file, kind, line, accessor_kind AS accessorKind FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
+    ),
+    listSymbols: db.prepare("SELECT name, kind, line FROM nodes WHERE file = ? AND kind != 'file'"),
+    upsertFileHash: db.prepare(
+      'INSERT OR REPLACE INTO file_hashes (file, hash, mtime, size) VALUES (?, ?, ?, ?)',
+    ),
+    deleteFileHash: db.prepare('DELETE FROM file_hashes WHERE file = ?'),
+  };
+}
+
+function runIncrementalParityScenario(engine: EngineMode): void {
+  describe(`incremental rebuild matches full build for cross-file accessor reads (#2030) — ${engine}`, () => {
+    let incDir: string;
+    let refDir: string;
+
+    beforeAll(async () => {
+      incDir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2030-inc-${engine}-`));
+      writeFixture(incDir);
+      await buildGraph(incDir, { engine, incremental: false, skipRegistry: true });
+
+      // Touch the reading file and rebuild it through the single-file
+      // incremental path — the accessor's own file (sqlite-repository.ts) is
+      // untouched, so its accessor_kind must already be visible to the
+      // incremental rebuild's global-by-name lookup.
+      const filePath = path.join(incDir, 'sequence.ts');
+      fs.appendFileSync(filePath, '\n// touched\n');
+      const dbPath = path.join(incDir, '.codegraph', 'graph.db');
+      const db = openDb(dbPath);
+      try {
+        initSchema(db);
+        const stmts = makeStmts(db);
+        await rebuildFile(db, incDir, filePath, stmts, { engine }, null);
+      } finally {
+        db.close();
+      }
+
+      refDir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2030-ref-${engine}-`));
+      writeFixture(refDir);
+      fs.appendFileSync(path.join(refDir, 'sequence.ts'), '\n// touched\n');
+      await buildGraph(refDir, { engine, incremental: false, skipRegistry: true });
+    }, 60_000);
+
+    afterAll(() => {
+      fs.rmSync(incDir, { recursive: true, force: true });
+      fs.rmSync(refDir, { recursive: true, force: true });
+    });
+
+    it('produces the same cross-file accessor-read call edges as a full rebuild', () => {
+      const incremental = readCallEdges(path.join(incDir, '.codegraph', 'graph.db'));
+      const reference = readCallEdges(path.join(refDir, '.codegraph', 'graph.db'));
+      expect(incremental).toEqual(reference);
+      expect(incremental).toContainEqual({
+        src: 'annotateDataflow',
+        srcKind: 'function',
+        tgt: 'SqliteRepository.db',
+        tgtKind: 'method',
+        kind: 'calls',
+      });
+    });
+  });
+}
+
+runIncrementalParityScenario('wasm');
+describe.skipIf(!isNativeAvailable())('native engine incremental parity coverage', () => {
+  runIncrementalParityScenario('native');
+});

--- a/tests/integration/watcher-fk-embeddings.test.ts
+++ b/tests/integration/watcher-fk-embeddings.test.ts
@@ -32,7 +32,7 @@ function copyDirSync(src: string, dest: string): void {
 function makeStmts(db: Database.Database): Parameters<typeof rebuildFile>[3] {
   return {
     insertNode: db.prepare(
-      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line) VALUES (?, ?, ?, ?, ?)',
+      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
     ),
     getNodeId: {
       get: (name: string, kind: string, file: string, line: number) => {

--- a/tests/integration/watcher-rebuild.test.ts
+++ b/tests/integration/watcher-rebuild.test.ts
@@ -55,7 +55,7 @@ function readGraph(dbPath) {
 function makeStmts(db) {
   return {
     insertNode: db.prepare(
-      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line) VALUES (?, ?, ?, ?, ?)',
+      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
     ),
     getNodeId: {
       get: (name, kind, file, line) => {

--- a/tests/parsers/javascript.test.ts
+++ b/tests/parsers/javascript.test.ts
@@ -2898,4 +2898,120 @@ function runDemo(reporter: Reporter, users: string[]): void {
       );
     });
   });
+
+  describe('ES6 getter/setter cross-file property-read call attribution (#2030)', () => {
+    function parseJS(code) {
+      const parser = parsers.get('javascript');
+      const tree = parser.parse(code);
+      return extractSymbols(tree, 'test.js');
+    }
+
+    function parseTS(code) {
+      const parser = parsers.get('typescript');
+      const tree = parser.parse(code);
+      return extractSymbols(tree, 'test.ts');
+    }
+
+    it('tags a cross-file `varName.prop` read with accessorRead="get" and the resolved class name', () => {
+      const symbols = parseTS(`
+        function useRepo(repo: SqliteRepository) {
+          return repo.db;
+        }
+      `);
+      expect(symbols.calls).toContainEqual(
+        expect.objectContaining({ name: 'db', receiver: 'SqliteRepository', accessorRead: 'get' }),
+      );
+    });
+
+    it('tags a cross-file plain-assignment write with accessorRead="set"', () => {
+      const symbols = parseTS(`
+        function useRepo(repo: SqliteRepository) {
+          repo.db = null;
+        }
+      `);
+      expect(symbols.calls).toContainEqual(
+        expect.objectContaining({ name: 'db', receiver: 'SqliteRepository', accessorRead: 'set' }),
+      );
+    });
+
+    it('does not tag a same-file confirmed accessor call', () => {
+      const symbols = parseTS(`
+        class Repo {
+          get db() { return this._db; }
+        }
+        function useRepo(repo: Repo) {
+          return repo.db;
+        }
+      `);
+      const call = symbols.calls.find((c) => c.name === 'db' && c.receiver === 'repo');
+      expect(call).toBeDefined();
+      expect(call.accessorRead).toBeUndefined();
+    });
+
+    it('narrows the receiver type via `instanceof` for a cross-file accessor read', () => {
+      const symbols = parseJS(`
+        function useRepo(repo) {
+          if (repo instanceof SqliteRepository) {
+            return repo.db;
+          }
+        }
+      `);
+      expect(symbols.calls).toContainEqual(
+        expect.objectContaining({ name: 'db', receiver: 'SqliteRepository', accessorRead: 'get' }),
+      );
+    });
+
+    it('narrows across an `&&`-chained instanceof condition', () => {
+      const symbols = parseJS(`
+        function useRepo(x, repo) {
+          if (x && repo instanceof SqliteRepository) {
+            return repo.db;
+          }
+        }
+      `);
+      expect(symbols.calls).toContainEqual(
+        expect.objectContaining({ name: 'db', receiver: 'SqliteRepository' }),
+      );
+    });
+
+    it('does not narrow across an `||` condition (unsafe — falls back to the declared type)', () => {
+      const symbols = parseTS(`
+        function useRepo(repo: Repository) {
+          if (repo instanceof SqliteRepository || true) {
+            return repo.db;
+          }
+        }
+      `);
+      expect(symbols.calls).toContainEqual(
+        expect.objectContaining({ name: 'db', receiver: 'Repository' }),
+      );
+      expect(symbols.calls).not.toContainEqual(
+        expect.objectContaining({ name: 'db', receiver: 'SqliteRepository' }),
+      );
+    });
+
+    it('does not leak instanceof narrowing into the else branch', () => {
+      const symbols = parseTS(`
+        function useRepo(repo: Repository) {
+          if (repo instanceof SqliteRepository) {
+            return 1;
+          } else {
+            return repo.db;
+          }
+        }
+      `);
+      expect(symbols.calls).toContainEqual(
+        expect.objectContaining({ name: 'db', receiver: 'Repository' }),
+      );
+    });
+
+    it('never tags a plain `this.field` read even when not locally confirmed', () => {
+      const symbols = parseJS(`
+        class Widget {
+          useOther() { return this.unknownProp; }
+        }
+      `);
+      expect(symbols.calls).not.toContainEqual(expect.objectContaining({ name: 'unknownProp' }));
+    });
+  });
 });

--- a/tests/unit/call-resolver.test.ts
+++ b/tests/unit/call-resolver.test.ts
@@ -1117,18 +1117,50 @@ describe('resolveCallTargets — accessor-read de-aliasing and import scoping (#
     // `import { SqliteRepository as SR } from './sqlite-repository.js'` seeds
     // the extractor's typeMap with the local alias 'SR', so the tagged call's
     // receiver is 'SR' — the accessor is persisted under the real name.
+    // `importedNames` is keyed by the local alias 'SR' (as the extractor's
+    // import bookkeeping actually populates it), NOT the de-aliased original
+    // — this must still resolve via the scoped (not global) lookup tier.
     const getter = { id: 1, file: 'sqlite-repository.js', kind: 'method', accessorKind: 'get' };
-    const lookup = makeAccessorLookup({}, { 'SqliteRepository.db': [getter] });
+    const lookup = makeAccessorLookup({ 'SqliteRepository.db:sqlite-repository.js': [getter] }, {});
     const { targets } = resolveCallTargets(
       lookup,
       { name: 'db', receiver: 'SR', accessorRead: 'get' },
       'consumer.js',
-      new Map(),
+      new Map([['SR', 'sqlite-repository.js']]),
       new Map(),
       null,
       new Map([['SR', 'SqliteRepository']]),
     );
     expect(targets).toEqual([getter]);
+  });
+
+  it('scopes a renamed-import alias to its own file, not an unrelated same-named global match', () => {
+    // Regression: a first attempt at this fix looked up `importedNames` under
+    // the de-aliased name ('SqliteRepository') instead of the local alias
+    // ('SR') actually used as the map key, always missing for a renamed
+    // import and silently falling through to the unscoped global lookup —
+    // which would have returned this test's unrelated getter too.
+    const realGetter = { id: 1, file: 'sqlite-repository.js', kind: 'method', accessorKind: 'get' };
+    const unrelatedGetter = {
+      id: 2,
+      file: 'unrelated-other-file.js',
+      kind: 'method',
+      accessorKind: 'get',
+    };
+    const lookup = makeAccessorLookup(
+      { 'SqliteRepository.db:sqlite-repository.js': [realGetter] },
+      { 'SqliteRepository.db': [realGetter, unrelatedGetter] },
+    );
+    const { targets } = resolveCallTargets(
+      lookup,
+      { name: 'db', receiver: 'SR', accessorRead: 'get' },
+      'consumer.js',
+      new Map([['SR', 'sqlite-repository.js']]),
+      new Map(),
+      null,
+      new Map([['SR', 'SqliteRepository']]),
+    );
+    expect(targets).toEqual([realGetter]);
   });
 
   it('prefers the file the class is imported from over an unrelated same-named global match', () => {

--- a/tests/unit/call-resolver.test.ts
+++ b/tests/unit/call-resolver.test.ts
@@ -1073,3 +1073,134 @@ describe('resolveReflectionKeyExprFallback — shared between full-build and inc
     expect(targets).toEqual([]);
   });
 });
+
+/**
+ * Regression tests for #2030's Greptile review findings on the cross-file
+ * accessor-read short-circuit in resolveCallTargets:
+ *   1. Renamed import aliases must be de-aliased before the qualified lookup
+ *      (mirrors #1730's general-cascade de-aliasing) — otherwise a receiver
+ *      resolved via `import { Original as Alias }` looks up `Alias.prop`
+ *      instead of the persisted `Original.prop` and silently drops the edge.
+ *   2. The lookup must prefer the specific file the class is imported from
+ *      when known, not the unscoped global byName — otherwise two unrelated
+ *      files that happen to declare the same `ClassName.prop` accessor (same
+ *      kind) both "confirm" a read that only targets one of them.
+ */
+function makeAccessorLookup(
+  sameFile: Record<
+    string,
+    Array<{ id: number; file: string; kind: string; accessorKind?: string }>
+  >,
+  global: Record<string, Array<{ id: number; file: string; kind: string; accessorKind?: string }>>,
+): CallNodeLookup {
+  return {
+    byNameAndFile(name, file) {
+      return sameFile[`${name}:${file}`] ?? [];
+    },
+    byName(name) {
+      return global[name] ?? [];
+    },
+    isBarrel() {
+      return false;
+    },
+    resolveBarrel() {
+      return null;
+    },
+    nodeId() {
+      return undefined;
+    },
+  };
+}
+
+describe('resolveCallTargets — accessor-read de-aliasing and import scoping (#2030)', () => {
+  it('de-aliases a renamed import binding before the qualified accessor lookup', () => {
+    // `import { SqliteRepository as SR } from './sqlite-repository.js'` seeds
+    // the extractor's typeMap with the local alias 'SR', so the tagged call's
+    // receiver is 'SR' — the accessor is persisted under the real name.
+    const getter = { id: 1, file: 'sqlite-repository.js', kind: 'method', accessorKind: 'get' };
+    const lookup = makeAccessorLookup({}, { 'SqliteRepository.db': [getter] });
+    const { targets } = resolveCallTargets(
+      lookup,
+      { name: 'db', receiver: 'SR', accessorRead: 'get' },
+      'consumer.js',
+      new Map(),
+      new Map(),
+      null,
+      new Map([['SR', 'SqliteRepository']]),
+    );
+    expect(targets).toEqual([getter]);
+  });
+
+  it('prefers the file the class is imported from over an unrelated same-named global match', () => {
+    const realGetter = {
+      id: 1,
+      file: 'sqlite-repository.js',
+      kind: 'method',
+      accessorKind: 'get',
+    };
+    const unrelatedGetter = {
+      id: 2,
+      file: 'unrelated-other-file.js',
+      kind: 'method',
+      accessorKind: 'get',
+    };
+    const lookup = makeAccessorLookup(
+      { 'SqliteRepository.db:sqlite-repository.js': [realGetter] },
+      { 'SqliteRepository.db': [realGetter, unrelatedGetter] },
+    );
+    const { targets } = resolveCallTargets(
+      lookup,
+      { name: 'db', receiver: 'SqliteRepository', accessorRead: 'get' },
+      'consumer.js',
+      new Map([['SqliteRepository', 'sqlite-repository.js']]),
+      new Map(),
+      null,
+    );
+    expect(targets).toEqual([realGetter]);
+  });
+
+  it('falls back to the unscoped global lookup when the class is not a known import', () => {
+    // e.g. an ambient/global class never explicitly imported in this file.
+    const getter = { id: 1, file: 'sqlite-repository.js', kind: 'method', accessorKind: 'get' };
+    const lookup = makeAccessorLookup({}, { 'SqliteRepository.db': [getter] });
+    const { targets } = resolveCallTargets(
+      lookup,
+      { name: 'db', receiver: 'SqliteRepository', accessorRead: 'get' },
+      'consumer.js',
+      new Map(),
+      new Map(),
+      null,
+    );
+    expect(targets).toEqual([getter]);
+  });
+
+  it('drops the call when the imported-scoped file has no matching accessor kind, without falling back to the global match', () => {
+    // The scoped file's own db is a setter, not a getter — the read needs a
+    // getter, so it must not silently pick up an unrelated global getter.
+    const scopedSetter = {
+      id: 1,
+      file: 'sqlite-repository.js',
+      kind: 'method',
+      accessorKind: 'set',
+    };
+    const unrelatedGetter = {
+      id: 2,
+      file: 'unrelated-other-file.js',
+      kind: 'method',
+      accessorKind: 'get',
+    };
+    const lookup = makeAccessorLookup(
+      { 'SqliteRepository.db:sqlite-repository.js': [scopedSetter] },
+      { 'SqliteRepository.db': [scopedSetter, unrelatedGetter] },
+    );
+    const { targets } = resolveCallTargets(
+      lookup,
+      { name: 'db', receiver: 'SqliteRepository', accessorRead: 'get' },
+      'consumer.js',
+      new Map([['SqliteRepository', 'sqlite-repository.js']]),
+      new Map(),
+      null,
+    );
+    expect(targets).toEqual([]);
+  });
+});

--- a/tests/unit/db.test.ts
+++ b/tests/unit/db.test.ts
@@ -101,6 +101,14 @@ describe('MIGRATIONS', () => {
     db.prepare(
       "INSERT INTO edges (source_id, target_id, kind, confidence, dynamic, technique) VALUES (?, ?, 'calls', 0.8, 0, 'cha-expanded')",
     ).run(ids[0]!.id, ids[1]!.id);
+    // #2030 added migration v27 (a non-idempotent `ALTER TABLE ... ADD
+    // COLUMN`) after this test was written. Rolling schema_version back to 25
+    // below replays every migration after it — including v27 — on the second
+    // initSchema() call; the first call above already added `accessor_kind`
+    // once, so replaying v27 without also undoing it would hit "duplicate
+    // column name". Drop it back out here first.
+    db.exec('DROP INDEX IF EXISTS idx_nodes_accessor_kind');
+    db.exec('ALTER TABLE nodes DROP COLUMN accessor_kind');
     db.prepare('UPDATE schema_version SET version = 25').run();
 
     initSchema(db);


### PR DESCRIPTION
## Summary

#1893 fixed bare (non-call) property reads on ES6 `get`/`set` accessors (`obj.isReady`, no call parens) never producing a `calls` edge, but only for the **same-file** case: the accessor's declaring class had to live in the same file as the read site, since that was the only way to confirm at extraction time that the read really targets an accessor rather than an unrelated same-named method/field.

This PR covers the **cross-file** case: the accessor's class is declared in a different file than the read site (the issue's own repro — `SqliteRepository.db` read from `src/features/sequence.ts` after `instanceof SqliteRepository` narrowing).

## Approach

1. **Schema**: new migration `accessor_kind` (`'get'`/`'set'`/`NULL`) column on `nodes`, mirrored in both engines' migration lists (`src/db/migrations.ts`, `crates/codegraph-core/src/db/connection.rs`) and set at insertion time for every ES6 accessor method (`buildMethodDefinition` / `handle_method_def`).
2. **Extraction**: `collectAccessorPropertyRead` (and the Rust mirror `handle_accessor_property_read`) keeps the existing same-file confirmation path unchanged, but now falls through to a *tagged* candidate when the receiver's type isn't declared locally — the `Call` carries `accessorRead: 'get'|'set'` and its `receiver` is the *resolved class name* rather than the read site's variable text.
3. **Resolution**: `resolveCallTargets` (and native `resolve_call_targets_core`) short-circuits on `accessorRead`, resolving directly against the qualified `receiver.name` filtered by the DB's `accessor_kind` column — bypassing the usual directory-proximity confidence gate (kind-plus-exact-name match is a strictly stronger signal than proximity), and dropping the call outright when nothing matches rather than falling through to an unrelated same-named non-accessor declaration.
4. **`instanceof` narrowing**: `if (x instanceof Y) { x.prop }` (including `&&` chains) narrows `x`'s type to `Y` for the property read, so a wider declared type doesn't shadow the accessor that only exists on the narrowed subclass — needed for the issue's own repro, where the parameter is typed `Repository` but the accessor lives on `SqliteRepository`.

The same-file case is unchanged: a same-file-confirmed call still flows through untagged (no accessor_kind filtering needed), and `this` reads never take the cross-file path since `this`'s class is always declared in the same file.

Because a getter and setter sharing a name are now distinguishable by `accessor_kind`, this also incidentally fixes ambiguous get+set disambiguation for the *cross-file* case (same-file get+set pairs keep #1893's original "skip, don't guess" behavior — left unchanged as a separate, deliberately out-of-scope improvement, see follow-up issue below).

## Verification

- Real-world repro confirmed against this repo's own `src/features/sequence.ts` ↔ `src/db/repository/sqlite-repository.ts`, on both engines:
  ```
  annotateDataflow -> SqliteRepository.db  [calls]
  SqliteRepository.db  accessor_kind=get
  ```
- New dedicated fixture + integration test (`tests/integration/issue-2030-cross-file-accessor-recognition.test.ts`) covering: cross-file edge, `accessor_kind` persistence, plain-method false-positive rejection, both engines, and incremental-vs-full-build parity.
- New unit tests in both engines' extractors (narrowing, `&&`/`||` handling, else-branch non-leakage, same-file-untagged invariant, `this`-never-tagged volume guard) and in the native resolver (distant-directory resolution, plain-method rejection, get/set disambiguation).
- `npm run lint`, `npm run typecheck`, `npm test` (271 files / 4376 tests), `cargo test --lib` and `--release` (725 tests) all green.
- `tests/benchmarks/resolution/` (317 tests) and CI's dedicated parity suites (`tests/engines/`, `tests/integration/build-parity.test.ts`, `tests/integration/dropped-language-gap.test.ts`) all green.
- Full `scripts/parity-compare.mjs` run across all 34 language fixtures: one pre-existing, unrelated divergence found (`jelly-micro`, `super()` dispatch across same-named classes in different files) — confirmed present on a clean `origin/main` checkout and filed separately as #2251, not touched by this change.
- `codegraph diff-impact --staged -T` reviewed: 21 functions changed, 68 transitive callers, all within the expected schema/extraction/resolution surface.

Closes #2030