### PR TITLE
fix(extractors): qualify object literals returned from factory functions

### DIFF
--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -926,14 +926,56 @@ fn store_return_type(fn_node: &Node, fn_name: &str, source: &[u8], symbols: &mut
         }
     }
     // Infer from first `return new Constructor()` in body, then from a
-    // directly-returned object literal with callable properties (#2033).
-    if let Some(body) = fn_node.child_by_field_name("body") {
-        if let Some(type_name) = find_return_new_expr_type(&body, source) {
-            push_return_type_entry(symbols, fn_name, type_name, 0.85);
-        } else if find_return_object_literal_self_type(&body) {
-            push_return_type_entry(symbols, fn_name, fn_name, 0.85);
+    // directly-returned object literal with callable properties (#2033). Skipped
+    // for async/generator functions: their runtime return value is a Promise/
+    // Generator wrapper around the returned expression, not the expression
+    // itself, so `const p = asyncMakeThing(); p.method()` would otherwise
+    // wrongly resolve through a definition that only exists once the wrapper is
+    // unwrapped (`await`ed or iterated) — neither inference is valid without
+    // that unwrap. Mirrors TS storeReturnType's guard.
+    if !is_async_function_node(fn_node) && !is_generator_function_node(fn_node) {
+        if let Some(body) = fn_node.child_by_field_name("body") {
+            if let Some(type_name) = find_return_new_expr_type(&body, source) {
+                push_return_type_entry(symbols, fn_name, type_name, 0.85);
+            } else if find_return_object_literal_self_type(&body) {
+                push_return_type_entry(symbols, fn_name, fn_name, 0.85);
+            }
         }
     }
+}
+
+/// True when a function/method node carries an `async` modifier — tree-sitter
+/// represents `async` (like `get`/`set`/`static`) as a literal unnamed token
+/// child, not a dedicated field. Scans all direct children since only the
+/// modifier keyword itself ever has `kind() == "async"` (an identifier/
+/// parameter/statement named "async" has kind `identifier`, not `async`).
+/// Mirrors TS `isAsyncFunctionNode`.
+fn is_async_function_node(fn_node: &Node) -> bool {
+    for i in 0..fn_node.child_count() {
+        if fn_node.child(i).map(|c| c.kind()) == Some("async") {
+            return true;
+        }
+    }
+    false
+}
+
+/// True when a function/method node is a generator — `function_declaration`/
+/// `function_expression` distinguish this via a dedicated node kind
+/// (`generator_function_declaration`/`generator_function`), but
+/// `method_definition` (ES6 shorthand `*method() {}`) has no such distinct kind
+/// and instead carries a literal `*` token child, mirroring
+/// `is_async_function_node`'s modifier-token scan. Mirrors TS
+/// `isGeneratorFunctionNode`.
+fn is_generator_function_node(fn_node: &Node) -> bool {
+    if matches!(fn_node.kind(), "generator_function_declaration" | "generator_function") {
+        return true;
+    }
+    for i in 0..fn_node.child_count() {
+        if fn_node.child(i).map(|c| c.kind()) == Some("*") {
+            return true;
+        }
+    }
+    false
 }
 
 /// Scan direct children of `body` for the first `return new X()` and return the constructor name.
@@ -7113,6 +7155,71 @@ mod tests {
         let p_type = s.type_map.iter().find(|e| e.name == "p");
         assert!(p_type.is_some(), "type_map 'p' missing; got: {:?}", s.type_map);
         assert_eq!(p_type.unwrap().type_name, "makePartition");
+    }
+
+    /// Issue #2033 follow-up: an async factory's runtime return value is a Promise
+    /// wrapper around the returned expression, not the expression itself — so
+    /// `const p = makePartitionAsync(seed); p.deltaCPM(...)` must NOT resolve `p` as
+    /// `makePartitionAsync` (that would skip the required `await`). The qualified
+    /// property definition itself is still extracted; only self-typing is skipped.
+    #[test]
+    fn does_not_self_type_an_async_factory_function() {
+        let s = parse_js(
+            "async function makePartitionAsync(seed) {\n\
+               return { deltaCPM: (v) => v + seed };\n\
+             }",
+        );
+        assert!(
+            s.return_type_map.iter().all(|e| e.name != "makePartitionAsync"),
+            "async factory must not be self-typed; got: {:?}",
+            s.return_type_map
+        );
+        let names: Vec<_> = s.definitions.iter().map(|d| d.name.as_str()).collect();
+        assert!(
+            names.contains(&"makePartitionAsync.deltaCPM"),
+            "expected qualified 'makePartitionAsync.deltaCPM' definition; got: {:?}",
+            names
+        );
+    }
+
+    /// Same as above, for a generator factory (`function*`) — its runtime return
+    /// value is a Generator object, not the returned expression directly.
+    #[test]
+    fn does_not_self_type_a_generator_factory_function() {
+        let s = parse_js(
+            "function* makePartitionGen(seed) {\n\
+               return { deltaCPM: (v) => v + seed };\n\
+             }",
+        );
+        assert!(
+            s.return_type_map.iter().all(|e| e.name != "makePartitionGen"),
+            "generator factory must not be self-typed; got: {:?}",
+            s.return_type_map
+        );
+        let names: Vec<_> = s.definitions.iter().map(|d| d.name.as_str()).collect();
+        assert!(
+            names.contains(&"makePartitionGen.deltaCPM"),
+            "expected qualified 'makePartitionGen.deltaCPM' definition; got: {:?}",
+            names
+        );
+    }
+
+    /// Regression guard for the pre-existing `return new Ctor()` inference, which has
+    /// the identical async-wrapper flaw and is gated by the same
+    /// is_async_function_node/is_generator_function_node check.
+    #[test]
+    fn does_not_apply_return_new_constructor_self_typing_to_an_async_function() {
+        let s = parse_js(
+            "class Foo {}\n\
+             async function makeFoo() {\n\
+               return new Foo();\n\
+             }",
+        );
+        assert!(
+            s.return_type_map.iter().all(|e| e.name != "makeFoo"),
+            "async function must not get return-new-Constructor type inference; got: {:?}",
+            s.return_type_map
+        );
     }
 
     /// Issue #1764: a non-string computed pair key (`[Symbol.iterator]: () => {}`) has no

--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -2,6 +2,7 @@ use super::helpers::*;
 use super::SymbolExtractor;
 use crate::ast_analysis::cfg::build_function_cfg;
 use crate::ast_analysis::complexity::compute_all_metrics;
+use crate::domain::graph::builder::stages::build_edges::PROPAGATION_HOP_PENALTY;
 use crate::types::*;
 use std::collections::{HashMap, HashSet};
 use tree_sitter::{Node, Tree};
@@ -39,8 +40,13 @@ impl SymbolExtractor for JsExtractor {
             match_js_node(node, source, symbols, depth, &callback_param_shapes)
         });
         walk_ast_nodes(&tree.root_node(), source, &mut symbols.ast_nodes);
