### PR TITLE
fix(skills): seed current-pr for drain-phase post-merge CI check

### DIFF
--- a/.claude/skills/fixer/SKILL.md
+++ b/.claude/skills/fixer/SKILL.md
@@ -1209,6 +1209,13 @@ Each pass does three things, in order:
 
    Then apply I8 exactly as in step 2f-bis: verify the post-merge `CI` workflow run on `main` for this merge's commit, wait for it if still in progress, and diagnose-and-fix (or confirm-transient-via-rerun) a red result before merging the next parked PR or starting another pass. A drain-phase merge lands on `main` the same way a Phase 2 merge does, so it carries the identical risk of tipping shared CI capacity into failure.
 
+   2f-bis's own script reads the merged PR's number from `.codegraph/fixer/current-pr` — but by the time draining starts, normal per-issue cleanup (2g) has already removed that file, and this loop only ever holds the PR number in `MERGED_PR`. Seed `current-pr` from `MERGED_PR` before running 2f-bis's two bash blocks exactly as written, then remove it again so it does not leak into the next drain iteration:
+   ```bash
+   printf '%s\n' "$MERGED_PR" > .codegraph/fixer/current-pr
+   # ... run 2f-bis's two bash blocks unmodified here ...
+   rm -f .codegraph/fixer/current-pr
+   ```
+
 **After each pass**, record whether it made progress and decide whether to run another one:
 
 ```bash

--- a/.claude/skills/fixer/SKILL.md
+++ b/.claude/skills/fixer/SKILL.md
@@ -1209,10 +1209,12 @@ Each pass does three things, in order:
 
    Then apply I8 exactly as in step 2f-bis: verify the post-merge `CI` workflow run on `main` for this merge's commit, wait for it if still in progress, and diagnose-and-fix (or confirm-transient-via-rerun) a red result before merging the next parked PR or starting another pass. A drain-phase merge lands on `main` the same way a Phase 2 merge does, so it carries the identical risk of tipping shared CI capacity into failure.
 
-   2f-bis's own script reads the merged PR's number from `.codegraph/fixer/current-pr` — but by the time draining starts, normal per-issue cleanup (2g) has already removed that file, and this loop only ever holds the PR number in `MERGED_PR`. Seed `current-pr` from `MERGED_PR` before running 2f-bis's two bash blocks exactly as written, then remove it again so it does not leak into the next drain iteration:
+   2f-bis's own script reads the merged PR's number from `.codegraph/fixer/current-pr` — but by the time draining starts, normal per-issue cleanup (2g) has already removed that file, and this loop only ever holds the PR number in `MERGED_PR`. Seed `current-pr` from `MERGED_PR` before running 2f-bis's two bash blocks exactly as written. Register a trap first: 2f-bis's own blocks contain several `exit 1` paths (no matching CI run found, post-merge CI still red after a rerun), and a plain `rm` placed only after those blocks would never run on any of them, leaving this drain-specific artifact behind:
    ```bash
    printf '%s\n' "$MERGED_PR" > .codegraph/fixer/current-pr
+   trap 'rm -f .codegraph/fixer/current-pr' EXIT
    # ... run 2f-bis's two bash blocks unmodified here ...
+   trap - EXIT
    rm -f .codegraph/fixer/current-pr
    ```
 


### PR DESCRIPTION
## Summary

Follow-up to #2250. Greptile's second review on that PR (4/5, unresolved at merge time) correctly flagged that the Phase: Drain Parked PRs pointer to step 2f-bis was broken: 2f-bis's own script reads the just-merged PR's number from `.codegraph/fixer/current-pr`, but by the time draining starts, normal per-issue cleanup (step 2g) has already removed that file. The drain loop only ever holds the merged PR's number in its own `$MERGED_PR` shell variable, so a literal "apply 2f-bis" would read a missing or stale `current-pr` and either exit early or verify the wrong PR's CI run — leaving the just-merged commit's post-merge CI effectively unchecked in the one phase most likely to need it (draining happens precisely when merges are less routine).

## Fix

Seed `.codegraph/fixer/current-pr` from `$MERGED_PR` immediately before running 2f-bis's two bash blocks unmodified, then remove it again so it doesn't leak into the next drain iteration.

## Verification
- lint: pass (`npm run lint`)
- `.claude/skills/create-skill/scripts/lint-skill.sh` against the edited file: same pre-existing error/warning count as before this change (2 known false-positive errors, 13 pre-existing warnings) — no new issues introduced.

Closes nothing directly; this is a direct correctness fix for the drain-phase pointer added in #2250.