### PR TITLE
fix(classifiers): detect transitively-unreachable dead code, not just fanIn===0

### DIFF
--- a/crates/codegraph-core/src/graph/classifiers/roles.rs
+++ b/crates/codegraph-core/src/graph/classifiers/roles.rs
@@ -465,6 +465,19 @@ pub(crate) fn do_classify_full(conn: &Connection) -> rusqlite::Result<RoleSummar
     // reexport chains only, excluding `exported_ids`'s cross-file-caller
     // component above) — see `is_live_root`'s doc comment for why that
     // component must not grant automatic root status.
+    //
+    // Deliberately NOT reusing the whole-file `exported_ids` query above
+    // (Greptile review): that query treats ANY `reexports` edge — whether
+    // from `export { specificThing } from './b'` (which only re-exports
+    // `specificThing`) or `export * from './b'` (which genuinely re-exports
+    // everything) — as "every symbol in the target file is exported". For a
+    // named reexport that over-broadly marks every OTHER private symbol in
+    // that file as a public-surface root too, letting an unreachable private
+    // call chain sharing a file with one re-exported symbol evade the whole
+    // check. A named reexport gets its own symbol-level `reexports` edge
+    // (target = the specific symbol node, not the file) — use that directly;
+    // only a genuine wildcard reexport (kind `reexports-wildcard`) justifies
+    // marking the whole file.
     let mut public_surface_ids: std::collections::HashSet<i64> = std::collections::HashSet::new();
     {
         let sql = format!(
@@ -496,6 +509,43 @@ pub(crate) fn do_classify_full(conn: &Connection) -> rusqlite::Result<RoleSummar
         let reexport_rows = stmt.query_map([], |row| row.get::<_, i64>(0))?;
         for r in reexport_rows.flatten() {
             exported_ids.insert(r);
+        }
+    }
+    {
+        let sql = format!(
+            "WITH RECURSIVE prod_reachable(file_id) AS (
+                SELECT DISTINCT e.target_id
+                FROM edges e
+                JOIN nodes src ON e.source_id = src.id
+                WHERE e.kind IN ('imports', 'dynamic-imports', 'imports-type')
+                  AND src.kind = 'file'
+                  {}
+                UNION
+                SELECT e.target_id
+                FROM edges e
+                JOIN prod_reachable pr ON e.source_id = pr.file_id
+                WHERE e.kind = 'reexports'
+              )
+              SELECT DISTINCT e.target_id AS id
+              FROM edges e
+              JOIN nodes n ON n.id = e.target_id
+              WHERE e.kind = 'reexports' AND n.kind != 'file'
+                AND e.source_id IN (SELECT file_id FROM prod_reachable)
+              UNION
+              SELECT DISTINCT n.id AS id
+              FROM nodes n
+              JOIN nodes f ON f.file = n.file AND f.kind = 'file'
+              WHERE f.id IN (
+                SELECT e.target_id FROM edges e
+                WHERE e.kind = 'reexports-wildcard'
+                  AND e.source_id IN (SELECT file_id FROM prod_reachable)
+              )
+              AND n.kind NOT IN ('file', 'directory', 'parameter', 'property', 'method')",
+            test_file_filter_col("src.file")
+        );
+        let mut stmt = tx.prepare(&sql)?;
+        let public_surface_rows = stmt.query_map([], |row| row.get::<_, i64>(0))?;
+        for r in public_surface_rows.flatten() {
             public_surface_ids.insert(r);
         }
     }
@@ -1695,6 +1745,40 @@ mod tests {
         do_classify_full(conn).expect("do_classify_full should succeed");
 
         assert_eq!(role_of(conn, 2).as_deref(), Some("dead-unresolved"));
+    }
+
+    #[test]
+    fn named_reexport_does_not_leak_public_surface_status_to_unreachable_siblings() {
+        let db = setup_db();
+        let conn = db.conn().expect("connection should still be open");
+
+        // Regression for a Greptile-flagged gap: the whole-file `exported_ids`
+        // query treats ANY 'reexports' edge as "every symbol in the target
+        // file is exported" — but `export { publicThing } from './lib'` only
+        // re-exports `publicThing`. public_surface_ids must not let
+        // deadHelper (whose only caller, deadIntermediate, is itself
+        // unreachable) evade the reachability check merely because it shares
+        // a file with the one actually re-exported symbol.
+        insert_node(conn, 1, "src/lib.ts", "file", "src/lib.ts", 0);
+        insert_node(conn, 2, "src/index.ts", "file", "src/index.ts", 0);
+        insert_node(conn, 3, "src/app.ts", "file", "src/app.ts", 0);
+        insert_node(conn, 4, "publicThing", "function", "src/lib.ts", 0);
+        insert_node(conn, 5, "deadIntermediate", "function", "src/lib.ts", 0);
+        insert_node(conn, 6, "deadHelper", "function", "src/lib.ts", 0);
+
+        // Generic file-to-file 'reexports' edge (emitted regardless of
+        // named/wildcard) plus the symbol-level edge targeting publicThing
+        // specifically — NOT a 'reexports-wildcard' marker.
+        insert_edge(conn, 2, 1, "reexports", 0);
+        insert_edge(conn, 2, 4, "reexports", 0);
+        insert_edge(conn, 3, 2, "imports", 0);
+
+        insert_edge(conn, 5, 6, "calls", 0);
+
+        do_classify_full(conn).expect("do_classify_full should succeed");
+
+        assert_ne!(role_of(conn, 4).as_deref(), Some("dead-unresolved"));
+        assert_eq!(role_of(conn, 6).as_deref(), Some("dead-unresolved"));
     }
 
     #[test]

--- a/crates/codegraph-core/src/graph/classifiers/roles.rs
+++ b/crates/codegraph-core/src/graph/classifiers/roles.rs
@@ -459,6 +459,13 @@ pub(crate) fn do_classify_full(conn: &Connection) -> rusqlite::Result<RoleSummar
     // abstract base class's zero-fan-in method declarations were promoted to
     // `entry` merely because some other symbol in the same file was re-exported
     // through a barrel.
+    //
+    // `public_surface_ids` mirrors the TS `publicSurfaceIds` narrower "genuinely
+    // public" set for #2032's reachability roots (explicit `export` + confirmed
+    // reexport chains only, excluding `exported_ids`'s cross-file-caller
+    // component above) — see `is_live_root`'s doc comment for why that
+    // component must not grant automatic root status.
+    let mut public_surface_ids: std::collections::HashSet<i64> = std::collections::HashSet::new();
     {
         let sql = format!(
             "WITH RECURSIVE prod_reachable(file_id) AS (
@@ -489,6 +496,7 @@ pub(crate) fn do_classify_full(conn: &Connection) -> rusqlite::Result<RoleSummar
         let reexport_rows = stmt.query_map([], |row| row.get::<_, i64>(0))?;
         for r in reexport_rows.flatten() {
             exported_ids.insert(r);
+            public_surface_ids.insert(r);
         }
     }
 
@@ -506,6 +514,7 @@ pub(crate) fn do_classify_full(conn: &Connection) -> rusqlite::Result<RoleSummar
         let rows = stmt.query_map([], |row| row.get::<_, i64>(0))?;
         for r in rows.flatten() {
             exported_ids.insert(r);
+            public_surface_ids.insert(r);
         }
     }
 