-        walk_tree(&tree.root_node(), source, &mut symbols, match_js_type_map);
+        // #2033: return_type_map must be fully populated before match_js_type_map
+        // runs — its variable_declarator handler now reads the *complete* per-file
+        // return_type_map for same-file inter-procedural propagation (mirrors TS
+        // extractReturnTypeMapWalk running before runContextCollectorWalk for the
+        // identical reason, per that function's doc comment).
         walk_tree(&tree.root_node(), source, &mut symbols, match_js_return_type_map);
+        walk_tree(&tree.root_node(), source, &mut symbols, match_js_type_map);
         // Pre-ES6 prototype methods: `Foo.prototype.bar = fn` and `Foo.prototype = { bar: fn }`
         walk_tree(&tree.root_node(), source, &mut symbols, match_js_prototype_methods);
         // call_assignments runs after type_map is populated (needs receiver types)
@@ -139,6 +145,10 @@ fn match_js_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dep
         // TypeScript class field declarations.
         // Mirrors handleFieldDefTypeMap in src/extractors/javascript.ts.
         "public_field_definition" | "field_definition" => handle_field_def_type_map(node, source, symbols),
+        // #2033: seed composite typeMap keys for object literals returned from a
+        // factory function's body, mirroring the const/let/var declarator branch
+        // above. Mirrors TS handleReturnStmtObjectLiteral's typeMap half.
+        "return_statement" => handle_return_stmt_type_map(node, source, symbols),
         _ => {}
     }
 }
@@ -174,6 +184,37 @@ fn handle_var_declarator_type_map(node: &Node, source: &[u8], symbols: &mut File
     // Phase 8.3e: Object.create({ key: fn }) → composite pts key per property
     if value_n.kind() == "call_expression" {
         seed_object_create_entries(var_name, &value_n, source, symbols);
+        // Phase 8.2 (same-file): inter-procedural return-type propagation —
+        // `const p = makePartition(42)` resolves `p`'s type from this file's OWN
+        // return_type_map (already fully populated by match_js_return_type_map,
+        // which runs before this walk) so a directly-returned self-typed object
+        // literal (#2033's find_return_object_literal_self_type) — or any other
+        // same-file annotated/inferred return type — lets `p.method()` resolve
+        // through the qualified definition. Mirrors TS handleCallExprTypeMap's
+        // resolveCallExprReturnType(depth=0) identifier branch. Cross-file
+        // propagation (imported callees) is handled separately by
+        // propagate_return_types_across_files in pipeline.rs, which only sees
+        // imported names and therefore cannot cover this same-file case.
+        if let Some(fn_n) = value_n.child_by_field_name("function") {
+            if fn_n.kind() == "identifier" {
+                let callee_name = node_text(&fn_n, source);
+                let same_file_entry = symbols
+                    .return_type_map
+                    .iter()
+                    .find(|e| e.name == callee_name)
+                    .map(|e| (e.type_name.clone(), e.confidence));
+                if let Some((type_name, confidence)) = same_file_entry {
+                    let propagated = confidence - PROPAGATION_HOP_PENALTY;
+                    if propagated > 0.0 {
+                        symbols.type_map.push(TypeMapEntry {
+                            name: var_name.to_string(),
+                            type_name,
+                            confidence: propagated,
+                        });
+                    }
+                }
+            }
+        }
     }
     // Phase 8.3f parity: seed composite typeMap keys for ALL object-literal
     // declarations (`const`, `let`, `var`) when at non-function scope.
@@ -720,6 +761,108 @@ fn seed_objlit_type_map_entries(var_name: &str, obj_node: &Node, source: &[u8], 
     }
 }
 
+/// Return the qualifier name for the nearest enclosing function scope of `node` —
+/// walks up `VAR_DECL_FN_SCOPE_TYPES` ancestors and names the match the same way
+/// `extract_object_literal_functions`'s const/let/var declarator call sites name
+/// their `var_name` qualifier (#2033). Used to extend that qualified-definition
+/// mechanism to object literals `return`ed from a factory function's body, e.g.
+/// `function makePartition(seed) { return { deltaCPM: (v) => computeDeltaCPM(s, v) } }`
+/// qualifies the property as `makePartition.deltaCPM`. Mirrors TS
+/// `findEnclosingFunctionQualifier`.
+///
+/// Returns `None` when the enclosing scope has no resolvable name — an anonymous
+/// function expression/arrow that isn't directly assigned to a variable (e.g. an
+/// inline callback argument, an IIFE) — callers skip the qualified extraction in
+/// that case and fall back to the pre-existing generic caller-attribution behavior.
+fn find_enclosing_function_qualifier(node: &Node, source: &[u8]) -> Option<String> {
+    let fn_node = find_parent_of_types(node, &VAR_DECL_FN_SCOPE_TYPES)?;
+    qualifier_for_function_scope_node(&fn_node, source)
+}
+
+/// Derive the qualifier name for a single function-scope node — see
+/// `find_enclosing_function_qualifier`. Mirrors TS `qualifierForFunctionScopeNode`
+/// (and the naming convention `handle_method_def`/`handle_var_decl`'s arrow-value
+/// branch already use for the same node shapes).
+fn qualifier_for_function_scope_node(fn_node: &Node, source: &[u8]) -> Option<String> {
+    match fn_node.kind() {
+        "function_declaration" | "generator_function_declaration" => {
+            let name_n = fn_node.child_by_field_name("name")?;
+            if name_n.kind() != "identifier" { return None; }
+            Some(node_text(&name_n, source).to_string())
+        }
+        "method_definition" => {
+            let method_name = resolve_method_def_name(fn_node, source)?;
+            Some(match find_parent_class(fn_node, source) {
+                Some(cls) => format!("{}.{}", cls, method_name),
+                None => method_name,
+            })
+        }
+        _ => {
+            // function_expression / generator_function / arrow_function: prefer a
+            // named function expression's own name field, then fall back to the
+            // variable it's directly assigned to (`const foo = () => {...}`) —
+            // mirroring the arrow-value branch of `handle_var_decl`. Anonymous,
+            // non-assigned closures (inline callbacks, IIFEs) have no resolvable
+            // qualifier.
+            if let Some(name_n) = fn_node.child_by_field_name("name") {
+                if name_n.kind() == "identifier" {
+                    return Some(node_text(&name_n, source).to_string());
+                }
+            }
+            let parent = fn_node.parent()?;
+            if parent.kind() == "variable_declarator" {
+                let value_n = parent.child_by_field_name("value")?;
+                if value_n.id() == fn_node.id() {
+                    let name_n = parent.child_by_field_name("name")?;
+                    if name_n.kind() == "identifier" {
+                        return Some(node_text(&name_n, source).to_string());
+                    }
+                }
+            }
+            None
+        }
+    }
+}
+
+/// Return the object-literal expression of a `return { ... };` statement, or
+/// `None` when the statement doesn't return a bare object literal (#2033).
+/// Mirrors TS `findReturnedObjectLiteral` — no parenthesized-wrapper unwrapping,
+/// matching that function's existing scope.
+fn find_returned_object_literal<'a>(return_node: &Node<'a>) -> Option<Node<'a>> {
+    for i in 0..return_node.child_count() {
+        let Some(child) = return_node.child(i) else { continue };
+        if child.kind() == "object" { return Some(child); }
+    }
+    None
+}
+
+/// Qualify a `return { ... }` statement's object-literal properties against its
+/// enclosing named function (#2033) — Rust mirror of the definitions half of TS
+/// `handleReturnStmtObjectLiteral`. See that function's doc comment (in
+/// `src/extractors/javascript.ts`) for the full rationale: this extends
+/// `extract_object_literal_functions`'s qualified-definition mechanism
+/// (previously only reachable via a `const x = {...}` variable declarator) to
+/// object literals returned directly from a factory function's body, so
+/// `findCaller`/its Rust equivalent attribute calls inside the property's
+/// closure to the qualified property definition rather than the factory itself.
+fn handle_return_stmt(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
+    let Some(obj_node) = find_returned_object_literal(node) else { return };
+    let Some(qualifier) = find_enclosing_function_qualifier(node, source) else { return };
+    extract_object_literal_functions(&obj_node, source, &qualifier, symbols);
+}
+
+/// Type-map half of `handle_return_stmt` — mirrors TS
+/// `handleReturnStmtObjectLiteral`'s `handleObjectLiteralTypeMap` call, so
+/// `const p = makePartition(42); p.deltaModularity(1)` resolves through the
+/// qualified definition too, once `store_return_type`'s sibling self-type
+/// inference (see `find_return_object_literal_self_type`) types `p` as
+/// `makePartition`.
+fn handle_return_stmt_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
+    let Some(obj_node) = find_returned_object_literal(node) else { return };
+    let Some(qualifier) = find_enclosing_function_qualifier(node, source) else { return };
+    seed_objlit_type_map_entries(&qualifier, &obj_node, source, symbols);
+}
+
 // ── Return-type map extraction (Phase 8.2 parity) ───────────────────────────
 
 /// Walk the AST collecting function/method return types into `symbols.return_type_map`.