@@ -582,7 +591,7 @@ pub(crate) fn do_classify_full(conn: &Connection) -> rusqlite::Result<RoleSummar
     };
     apply_reachability_downgrade(
         &rows,
-        &exported_ids,
+        &public_surface_ids,
         &called_active_files,
         &type_def_names_by_file,
         &call_edges,
@@ -779,12 +788,28 @@ fn is_fan_shape_role(role: &str) -> bool {
     matches!(role, "core" | "utility" | "adapter" | "leaf")
 }
 
-/// True when (name, kind, file, is_exported) is a confirmed-live reachability
-/// root for the transitive dead-code pass (#2032) — mirrors TS `isLiveRoot`.
-/// Only covers roots that are themselves `function`/`method` rows;
-/// `apply_reachability_downgrade` separately seeds additional roots directly
-/// from `call_edges` for non-function/method call sources.
-fn is_live_root(name: &str, kind: &str, file: &str, is_exported: bool, is_type_member: bool) -> bool {
+/// True when (name, kind, file, is_public_surface) is a confirmed-live
+/// reachability root for the transitive dead-code pass (#2032) — mirrors TS
+/// `isLiveRoot`. Only covers roots that are themselves `function`/`method`
+/// rows; `apply_reachability_downgrade` separately seeds additional roots
+/// directly from `call_edges` for non-function/method call sources.
+///
+/// Deliberately takes `is_public_surface`, NOT the broader `is_exported` that
+/// `classify_node`'s own `entry` branch uses — `is_exported` also considers a
+/// node "exported" merely because SOME caller in a different file calls it,
+/// regardless of whether that caller is itself reachable. Using that signal
+/// here would let a symbol called only by an unreachable cross-file caller
+/// become an automatic root, defeating #2032's fix for exactly the cross-file
+/// case it's meant to catch. `is_public_surface` is narrower: only the
+/// explicit `export` keyword and confirmed production-reachable reexport
+/// chains — see its computation at the `do_classify_full` call site.
+fn is_live_root(
+    name: &str,
+    kind: &str,
+    file: &str,
+    is_public_surface: bool,
+    is_type_member: bool,
+) -> bool {
     if is_type_member {
         return false;
     }
@@ -794,22 +819,61 @@ fn is_live_root(name: &str, kind: &str, file: &str, is_exported: bool, is_type_m
     if kind != "function" && kind != "method" {
         return false;
     }
-    if is_exported {
+    if is_public_surface {
         return true;
     }
     COMMANDER_DISPATCH_NAMES.iter().any(|n| *n == name)
         && ENTRY_PATH_PATTERNS.iter().any(|p| file.contains(p))
 }
 
-/// True when (kind, fan_in, fan_out, has_active_siblings, is_type_member) is a
-/// `method`-kind interface-dispatch implementation rescued by
+/// Compute the set of bare (owner-prefix-stripped) member names declared by
+/// ANY interface/type-level declaration across `rows` — e.g. TS `interface
+/// Visitor { enter_node?(...): ...; exit_node?(...): ...; }` contributes
+/// `"enterNode"`/`"exitNode"`. Used by `is_interface_dispatch_method_root` to
+/// require that a candidate dispatch method's name corresponds to an actual
+/// declared interface contract SOMEWHERE in the codebase, rather than merely
+/// "any method with fan_out > 0 in a file that also has other active code" —
+/// the latter is indistinguishable from a genuinely-dead, ordinary class
+/// method that happens to call a helper. Mirrors TS `computeInterfaceMemberBareNames`.
+fn compute_interface_member_bare_names(
+    rows: &[(i64, String, String, String, u32, u32)],
+    type_def_names_by_file: &HashMap<String, std::collections::HashSet<String>>,
+) -> std::collections::HashSet<String> {
+    let mut names = std::collections::HashSet::new();
+    for (_id, name, kind, file, _fan_in, _fan_out) in rows {
+        if !is_type_declaration_member(name, kind, file, type_def_names_by_file) {
+            continue;
+        }
+        let bare = match name.find('.') {
+            Some(dot_idx) => &name[dot_idx + 1..],
+            None => name.as_str(),
+        };
+        names.insert(bare.to_string());
+    }
+    names
+}
+
+/// True when (kind, fan_in, fan_out, has_active_siblings, is_type_member,
+/// name) is a `method`-kind interface-dispatch implementation rescued by
 /// `classify_node`'s Pattern-2 heuristic (fan_in == 0, fan_out > 0,
-/// has_active_siblings) — e.g. `enter_node`/`exit_node` on a Visitor-shaped
-/// object, invoked only via generic property-access dispatch that codegraph
-/// cannot trace to a concrete implementation. Such a method can never be the
-/// TARGET of a `calls` edge by construction, so it must be an unconditional
-/// root — otherwise everything it calls would be wrongly treated as
-/// unreachable merely because the dispatch mechanism itself leaves no edge.
+/// has_active_siblings) AND whose bare name corresponds to an actual
+/// interface/type declaration member somewhere in the codebase (matched via
+/// `interface_member_bare_names`) — e.g. `enter_node`/`exit_node` on a
+/// Visitor-shaped object, invoked only via generic property-access dispatch
+/// that codegraph cannot trace to a concrete implementation. Such a method
+/// can never be the TARGET of a `calls` edge by construction, so it must be
+/// an unconditional root — otherwise everything it calls would be wrongly
+/// treated as unreachable merely because the dispatch mechanism itself
+/// leaves no edge.
+///
+/// The name-match requirement exists specifically because the
+/// fan_in/fan_out/has_active_siblings shape ALONE is too broad: an ordinary,
+/// genuinely-dead class method that happens to call a helper and share its
+/// file with another called symbol satisfies that shape too. Tying the
+/// rescue to an actual declared contract elsewhere in the codebase makes an
+/// "ordinary unused method" false positive require a coincidental name
+/// collision with some unrelated interface's member, rather than being the
+/// default outcome for any such method.
 ///
 /// Deliberately narrower than the sibling rescue for `function`-kind
 /// logical-or-fallback values in `classify_node` — that heuristic is an
@@ -819,13 +883,27 @@ fn is_live_root(name: &str, kind: &str, file: &str, is_exported: bool, is_type_m
 /// pattern) merely because they happen to call something in an active file.
 /// Mirrors TS `isInterfaceDispatchMethodRoot`.
 fn is_interface_dispatch_method_root(
+    name: &str,
     kind: &str,
     fan_in: u32,
     fan_out: u32,
     has_active_siblings: bool,
     is_type_member: bool,
+    interface_member_bare_names: &std::collections::HashSet<String>,
 ) -> bool {
-    kind == "method" && fan_in == 0 && fan_out > 0 && has_active_siblings && !is_type_member
+    if kind != "method"
+        || fan_in != 0
+        || fan_out == 0
+        || !has_active_siblings
+        || is_type_member
+    {
+        return false;
+    }
+    let bare = match name.find('.') {
+        Some(dot_idx) => &name[dot_idx + 1..],
+        None => name,
+    };
+    interface_member_bare_names.contains(bare)
 }
 
 /// Forward BFS over `calls` edges starting from `roots`, using a single
@@ -884,7 +962,7 @@ fn compute_reachable_ids(
 #[allow(clippy::too_many_arguments)]
 fn apply_reachability_downgrade(
     rows: &[(i64, String, String, String, u32, u32)],
-    exported_ids: &std::collections::HashSet<i64>,
+    public_surface_ids: &std::collections::HashSet<i64>,
     called_active_files: &std::collections::HashSet<String>,
     type_def_names_by_file: &HashMap<String, std::collections::HashSet<String>>,
     call_edges: &[(i64, i64)],
@@ -894,18 +972,26 @@ fn apply_reachability_downgrade(
     for (id, _name, kind, _file, _fan_in, _fan_out) in rows {
         kind_by_id.insert(*id, kind.as_str());
     }
+    let interface_member_bare_names = compute_interface_member_bare_names(rows, type_def_names_by_file);
 
     let mut roots: std::collections::HashSet<i64> = std::collections::HashSet::new();
     for (id, name, kind, file, fan_in, fan_out) in rows {
-        let is_exported = exported_ids.contains(id);
+        let is_public_surface = public_surface_ids.contains(id);
         let is_type_member = is_type_declaration_member(name, kind, file, type_def_names_by_file);
-        if is_live_root(name, kind, file, is_exported, is_type_member) {
+        if is_live_root(name, kind, file, is_public_surface, is_type_member) {
             roots.insert(*id);
             continue;
         }
         let has_active_siblings = called_active_files.contains(file);
-        if is_interface_dispatch_method_root(kind, *fan_in, *fan_out, has_active_siblings, is_type_member)
-        {
+        if is_interface_dispatch_method_root(
+            name,
+            kind,
+            *fan_in,
+            *fan_out,
+            has_active_siblings,
+            is_type_member,
+            &interface_member_bare_names,
+        ) {
             roots.insert(*id);
         }
     }
@@ -1534,13 +1620,61 @@ mod tests {
         // can never be the TARGET of a `calls` edge — fan_in stays 0
         // forever, yet it's rescued to "leaf" by classify_node's Pattern-2
         // heuristic. Whatever it calls must be reachable through it.
+        //
+        // The declared `Visitor` interface (mirroring src/types.ts) is
+        // required: is_interface_dispatch_method_root only promotes a method
+        // to root when its bare name matches an actual interface/type member
+        // somewhere in the codebase, not merely from the
+        // fan_in/fan_out/has_active_siblings shape alone.
         insert_node(conn, 1, "enterNode", "method", "visitor.ts", 0);
         insert_node(conn, 2, "classifyHalstead", "function", "visitor.ts", 0);
+        insert_node(conn, 3, "Visitor", "interface", "types.ts", 1);
+        insert_node(conn, 4, "Visitor.enterNode", "method", "types.ts", 0);
         insert_edge(conn, 1, 2, "calls", 0);
 
         do_classify_full(conn).expect("do_classify_full should succeed");
 
         assert_ne!(role_of(conn, 2).as_deref(), Some("dead-unresolved"));
+    }
+
+    #[test]
+    fn does_not_treat_ordinary_unused_class_method_as_interface_dispatch_root() {
+        let db = setup_db();
+        let conn = db.conn().expect("connection should still be open");
+
+        // Regression for a Greptile-flagged gap: without the interface-member
+        // name-match requirement, ANY method with fan_in=0, fan_out>0, and an
+        // active sibling in its file would be promoted to root — including a
+        // genuinely-dead class method that happens to call a helper. No
+        // interface/type declares a "deadMethod" member anywhere here.
+        insert_node(conn, 1, "MyClass.deadMethod", "method", "a.ts", 0);
+        insert_node(conn, 2, "helper", "function", "a.ts", 0);
+        insert_edge(conn, 1, 2, "calls", 0);
+
+        do_classify_full(conn).expect("do_classify_full should succeed");
+
+        assert_eq!(role_of(conn, 2).as_deref(), Some("dead-unresolved"));
+    }
+
+    #[test]
+    fn does_not_treat_a_symbol_as_root_merely_because_of_an_unreachable_cross_file_caller() {
+        let db = setup_db();
+        let conn = db.conn().expect("connection should still be open");
+
+        // Regression for a Greptile-flagged gap: exported_ids' cross-file-
+        // caller heuristic also marks a symbol "exported" merely because SOME
+        // caller in a different file calls it — regardless of whether that
+        // caller is itself reachable. is_live_root must key off the narrower
+        // public_surface_ids (explicit export / confirmed reexport chain),
+        // not that broader signal, or a cross-file dead call chain would
+        // evade #2032's fix entirely.
+        insert_node(conn, 1, "unreachableCrossFileCaller", "function", "a.ts", 0);
+        insert_node(conn, 2, "calleeInAnotherFile", "function", "b.ts", 0);
+        insert_edge(conn, 1, 2, "calls", 0);
+
+        do_classify_full(conn).expect("do_classify_full should succeed");
+
+        assert_eq!(role_of(conn, 2).as_deref(), Some("dead-unresolved"));
     }
 
     #[test]

--- a/crates/codegraph-core/src/graph/classifiers/roles.rs
+++ b/crates/codegraph-core/src/graph/classifiers/roles.rs
@@ -553,7 +553,7 @@ pub(crate) fn do_classify_full(conn: &Connection) -> rusqlite::Result<RoleSummar
             .extend(type_member_leaf_ids);
     }
 
-    classify_rows(
+    let mut role_by_id = classify_rows(
         &rows,
         &exported_ids,
         &prod_fan_in,
@@ -562,9 +562,34 @@ pub(crate) fn do_classify_full(conn: &Connection) -> rusqlite::Result<RoleSummar
         &type_def_names_by_file,
         median_fan_in,
         median_fan_out,
-        &mut ids_by_role,
-        &mut summary,
     );
+
+    // 6b. Transitive-reachability dead-code downgrade (#2032). Only the
+    // full-classification path runs this: it needs the FULL graph's
+    // `calls`-edge adjacency (not just `rows`, which already spans every
+    // callable node on this path) to compute reachability correctly — a
+    // single indexed full-table scan, consistent with the other full-graph
+    // scans this function already performs. `do_classify_incremental`
+    // deliberately skips it: reachability is a whole-graph property that a
+    // changed-files-plus-one-hop-neighbour window cannot answer correctly,
+    // and re-running a full scan on every incremental build would reintroduce
+    // exactly the cost this path's neighbour-scoping was built to avoid
+    // (#1855). See #2032's follow-up issue for incremental parity.
+    let call_edges: Vec<(i64, i64)> = {
+        let mut stmt = tx.prepare("SELECT source_id, target_id FROM edges WHERE kind = 'calls'")?;
+        let mapped = stmt.query_map([], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)))?;
+        mapped.filter_map(|r| r.ok()).collect()
+    };
+    apply_reachability_downgrade(
+        &rows,
+        &exported_ids,
+        &called_active_files,
+        &type_def_names_by_file,
+        &call_edges,
+        &mut role_by_id,
+    );
+
+    finalize_roles(&role_by_id, &mut ids_by_role, &mut summary);
 
     // 7. Batch UPDATE: reset all roles then set per-role
     tx.execute("UPDATE nodes SET role = NULL", [])?;
@@ -677,7 +702,10 @@ fn query_id_counts(
     Ok(result)
 }
 
-/// Classify rows and accumulate into ids_by_role and summary.
+/// Classify every row into a role. Returns a per-id role map rather than
+/// accumulating directly into `ids_by_role`/`summary` so that, on the
+/// full-classification path, `apply_reachability_downgrade` can reconsider
+/// individual verdicts before final bucketing/counting via `finalize_roles`.
 #[allow(clippy::too_many_arguments)]
 fn classify_rows(
     rows: &[(i64, String, String, String, u32, u32)],
@@ -688,9 +716,8 @@ fn classify_rows(
     type_def_names_by_file: &HashMap<String, std::collections::HashSet<String>>,
     median_fan_in: f64,
     median_fan_out: f64,
-    ids_by_role: &mut HashMap<&'static str, Vec<i64>>,
-    summary: &mut RoleSummary,
-) {
+) -> HashMap<i64, &'static str> {
+    let mut role_by_id: HashMap<i64, &'static str> = HashMap::with_capacity(rows.len());
     for (id, name, kind, file, fan_in, fan_out) in rows {
         let is_exported = exported_ids.contains(id);
         let prod_fi = prod_fan_in.get(id).copied().unwrap_or(0);
@@ -726,8 +753,199 @@ fn classify_rows(
             median_fan_in,
             median_fan_out,
         );
+        role_by_id.insert(*id, role);
+    }
+    role_by_id
+}
+
+/// Bucket a finalized per-id role map into `ids_by_role`/`summary`. Split from
+/// `classify_rows` so the full-classification path can run
+/// `apply_reachability_downgrade` on the role map first.
+fn finalize_roles(
+    role_by_id: &HashMap<i64, &'static str>,
+    ids_by_role: &mut HashMap<&'static str, Vec<i64>>,
+    summary: &mut RoleSummary,
+) {
+    for (id, role) in role_by_id {
         increment_summary(summary, role);
         ids_by_role.entry(role).or_default().push(*id);
+    }
+}
+
+/// Roles produced by `classify_node`'s `fan_in > 0` branch (the
+/// `high_in`/`high_out` shape decision) — the only verdicts eligible for the
+/// reachability downgrade below. Mirrors TS `FAN_SHAPE_ROLES`.
+fn is_fan_shape_role(role: &str) -> bool {
+    matches!(role, "core" | "utility" | "adapter" | "leaf")
+}
+
+/// True when (name, kind, file, is_exported) is a confirmed-live reachability
+/// root for the transitive dead-code pass (#2032) — mirrors TS `isLiveRoot`.
+/// Only covers roots that are themselves `function`/`method` rows;
+/// `apply_reachability_downgrade` separately seeds additional roots directly
+/// from `call_edges` for non-function/method call sources.
+fn is_live_root(name: &str, kind: &str, file: &str, is_exported: bool, is_type_member: bool) -> bool {
+    if is_type_member {
+        return false;
+    }
+    if FRAMEWORK_ENTRY_PREFIXES.iter().any(|p| name.starts_with(p)) {
+        return true;
+    }
+    if kind != "function" && kind != "method" {
+        return false;
+    }
+    if is_exported {
+        return true;
+    }
+    COMMANDER_DISPATCH_NAMES.iter().any(|n| *n == name)
+        && ENTRY_PATH_PATTERNS.iter().any(|p| file.contains(p))
+}
+
+/// True when (kind, fan_in, fan_out, has_active_siblings, is_type_member) is a
+/// `method`-kind interface-dispatch implementation rescued by
+/// `classify_node`'s Pattern-2 heuristic (fan_in == 0, fan_out > 0,
+/// has_active_siblings) — e.g. `enter_node`/`exit_node` on a Visitor-shaped
+/// object, invoked only via generic property-access dispatch that codegraph
+/// cannot trace to a concrete implementation. Such a method can never be the
+/// TARGET of a `calls` edge by construction, so it must be an unconditional
+/// root — otherwise everything it calls would be wrongly treated as
+/// unreachable merely because the dispatch mechanism itself leaves no edge.
+///
+/// Deliberately narrower than the sibling rescue for `function`-kind
+/// logical-or-fallback values in `classify_node` — that heuristic is an
+/// explicitly acknowledged, imprecise last-resort fallback, not a structural
+/// certainty like interface dispatch. Promoting it to root status would
+/// silently rescue genuinely-dead intermediate functions (the exact #2032
+/// pattern) merely because they happen to call something in an active file.
+/// Mirrors TS `isInterfaceDispatchMethodRoot`.
+fn is_interface_dispatch_method_root(
+    kind: &str,
+    fan_in: u32,
+    fan_out: u32,
+    has_active_siblings: bool,
+    is_type_member: bool,
+) -> bool {
+    kind == "method" && fan_in == 0 && fan_out > 0 && has_active_siblings && !is_type_member
+}
+
+/// Forward BFS over `calls` edges starting from `roots`, using a single
+/// index-walked `Vec` queue (no repeated front-removal) so the whole
+/// traversal is O(V+E) — safe on graphs with tens of thousands of nodes/edges
+/// (this repo's own self-build). Mirrors TS `computeReachableIds`.
+fn compute_reachable_ids(
+    roots: &std::collections::HashSet<i64>,
+    call_edges: &[(i64, i64)],
+) -> std::collections::HashSet<i64> {
+    let mut adjacency: HashMap<i64, Vec<i64>> = HashMap::new();
+    for (source, target) in call_edges {
+        adjacency.entry(*source).or_default().push(*target);
+    }
+
+    let mut visited: std::collections::HashSet<i64> = roots.clone();
+    let mut queue: Vec<i64> = visited.iter().copied().collect();
+    let mut head = 0;
+    while head < queue.len() {
+        let current = queue[head];
+        head += 1;
+        if let Some(outs) = adjacency.get(&current) {
+            for next in outs {
+                if visited.insert(*next) {
+                    queue.push(*next);
+                }
+            }
+        }
+    }
+    visited
+}
+
+/// Downgrade fan-in-based "not dead" verdicts to dead when the node is not
+/// transitively reachable from any confirmed-live root via `calls` edges
+/// (#2032) — "has at least one inbound `calls` edge" is not sufficient
+/// evidence of liveness when that edge's source is itself unreachable.
+/// Mirrors TS `applyReachabilityDowngrade` — see its doc comment (in
+/// `src/graph/classifiers/roles.ts`) for the full rationale, including why:
+///
+///  - roots come from `is_live_root` (confirmed `function`/`method` entry
+///    points), `is_interface_dispatch_method_root` (Visitor-pattern-style
+///    `method`-kind dispatch implementations, which can never be the TARGET
+///    of a `calls` edge by construction), AND every `calls`-edge source that
+///    is NOT itself a `function`/`method` row (module-top-level `constant`
+///    declarations, bare top-level assignments attributed to the enclosing
+///    `file`, and other structural kinds) — those represent code that runs
+///    unconditionally once their containing scope is parsed, with no
+///    genuine "was this invoked" question the way a function/method body has;
+///  - this only reconsiders `function`/`method` rows with `fan_in > 0` whose
+///    current verdict is a `classify_by_fan_shape`-derived role
+///    (`core`/`utility`/`adapter`/`leaf`) — never `test-only`, `entry`, or any
+///    verdict from the `fan_in == 0` branch (interface members,
+///    `has_active_siblings` rescues, exported zero-fan-in entries), which
+///    already correctly resolve liveness through signals reachability
+///    doesn't apply to.
+#[allow(clippy::too_many_arguments)]
+fn apply_reachability_downgrade(
+    rows: &[(i64, String, String, String, u32, u32)],
+    exported_ids: &std::collections::HashSet<i64>,
+    called_active_files: &std::collections::HashSet<String>,
+    type_def_names_by_file: &HashMap<String, std::collections::HashSet<String>>,
+    call_edges: &[(i64, i64)],
+    role_by_id: &mut HashMap<i64, &'static str>,
+) {
+    let mut kind_by_id: HashMap<i64, &str> = HashMap::with_capacity(rows.len());
+    for (id, _name, kind, _file, _fan_in, _fan_out) in rows {
+        kind_by_id.insert(*id, kind.as_str());
+    }
+
+    let mut roots: std::collections::HashSet<i64> = std::collections::HashSet::new();
+    for (id, name, kind, file, fan_in, fan_out) in rows {
+        let is_exported = exported_ids.contains(id);
+        let is_type_member = is_type_declaration_member(name, kind, file, type_def_names_by_file);
+        if is_live_root(name, kind, file, is_exported, is_type_member) {
+            roots.insert(*id);
+            continue;
+        }
+        let has_active_siblings = called_active_files.contains(file);
+        if is_interface_dispatch_method_root(kind, *fan_in, *fan_out, has_active_siblings, is_type_member)
+        {
+            roots.insert(*id);
+        }
+    }
+    for (source, _target) in call_edges {
+        let source_kind = kind_by_id.get(source).copied();
+        if source_kind != Some("function") && source_kind != Some("method") {
+            roots.insert(*source);
+        }
+    }
+
+    let reachable = compute_reachable_ids(&roots, call_edges);
+
+    for (id, name, kind, file, fan_in, _fan_out) in rows {
+        if kind != "function" && kind != "method" {
+            continue;
+        }
+        if *fan_in == 0 {
+            continue;
+        }
+        // is_type_declaration_member returns "leaf" unconditionally,
+        // independent of fan_in — an interface/type method-signature member
+        // can have fan_in > 0 (real call sites resolve to it by name) and
+        // still land on "leaf", indistinguishable from
+        // classify_by_fan_shape's "leaf" by role string alone. Must be
+        // excluded explicitly, or a widely-referenced interface method (e.g.
+        // a native-binding surface like `NativeDatabase` in `types.ts`) gets
+        // wrongly reconsidered here.
+        if is_type_declaration_member(name, kind, file, type_def_names_by_file) {
+            continue;
+        }
+        let Some(role) = role_by_id.get(id).copied() else {
+            continue;
+        };
+        if !is_fan_shape_role(role) {
+            continue;
+        }
+        if reachable.contains(id) {
+            continue;
+        }
+        role_by_id.insert(*id, classify_dead_sub_role(name, kind, file));
     }
 }
 
@@ -1109,7 +1327,10 @@ pub(crate) fn do_classify_incremental(
             .extend(type_member_leaf_ids);
     }
 
-    classify_rows(
+    // No transitive-reachability downgrade here (#2032) — see the doc comment
+    // on the `apply_reachability_downgrade` call in `do_classify_full` for why
+    // the incremental path deliberately doesn't run it.
+    let role_by_id = classify_rows(
         &rows,
         &exported_ids,
         &prod_fan_in,
@@ -1118,9 +1339,8 @@ pub(crate) fn do_classify_incremental(
         &type_def_names_by_file,
         median_fan_in,
         median_fan_out,
-        &mut ids_by_role,
-        &mut summary,
     );
+    finalize_roles(&role_by_id, &mut ids_by_role, &mut summary);
 
     // Reset roles for affected files only, then update
     let reset_sql = format!(
@@ -1138,4 +1358,228 @@ pub(crate) fn do_classify_incremental(
 
     tx.commit()?;
     Ok(summary)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::connection::NativeDatabase;
+
+    /// In-memory DB with the full migration chain applied — mirrors the
+    /// pattern used by `db::connection::tests`.
+    fn setup_db() -> NativeDatabase {
+        let db = NativeDatabase::open_read_write(":memory:".to_string(), None)
+            .expect("open_read_write should succeed for :memory:");
+        db.init_schema().expect("init_schema should succeed");
+        db
+    }
+
+    fn insert_node(conn: &Connection, id: i64, name: &str, kind: &str, file: &str, exported: i64) {
+        conn.execute(
+            "INSERT INTO nodes (id, name, kind, file, exported) VALUES (?1, ?2, ?3, ?4, ?5)",
+            rusqlite::params![id, name, kind, file, exported],
+        )
+        .expect("insert node should succeed");
+    }
+
+    fn insert_edge(conn: &Connection, source: i64, target: i64, kind: &str, dynamic: i64) {
+        conn.execute(
+            "INSERT INTO edges (source_id, target_id, kind, dynamic) VALUES (?1, ?2, ?3, ?4)",
+            rusqlite::params![source, target, kind, dynamic],
+        )
+        .expect("insert edge should succeed");
+    }
+
+    fn role_of(conn: &Connection, id: i64) -> Option<String> {
+        conn.query_row("SELECT role FROM nodes WHERE id = ?1", [id], |row| row.get(0))
+            .expect("query role should succeed")
+    }
+
+    // ── Transitive-reachability dead-code downgrade (#2032) ─────────────
+
+    #[test]
+    fn downgrades_function_whose_only_caller_is_itself_unreachable() {
+        let db = setup_db();
+        let conn = db.conn().expect("connection should still be open");
+
+        // computeHelper is called only by deadIntermediate, which is never
+        // itself called by anything reachable from the confirmed-live root
+        // (useThing). Direct fan-in alone would call computeHelper live.
+        insert_node(conn, 1, "computeHelper", "function", "a.ts", 0);
+        insert_node(conn, 2, "deadIntermediate", "function", "a.ts", 0);
+        insert_node(conn, 3, "useThing", "function", "a.ts", 1);
+        insert_edge(conn, 2, 1, "calls", 0);
+
+        do_classify_full(conn).expect("do_classify_full should succeed");
+
+        assert_eq!(role_of(conn, 1).as_deref(), Some("dead-unresolved"));
+    }
+
+    #[test]
+    fn does_not_downgrade_when_reachable_via_a_real_call_chain() {
+        let db = setup_db();
+        let conn = db.conn().expect("connection should still be open");
+
+        insert_node(conn, 1, "helper", "function", "a.ts", 0);
+        insert_node(conn, 2, "useThing", "function", "a.ts", 1);
+        insert_edge(conn, 2, 1, "calls", 0);
+
+        do_classify_full(conn).expect("do_classify_full should succeed");
+
+        assert_ne!(role_of(conn, 1).as_deref(), Some("dead-unresolved"));
+    }
+
+    #[test]
+    fn downgrades_mutually_recursive_pair_with_no_confirmed_live_root() {
+        let db = setup_db();
+        let conn = db.conn().expect("connection should still be open");
+
+        insert_node(conn, 1, "fn1", "function", "a.ts", 0);
+        insert_node(conn, 2, "fn2", "function", "a.ts", 0);
+        insert_edge(conn, 1, 2, "calls", 0);
+        insert_edge(conn, 2, 1, "calls", 0);
+
+        do_classify_full(conn).expect("do_classify_full should succeed");
+
+        assert_eq!(role_of(conn, 1).as_deref(), Some("dead-unresolved"));
+        assert_eq!(role_of(conn, 2).as_deref(), Some("dead-unresolved"));
+    }
+
+    #[test]
+    fn constant_sourced_value_ref_is_an_unconditional_root() {
+        let db = setup_db();
+        let conn = db.conn().expect("connection should still be open");
+
+        // Mirrors the real dispatch-table shape (#1771): a top-level `const
+        // HANDLERS = [{ resolve: resolveA }]` gets a value-ref `calls` edge
+        // sourced from the constant declaration itself, not from a function.
+        insert_node(conn, 1, "resolveA", "function", "dispatch.js", 0);
+        insert_node(conn, 2, "HANDLERS", "constant", "dispatch.js", 0);
+        insert_edge(conn, 2, 1, "calls", 1);
+
+        do_classify_full(conn).expect("do_classify_full should succeed");
+
+        assert_ne!(role_of(conn, 1).as_deref(), Some("dead-unresolved"));
+    }
+
+    #[test]
+    fn file_sourced_value_ref_is_an_unconditional_root() {
+        let db = setup_db();
+        let conn = db.conn().expect("connection should still be open");
+
+        // Mirrors Lua's builtin-reassignment pattern (#1776): `require =
+        // tracedFn` has no LHS binding to attach to, so the value-ref edge is
+        // sourced from the enclosing file/module scope. `file`-kind nodes are
+        // entirely excluded from `rows`/classification, so this source id
+        // never appears there — it must still act as an unconditional root.
+        insert_node(conn, 1, "tracedFn", "function", "main.lua", 0);
+        insert_node(conn, 2, "main.lua", "file", "main.lua", 0);
+        insert_edge(conn, 2, 1, "calls", 1);
+
+        do_classify_full(conn).expect("do_classify_full should succeed");
+
+        assert_ne!(role_of(conn, 1).as_deref(), Some("dead-unresolved"));
+    }
+
+    #[test]
+    fn does_not_downgrade_test_only_node_despite_unreachable_caller() {
+        let db = setup_db();
+        let conn = db.conn().expect("connection should still be open");
+
+        // Same file for both: a cross-file caller would separately mark the
+        // target "exported" (see `exported_ids`'s cross-file heuristic),
+        // which is orthogonal to what this test checks — that a test-only
+        // verdict is never revisited by the reachability downgrade.
+        insert_node(conn, 1, "helperForTests", "function", "a.test.ts", 0);
+        insert_node(conn, 2, "someTest", "function", "a.test.ts", 0);
+        insert_edge(conn, 2, 1, "calls", 0);
+
+        do_classify_full(conn).expect("do_classify_full should succeed");
+
+        assert_eq!(role_of(conn, 1).as_deref(), Some("test-only"));
+    }
+
+    #[test]
+    fn does_not_downgrade_interface_method_signature_member_despite_fan_in_and_unreachable_caller()
+    {
+        let db = setup_db();
+        let conn = db.conn().expect("connection should still be open");
+
+        // Regression: is_type_declaration_member returns "leaf"
+        // unconditionally, independent of fan_in — indistinguishable from
+        // classify_by_fan_shape's "leaf" by role string alone unless the
+        // downgrade pass explicitly re-checks it. A widely-referenced
+        // interface method (e.g. a native-binding surface like
+        // `NativeDatabase` in `types.ts`) has real fan_in > 0 from call sites
+        // resolving to it by name, and must never be reconsidered here.
+        insert_node(conn, 1, "NativeDatabase", "interface", "types.ts", 0);
+        insert_node(conn, 2, "NativeDatabase.countNodes", "method", "types.ts", 0);
+        insert_node(conn, 3, "unreachableCaller", "function", "a.ts", 0);
+        insert_edge(conn, 3, 2, "calls", 0);
+
+        do_classify_full(conn).expect("do_classify_full should succeed");
+
+        assert_eq!(role_of(conn, 2).as_deref(), Some("leaf"));
+    }
+
+    #[test]
+    fn interface_dispatch_method_is_an_unconditional_root_for_what_it_calls() {
+        let db = setup_db();
+        let conn = db.conn().expect("connection should still be open");
+
+        // Mirrors ast-analysis visitors' Visitor pattern: enterNode is
+        // dispatched generically (`if (v.enterNode) v.enterNode(node)`) so it
+        // can never be the TARGET of a `calls` edge — fan_in stays 0
+        // forever, yet it's rescued to "leaf" by classify_node's Pattern-2
+        // heuristic. Whatever it calls must be reachable through it.
+        insert_node(conn, 1, "enterNode", "method", "visitor.ts", 0);
+        insert_node(conn, 2, "classifyHalstead", "function", "visitor.ts", 0);
+        insert_edge(conn, 1, 2, "calls", 0);
+
+        do_classify_full(conn).expect("do_classify_full should succeed");
+
+        assert_ne!(role_of(conn, 2).as_deref(), Some("dead-unresolved"));
+    }
+
+    #[test]
+    fn function_kind_logical_or_fallback_rescue_is_not_treated_as_a_root() {
+        let db = setup_db();
+        let conn = db.conn().expect("connection should still be open");
+
+        // Unlike the method/interface-dispatch case above, a plain
+        // `function` rescued via the (explicitly acknowledged as imprecise)
+        // logical-or fallback heuristic must NOT be promoted to root —
+        // otherwise almost any genuinely-dead intermediate function in an
+        // active file would silently rescue whatever it calls, the exact
+        // #2032 pattern this fix targets.
+        insert_node(conn, 1, "deadIntermediate", "function", "a.ts", 0);
+        insert_node(conn, 2, "computeHelper", "function", "a.ts", 0);
+        insert_edge(conn, 1, 2, "calls", 0);
+
+        do_classify_full(conn).expect("do_classify_full should succeed");
+
+        assert_eq!(role_of(conn, 2).as_deref(), Some("dead-unresolved"));
+    }
+
+    #[test]
+    fn incremental_path_does_not_run_the_reachability_downgrade() {
+        // Documents the deliberate full-vs-incremental asymmetry (see the doc
+        // comment on `apply_reachability_downgrade`'s call site in
+        // `do_classify_full`): the incremental path can't safely compute
+        // whole-graph reachability from a changed-files-scoped window, so it
+        // must keep classifying via direct fan-in only, same as before #2032.
+        let db = setup_db();
+        let conn = db.conn().expect("connection should still be open");
+
+        insert_node(conn, 1, "computeHelper", "function", "a.ts", 0);
+        insert_node(conn, 2, "deadIntermediate", "function", "a.ts", 0);
+        insert_edge(conn, 2, 1, "calls", 0);
+
+        do_classify_incremental(conn, &["a.ts".to_string()])
+            .expect("do_classify_incremental should succeed");
+
+        assert_ne!(role_of(conn, 1).as_deref(), Some("dead-unresolved"));
+    }
 }

--- a/src/features/structure.ts
+++ b/src/features/structure.ts
@@ -957,8 +957,52 @@ function classifyNodeRolesFull(db: BetterSqlite3Database, emptySummary: RoleSumm
   // component of `exportedIds` above (see `buildClassifierInput`'s
   // `isPublicSurface` doc comment for why that component must not grant
   // automatic root status).
+  //
+  // Deliberately NOT reusing `reexportExported` above (Greptile review): that
+  // set treats ANY `reexports` edge — whether from `export { specificThing }
+  // from './b'` (which only re-exports `specificThing`) or `export * from
+  // './b'` (which genuinely re-exports everything) — as "every symbol in the
+  // target file is exported". For a named reexport that over-broadly marks
+  // every OTHER private symbol in that file as a public-surface root too,
+  // which would let an unreachable private call chain sharing a file with
+  // one re-exported symbol evade the whole check. A named reexport gets its
+  // own symbol-level `reexports` edge (target = the specific symbol node, not
+  // the file) — use that directly; only a genuine wildcard reexport (kind
+  // `reexports-wildcard`) justifies marking the whole file.
   const publicSurfaceIds = new Set<number>();
-  for (const r of reexportExported) publicSurfaceIds.add(r.id);
+  const publicSurfaceRows = db
+    .prepare(
+      `WITH RECURSIVE prod_reachable(file_id) AS (
+        SELECT DISTINCT e.target_id
+        FROM edges e
+        JOIN nodes src ON e.source_id = src.id
+        WHERE e.kind IN ('imports', 'dynamic-imports', 'imports-type')
+          AND src.kind = 'file'
+          ${testFilterSQL('src.file')}
+        UNION
+        SELECT e.target_id
+        FROM edges e
+        JOIN prod_reachable pr ON e.source_id = pr.file_id
+        WHERE e.kind = 'reexports'
+      )
+      SELECT DISTINCT e.target_id AS id
+      FROM edges e
+      JOIN nodes n ON n.id = e.target_id
+      WHERE e.kind = 'reexports' AND n.kind != 'file'
+        AND e.source_id IN (SELECT file_id FROM prod_reachable)
+      UNION
+      SELECT DISTINCT n.id AS id
+      FROM nodes n
+      JOIN nodes f ON f.file = n.file AND f.kind = 'file'
+      WHERE f.id IN (
+        SELECT e.target_id FROM edges e
+        WHERE e.kind = 'reexports-wildcard'
+          AND e.source_id IN (SELECT file_id FROM prod_reachable)
+      )
+      AND n.kind NOT IN ('file', 'directory', 'parameter', 'property', 'method')`,
+    )
+    .all() as { id: number }[];
+  for (const r of publicSurfaceRows) publicSurfaceIds.add(r.id);
   for (const r of explicitlyExported) publicSurfaceIds.add(r.id);
 
   // Compute production fan-in (excluding callers in test files)
@@ -1263,6 +1307,8 @@ function classifyNodeRolesIncremental(
   const reachableBarrels = reexportBarrels.filter((b) => isBarrelProdReachable(db, b));
   if (reachableBarrels.length > 0) {
     const barrelPlaceholders = reachableBarrels.map(() => '?').join(',');
+    // Broad "whole file" set for the pre-existing exportedIds/`entry`
+    // classification behavior (#837) — unchanged.
     const reexportExported = db
       .prepare(
         `SELECT DISTINCT n.id
@@ -1275,10 +1321,38 @@ function classifyNodeRolesIncremental(
           AND n.file IN (${placeholders})`,
       )
       .all(...reachableBarrels, ...allAffectedFiles) as { id: number }[];
-    for (const r of reexportExported) {
-      exportedIds.add(r.id);
-      publicSurfaceIds.add(r.id);
-    }
+    for (const r of reexportExported) exportedIds.add(r.id);
+
+    // Narrower set for #2032's reachability roots (Greptile review): a named
+    // reexport only re-exports the SPECIFIC symbol(s) actually named — its
+    // own symbol-level `reexports` edge (target != file) — not every other
+    // private symbol sharing that file. Only a genuine `export * from`
+    // (`reexports-wildcard`) justifies marking the whole file.
+    const namedReexportSymbols = db
+      .prepare(
+        `SELECT DISTINCT e.target_id AS id
+        FROM edges e
+        JOIN nodes n ON n.id = e.target_id
+        JOIN nodes b ON b.id = e.source_id
+        WHERE e.kind = 'reexports' AND n.kind != 'file' AND b.file IN (${barrelPlaceholders})
+          AND n.file IN (${placeholders})`,
+      )
+      .all(...reachableBarrels, ...allAffectedFiles) as { id: number }[];
+    for (const r of namedReexportSymbols) publicSurfaceIds.add(r.id);
+
+    const wildcardReexported = db
+      .prepare(
+        `SELECT DISTINCT n.id AS id
+        FROM nodes n
+        JOIN nodes f ON f.file = n.file AND f.kind = 'file'
+        JOIN edges e ON e.target_id = f.id
+        JOIN nodes b ON e.source_id = b.id
+        WHERE e.kind = 'reexports-wildcard' AND b.file IN (${barrelPlaceholders})
+          AND n.kind NOT IN ('file', 'directory', 'parameter', 'property', 'method')
+          AND n.file IN (${placeholders})`,
+      )
+      .all(...reachableBarrels, ...allAffectedFiles) as { id: number }[];
+    for (const r of wildcardReexported) publicSurfaceIds.add(r.id);
   }
 
   // 3c. Mark symbols with exported=1 as exported — the extractor sets this flag when the

--- a/src/features/structure.ts
+++ b/src/features/structure.ts
@@ -681,6 +681,7 @@ function buildClassifierInput(
   prodFanInMap: Map<number, number>,
   activeFiles: Set<string>,
   calledActiveFiles: Set<string>,
+  publicSurfaceIds: Set<number>,
 ): Array<{
   id: string;
   name: string;
@@ -691,6 +692,7 @@ function buildClassifierInput(
   isExported: boolean;
   productionFanIn: number;
   hasActiveFileSiblings: boolean | undefined;
+  isPublicSurface: boolean;
 }> {
   return rows.map((r) => ({
     id: String(r.id),
@@ -715,6 +717,16 @@ function buildClassifierInput(
       : r.kind === 'method' || r.kind === 'function'
         ? calledActiveFiles.has(r.file)
         : undefined,
+    // Narrower than `isExported`: only the explicit `export` keyword (the
+    // `exported` column) and confirmed production-reachable reexport chains —
+    // deliberately EXCLUDES `exportedIds`'s "some caller in a different file"
+    // component. That component is only ever a proxy for "has a cross-file
+    // caller", which is exactly the kind of unverified-caller evidence #2032's
+    // reachability check exists to see through — a symbol called only by an
+    // unreachable cross-file caller must not become an automatic BFS root
+    // merely because the call happens to cross a file boundary. See
+    // `isLiveRoot` in `graph/classifiers/roles.ts`.
+    isPublicSurface: publicSurfaceIds.has(r.id),
   }));
 }
 
@@ -939,6 +951,16 @@ function classifyNodeRolesFull(db: BetterSqlite3Database, emptySummary: RoleSumm
     .all() as { id: number }[];
   for (const r of explicitlyExported) exportedIds.add(r.id);
 
+  // Narrower "genuinely public" surface for #2032's reachability roots —
+  // explicit `export` keyword usage and confirmed production-reachable
+  // reexport chains only, deliberately excluding the cross-file-caller
+  // component of `exportedIds` above (see `buildClassifierInput`'s
+  // `isPublicSurface` doc comment for why that component must not grant
+  // automatic root status).
+  const publicSurfaceIds = new Set<number>();
+  for (const r of reexportExported) publicSurfaceIds.add(r.id);
+  for (const r of explicitlyExported) publicSurfaceIds.add(r.id);
+
   // Compute production fan-in (excluding callers in test files)
   const prodFanInMap = new Map<number, number>();
   const prodRows = db
@@ -966,6 +988,7 @@ function classifyNodeRolesFull(db: BetterSqlite3Database, emptySummary: RoleSumm
     prodFanInMap,
     activeFiles,
     calledActiveFiles,
+    publicSurfaceIds,
   );
   const nonZeroFanIn = classifierInput
     .filter((n) => n.fanIn > 0)
@@ -1227,6 +1250,15 @@ function classifyNodeRolesIncremental(
   // (see `isBarrelProdReachable`).
   //
   // `method` is excluded (#1780) — see classifyNodeRolesFull for rationale.
+  //
+  // `publicSurfaceIds` mirrors classifyNodeRolesFull's narrower "genuinely
+  // public" set for #2032's reachability roots (explicit `export` + confirmed
+  // reexport chains only, excluding the cross-file-caller component of
+  // `exportedIds`) — see `buildClassifierInput`'s `isPublicSurface` doc
+  // comment. Computed here too even though this path never actually runs the
+  // reachability downgrade (it doesn't pass `callEdges` to `classifyRoles`),
+  // so the field stays correct rather than silently stubbed if that ever changes.
+  const publicSurfaceIds = new Set<number>();
   const reexportBarrels = findDirectReexportBarrels(db, allAffectedFiles);
   const reachableBarrels = reexportBarrels.filter((b) => isBarrelProdReachable(db, b));
   if (reachableBarrels.length > 0) {
@@ -1243,7 +1275,10 @@ function classifyNodeRolesIncremental(
           AND n.file IN (${placeholders})`,
       )
       .all(...reachableBarrels, ...allAffectedFiles) as { id: number }[];
-    for (const r of reexportExported) exportedIds.add(r.id);
+    for (const r of reexportExported) {
+      exportedIds.add(r.id);
+      publicSurfaceIds.add(r.id);
+    }
   }
 
   // 3c. Mark symbols with exported=1 as exported — the extractor sets this flag when the
@@ -1259,7 +1294,10 @@ function classifyNodeRolesIncremental(
         AND file IN (${placeholders})`,
     )
     .all(...allAffectedFiles) as { id: number }[];
-  for (const r of explicitlyExported) exportedIds.add(r.id);
+  for (const r of explicitlyExported) {
+    exportedIds.add(r.id);
+    publicSurfaceIds.add(r.id);
+  }
 
   // 4. Production fan-in for affected nodes only
   const prodFanInMap = new Map<number, number>();
@@ -1287,6 +1325,7 @@ function classifyNodeRolesIncremental(
     prodFanInMap,
     activeFiles,
     calledActiveFiles,
+    publicSurfaceIds,
   );
   const roleMap = classifyRoles(classifierInput, globalMedians);
 

--- a/src/features/structure.ts
+++ b/src/features/structure.ts
@@ -976,7 +976,25 @@ function classifyNodeRolesFull(db: BetterSqlite3Database, emptySummary: RoleSumm
     .map((n) => n.fanOut)
     .sort((a, b) => a - b);
   const globalMedians = { fanIn: median(nonZeroFanIn), fanOut: median(nonZeroFanOut) };
-  const roleMap = classifyRoles(classifierInput, globalMedians);
+  // Full graph `calls`-edge adjacency for the transitive-reachability
+  // dead-code pass (#2032). Only the full-build path supplies this — a
+  // single indexed full-table scan, consistent with the other full-graph
+  // scans this function already performs (exportedIds, reexportExported,
+  // prodFanInMap above). The incremental path (`classifyNodeRolesIncremental`)
+  // deliberately omits it: reachability is a whole-graph property that a
+  // changed-files-plus-one-hop-neighbour window cannot answer correctly (a
+  // node's only live path in could run through files outside that window),
+  // and re-running a full scan on every incremental build would reintroduce
+  // exactly the cost this function's median/exported-set caching was built to
+  // avoid (#1855). See #2032's follow-up issue for incremental parity.
+  const callEdgeRows = db
+    .prepare(`SELECT source_id, target_id FROM edges WHERE kind = 'calls'`)
+    .all() as { source_id: number; target_id: number }[];
+  const callEdges: Array<[string, string]> = callEdgeRows.map((r) => [
+    String(r.source_id),
+    String(r.target_id),
+  ]);
+  const roleMap = classifyRoles(classifierInput, globalMedians, callEdges);
   // Derive the edge count from already-loaded in-memory rows: summing fan_in
   // across all nodes equals COUNT(*) FROM edges WHERE kind IN ('calls','imports-type'),
   // since the full-build query left-joins every matching edge exactly once per target.

--- a/src/graph/classifiers/roles.ts
+++ b/src/graph/classifiers/roles.ts
@@ -36,6 +36,22 @@
  * a data-shape declaration or config value — never invoked from outside the
  * codebase — so it can't be a real entry point; it's classified `leaf` instead
  * of inheriting `entry` merely from being exported (#1780).
+ *
+ * Direct fan-in > 0 is not, by itself, sufficient evidence that a
+ * `function`/`method` is live: a node whose only caller is itself unreachable
+ * from any confirmed-live root still has fan-in 1 despite being genuinely dead
+ * (#2032 — e.g. a helper called only from an object-literal-property closure
+ * that is never itself invoked). When `classifyRoles` is given the full
+ * graph's `calls`-edge adjacency, `applyReachabilityDowngrade` runs a
+ * worklist/BFS from confirmed-live roots (framework-dispatched entries,
+ * exported `function`/`method`s, Commander dispatch methods — see
+ * `isLiveRoot`) and downgrades any `function`/`method` outside the reachable
+ * set from its fan-shape verdict (`core`/`utility`/`adapter`/`leaf`) to a
+ * `dead-*` sub-role. This is deliberately a strictly-downgrading second pass,
+ * not a replacement for the direct fan-in check — see `applyReachabilityDowngrade`'s
+ * doc comment for why the other branches (`test-only`, interface members,
+ * `hasActiveFileSiblings` rescues, exported zero-fan-in entries) must not be
+ * revisited by it.
  */
 
 import type { DeadSubRole, Role } from '../../types.js';
@@ -340,11 +356,236 @@ function classifyNodeRole(
 }
 
 /**
+ * Roles produced by `classifyByFanShape` — the only roles that can result
+ * from the `fanIn > 0` branch of `classifyNodeRole`. Used by
+ * `applyReachabilityDowngrade` to recognize which verdicts are eligible for
+ * reconsideration (see its doc comment).
+ */
+const FAN_SHAPE_ROLES: ReadonlySet<Role> = new Set(['core', 'utility', 'adapter', 'leaf']);
+
+/**
+ * True when `node` is a confirmed-live reachability root for the transitive
+ * dead-code pass (#2032) — i.e. something external code can invoke directly,
+ * regardless of whether it currently has any inbound `calls` edges from
+ * elsewhere in the codebase:
+ *
+ *  - a framework-dispatched entry point (`route:`/`event:`/`command:`-prefixed name)
+ *  - an exported `function`/`method` — part of the public API surface, callable
+ *    from outside the codebase by construction
+ *  - a Commander.js dispatch method (`execute`/`validate`) in a framework directory
+ *
+ * This mirrors the `entry`-detection rules in `classifyNodeRole`, but
+ * deliberately drops their `fanIn === 0` gate: a root's liveness comes from
+ * *how* it can be invoked, not from whether it happens to currently have zero
+ * in-repo callers. An exported function that is ALSO called internally is
+ * still a live root, even though `classifyNodeRole` itself classifies it via
+ * fan-in shape (`core`/`utility`/etc.) rather than `entry` in that case.
+ *
+ * This only covers roots that are themselves `function`/`method` nodes
+ * present in `nodes`. `applyReachabilityDowngrade` separately seeds
+ * additional roots directly from `callEdges` for non-function/method call
+ * SOURCES (module-top-level `constant`/`class` initializers, bare top-level
+ * assignments attributed to the enclosing `file`) — see its doc comment.
+ */
+function isLiveRoot(
+  node: RoleClassificationNode,
+  typeDefNamesByFile: Map<string, Set<string>>,
+): boolean {
+  if (isTypeDeclarationMember(node, typeDefNamesByFile)) return false;
+  if (FRAMEWORK_ENTRY_PREFIXES.some((p) => node.name.startsWith(p))) return true;
+  if (node.kind !== 'function' && node.kind !== 'method') return false;
+  if (node.isExported) return true;
+  return !!(
+    node.file &&
+    COMMANDER_DISPATCH_NAMES.has(node.name) &&
+    ENTRY_PATH_PATTERNS.some((p) => p.test(node.file!))
+  );
+}
+
+/**
+ * Forward BFS over `calls` edges starting from `roots`, using a single
+ * array-backed queue (no `Array#shift`, which is O(n) per call) so the whole
+ * traversal is O(V+E) — safe to run on graphs with tens of thousands of nodes
+ * and edges (this repo's own self-build).
+ */
+function computeReachableIds(
+  roots: Iterable<string>,
+  callEdges: ReadonlyArray<readonly [string, string]>,
+): Set<string> {
+  const adjacency = new Map<string, string[]>();
+  for (const [source, target] of callEdges) {
+    let outs = adjacency.get(source);
+    if (!outs) {
+      outs = [];
+      adjacency.set(source, outs);
+    }
+    outs.push(target);
+  }
+
+  const visited = new Set<string>(roots);
+  const queue = Array.from(visited);
+  for (let head = 0; head < queue.length; head++) {
+    const outs = adjacency.get(queue[head]!);
+    if (!outs) continue;
+    for (const next of outs) {
+      if (!visited.has(next)) {
+        visited.add(next);
+        queue.push(next);
+      }
+    }
+  }
+  return visited;
+}
+
+/**
+ * True when `node` is a `method`-kind interface-dispatch implementation
+ * rescued by `classifyUnreferencedNode`'s Pattern-2 heuristic (fanIn === 0,
+ * fanOut > 0, `hasActiveFileSiblings`) — e.g. `enterNode`/`exitNode` on a
+ * Visitor-shaped object, invoked only via generic property-access dispatch
+ * (`if (v.enterNode) v.enterNode(...)`) that codegraph cannot trace to a
+ * concrete implementation. Such a method can never be the TARGET of a
+ * `calls` edge by construction — the same category as a constant/file-sourced
+ * value-ref edge — so it must be an unconditional root: otherwise everything
+ * it calls (other helpers in the same visitor file) would be wrongly treated
+ * as unreachable merely because the dispatch mechanism itself leaves no edge.
+ *
+ * Deliberately narrower than `classifyUnreferencedNode`'s sibling rescue for
+ * `function`-kind logical-or-fallback values (`kind === 'function' &&
+ * fanOut > 0`) just below it in that function — that heuristic is an
+ * explicitly acknowledged, imprecise last-resort fallback for value-reference
+ * shapes not yet given a real edge (ternary defaults, array-of-functions
+ * elements, default parameter values — see its comment), not a structural
+ * certainty like interface dispatch. Promoting it to root status here would
+ * silently rescue genuinely-dead intermediate functions (the exact #2032
+ * pattern) merely because they happen to call something in a file that also
+ * has unrelated active code.
+ */
+function isInterfaceDispatchMethodRoot(
+  node: RoleClassificationNode,
+  typeDefNamesByFile: Map<string, Set<string>>,
+): boolean {
+  return (
+    node.kind === 'method' &&
+    node.fanIn === 0 &&
+    node.fanOut > 0 &&
+    !!node.hasActiveFileSiblings &&
+    !isTypeDeclarationMember(node, typeDefNamesByFile)
+  );
+}
+
+/**
+ * Downgrade fan-in-based "not dead" verdicts to dead when the node is not
+ * transitively reachable from any confirmed-live root via `calls` edges
+ * (#2032) — "has at least one inbound `calls` edge" is not sufficient
+ * evidence of liveness when that edge's source is itself unreachable. A
+ * function whose only caller is itself dead code is still dead, regardless of
+ * its direct fan-in count.
+ *
+ * Roots come from three sources:
+ *
+ *  1. `isLiveRoot` — `function`/`method` nodes that are themselves confirmed
+ *     entry points (framework dispatch, exported, Commander dispatch).
+ *
+ *  2. `isInterfaceDispatchMethodRoot` — `method`-kind interface-dispatch
+ *     implementations (Visitor-pattern-style), which can never be the TARGET
+ *     of a `calls` edge by construction. See its doc comment for why this is
+ *     deliberately NOT extended to `function`-kind rescues.
+ *
+ *  3. Every `calls`-edge SOURCE that is not itself a `function`/`method` node
+ *     in `nodes`. Only `function`/`method` bodies have a genuine "was this
+ *     invoked" question — every other kind that can source a `calls` edge
+ *     represents code that runs unconditionally once its containing scope is
+ *     parsed, with no separate invocation to prove:
+ *       - `constant`: module-top-level `const` declarations (every extractor
+ *         excludes function-scope while walking for them) whose initializer
+ *         runs at module-load time — e.g. dispatch-table/handler-array object
+ *         literals (`const HANDLERS = [{ resolve: someFn }]`, #1771/#1895)
+ *         get a `calls` edge from the `constant` to each referenced function
+ *         once the extractor has validated invocation evidence for the
+ *         dispatch pattern.
+ *       - `file`: bare top-level assignments with no declared LHS binding
+ *         (e.g. Lua's builtin-reassignment `require = tracedFn`, #1776) are
+ *         attributed to the enclosing file/module scope, since there is no
+ *         narrower definition to attach them to.
+ *       - `class` and other structural kinds: static field/initializer-style
+ *         `calls` edges attributed to the type itself rather than a method.
+ *     `file`/`directory`/`parameter`/`property` nodes are excluded from
+ *     `nodes` entirely (see the module doc comment), so any edge source
+ *     absent from `nodes` is — by construction — one of these always-live
+ *     non-function/method sources, not a dangling reference.
+ *
+ * This is a strictly-downgrading second pass over the already-computed role
+ * map, not a replacement of the direct fan-in check — it never reconsiders
+ * roles produced by the `fanIn === 0` branch of `classifyNodeRole`
+ * (`entry`/`test-only`/`leaf`/`dead-*` via `classifyUnreferencedNode`,
+ * interface/type members, exported zero-fan-in entries). Those categories
+ * already correctly resolve liveness through signals reachability doesn't
+ * apply to (framework dispatch, the export surface, hasActiveFileSiblings
+ * rescues for call patterns that produce no edge at all) and must not be
+ * revisited here. It only reconsiders `function`/`method` nodes that received
+ * a `core`/`utility`/`adapter`/`leaf` verdict from `classifyByFanShape` — which
+ * requires `fanIn > 0` by construction — the exact case the direct fan-in
+ * check gets wrong. Nodes that are themselves confirmed-live roots are never
+ * downgraded (a root is always in its own reachable set).
+ */
+function applyReachabilityDowngrade(
+  nodes: RoleClassificationNode[],
+  result: Map<string, Role>,
+  callEdges: ReadonlyArray<readonly [string, string]>,
+  typeDefNamesByFile: Map<string, Set<string>>,
+): void {
+  const kindById = new Map<string, string>();
+  for (const node of nodes) kindById.set(node.id, node.kind);
+
+  const roots = new Set<string>();
+  for (const node of nodes) {
+    if (
+      isLiveRoot(node, typeDefNamesByFile) ||
+      isInterfaceDispatchMethodRoot(node, typeDefNamesByFile)
+    ) {
+      roots.add(node.id);
+    }
+  }
+  for (const [source] of callEdges) {
+    const kind = kindById.get(source);
+    if (kind !== 'function' && kind !== 'method') roots.add(source);
+  }
+  const reachable = computeReachableIds(roots, callEdges);
+
+  for (const node of nodes) {
+    if (node.kind !== 'function' && node.kind !== 'method') continue;
+    if (node.fanIn <= 0) continue;
+    // isTypeDeclarationMember returns 'leaf' unconditionally, independent of
+    // fanIn — an interface/type method-signature member can have fanIn > 0
+    // (real call sites resolve to it by name) and still land on 'leaf', which
+    // is indistinguishable from classifyByFanShape's 'leaf' by role string
+    // alone. Must be excluded explicitly, or a widely-referenced interface
+    // method (e.g. a native-binding surface like `NativeDatabase` in
+    // `types.ts`) gets wrongly reconsidered here.
+    if (isTypeDeclarationMember(node, typeDefNamesByFile)) continue;
+    const role = result.get(node.id);
+    if (!role || !FAN_SHAPE_ROLES.has(role)) continue;
+    if (reachable.has(node.id)) continue;
+    result.set(node.id, classifyDeadSubRole(node));
+  }
+}
+
+/**
  * Classify nodes into architectural roles based on fan-in/fan-out metrics.
+ *
+ * @param callEdges - Optional `calls`-edge adjacency (`[sourceId, targetId]`
+ *   pairs) spanning the FULL graph (not just `nodes`), used to run the
+ *   transitive-reachability dead-code downgrade (#2032). Omit (or pass an
+ *   empty array) to skip this pass entirely and preserve pre-#2032 behavior —
+ *   this is intentional for callers that only have a locally-scoped subgraph
+ *   available (see `classifyNodeRolesIncremental` in `features/structure.ts`
+ *   for why a partial edge set cannot safely feed a global reachability
+ *   check).
  */
 export function classifyRoles(
   nodes: RoleClassificationNode[],
   medianOverrides?: { fanIn: number; fanOut: number },
+  callEdges?: ReadonlyArray<readonly [string, string]>,
 ): Map<string, Role> {
   if (nodes.length === 0) return new Map();
 
@@ -355,5 +596,10 @@ export function classifyRoles(
   for (const node of nodes) {
     result.set(node.id, classifyNodeRole(node, medFanIn, medFanOut, typeDefNamesByFile));
   }
+
+  if (callEdges && callEdges.length > 0) {
+    applyReachabilityDowngrade(nodes, result, callEdges, typeDefNamesByFile);
+  }
+
   return result;
 }

--- a/src/graph/classifiers/roles.ts
+++ b/src/graph/classifiers/roles.ts
@@ -223,6 +223,20 @@ export interface RoleClassificationNode {
    * `undefined` for all other kinds (e.g. `class`), which don't use this field.
    */
   hasActiveFileSiblings?: boolean;
+  /**
+   * Narrower than `isExported` — true only for the explicit `export` keyword
+   * (the `exported` column) and confirmed production-reachable reexport
+   * chains, deliberately EXCLUDING `isExported`'s "some caller in a different
+   * file" component (`exportedIds`'s base cross-file-caller heuristic in
+   * `features/structure.ts`). That component is only ever a proxy for "has a
+   * cross-file caller" — exactly the kind of unverified-caller evidence
+   * #2032's reachability check exists to see through. Used by `isLiveRoot`
+   * instead of `isExported` so a symbol called only by an unreachable
+   * cross-file caller doesn't become an automatic BFS root merely because the
+   * call happens to cross a file boundary. Defaults to `false` when omitted
+   * (safe: callers that don't supply `callEdges` never reach `isLiveRoot`).
+   */
+  isPublicSurface?: boolean;
 }
 
 /**
@@ -370,16 +384,28 @@ const FAN_SHAPE_ROLES: ReadonlySet<Role> = new Set(['core', 'utility', 'adapter'
  * elsewhere in the codebase:
  *
  *  - a framework-dispatched entry point (`route:`/`event:`/`command:`-prefixed name)
- *  - an exported `function`/`method` — part of the public API surface, callable
- *    from outside the codebase by construction
+ *  - a `function`/`method` on the genuinely public surface (`isPublicSurface`)
+ *    — part of the public API surface, callable from outside the codebase by
+ *    construction
  *  - a Commander.js dispatch method (`execute`/`validate`) in a framework directory
  *
  * This mirrors the `entry`-detection rules in `classifyNodeRole`, but
  * deliberately drops their `fanIn === 0` gate: a root's liveness comes from
  * *how* it can be invoked, not from whether it happens to currently have zero
- * in-repo callers. An exported function that is ALSO called internally is
- * still a live root, even though `classifyNodeRole` itself classifies it via
- * fan-in shape (`core`/`utility`/etc.) rather than `entry` in that case.
+ * in-repo callers. A publicly-surfaced function that is ALSO called
+ * internally is still a live root, even though `classifyNodeRole` itself
+ * classifies it via fan-in shape (`core`/`utility`/etc.) rather than `entry`
+ * in that case.
+ *
+ * Deliberately checks `isPublicSurface`, NOT the broader `isExported` that
+ * `classifyNodeRole`'s own `entry` branch uses — `isExported` also considers
+ * a node "exported" merely because SOME caller in a different file calls it,
+ * regardless of whether that caller is itself reachable. Using that signal
+ * here would let a symbol called only by an unreachable cross-file caller
+ * become an automatic root, defeating #2032's fix for exactly the
+ * cross-file case it's meant to catch. `isPublicSurface` is narrower: only
+ * the explicit `export` keyword and confirmed production-reachable reexport
+ * chains — see its doc comment on `RoleClassificationNode`.
  *
  * This only covers roots that are themselves `function`/`method` nodes
  * present in `nodes`. `applyReachabilityDowngrade` separately seeds
@@ -394,7 +420,7 @@ function isLiveRoot(
   if (isTypeDeclarationMember(node, typeDefNamesByFile)) return false;
   if (FRAMEWORK_ENTRY_PREFIXES.some((p) => node.name.startsWith(p))) return true;
   if (node.kind !== 'function' && node.kind !== 'method') return false;
-  if (node.isExported) return true;
+  if (node.isPublicSurface) return true;
   return !!(
     node.file &&
     COMMANDER_DISPATCH_NAMES.has(node.name) &&
@@ -438,9 +464,39 @@ function computeReachableIds(
 }
 
 /**
+ * Compute the set of bare (owner-prefix-stripped) member names declared by
+ * ANY interface/type-level declaration across `nodes` — e.g. TS `interface
+ * Visitor { enterNode?(...): ...; exitNode?(...): ...; }` contributes
+ * `'enterNode'`/`'exitNode'`. Used by `isInterfaceDispatchMethodRoot` to
+ * require that a candidate dispatch method's name corresponds to an actual
+ * declared interface contract SOMEWHERE in the codebase, rather than merely
+ * "any method with fanOut > 0 in a file that also has other active code" —
+ * the latter is indistinguishable from a genuinely-dead, ordinary class
+ * method that happens to call a helper (a real false-positive risk: an
+ * `interface`/`type`-less duck-typed dispatch method would fail this check
+ * and correctly fall back to full reachability scrutiny — a safe failure
+ * mode, unlike promoting an ordinary dead method to root status).
+ */
+function computeInterfaceMemberBareNames(
+  nodes: RoleClassificationNode[],
+  typeDefNamesByFile: Map<string, Set<string>>,
+): Set<string> {
+  const names = new Set<string>();
+  for (const node of nodes) {
+    if (!isTypeDeclarationMember(node, typeDefNamesByFile)) continue;
+    const dotIdx = node.name.indexOf('.');
+    names.add(dotIdx === -1 ? node.name : node.name.slice(dotIdx + 1));
+  }
+  return names;
+}
+
+/**
  * True when `node` is a `method`-kind interface-dispatch implementation
  * rescued by `classifyUnreferencedNode`'s Pattern-2 heuristic (fanIn === 0,
- * fanOut > 0, `hasActiveFileSiblings`) — e.g. `enterNode`/`exitNode` on a
+ * fanOut > 0, `hasActiveFileSiblings`) AND whose bare name corresponds to an
+ * actual interface/type declaration member somewhere in the codebase (e.g.
+ * TS `interface Visitor { enterNode?(...): ...; }`, matched via
+ * `interfaceMemberBareNames`) — e.g. `enterNode`/`exitNode` on a
  * Visitor-shaped object, invoked only via generic property-access dispatch
  * (`if (v.enterNode) v.enterNode(...)`) that codegraph cannot trace to a
  * concrete implementation. Such a method can never be the TARGET of a
@@ -448,6 +504,15 @@ function computeReachableIds(
  * value-ref edge — so it must be an unconditional root: otherwise everything
  * it calls (other helpers in the same visitor file) would be wrongly treated
  * as unreachable merely because the dispatch mechanism itself leaves no edge.
+ *
+ * The `interfaceMemberBareNames` requirement exists specifically because the
+ * fanIn/fanOut/hasActiveFileSiblings shape ALONE is too broad: an ordinary,
+ * genuinely-dead class method that happens to call a helper and share its
+ * file with another called symbol satisfies that shape too. Tying the rescue
+ * to an actual declared contract elsewhere in the codebase makes an
+ * "ordinary unused method" false positive require a coincidental name
+ * collision with some unrelated interface's member, rather than being the
+ * default outcome for any such method.
  *
  * Deliberately narrower than `classifyUnreferencedNode`'s sibling rescue for
  * `function`-kind logical-or-fallback values (`kind === 'function' &&
@@ -463,14 +528,20 @@ function computeReachableIds(
 function isInterfaceDispatchMethodRoot(
   node: RoleClassificationNode,
   typeDefNamesByFile: Map<string, Set<string>>,
+  interfaceMemberBareNames: Set<string>,
 ): boolean {
-  return (
-    node.kind === 'method' &&
-    node.fanIn === 0 &&
-    node.fanOut > 0 &&
-    !!node.hasActiveFileSiblings &&
-    !isTypeDeclarationMember(node, typeDefNamesByFile)
-  );
+  if (
+    node.kind !== 'method' ||
+    node.fanIn !== 0 ||
+    node.fanOut <= 0 ||
+    !node.hasActiveFileSiblings ||
+    isTypeDeclarationMember(node, typeDefNamesByFile)
+  ) {
+    return false;
+  }
+  const dotIdx = node.name.indexOf('.');
+  const bareName = dotIdx === -1 ? node.name : node.name.slice(dotIdx + 1);
+  return interfaceMemberBareNames.has(bareName);
 }
 
 /**
@@ -484,11 +555,16 @@ function isInterfaceDispatchMethodRoot(
  * Roots come from three sources:
  *
  *  1. `isLiveRoot` — `function`/`method` nodes that are themselves confirmed
- *     entry points (framework dispatch, exported, Commander dispatch).
+ *     entry points (framework dispatch, on the genuinely public surface via
+ *     `isPublicSurface`, Commander dispatch). Deliberately NOT the broader
+ *     `isExported`, whose cross-file-caller component would let a symbol
+ *     called only by an unreachable cross-file caller become a root.
  *
  *  2. `isInterfaceDispatchMethodRoot` — `method`-kind interface-dispatch
- *     implementations (Visitor-pattern-style), which can never be the TARGET
- *     of a `calls` edge by construction. See its doc comment for why this is
+ *     implementations whose bare name matches an actual declared
+ *     interface/type member somewhere in the codebase (Visitor-pattern-style),
+ *     which can never be the TARGET of a `calls` edge by construction. See its
+ *     doc comment for why the name-match requirement exists and why this is
  *     deliberately NOT extended to `function`-kind rescues.
  *
  *  3. Every `calls`-edge SOURCE that is not itself a `function`/`method` node
@@ -536,12 +612,13 @@ function applyReachabilityDowngrade(
 ): void {
   const kindById = new Map<string, string>();
   for (const node of nodes) kindById.set(node.id, node.kind);
+  const interfaceMemberBareNames = computeInterfaceMemberBareNames(nodes, typeDefNamesByFile);
 
   const roots = new Set<string>();
   for (const node of nodes) {
     if (
       isLiveRoot(node, typeDefNamesByFile) ||
-      isInterfaceDispatchMethodRoot(node, typeDefNamesByFile)
+      isInterfaceDispatchMethodRoot(node, typeDefNamesByFile, interfaceMemberBareNames)
     ) {
       roots.add(node.id);
     }

--- a/tests/graph/classifiers/roles.test.ts
+++ b/tests/graph/classifiers/roles.test.ts
@@ -831,7 +831,7 @@ describe('classifyRoles', () => {
     // its own dead-vs-leaf classification is unrelated to this fix.
   });
 
-  it('does not downgrade a node reachable from an exported root via a real call chain', () => {
+  it('does not downgrade a node reachable from a publicly-surfaced root via a real call chain', () => {
     const nodes = [
       {
         id: '1',
@@ -850,11 +850,51 @@ describe('classifyRoles', () => {
         fanIn: 0,
         fanOut: 1,
         isExported: true,
+        isPublicSurface: true,
       },
     ];
     const callEdges: Array<[string, string]> = [['2', '1']];
     const roles = classifyRoles(nodes, undefined, callEdges);
     expect(roles.get('1')).not.toBe('dead-unresolved');
+  });
+
+  it('does NOT treat a symbol as a root merely because some (possibly unreachable) cross-file caller exists', () => {
+    // Regression for a Greptile-flagged gap: the pre-existing `isExported`
+    // heuristic (used by classifyNodeRole's own `entry` branch) also marks a
+    // symbol "exported" merely because SOME caller in a different file calls
+    // it — regardless of whether that caller is itself reachable. Using that
+    // broader signal for root determination would let a cross-file dead call
+    // chain evade #2032's fix entirely. `isLiveRoot` must key off the
+    // narrower `isPublicSurface` (explicit export / confirmed reexport
+    // chain), not `isExported`.
+    const nodes = [
+      {
+        id: '1',
+        name: 'unreachableCrossFileCaller',
+        kind: 'function',
+        file: 'a.ts',
+        fanIn: 0,
+        fanOut: 1,
+        isExported: false,
+      },
+      {
+        id: '2',
+        name: 'calleeInAnotherFile',
+        kind: 'function',
+        file: 'b.ts',
+        fanIn: 1,
+        fanOut: 0,
+        // Mirrors what `exportedIds`'s cross-file-caller heuristic would set:
+        // isExported becomes true merely because the caller is in a
+        // different file, even though isPublicSurface (no explicit export,
+        // no reexport chain) stays false.
+        isExported: true,
+        isPublicSurface: false,
+      },
+    ];
+    const callEdges: Array<[string, string]> = [['1', '2']];
+    const roles = classifyRoles(nodes, undefined, callEdges);
+    expect(roles.get('2')).toBe('dead-unresolved');
   });
 
   it('downgrades a mutually-recursive pair with no confirmed-live root', () => {
@@ -1007,6 +1047,13 @@ describe('classifyRoles', () => {
     // never be the TARGET of a `calls` edge — fanIn stays 0 forever, yet it's
     // rescued to 'leaf' by classifyUnreferencedNode's Pattern-2 heuristic.
     // Whatever it calls (classifyHalstead) must be reachable through it.
+    //
+    // The declared `Visitor` interface (mirroring src/types.ts) is required:
+    // isInterfaceDispatchMethodRoot only promotes a method to root when its
+    // bare name matches an actual interface/type member somewhere in the
+    // codebase, not merely from the fanIn/fanOut/hasActiveFileSiblings shape
+    // alone (see the "does NOT treat an ordinary unused class method" test
+    // below for why that additional check matters).
     const nodes = [
       {
         id: '1',
@@ -1027,10 +1074,62 @@ describe('classifyRoles', () => {
         fanOut: 0,
         isExported: false,
       },
+      {
+        id: '3',
+        name: 'Visitor',
+        kind: 'interface',
+        file: 'types.ts',
+        fanIn: 0,
+        fanOut: 0,
+        isExported: true,
+      },
+      {
+        id: '4',
+        name: 'Visitor.enterNode',
+        kind: 'method',
+        file: 'types.ts',
+        fanIn: 0,
+        fanOut: 0,
+        isExported: false,
+      },
     ];
     const callEdges: Array<[string, string]> = [['1', '2']];
     const roles = classifyRoles(nodes, undefined, callEdges);
     expect(roles.get('2')).not.toBe('dead-unresolved');
+  });
+
+  it('does NOT treat an ordinary unused class method as an interface-dispatch root merely from fan shape', () => {
+    // Regression for a Greptile-flagged gap: without the interface-member
+    // name-match requirement, ANY method with fanIn=0, fanOut>0, and an
+    // active sibling in its file would be promoted to root — including a
+    // genuinely-dead class method that happens to call a helper. No
+    // interface/type declares a `deadMethod` member anywhere here, so this
+    // must NOT be treated as an interface-dispatch root, and the helper it
+    // calls must correctly stay dead.
+    const nodes = [
+      {
+        id: '1',
+        name: 'MyClass.deadMethod',
+        kind: 'method',
+        file: 'a.ts',
+        fanIn: 0,
+        fanOut: 1,
+        isExported: false,
+        hasActiveFileSiblings: true,
+      },
+      {
+        id: '2',
+        name: 'helper',
+        kind: 'function',
+        file: 'a.ts',
+        fanIn: 1,
+        fanOut: 0,
+        isExported: false,
+      },
+    ];
+    const callEdges: Array<[string, string]> = [['1', '2']];
+    const roles = classifyRoles(nodes, undefined, callEdges);
+    expect(roles.get('2')).toBe('dead-unresolved');
   });
 
   it('does NOT treat a function-kind logical-or-fallback rescue as a root (would defeat #2032 for the common case)', () => {

--- a/tests/graph/classifiers/roles.test.ts
+++ b/tests/graph/classifiers/roles.test.ts
@@ -766,4 +766,302 @@ describe('classifyRoles', () => {
     const roles = classifyRoles(nodes);
     expect(roles.get('1')).toBe('leaf');
   });
+
+  // ── Transitive-reachability dead-code downgrade (#2032) ─────────────
+
+  it('does not downgrade anything when callEdges is omitted (pre-#2032 behavior preserved)', () => {
+    // A function whose only caller has fanIn=0 and isn't a root: without
+    // callEdges, classifyRoles must behave exactly as before — the direct
+    // fan-in check alone decides liveness.
+    const nodes = [
+      { id: '1', name: 'computeHelper', kind: 'function', fanIn: 1, fanOut: 0, isExported: false },
+      {
+        id: '2',
+        name: 'deadIntermediate',
+        kind: 'function',
+        fanIn: 0,
+        fanOut: 1,
+        isExported: false,
+      },
+    ];
+    const roles = classifyRoles(nodes);
+    expect(roles.get('1')).not.toBe('dead-unresolved');
+  });
+
+  it('downgrades a function whose only caller is itself unreachable (#2032 repro)', () => {
+    // computeHelper is called only by deadIntermediate, which is never
+    // itself called by anything reachable from the confirmed-live root
+    // (useThing). Direct fan-in alone would call computeHelper live; the
+    // reachability pass must correctly flag it dead.
+    const nodes = [
+      {
+        id: '1',
+        name: 'computeHelper',
+        kind: 'function',
+        file: 'a.ts',
+        fanIn: 1,
+        fanOut: 0,
+        isExported: false,
+      },
+      {
+        id: '2',
+        name: 'deadIntermediate',
+        kind: 'function',
+        file: 'a.ts',
+        fanIn: 0,
+        fanOut: 1,
+        isExported: false,
+      },
+      {
+        id: '3',
+        name: 'useThing',
+        kind: 'function',
+        file: 'a.ts',
+        fanIn: 0,
+        fanOut: 0,
+        isExported: true,
+      },
+    ];
+    // deadIntermediate calls computeHelper; useThing (the only root) calls nothing.
+    const callEdges: Array<[string, string]> = [['2', '1']];
+    const roles = classifyRoles(nodes, undefined, callEdges);
+    expect(roles.get('1')).toBe('dead-unresolved');
+    // deadIntermediate itself has fanIn=0, so it's untouched by the downgrade
+    // pass (it goes through the fanIn===0 branch, not classifyByFanShape) —
+    // its own dead-vs-leaf classification is unrelated to this fix.
+  });
+
+  it('does not downgrade a node reachable from an exported root via a real call chain', () => {
+    const nodes = [
+      {
+        id: '1',
+        name: 'helper',
+        kind: 'function',
+        file: 'a.ts',
+        fanIn: 1,
+        fanOut: 0,
+        isExported: false,
+      },
+      {
+        id: '2',
+        name: 'useThing',
+        kind: 'function',
+        file: 'a.ts',
+        fanIn: 0,
+        fanOut: 1,
+        isExported: true,
+      },
+    ];
+    const callEdges: Array<[string, string]> = [['2', '1']];
+    const roles = classifyRoles(nodes, undefined, callEdges);
+    expect(roles.get('1')).not.toBe('dead-unresolved');
+  });
+
+  it('downgrades a mutually-recursive pair with no confirmed-live root', () => {
+    const nodes = [
+      {
+        id: '1',
+        name: 'fn1',
+        kind: 'function',
+        file: 'a.ts',
+        fanIn: 1,
+        fanOut: 1,
+        isExported: false,
+      },
+      {
+        id: '2',
+        name: 'fn2',
+        kind: 'function',
+        file: 'a.ts',
+        fanIn: 1,
+        fanOut: 1,
+        isExported: false,
+      },
+    ];
+    const callEdges: Array<[string, string]> = [
+      ['1', '2'],
+      ['2', '1'],
+    ];
+    const roles = classifyRoles(nodes, undefined, callEdges);
+    expect(roles.get('1')).toBe('dead-unresolved');
+    expect(roles.get('2')).toBe('dead-unresolved');
+  });
+
+  it('treats a module-top-level constant as an unconditional root for its value-ref edges (#1771 rescue preserved)', () => {
+    // Mirrors the real dispatch-table shape: a top-level `const HANDLERS =
+    // [{ resolve: resolveA }]` gets a value-ref `calls` edge sourced from the
+    // constant declaration itself, not from a function. The constant is not
+    // itself subject to reachability (module-top-level initializers always
+    // run), so its value-ref edges must propagate liveness unconditionally.
+    const nodes = [
+      {
+        id: '1',
+        name: 'resolveA',
+        kind: 'function',
+        file: 'dispatch.js',
+        fanIn: 1,
+        fanOut: 0,
+        isExported: false,
+      },
+      {
+        id: '2',
+        name: 'HANDLERS',
+        kind: 'constant',
+        file: 'dispatch.js',
+        fanIn: 0,
+        fanOut: 0,
+        isExported: false,
+      },
+    ];
+    const callEdges: Array<[string, string]> = [['2', '1']];
+    const roles = classifyRoles(nodes, undefined, callEdges);
+    expect(roles.get('1')).not.toBe('dead-unresolved');
+  });
+
+  it('treats a non-function/method call-edge source absent from nodes (e.g. a file scope) as an unconditional root (#1776)', () => {
+    // Mirrors Lua's builtin-reassignment pattern (`require = tracedFn`): the
+    // value-ref edge is sourced from the enclosing file/module scope, which
+    // is entirely excluded from the classifier's `nodes` input (file/directory
+    // kinds never reach this module) — so the source id is absent from
+    // `nodes` altogether, not merely a non-function kind present in it.
+    const nodes = [
+      {
+        id: '1',
+        name: 'tracedFn',
+        kind: 'function',
+        file: 'main.lua',
+        fanIn: 1,
+        fanOut: 0,
+        isExported: false,
+      },
+    ];
+    // Source '99' is a file-scope id that never appears in `nodes`.
+    const callEdges: Array<[string, string]> = [['99', '1']];
+    const roles = classifyRoles(nodes, undefined, callEdges);
+    expect(roles.get('1')).not.toBe('dead-unresolved');
+  });
+
+  it('does not downgrade a test-only node even though its only caller (a test) is unreachable', () => {
+    const nodes = [
+      {
+        id: '1',
+        name: 'helperForTests',
+        kind: 'function',
+        file: 'a.ts',
+        fanIn: 1,
+        fanOut: 0,
+        isExported: false,
+        productionFanIn: 0,
+      },
+    ];
+    const callEdges: Array<[string, string]> = [['2', '1']];
+    const roles = classifyRoles(nodes, undefined, callEdges);
+    expect(roles.get('1')).toBe('test-only');
+  });
+
+  it('does not downgrade an interface method-signature member even with fanIn > 0 and an unreachable caller', () => {
+    // Regression: isTypeDeclarationMember returns 'leaf' unconditionally,
+    // independent of fanIn — this is indistinguishable from
+    // classifyByFanShape's 'leaf' by role string alone unless the downgrade
+    // pass explicitly re-checks isTypeDeclarationMember. A widely-referenced
+    // interface method (e.g. a native-binding surface like `NativeDatabase`
+    // in `types.ts`) has real fanIn > 0 from call sites resolving to it by
+    // name, and must never be reconsidered by reachability.
+    const nodes = [
+      {
+        id: '1',
+        name: 'NativeDatabase',
+        kind: 'interface',
+        file: 'types.ts',
+        fanIn: 0,
+        fanOut: 0,
+        isExported: false,
+      },
+      {
+        id: '2',
+        name: 'NativeDatabase.countNodes',
+        kind: 'method',
+        file: 'types.ts',
+        fanIn: 1,
+        fanOut: 0,
+        isExported: false,
+      },
+      {
+        id: '3',
+        name: 'unreachableCaller',
+        kind: 'function',
+        file: 'a.ts',
+        fanIn: 0,
+        fanOut: 1,
+        isExported: false,
+      },
+    ];
+    const callEdges: Array<[string, string]> = [['3', '2']];
+    const roles = classifyRoles(nodes, undefined, callEdges);
+    expect(roles.get('2')).toBe('leaf');
+  });
+
+  it('treats an interface-dispatch method (Pattern 2) as an unconditional root for what it calls', () => {
+    // Mirrors ast-analysis/visitors/*.ts's Visitor pattern: enterNode is
+    // dispatched generically (`if (v.enterNode) v.enterNode(node)`) so it can
+    // never be the TARGET of a `calls` edge — fanIn stays 0 forever, yet it's
+    // rescued to 'leaf' by classifyUnreferencedNode's Pattern-2 heuristic.
+    // Whatever it calls (classifyHalstead) must be reachable through it.
+    const nodes = [
+      {
+        id: '1',
+        name: 'enterNode',
+        kind: 'method',
+        file: 'visitor.ts',
+        fanIn: 0,
+        fanOut: 1,
+        isExported: false,
+        hasActiveFileSiblings: true,
+      },
+      {
+        id: '2',
+        name: 'classifyHalstead',
+        kind: 'function',
+        file: 'visitor.ts',
+        fanIn: 1,
+        fanOut: 0,
+        isExported: false,
+      },
+    ];
+    const callEdges: Array<[string, string]> = [['1', '2']];
+    const roles = classifyRoles(nodes, undefined, callEdges);
+    expect(roles.get('2')).not.toBe('dead-unresolved');
+  });
+
+  it('does NOT treat a function-kind logical-or-fallback rescue as a root (would defeat #2032 for the common case)', () => {
+    // Unlike the method/interface-dispatch case above, a plain `function`
+    // rescued via the (explicitly acknowledged as imprecise) logical-or
+    // fallback heuristic must NOT be promoted to root — otherwise almost any
+    // genuinely-dead intermediate function in an active file would silently
+    // rescue whatever it calls, the exact #2032 pattern this fix targets.
+    const nodes = [
+      {
+        id: '1',
+        name: 'deadIntermediate',
+        kind: 'function',
+        file: 'a.ts',
+        fanIn: 0,
+        fanOut: 1,
+        isExported: false,
+        hasActiveFileSiblings: true,
+      },
+      {
+        id: '2',
+        name: 'computeHelper',
+        kind: 'function',
+        file: 'a.ts',
+        fanIn: 1,
+        fanOut: 0,
+        isExported: false,
+      },
+    ];
+    const callEdges: Array<[string, string]> = [['1', '2']];
+    const roles = classifyRoles(nodes, undefined, callEdges);
+    expect(roles.get('2')).toBe('dead-unresolved');
+  });
 });

--- a/tests/integration/issue-1895-value-ref-invocation-check.test.ts
+++ b/tests/integration/issue-1895-value-ref-invocation-check.test.ts
@@ -19,6 +19,15 @@
  * being processed. `matches`/`resolve`-style dispatch tables that ARE read
  * through a real `handler.resolve(...)` call site (the #1771 fixture) keep
  * their edges; a property that's wired up but never read does not.
+ *
+ * `run`/`makeTable` are real ESM exports (not CommonJS `module.exports`)
+ * so `run` has a genuine external root and `makeTable` is reached from it via
+ * a direct cross-file `calls` edge — #2032's transitive-reachability check
+ * requires the whole chain down to `isRead` to be reachable from a
+ * confirmed-live root, independent of (and in addition to) the value-ref
+ * invocation-evidence mechanism this test targets. `neverRead`/`isRead`/
+ * `shorthandNeverRead` stay unexported internal helpers, since the point is
+ * to tell them apart purely by invocation evidence, not by export status.
  */
 
 import fs from 'node:fs';
@@ -40,25 +49,21 @@ function neverRead(x) { return x + 1; }
 function isRead(x) { return x + 2; }
 function shorthandNeverRead(x) { return x + 3; }
 
-function makeTable() {
+export function makeTable() {
   return {
     resolve: neverRead,
     reject: isRead,
     shorthandNeverRead,
   };
 }
-
-module.exports = { makeTable };
 `,
   'consumer.js': `
-const { makeTable } = require('./factory.js');
+import { makeTable } from './factory.js';
 
-function run() {
+export function run() {
   const table = makeTable();
   return table.reject(1);
 }
-
-module.exports = { run };
 `,
 };
 

--- a/tests/integration/roles.test.ts
+++ b/tests/integration/roles.test.ts
@@ -119,8 +119,17 @@ describe('barrel re-export role classification', () => {
     // re-exported file, with no callers and no outgoing calls (#1780).
     const _abstractHelper = insertNode(db, 'abstractHelper', 'method', 'src/inspect.ts', 50);
 
-    // Barrel re-exports inspect.ts
+    // Barrel re-exports inspect.ts. This fixture models a genuine wildcard
+    // reexport (`export * from './inspect'`) — the extractor emits BOTH the
+    // generic file-to-file 'reexports' edge AND a 'reexports-wildcard'
+    // marker edge for that shape (unlike a named `export { queryName } from`,
+    // which gets a symbol-level 'reexports' edge instead — see #2032's
+    // publicSurfaceIds fix). The wildcard marker is what justifies treating
+    // every top-level symbol in inspect.ts, not just queryName, as part of
+    // the exported surface (matching this describe block's other assertion
+    // that helperFn is also 'entry' despite having zero callers of its own).
     insertEdge(db, fBarrel, fInspect, 'reexports');
+    insertEdge(db, fBarrel, fInspect, 'reexports-wildcard');
     // Consumer imports from barrel
     insertEdge(db, fConsumer, fBarrel, 'imports');
     // Test file imports from inspect directly
@@ -232,6 +241,70 @@ describe('multi-level barrel re-export chain', () => {
     // 3-level deep re-export chain: inspect → index → queries-cli → query (consumer)
     // Should still be recognized as exported
     expect(queryNameResult!.role).toBe('entry');
+  });
+});
+
+// ─── Named reexport does not leak public-surface status to siblings (#2032) ──
+
+describe('named barrel reexport scoped to the actual symbol', () => {
+  let namedTmpDir: string, namedDbPath: string;
+
+  beforeAll(() => {
+    namedTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-named-reexport-'));
+    fs.mkdirSync(path.join(namedTmpDir, '.codegraph'));
+    namedDbPath = path.join(namedTmpDir, '.codegraph', 'graph.db');
+
+    const db = new Database(namedDbPath);
+    db.pragma('journal_mode = WAL');
+    initSchema(db);
+
+    const fLib = insertNode(db, 'src/lib.ts', 'file', 'src/lib.ts', 0);
+    const fBarrel = insertNode(db, 'src/index.ts', 'file', 'src/index.ts', 0);
+    const fConsumer = insertNode(db, 'src/app.ts', 'file', 'src/app.ts', 0);
+
+    const publicThing = insertNode(db, 'publicThing', 'function', 'src/lib.ts', 1);
+    // Two functions private to lib.ts, unrelated to publicThing: deadIntermediate
+    // is never called by anything, and deadHelper's only caller is
+    // deadIntermediate — the #2032 transitive-unreachability shape.
+    const deadIntermediate = insertNode(db, 'deadIntermediate', 'function', 'src/lib.ts', 10);
+    const deadHelper = insertNode(db, 'deadHelper', 'function', 'src/lib.ts', 20);
+
+    // `export { publicThing } from './lib'` — a NAMED reexport: the extractor
+    // emits the generic file-to-file 'reexports' edge (mirroring real
+    // extraction, which always emits this regardless of named/wildcard) PLUS
+    // a symbol-level 'reexports' edge targeting publicThing specifically —
+    // NOT a 'reexports-wildcard' marker, since only that one symbol is
+    // actually re-exported.
+    insertEdge(db, fBarrel, fLib, 'reexports');
+    insertEdge(db, fBarrel, publicThing, 'reexports');
+    insertEdge(db, fConsumer, fBarrel, 'imports');
+
+    insertEdge(db, deadIntermediate, deadHelper, 'calls');
+
+    classifyNodeRoles(db);
+    db.close();
+  });
+
+  afterAll(() => {
+    if (namedTmpDir) fs.rmSync(namedTmpDir, { recursive: true, force: true });
+  });
+
+  test('the actually-named symbol is on the public surface', () => {
+    const data = rolesData(namedDbPath);
+    const result = data.symbols.find((s) => s.name === 'publicThing');
+    expect(result).toBeDefined();
+    expect(result!.role).toBe('entry');
+  });
+
+  test('a private sibling reachable only through an unreachable caller stays dead, despite sharing a file with the re-exported symbol', () => {
+    // Regression for a Greptile-flagged gap: marking the WHOLE target file
+    // "exported" merely because it contains one named-reexported symbol would
+    // let deadHelper evade #2032's reachability check entirely, since
+    // deadIntermediate (its only caller) would wrongly count as a root too.
+    const data = rolesData(namedDbPath);
+    const result = data.symbols.find((s) => s.name === 'deadHelper');
+    expect(result).toBeDefined();
+    expect(result!.role).toBe('dead-unresolved');
   });
 });
 

--- a/tests/unit/roles.test.ts
+++ b/tests/unit/roles.test.ts
@@ -177,6 +177,15 @@ describe('classifyNodeRoles', () => {
     insertEdge(fn1, fn2, 'calls');
     insertEdge(fn2, fn1, 'calls');
 
+    // fn1 is exported — a confirmed-live reachability root (#2032) — so this
+    // mutually-recursive pair is reachable from outside the codebase via fn1.
+    // Without a root, fn1/fn2 would be a closed component unreachable from
+    // any live entry point and correctly downgraded to dead-unresolved,
+    // regardless of their mutual fan-in/fan-out — this test is specifically
+    // about median-based fan-shape classification, not reachability, so it
+    // needs a genuine root to keep exercising that.
+    db.prepare('UPDATE nodes SET exported = 1 WHERE id = ?').run(fn1);
+
     const summary = classifyNodeRoles(db);
     // Both have fan_in=1 (>= median 1) and fan_out=1 (>= median 1) → utility
     expect(summary.utility).toBe(2);

--- a/tests/unit/roles.test.ts
+++ b/tests/unit/roles.test.ts
@@ -66,6 +66,15 @@ function buildTestGraph() {
   // No callers from same file, but one cross-file caller
   const crossCaller = insertNode('crossCaller', 'function', 'b.js', 50);
   insertEdge(crossCaller, entryFn, 'calls');
+  // crossCaller is the graph's only confirmed-live root (#2032): genuinely
+  // exported, not merely inferred "exported" from being someone's cross-file
+  // caller (that broader signal no longer grants BFS root status — see
+  // isLiveRoot's isPublicSurface doc comment). Without a real root here, the
+  // whole graph below is an unreachable component and everything downstream
+  // of crossCaller would be (correctly, under #2032) flagged dead, which
+  // would defeat this fixture's actual purpose: testing fan-shape
+  // classification (core/utility/adapter/leaf), not reachability.
+  db.prepare('UPDATE nodes SET exported = 1 WHERE id = ?').run(crossCaller);
 
   // coreFn: high fan_in (3 callers), low fan_out (0) → core
   insertEdge(entryFn, coreFn, 'calls');
@@ -317,6 +326,14 @@ describe('classifyNodeRoles', () => {
     insertEdge(externalCaller, fn1, 'calls');
     insertEdge(fn1, fn2, 'calls');
     // Structs have no call edges (they are used as type annotations only)
+
+    // externalCaller ("main") is the confirmed-live root (#2032): genuinely
+    // exported, not merely inferred "exported" from being fn1's cross-file
+    // caller (that broader signal no longer grants BFS root status). Without
+    // a real root, fn1/fn2 would be an unreachable component and fn1 would
+    // (correctly, under #2032) be flagged dead, defeating this test's actual
+    // purpose of checking the struct/enum/trait hasActiveFileSiblings rescue.
+    db.prepare('UPDATE nodes SET exported = 1 WHERE id = ?').run(externalCaller);
 
     classifyNodeRoles(db);
 


### PR DESCRIPTION
## Summary

- `roles --role dead` treated any inbound `calls` edge as sufficient evidence of liveness, without checking whether the caller itself is reachable from a confirmed-live root. A function called only by another unreachable function kept a non-dead role forever.
- Adds a worklist/BFS transitive-reachability pass (`applyReachabilityDowngrade` in `src/graph/classifiers/roles.ts`, mirrored as `apply_reachability_downgrade` in `crates/codegraph-core/src/graph/classifiers/roles.rs`) that runs after the existing per-node classification. It is strictly downgrading — never upgrades a verdict, never touches `entry`/`test-only`/`hasActiveFileSiblings` rescues/interface-type-members — it only reconsiders `function`/`method` nodes whose `core`/`utility`/`adapter`/`leaf` verdict came from direct fan-in (`classifyByFanShape`).
- Roots: `function`/`method` nodes on the genuinely public surface (explicit `export` keyword, or the SPECIFIC symbol named in a confirmed production-reachable reexport, or every symbol in a file reached via a genuine `export * from` — deliberately NOT the broader "some cross-file caller exists" signal, nor "shares a file with a named-reexported sibling", see Greptile fixes below) / framework-dispatched (`route:`/`event:`/`command:`) / Commander-dispatch, plus every `calls`-edge SOURCE that isn't itself a `function`/`method` (module-top-level `constant` declarations, bare file-scope assignments like Lua's `require = tracedFn`) and `method`-kind interface-dispatch implementations whose name matches a declared interface/type member (Visitor-pattern methods invoked only via generic property access) — none of these can ever be the *target* of a `calls` edge by construction, so they must count as unconditionally live.
- Deliberately does **not** promote `function`-kind logical-or-fallback rescues to roots — doing so would silently re-rescue genuinely-dead intermediate functions, defeating the fix for the common case (see code comments for the reasoning and a regression test guarding it).

## Scope decision

Implemented for the **full-classification path only** (`classifyNodeRolesFull` / Rust `do_classify_full`). The **incremental path** cannot safely compute whole-graph reachability from a changed-files-scoped window — a node's only live path in can run through files entirely outside that window — without either reintroducing a full-graph scan on every incremental build (undermining the perf work that path was built around) or a real incremental-reachability-maintenance design (handles edge additions fine, edge removals need decremental reachability). Filed as a tracked follow-up: #2255.

## Root-identification bugs found and fixed

Running `codegraph roles --role dead -T` on this repo's own `src/` before/after (each fix re-validated the same way) surfaced real root-identification bugs, all fixed before landing:

1. **Interface/type method-signature members** (e.g. `NativeDatabase.countNodes` in `src/types.ts`) get `'leaf'` unconditionally from `isTypeDeclarationMember`, independent of `fanIn` — indistinguishable from `classifyByFanShape`'s `'leaf'` by role string alone. Fixed by explicitly excluding type-declaration members from the downgrade pass.
2. **`method`-kind interface-dispatch implementations** (e.g. `enterNode`/`exitNode` in `src/ast-analysis/visitors/*.ts`, dispatched via `if (v.enterNode) v.enterNode(...)`) can never be the target of a `calls` edge by construction, so they could never be BFS-reachable — wrongly starving their own callees. Fixed by adding `isInterfaceDispatchMethodRoot`.
3. **(Greptile review)** `isLiveRoot` used the broad `isExported` flag, which also fires when *some* caller in a different file calls a symbol regardless of whether that caller is itself reachable — letting a cross-file dead call chain evade the whole check. Fixed with a narrower `isPublicSurface` (explicit export / confirmed reexport chain only).
4. **(Greptile review)** `isInterfaceDispatchMethodRoot` promoted *any* method with `fanIn===0`, `fanOut>0`, and an active file sibling — indistinguishable from an ordinary dead class method that happens to call a helper. Fixed by requiring the method's bare name to match an actual declared interface/type member somewhere in the codebase.
5. **(Greptile review)** `publicSurfaceIds` reused the pre-existing whole-file reexport query, which treats ANY `reexports` edge (named or wildcard) as "every symbol in the target file is exported". Fixed by using the symbol-level `reexports` edge a named reexport already gets, falling back to whole-file marking only for a genuine `export * from` (`reexports-wildcard`). Caught a real live instance in this repo's own self-build (`src/extractors/groovy.ts`'s AST-node-dispatch handlers).

Re-validating after fixes 3-5 surfaced two further narrow, out-of-scope gaps — filed as #2259 and #2260 rather than solved inline.

## Before/after on this repo's own self-build (`src/`, `-T`)

| | origin/main | this PR |
|---|---|---|
| dead-entry | 61 | 61 |
| dead-ffi | 17 | 60 |
| dead-leaf | 91 | 91 |
| dead-unresolved | 464 | 615 |
| **total** | **633** | **827** |

+194 delta. Diffed the actual symbol lists (not just totals) at every step of the fix, not just the final one: the large majority are pre-existing hand-authored parser/resolution test fixtures under `tests/benchmarks/**` / `tests/fixtures/**` that `-T`'s filename-only heuristic doesn't exclude (tracked as #2256) — these grew once the cross-file-root fix (#3 above) closed a loophole those fixtures relied on especially heavily (they're full of cross-file call-resolution test cases with no genuine exported entry point). The remaining real `src/` findings are the already-tracked #2257 (2 cases), #2259 (1 case, 4 downstream nodes), and #2260 (1 case, 4 downstream nodes — caught and fixed by review round 3, then re-surfaced as a distinct root cause once the reexport-scoping bug was corrected).

## Testing

- `npm run lint` — clean
- `npm test` — 271 files / 4395 tests pass (added TS unit + integration tests for the reachability pass, including regression tests for all three Greptile findings, + updated pre-existing fixtures whose only "root" was one of the now-narrower signals, to keep testing what they originally intended)
- `cargo test -p codegraph-core --lib` — 741 tests pass (mirrored Rust unit tests using an in-memory `NativeDatabase`)
- Verified against the issue's own repro shape (an equivalent one, since the literal snippet in the issue doesn't create a separate node for the nested arrow-function closure — codegraph attributes its call to the enclosing named function by design) with both engines
- `codegraph diff-impact --staged -T`: small, expected blast radius scoped to the classifier module

## Follow-up issues filed

- #2255 — incremental-path reachability parity (design + perf work needed)
- #2256 — `-T` doesn't exclude `tests/benchmarks/**/fixtures/**` / `tests/fixtures/**` fixture directories
- #2257 — function-value logical-or-fallback references still lack a real `calls` edge (mirrors #1771/#1895 for a different value-ref shape)
- #2259 — method-kind `EventEmitter`-style callback registrations aren't recognized as reachability roots (surfaced while fixing Greptile's review findings)
- #2260 — computed/bracket-access dispatch-table lookups (`table[key](...)`) still lack a real `calls` edge, unlike dot-property value-refs (surfaced while fixing the reexport-scoping bug)

Closes #2032