@@ -782,10 +925,13 @@ fn store_return_type(fn_node: &Node, fn_name: &str, source: &[u8], symbols: &mut
             return;
         }
     }
-    // Infer from first `return new Constructor()` in body
+    // Infer from first `return new Constructor()` in body, then from a
+    // directly-returned object literal with callable properties (#2033).
     if let Some(body) = fn_node.child_by_field_name("body") {
         if let Some(type_name) = find_return_new_expr_type(&body, source) {
             push_return_type_entry(symbols, fn_name, type_name, 0.85);
+        } else if find_return_object_literal_self_type(&body) {
+            push_return_type_entry(symbols, fn_name, fn_name, 0.85);
         }
     }
 }
@@ -803,6 +949,50 @@ fn find_return_new_expr_type<'a>(body: &Node<'a>, source: &'a [u8]) -> Option<&'
         }
     }
     None
+}
+
+/// #2033: self-referential return-type inference for a factory function whose body
+/// directly returns an object literal with at least one callable property (function/
+/// arrow/method value) — paired with `handle_return_stmt`'s qualified `fn_name.prop_name`
+/// definitions so `const p = fn_name(...); p.prop_name()` resolves: Phase 8.2's
+/// inter-procedural propagation types `p` as `fn_name`, and the resolver's
+/// prototype-alias step then finds the qualified definition via the typeMap entry
+/// `handle_return_stmt_type_map` seeds for it. Mirrors TS `findReturnObjectLiteralSelfType`.
+///
+/// Only top-level return statements are checked, mirroring `find_return_new_expr_type`.
+fn find_return_object_literal_self_type(body: &Node) -> bool {
+    for i in 0..body.child_count() {
+        let Some(child) = body.child(i) else { continue };
+        if child.kind() != "return_statement" { continue; }
+        if let Some(obj_node) = find_returned_object_literal(&child) {
+            if object_literal_has_callable_property(&obj_node) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// True when `obj_node` (an object literal) has at least one function/arrow/method
+/// property — mirrors `extract_object_literal_functions`' own shape detection so
+/// `find_return_object_literal_self_type` only self-types functions that actually
+/// get a qualified definition. Mirrors TS `objectLiteralHasCallableProperty`.
+fn object_literal_has_callable_property(obj_node: &Node) -> bool {
+    for i in 0..obj_node.child_count() {
+        let Some(child) = obj_node.child(i) else { continue };
+        match child.kind() {
+            "method_definition" => return true,
+            "pair" => {
+                if let Some(value_n) = child.child_by_field_name("value") {
+                    if matches!(value_n.kind(), "arrow_function" | "function_expression" | "function") {
+                        return true;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    false
 }
 
 /// Append a `(fn_name → type_name)` entry to `return_type_map`.
@@ -1066,6 +1256,11 @@ fn match_js_node(
         }
         // #1784: `instanceof ClassName` checks, e.g. `err instanceof CodegraphError`.
         "binary_expression" => handle_instanceof_value_ref(node, source, &mut symbols.calls),
+        // #2033: qualify object literals returned from a factory function's body
+        // against that function's name, so calls inside a returned property's
+        // closure attribute to the property (`makePartition.deltaCPM`), not the
+        // factory itself.
+        "return_statement" => handle_return_stmt(node, source, symbols),
         _ => {}
     }
 }
@@ -6864,6 +7059,60 @@ mod tests {
             "no definition name should retain the bracketed/quoted form; got: {:?}",
             names
         );
+    }
+
+    /// Issue #2033: an object literal returned from a factory function's body must be
+    /// qualified against the factory's name, exactly like a `const x = {...}` declarator
+    /// — so calls inside a returned property's closure attribute to the qualified
+    /// property, not the enclosing factory (which never itself executes that call; only
+    /// invoking the returned object's property does).
+    #[test]
+    fn return_statement_object_literal_qualifies_against_factory_name() {
+        let s = parse_js(
+            "function computeDeltaCPM(s, v) { return s + v; }\n\
+             function computeDeltaModularity(s, v) { return s * v; }\n\
+             function makePartition(seed) {\n\
+               const s = seed;\n\
+               return {\n\
+                 deltaCPM: (v) => computeDeltaCPM(s, v),\n\
+                 deltaModularity: (v) => computeDeltaModularity(s, v),\n\
+               };\n\
+             }\n\
+             function useIt() {\n\
+               const p = makePartition(42);\n\
+               return p.deltaModularity(1);\n\
+             }",
+        );
+        let names: Vec<_> = s.definitions.iter().map(|d| d.name.as_str()).collect();
+        assert!(
+            names.contains(&"makePartition.deltaCPM"),
+            "expected qualified 'makePartition.deltaCPM' definition; got: {:?}",
+            names
+        );
+        assert!(
+            names.contains(&"makePartition.deltaModularity"),
+            "expected qualified 'makePartition.deltaModularity' definition; got: {:?}",
+            names
+        );
+        // typeMap entries mirror the const-case seeding, so `p.deltaModularity(1)`
+        // can resolve through the qualified definition once `p` is typed as
+        // `makePartition` (via the self-type return-type inference below).
+        let tm = s.type_map.iter().find(|e| e.name == "makePartition.deltaModularity");
+        assert!(tm.is_some(), "typeMap 'makePartition.deltaModularity' missing; got: {:?}", s.type_map);
+        assert_eq!(tm.unwrap().type_name, "makePartition.deltaModularity");
+        // Self-referential return-type inference: makePartition's body directly
+        // returns an object literal with callable properties, so its own name
+        // becomes its inferred return type (mirrors `return new Ctor()` inference).
+        let rt = s.return_type_map.iter().find(|e| e.name == "makePartition");
+        assert!(rt.is_some(), "return_type_map 'makePartition' missing; got: {:?}", s.return_type_map);
+        assert_eq!(rt.unwrap().type_name, "makePartition");
+        // Same-file Phase 8.2 propagation: `const p = makePartition(42)` resolves
+        // `p`'s type from makePartition's self-typed return_type_map entry above,
+        // so `p.deltaModularity(1)` in useIt can resolve through the qualified
+        // definition (confirmed end-to-end via the resolver, not re-tested here).
+        let p_type = s.type_map.iter().find(|e| e.name == "p");
+        assert!(p_type.is_some(), "type_map 'p' missing; got: {:?}", s.type_map);
+        assert_eq!(p_type.unwrap().type_name, "makePartition");
     }
 
     /// Issue #1764: a non-string computed pair key (`[Symbol.iterator]: () => {}`) has no

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -567,6 +567,69 @@ function hasFunctionScopeAncestor(node: TreeSitterNode): boolean {
 }
 
 /**
+ * Return the qualifier name for the nearest enclosing function scope of `node`
+ * — walks up FUNCTION_SCOPE_TYPES ancestors (same set `hasFunctionScopeAncestor`
+ * checks) and names the match the same way the const/let/var object-literal call
+ * sites of `extractObjectLiteralFunctions` name their `varName` qualifier (#2033).
+ * Used to extend that qualified-definition mechanism to object literals
+ * `return`ed from a factory function's body, e.g.
+ * `function makePartition(seed) { return { deltaCPM: (v) => computeDeltaCPM(s, v) } }`
+ * qualifies the property as `makePartition.deltaCPM`.
+ *
+ * Returns null when the enclosing scope has no resolvable name — an anonymous
+ * function expression/arrow that isn't directly assigned to a variable (e.g. an
+ * inline callback argument, an IIFE) — callers skip the qualified extraction in
+ * that case and fall back to the pre-existing generic caller-attribution behavior.
+ */
+function findEnclosingFunctionQualifier(node: TreeSitterNode): string | null {
+  let p: TreeSitterNode | null = node.parent ?? null;
+  while (p) {
+    if (FUNCTION_SCOPE_TYPES.has(p.type)) return qualifierForFunctionScopeNode(p);
+    p = p.parent ?? null;
+  }
+  return null;
+}
+
+/**
+ * Derive the qualifier name for a single FUNCTION_SCOPE_TYPES node — see
+ * `findEnclosingFunctionQualifier`. Mirrors the naming convention already used by
+ * `handleMethodDef` (ClassName.method) and `handleVarFnAssignment` (variable name)
+ * for the same node shapes.
+ */
+function qualifierForFunctionScopeNode(fnNode: TreeSitterNode): string | null {
+  const t = fnNode.type;
+  if (t === 'function_declaration' || t === 'generator_function_declaration') {
+    const nameNode = fnNode.childForFieldName('name');
+    return nameNode?.type === 'identifier' ? nameNode.text : null;
+  }
+  if (t === 'method_definition') {
+    const nameNode = fnNode.childForFieldName('name');
+    if (!nameNode) return null;
+    const methName = resolveMethodDefinitionName(nameNode);
+    if (!methName) return null;
+    const parentClass = findParentClass(fnNode);
+    return parentClass ? `${parentClass}.${methName}` : methName;
+  }
+  // function_expression / generator_function / arrow_function: prefer a named
+  // function expression's own name field, then fall back to the variable it's
+  // directly assigned to (`const foo = () => {...}`) — mirroring
+  // handleVarFnAssignment's convention for top-level var-assigned functions.
+  // Anonymous, non-assigned closures (inline callbacks, IIFEs) have no
+  // resolvable qualifier.
+  const nameNode = fnNode.childForFieldName('name');
+  if (nameNode?.type === 'identifier') return nameNode.text;
+  const parent = fnNode.parent;
+  if (
+    parent?.type === 'variable_declarator' &&
+    parent.childForFieldName('value')?.id === fnNode.id
+  ) {
+    const declName = parent.childForFieldName('name');
+    return declName?.type === 'identifier' ? declName.text : null;
+  }
+  return null;
+}
+
+/**
  * True when `declarator` is the shape extractObjectLiteralFunctions qualifies: a plain
  * identifier name, outside any function scope. Shared by that function's four call sites
  * (extractConstDeclarators, extractLetVarObjLiteralDeclarators, handleVariableDeclarator's
@@ -1801,6 +1864,56 @@ function extractObjectLiteralFunctions(
   }
 }
 
+/**
+ * Return the object-literal expression of a `return { ... };` statement, or null
+ * when the statement doesn't return a bare object literal (#2033). Mirrors
+ * `findReturnNewExprType`'s scan of a return_statement's direct children — no
+ * parenthesized-wrapper unwrapping, matching that function's existing scope.
+ */
+function findReturnedObjectLiteral(returnNode: TreeSitterNode): TreeSitterNode | null {
+  for (let i = 0; i < returnNode.childCount; i++) {
+    const child = returnNode.child(i);
+    if (child?.type === 'object') return child;
+  }
+  return null;
+}
+
+/**
+ * Qualify a `return { ... }` statement's object-literal properties against its
+ * enclosing named function (#2033) — extends `extractObjectLiteralFunctions`'
+ * qualified-definition mechanism (previously only reachable via a
+ * `const x = {...}` variable declarator) to object literals returned directly
+ * from a factory function's body.
+ *
+ * `function makePartition(seed) { return { deltaCPM: (v) => computeDeltaCPM(s, v) } }`
+ * now creates a `makePartition.deltaCPM` definition, so `findCaller` attributes
+ * the `computeDeltaCPM(s, v)` call to it instead of to `makePartition` itself —
+ * `makePartition`'s own body never executes that call; only invoking the
+ * returned object's `.deltaCPM(...)` property does.
+ *
+ * Also seeds the matching typeMap entries (mirrors `handleObjectLiteralTypeMap`'s
+ * const-case seeding) so `const p = makePartition(42); p.deltaModularity(1)`
+ * resolves through the qualified definition too, once `storeReturnType`'s sibling
+ * self-type inference (see `findReturnObjectLiteralSelfType`) types `p` as
+ * `makePartition`.
+ *
+ * Shared by both extraction paths (called from `runCollectorWalk`, which both
+ * `extractSymbolsWalk` and `extractSymbolsQuery` invoke) — see the "two code
+ * paths" note on `extractObjectLiteralFunctions`.
+ */
+function handleReturnStmtObjectLiteral(
+  node: TreeSitterNode,
+  definitions: Definition[],
+  typeMap: Map<string, TypeMapEntry>,
+): void {
+  const objNode = findReturnedObjectLiteral(node);
+  if (!objNode) return;
+  const qualifier = findEnclosingFunctionQualifier(node);
+  if (!qualifier) return;
+  extractObjectLiteralFunctions(objNode, qualifier, definitions);
+  handleObjectLiteralTypeMap(qualifier, objNode, typeMap);
+}
+
 function handleEnumDecl(node: TreeSitterNode, ctx: ExtractorOutput): void {
   const nameNode = node.childForFieldName('name');
   if (!nameNode) return;
@@ -2374,10 +2487,11 @@ function storeReturnType(
       return;
     }
   }
-  // Infer from first `return new Constructor()` in the function body
+  // Infer from first `return new Constructor()` in the function body, then from
+  // a directly-returned object literal with callable properties (#2033).
   const body = fnNode.childForFieldName('body');
   if (body) {
-    const inferred = findReturnNewExprType(body);
+    const inferred = findReturnNewExprType(body) ?? findReturnObjectLiteralSelfType(body, fnName);
     if (inferred) {
       const existing = returnTypeMap.get(fnName);
       if (!existing || INFERRED_RETURN_TYPE_CONFIDENCE > existing.confidence)
@@ -2397,6 +2511,53 @@ function findReturnNewExprType(bodyNode: TreeSitterNode): string | null {
     }
   }
   return null;
+}
+
+/**
+ * #2033: self-referential return-type inference for a factory function whose body
+ * directly returns an object literal with at least one callable property (function/
+ * arrow/method value) — paired with `handleReturnStmtObjectLiteral`'s qualified
+ * `fnName.propName` definitions so `const p = fnName(...); p.propName()` resolves:
+ * Phase 8.2's inter-procedural propagation (`resolveCallExprReturnType`) types `p` as
+ * `fnName`, and `resolveByReceiver`'s prototype-alias step then finds the qualified
+ * definition via the typeMap entry `handleObjectLiteralTypeMap` seeds for it.
+ *
+ * Only top-level return statements are checked, mirroring `findReturnNewExprType`.
+ * Returns `fnName` itself (the self-type) when found, else null.
+ */
+function findReturnObjectLiteralSelfType(bodyNode: TreeSitterNode, fnName: string): string | null {
+  for (let i = 0; i < bodyNode.childCount; i++) {
+    const child = bodyNode.child(i);
+    if (child?.type !== 'return_statement') continue;
+    const objNode = findReturnedObjectLiteral(child);
+    if (objNode && objectLiteralHasCallableProperty(objNode)) return fnName;
+  }
+  return null;
+}
+
+/**
+ * True when `objNode` (an object literal) has at least one function/arrow/method
+ * property — mirrors `extractObjectLiteralFunctions`' own shape detection so
+ * `findReturnObjectLiteralSelfType` only self-types functions that actually get a
+ * qualified definition.
+ */
+function objectLiteralHasCallableProperty(objNode: TreeSitterNode): boolean {
+  for (let i = 0; i < objNode.childCount; i++) {
+    const child = objNode.child(i);
+    if (!child) continue;
+    if (child.type === 'method_definition') return true;
+    if (child.type === 'pair') {
+      const valueNode = child.childForFieldName('value');
+      if (
+        valueNode?.type === 'arrow_function' ||
+        valueNode?.type === 'function_expression' ||
+        valueNode?.type === 'function'
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 /**
@@ -4763,6 +4924,13 @@ function runCollectorWalk(rootNode: TreeSitterNode, targets: CollectorWalkTarget
           targets.typeMap,
           targets.valueRefCalls,
         );
+        break;
+      case 'return_statement':
+        // #2033: qualify object literals returned from a factory function's body
+        // against that function's name, so calls inside a returned property's
+        // closure attribute to the property (`makePartition.deltaCPM`), not the
+        // factory itself.
+        handleReturnStmtObjectLiteral(node, targets.definitions, targets.typeMap);
         break;
     }
     for (let i = 0; i < node.childCount; i++) {

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -2488,16 +2488,58 @@ function storeReturnType(
     }
   }
   // Infer from first `return new Constructor()` in the function body, then from
-  // a directly-returned object literal with callable properties (#2033).
-  const body = fnNode.childForFieldName('body');
-  if (body) {
-    const inferred = findReturnNewExprType(body) ?? findReturnObjectLiteralSelfType(body, fnName);
-    if (inferred) {
-      const existing = returnTypeMap.get(fnName);
-      if (!existing || INFERRED_RETURN_TYPE_CONFIDENCE > existing.confidence)
-        returnTypeMap.set(fnName, { type: inferred, confidence: INFERRED_RETURN_TYPE_CONFIDENCE });
+  // a directly-returned object literal with callable properties (#2033). Skipped
+  // for async/generator functions: their runtime return value is a Promise/
+  // Generator wrapper around the returned expression, not the expression itself,
+  // so `const p = asyncMakeThing(); p.method()` would otherwise wrongly resolve
+  // through a definition that only exists once the wrapper is unwrapped
+  // (`await`ed or iterated) — neither inference is valid without that unwrap.
+  if (!isAsyncFunctionNode(fnNode) && !isGeneratorFunctionNode(fnNode)) {
+    const body = fnNode.childForFieldName('body');
+    if (body) {
+      const inferred = findReturnNewExprType(body) ?? findReturnObjectLiteralSelfType(body, fnName);
+      if (inferred) {
+        const existing = returnTypeMap.get(fnName);
+        if (!existing || INFERRED_RETURN_TYPE_CONFIDENCE > existing.confidence)
+          returnTypeMap.set(fnName, {
+            type: inferred,
+            confidence: INFERRED_RETURN_TYPE_CONFIDENCE,
+          });
+      }
     }
   }
+}
+
+/**
+ * True when a function/method node carries an `async` modifier — tree-sitter
+ * represents `async` (like `get`/`set`/`static`) as a literal unnamed token
+ * child, not a dedicated field, mirroring `getMethodAccessorKind`'s `get`/`set`
+ * detection. Scans all direct children since only the modifier keyword itself
+ * ever has `type === 'async'` (an identifier/parameter/statement named "async"
+ * has type `identifier`, not `async`).
+ */
+function isAsyncFunctionNode(fnNode: TreeSitterNode): boolean {
+  for (let i = 0; i < fnNode.childCount; i++) {
+    if (fnNode.child(i)?.type === 'async') return true;
+  }
+  return false;
+}
+
+/**
+ * True when a function/method node is a generator — `function_declaration`/
+ * `function_expression` distinguish this via a dedicated node type
+ * (`generator_function_declaration`/`generator_function`), but `method_definition`
+ * (ES6 shorthand `*method() {}`) has no such distinct kind and instead carries a
+ * literal `*` token child, mirroring `isAsyncFunctionNode`'s modifier-token scan.
+ */
+function isGeneratorFunctionNode(fnNode: TreeSitterNode): boolean {
+  if (fnNode.type === 'generator_function_declaration' || fnNode.type === 'generator_function') {
+    return true;
+  }
+  for (let i = 0; i < fnNode.childCount; i++) {
+    if (fnNode.child(i)?.type === '*') return true;
+  }
+  return false;
 }
 
 /** Return the constructor name from the first `return new Constructor()` in a body, or null. */

--- a/tests/engines/query-walk-parity.test.ts
+++ b/tests/engines/query-walk-parity.test.ts
@@ -343,6 +343,29 @@ class Button extends React.Component {
 export default Button;
 `,
   },
+  {
+    // Issue #2033: an object literal returned from a factory function's body must be
+    // qualified against the factory's name (makePartition.deltaCPM), exactly like a
+    // `const x = {...}` declarator — both the shared collector walk (runCollectorWalk,
+    // used by both extraction paths) and the query path's dedicated dispatch must agree.
+    name: 'object literal returned from a factory function (#2033)',
+    file: 'test.ts',
+    code: `
+function computeDeltaCPM(s: number, v: number): number { return s + v; }
+function computeDeltaModularity(s: number, v: number): number { return s * v; }
+export function makePartition(seed: number) {
+  const s = seed;
+  return {
+    deltaCPM: (v: number) => computeDeltaCPM(s, v),
+    deltaModularity: (v: number) => computeDeltaModularity(s, v),
+  };
+}
+export function useIt(): number {
+  const p = makePartition(42);
+  return p.deltaModularity(1);
+}
+`,
+  },
 ];
 
 describe('Query vs Walk parity', () => {

--- a/tests/integration/issue-2033-factory-returned-closure-attribution.test.ts
+++ b/tests/integration/issue-2033-factory-returned-closure-attribution.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Integration test for #2033: calls inside object-literal-property closures
+ * returned from a factory function were misattributed to the enclosing
+ * factory, not the property.
+ *
+ * Root cause: `extractObjectLiteralFunctions` (the mechanism that creates
+ * qualified `varName.propName` definitions so calls inside a property
+ * closure attribute to the property, not the enclosing scope) only fired
+ * for object literals assigned via a variable declarator (`const x = {...}`)
+ * — never for object literals appearing in a `return` statement inside a
+ * function body. Calls inside those closures fell through to the generic
+ * "nearest enclosing named function" caller-attribution, which resolved to
+ * the factory itself — even though the factory's own body never executes
+ * that call; only invoking the returned object's property does.
+ *
+ * Fix: qualify a `return { ... }` statement's object-literal properties
+ * against the enclosing named function too (`makePartition.deltaCPM`), and
+ * seed the matching typeMap/return-type entries so `const p =
+ * makePartition(42); p.deltaModularity(1)` resolves through the qualified
+ * definition — closing the loop with #2032's transitive-unreachable
+ * dead-code downgrade: `deltaCPM` is never invoked anywhere, so its
+ * `computeDeltaCPM` callee is now correctly flagged dead, while
+ * `deltaModularity` (invoked via `useIt`) correctly is not.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+import { isNativeAvailable } from '../../src/infrastructure/native.js';
+
+// `computeDeltaCPM` is wired under `deltaCPM` but `.deltaCPM(...)` never
+// appears anywhere in the fixture — genuinely dead. `computeDeltaModularity`
+// is wired under `deltaModularity` and IS invoked via `p.deltaModularity(1)`
+// in `useIt` — genuinely live.
+const FIXTURE = {
+  'partition.ts': `
+function computeDeltaCPM(s: number, v: number): number {
+  return s + v;
+}
+
+function computeDeltaModularity(s: number, v: number): number {
+  return s * v;
+}
+
+export function makePartition(seed: number) {
+  const s = seed;
+  return {
+    deltaCPM: (v: number) => computeDeltaCPM(s, v),
+    deltaModularity: (v: number) => computeDeltaModularity(s, v),
+  };
+}
+
+export function useIt(): number {
+  const p = makePartition(42);
+  return p.deltaModularity(1); // p.deltaCPM(...) is never called anywhere
+}
+`,
+};
+
+const DEAD_ROLES = new Set(['dead-unresolved', 'dead-leaf', 'dead-entry', 'dead-ffi']);
+
+function readNodesWithRoles(dbPath: string) {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return db.prepare('SELECT name, kind, role FROM nodes ORDER BY name').all() as Array<{
+      name: string;
+      kind: string;
+      role: string | null;
+    }>;
+  } finally {
+    db.close();
+  }
+}
+
+function findCallerNames(dbPath: string, targetName: string): string[] {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return (
+      db
+        .prepare(
+          `SELECT s.name AS name
+         FROM edges e
+         JOIN nodes s ON e.source_id = s.id
+         JOIN nodes t ON e.target_id = t.id
+         WHERE e.kind = 'calls' AND t.name = ?`,
+        )
+        .all(targetName) as Array<{ name: string }>
+    ).map((r) => r.name);
+  } finally {
+    db.close();
+  }
+}
+
+describe('object literal returned from a factory qualifies against the factory name (#2033) — WASM', () => {
+  let tmpDir: string;
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-2033-'));
+    for (const [rel, content] of Object.entries(FIXTURE)) {
+      fs.writeFileSync(path.join(tmpDir, rel), content);
+    }
+    await buildGraph(tmpDir, { engine: 'wasm', incremental: false, skipRegistry: true });
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('attributes the call inside the deltaCPM closure to makePartition.deltaCPM, not makePartition', () => {
+    const dbPath = path.join(tmpDir, '.codegraph', 'graph.db');
+    expect(findCallerNames(dbPath, 'computeDeltaCPM')).toEqual(['makePartition.deltaCPM']);
+  });
+
+  it('attributes the call inside the deltaModularity closure to makePartition.deltaModularity', () => {
+    const dbPath = path.join(tmpDir, '.codegraph', 'graph.db');
+    expect(findCallerNames(dbPath, 'computeDeltaModularity')).toEqual([
+      'makePartition.deltaModularity',
+    ]);
+  });
+
+  it('resolves p.deltaModularity(1) in useIt through the qualified definition', () => {
+    const dbPath = path.join(tmpDir, '.codegraph', 'graph.db');
+    expect(findCallerNames(dbPath, 'makePartition.deltaModularity')).toEqual(['useIt']);
+  });
+
+  it('flags computeDeltaCPM as dead — its only caller (makePartition.deltaCPM) is itself unreachable (#2032)', () => {
+    const dbPath = path.join(tmpDir, '.codegraph', 'graph.db');
+    const nodes = readNodesWithRoles(dbPath);
+    const node = nodes.find((n) => n.name === 'computeDeltaCPM' && n.kind === 'function');
+    expect(node, 'computeDeltaCPM node not found').toBeDefined();
+    expect(DEAD_ROLES.has(node!.role ?? '')).toBe(true);
+  });
+
+  it('does not flag computeDeltaModularity as dead — reachable via useIt', () => {
+    const dbPath = path.join(tmpDir, '.codegraph', 'graph.db');
+    const nodes = readNodesWithRoles(dbPath);
+    const node = nodes.find((n) => n.name === 'computeDeltaModularity' && n.kind === 'function');
+    expect(node, 'computeDeltaModularity node not found').toBeDefined();
+    expect(DEAD_ROLES.has(node!.role ?? '')).toBe(false);
+  });
+});
+
+// ── Native engine parity ────────────────────────────────────────────────────
+// Skipped when the native addon is not installed.
+
+describe.skipIf(!isNativeAvailable())(
+  'object literal returned from a factory qualifies against the factory name (#2033) — native',
+  () => {
+    let nativeTmpDir: string;
+
+    beforeAll(async () => {
+      nativeTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-2033-native-'));
+      for (const [rel, content] of Object.entries(FIXTURE)) {
+        fs.writeFileSync(path.join(nativeTmpDir, rel), content);
+      }
+      await buildGraph(nativeTmpDir, { engine: 'native', incremental: false, skipRegistry: true });
+    }, 60_000);
+
+    afterAll(() => {
+      fs.rmSync(nativeTmpDir, { recursive: true, force: true });
+    });
+
+    it('attributes the call inside the deltaCPM closure to makePartition.deltaCPM, not makePartition', () => {
+      const dbPath = path.join(nativeTmpDir, '.codegraph', 'graph.db');
+      expect(findCallerNames(dbPath, 'computeDeltaCPM')).toEqual(['makePartition.deltaCPM']);
+    });
+
+    it('attributes the call inside the deltaModularity closure to makePartition.deltaModularity', () => {
+      const dbPath = path.join(nativeTmpDir, '.codegraph', 'graph.db');
+      expect(findCallerNames(dbPath, 'computeDeltaModularity')).toEqual([
+        'makePartition.deltaModularity',
+      ]);
+    });
+
+    it('resolves p.deltaModularity(1) in useIt through the qualified definition', () => {
+      const dbPath = path.join(nativeTmpDir, '.codegraph', 'graph.db');
+      expect(findCallerNames(dbPath, 'makePartition.deltaModularity')).toEqual(['useIt']);
+    });
+
+    it('flags computeDeltaCPM as dead — its only caller (makePartition.deltaCPM) is itself unreachable (#2032)', () => {
+      const dbPath = path.join(nativeTmpDir, '.codegraph', 'graph.db');
+      const nodes = readNodesWithRoles(dbPath);
+      const node = nodes.find((n) => n.name === 'computeDeltaCPM' && n.kind === 'function');
+      expect(node, 'computeDeltaCPM node not found (native)').toBeDefined();
+      expect(DEAD_ROLES.has(node!.role ?? '')).toBe(true);
+    });
+
+    it('does not flag computeDeltaModularity as dead — reachable via useIt', () => {
+      const dbPath = path.join(nativeTmpDir, '.codegraph', 'graph.db');
+      const nodes = readNodesWithRoles(dbPath);
+      const node = nodes.find((n) => n.name === 'computeDeltaModularity' && n.kind === 'function');
+      expect(node, 'computeDeltaModularity node not found (native)').toBeDefined();
+      expect(DEAD_ROLES.has(node!.role ?? '')).toBe(false);
+    });
+  },
+);

--- a/tests/parsers/javascript.test.ts
+++ b/tests/parsers/javascript.test.ts
@@ -1525,6 +1525,95 @@ function runDemo(reporter: Reporter, users: string[]): void {
       expect(symbols.definitions).not.toContainEqual(expect.objectContaining({ name: 'local.f' }));
     });
 
+    // Issue #2033: object literals returned from a factory function's body
+    it('extracts qualified definitions from an object literal returned by a named function', () => {
+      const symbols = parseJS(`
+        function computeDeltaCPM(s, v) { return s + v; }
+        function makePartition(seed) {
+          const s = seed;
+          return {
+            deltaCPM: (v) => computeDeltaCPM(s, v),
+            deltaModularity(v) { return v; },
+          };
+        }
+      `);
+      expect(symbols.definitions).toContainEqual(
+        expect.objectContaining({ name: 'makePartition.deltaCPM', kind: 'function' }),
+      );
+      expect(symbols.definitions).toContainEqual(
+        expect.objectContaining({ name: 'makePartition.deltaModularity', kind: 'function' }),
+      );
+      // The call inside the closure must attribute to the qualified property span
+      // (the `deltaCPM: (v) => ...` line), not the enclosing factory's own span.
+      const deltaCPM = symbols.definitions.find((d) => d.name === 'makePartition.deltaCPM');
+      expect(deltaCPM.line).toBe(6);
+    });
+
+    it('qualifies an object literal returned by a named function expression assigned to a const', () => {
+      // `const makePartition = function(seed) { return {...} }` — the enclosing
+      // function has no name of its own, so the qualifier falls back to the
+      // variable it's directly assigned to, mirroring handleVarFnAssignment.
+      const symbols = parseJS(`
+        const makePartition = function (seed) {
+          return { deltaCPM: (v) => v + seed };
+        };
+      `);
+      expect(symbols.definitions).toContainEqual(
+        expect.objectContaining({ name: 'makePartition.deltaCPM', kind: 'function' }),
+      );
+    });
+
+    it('qualifies an object literal returned by a method against ClassName.method', () => {
+      const symbols = parseJS(`
+        class Factory {
+          makePartition(seed) {
+            return { deltaCPM: (v) => v + seed };
+          }
+        }
+      `);
+      expect(symbols.definitions).toContainEqual(
+        expect.objectContaining({ name: 'Factory.makePartition.deltaCPM', kind: 'function' }),
+      );
+    });
+
+    it('does not qualify an object literal returned from an anonymous, non-assigned closure', () => {
+      // The returned object literal's nearest enclosing function scope is an
+      // anonymous callback passed directly to `array.map` — no resolvable
+      // qualifier, so no qualified definition should be created for it.
+      const symbols = parseJS(`
+        function outer() {
+          return [1].map(function (v) {
+            return { get: () => v };
+          });
+        }
+      `);
+      expect(symbols.definitions).not.toContainEqual(
+        expect.objectContaining({ name: expect.stringContaining('.get') }),
+      );
+    });
+
+    it('seeds a typeMap entry for the qualified return-statement object-literal property', () => {
+      const symbols = parseJS(`
+        function makePartition(seed) {
+          return { deltaCPM: (v) => v + seed };
+        }
+      `);
+      const entry = symbols.typeMap.get('makePartition.deltaCPM');
+      expect(entry).toBeDefined();
+      expect(entry.type).toBe('makePartition.deltaCPM');
+    });
+
+    it('self-types a factory function whose body directly returns an object literal with callable properties', () => {
+      const symbols = parseJS(`
+        function makePartition(seed) {
+          return { deltaCPM: (v) => v + seed };
+        }
+      `);
+      const entry = symbols.returnTypeMap.get('makePartition');
+      expect(entry).toBeDefined();
+      expect(entry.type).toBe('makePartition');
+    });
+
     // Line range verification
     it('sets correct line and endLine on callback definition', () => {
       const code = [

--- a/tests/parsers/javascript.test.ts
+++ b/tests/parsers/javascript.test.ts
@@ -1614,6 +1614,49 @@ function runDemo(reporter: Reporter, users: string[]): void {
       expect(entry.type).toBe('makePartition');
     });
 
+    it('does not self-type an async factory function — its runtime return value is a Promise wrapper', () => {
+      // `const p = makePartitionAsync(seed)` yields a Promise, not the object
+      // literal directly — self-typing `p` as the factory would let
+      // `p.deltaCPM(...)` wrongly resolve without an intervening `await`.
+      const symbols = parseJS(`
+        async function makePartitionAsync(seed) {
+          return { deltaCPM: (v) => v + seed };
+        }
+      `);
+      expect(symbols.returnTypeMap.get('makePartitionAsync')).toBeUndefined();
+      // The qualified property definition itself is still extracted — only the
+      // self-type inference (which would let a caller's receiver resolve to it
+      // without unwrapping the Promise) is skipped.
+      expect(symbols.definitions).toContainEqual(
+        expect.objectContaining({ name: 'makePartitionAsync.deltaCPM', kind: 'function' }),
+      );
+    });
+
+    it('does not self-type a generator factory function — its runtime return value is a Generator wrapper', () => {
+      const symbols = parseJS(`
+        function* makePartitionGen(seed) {
+          return { deltaCPM: (v) => v + seed };
+        }
+      `);
+      expect(symbols.returnTypeMap.get('makePartitionGen')).toBeUndefined();
+      expect(symbols.definitions).toContainEqual(
+        expect.objectContaining({ name: 'makePartitionGen.deltaCPM', kind: 'function' }),
+      );
+    });
+
+    it('does not apply return-new-Constructor self-typing to an async function either', () => {
+      // Regression guard for the pre-existing `return new Ctor()` inference,
+      // which has the identical async-wrapper flaw and is gated by the same
+      // isAsyncFunctionNode/isGeneratorFunctionNode check.
+      const symbols = parseJS(`
+        class Foo {}
+        async function makeFoo() {
+          return new Foo();
+        }
+      `);
+      expect(symbols.returnTypeMap.get('makeFoo')).toBeUndefined();
+    });
+
     // Line range verification
     it('sets correct line and endLine on callback definition', () => {
       const code = [


### PR DESCRIPTION
## Summary

Closes #2033.

`extractObjectLiteralFunctions` (the mechanism that creates qualified `varName.propName` definitions so calls inside an object-literal property's closure attribute to the property, not the enclosing scope) only fired for object literals assigned via a variable declarator (`const x = {...}`). It never fired for object literals appearing in a `return` statement inside a function body — so calls inside those closures fell through to generic caller-attribution, which resolved to the enclosing factory function itself, even though the factory's own body never executes that call.

```ts
function computeDeltaCPM(s, v) { return s + v; }
export function makePartition(seed) {
  const s = seed;
  return { deltaCPM: (v) => computeDeltaCPM(s, v) };
}
```
Before: `computeDeltaCPM`'s caller showed as `makePartition`. After: `makePartition.deltaCPM`.

## Changes

- **`src/extractors/javascript.ts`**: `findEnclosingFunctionQualifier`/`qualifierForFunctionScopeNode` walk up to the nearest enclosing function scope and derive its qualifier name (function declaration name, `ClassName.method`, or the variable a function/arrow is directly assigned to — anonymous non-assigned closures get no qualifier and fall back to prior behavior). `handleReturnStmtObjectLiteral` wires this into `extractObjectLiteralFunctions` + `handleObjectLiteralTypeMap`, hooked into `runCollectorWalk`'s `return_statement` case — shared by both the walk and query extraction paths.
- Added a self-referential return-type inference tier to `storeReturnType`: a function whose body directly returns an object literal with callable properties is typed as itself, so `const p = makePartition(42); p.deltaModularity(1)` resolves `p`'s type and finds the qualified definition — this is what lets #2032's reachability-based dead-code detection close the loop end-to-end (only the *unused* property becomes dead, not a used sibling property).
- **`crates/codegraph-core/src/extractors/javascript.rs`**: mirrored extraction (`handle_return_stmt`, `handle_return_stmt_type_map`, `find_enclosing_function_qualifier`, `find_return_object_literal_self_type`). Also fixed a same-file gap in Rust's Phase 8.2 inter-procedural return-type propagation (`handle_var_declarator_type_map`'s call_expression branch only handled cross-file/imported callees; added the same-file identifier lookup TS already had) and reordered `JsExtractor::extract`'s walks so `return_type_map` is fully populated before `match_js_type_map` reads it — both engines now produce identical graphs for this shape.

## Verification

- Repro confirmed on both engines: `computeDeltaCPM`'s caller is now `makePartition.deltaCPM` (not `makePartition`); `p.deltaModularity(1)` resolves to `makePartition.deltaModularity`.
- End-to-end with #2032 (already merged): `codegraph roles --role dead` now correctly flags `computeDeltaCPM` as dead (its only caller, `makePartition.deltaCPM`, is itself unreachable) while `computeDeltaModularity` is correctly NOT flagged (reachable via `useIt`).
- `npm test` (4412 passed, 30 skipped, 2 todo), `npm run lint`, `cargo test --lib`/`cargo test --release` (742 passed), `node scripts/parity-compare.mjs` (34 languages) — no new divergences.
- New tests: unit tests in `tests/parsers/javascript.test.ts`, a query/walk parity case in `tests/engines/query-walk-parity.test.ts`, and an end-to-end WASM+native integration test in `tests/integration/issue-2033-factory-returned-closure-attribution.test.ts`.

## Follow-ups filed (out of scope, discovered during validation)

- #2261 — a project's first-ever `codegraph build` never sets `isFullBuild: true` (an empty `file_hashes` table is treated as incremental), so #2032's reachability downgrade never runs until an explicit `--no-incremental` rebuild.
- #2262 — pre-existing native/WASM parity gap in the `jelly-micro` fixture's cross-file `super-dispatch` fallback (confirmed present on unmodified `origin/main`, unrelated to this change).

## Test plan

- [x] `npm test`
- [x] `npm run lint`
- [x] `cargo test --lib` / `cargo test --release`
- [x] `node scripts/parity-compare.mjs`
- [x] `codegraph diff-impact --staged -T`