### PR TITLE
fix(lua): track complexity for anonymous function-expression assignments

### DIFF
--- a/crates/codegraph-core/src/ast_analysis/complexity.rs
+++ b/crates/codegraph-core/src/ast_analysis/complexity.rs
@@ -507,7 +507,15 @@ pub static LUA_RULES: LangRules = LangRules {
     logical_node_types: &["binary_expression"],
     optional_chain_type: None,
     nesting_nodes: &["if_statement", "for_statement", "while_statement", "repeat_statement"],
-    function_nodes: &["function_declaration"],
+    // "function_declaration" covers named forms (`function f() end`,
+    // `local function f() end`, `function M.foo() end`). "function_definition"
+    // is the anonymous function *expression* node — the RHS of the common
+    // module-table idiom `local M = {}; M.foo = function(...) end` (issue
+    // #2036) as well as `local f = function() end` and any function literal
+    // passed as a callback argument. Both node types have the same
+    // `_function_body` shape (parameters/body fields), so every rule below
+    // (branch/nesting/Halstead scope detection) applies identically to either.
+    function_nodes: &["function_declaration", "function_definition"],
     if_node_type: Some("if_statement"),
     else_node_type: Some("else_statement"),
     elif_node_type: Some("elseif_statement"),

--- a/crates/codegraph-core/src/extractors/lua.rs
+++ b/crates/codegraph-core/src/extractors/lua.rs
@@ -110,6 +110,9 @@ fn extract_lua_params(func_node: &Node, source: &[u8]) -> Vec<Definition> {
 /// Detect `<builtin> = <identifier>` assignments — a locally declared
 /// function bound to a Lua global/builtin identifier (e.g.
 /// `require = traced_require`), the monkey-patch pattern from issue #1776.
+/// Also detects anonymous `function(...) end` values assigned via a plain
+/// `identifier`/dotted target (issue #2036) — see
+/// `handle_lua_function_expr_assignment` below.
 /// Mirrors `handleLuaAssignmentStatement` in `src/extractors/lua.ts` — see
 /// that function's doc comment for the full rationale.
 ///
@@ -135,6 +138,12 @@ fn handle_lua_assignment_statement(node: &Node, source: &[u8], symbols: &mut Fil
     for i in 0..pair_count {
         let Some(lhs) = variable_list.named_child(i) else { continue };
         let Some(rhs) = expression_list.named_child(i) else { continue };
+
+        if rhs.kind() == "function_definition" {
+            handle_lua_function_expr_assignment(&lhs, &rhs, source, symbols);
+            continue;
+        }
+
         if lhs.kind() != "identifier" || rhs.kind() != "identifier" {
             continue;
         }
@@ -151,6 +160,61 @@ fn handle_lua_assignment_statement(node: &Node, source: &[u8], symbols: &mut Fil
             ..Default::default()
         });
     }
+}
+
+/// Emit a `Definition` for the Lua module-table idiom `local M = {}; M.foo =
+/// function(...) end` — an anonymous `function_definition` assigned via a
+/// plain assignment (bare, or nested inside a `local` `variable_declaration`
+/// — both shapes dispatch through `handle_lua_assignment_statement` since
+/// tree-sitter aliases the `local`-declared form to the same
+/// `assignment_statement` node), rather than the named `function M.foo() end`
+/// form `handle_lua_function_decl` already covers. Without this the RHS
+/// function has no `Definition` at all and silently gets zero complexity/
+/// Halstead data (issue #2036) — a fair portion of real Lua codebases use
+/// this module-table-of-functions idiom.
+///
+/// Handles a plain identifier target (`local f = function() end`, kind
+/// `function`) and a dotted target (`M.foo = function() end`, kind
+/// `method`), matching the two forms `_function_name` supports for the named
+/// declaration. Other LHS shapes (e.g. computed `M[k] = function() end`) are
+/// not handled here — see #2036 for the scope of this fix.
+fn handle_lua_function_expr_assignment(
+    lhs: &Node,
+    rhs: &Node,
+    source: &[u8],
+    symbols: &mut FileSymbols,
+) {
+    let (name, kind) = match lhs.kind() {
+        "identifier" => (node_text(lhs, source).to_string(), "function"),
+        "dot_index_expression" => {
+            let table = lhs.child_by_field_name("table");
+            let field = lhs.child_by_field_name("field");
+            match (table, field) {
+                (Some(t), Some(f)) => (
+                    format!("{}.{}", node_text(&t, source), node_text(&f, source)),
+                    "method",
+                ),
+                _ => return,
+            }
+        }
+        _ => return,
+    };
+
+    let params = extract_lua_params(rhs, source);
+
+    symbols.definitions.push(Definition {
+        name,
+        kind: kind.to_string(),
+        line: start_line(rhs),
+        end_line: Some(end_line(rhs)),
+        decorators: None,
+        complexity: compute_all_metrics(rhs, source, "lua"),
+        cfg: build_function_cfg(rhs, "lua", source),
+        children: opt_children(params),
+        bodyless: None,
+        content_hash: None,
+        accessor_kind: None,
+    });
 }
 
 fn handle_lua_function_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
@@ -432,5 +496,70 @@ mod tests {
         assert!(s.calls.iter().any(|c| c.dynamic == Some(true)
             && c.dynamic_kind.as_deref() == Some("computed-key")
             && c.receiver.as_deref() == Some("handlers")));
+    }
+
+    // ── #2036: anonymous function-expression assignment Definitions ────────
+
+    #[test]
+    fn creates_method_definition_for_module_table_function_assignment() {
+        let s = parse_lua(
+            "local M = {}\nM.foo = function(x)\n  if x then\n    return 1\n  else\n    return 2\n  end\nend",
+        );
+        let def = s
+            .definitions
+            .iter()
+            .find(|d| d.name == "M.foo")
+            .expect("expected a Definition for M.foo");
+        assert_eq!(def.kind, "method");
+        let complexity = def.complexity.as_ref().expect("expected complexity to be computed");
+        assert_eq!(complexity.cyclomatic, 2);
+        assert_eq!(complexity.cognitive, 2);
+        assert_eq!(complexity.max_nesting, 1);
+    }
+
+    #[test]
+    fn creates_function_definition_for_local_anonymous_function_assignment() {
+        let s = parse_lua("local f = function(x)\n  return x + 1\nend");
+        let def = s
+            .definitions
+            .iter()
+            .find(|d| d.name == "f")
+            .expect("expected a Definition for f");
+        assert_eq!(def.kind, "function");
+        let complexity = def.complexity.as_ref().expect("expected complexity to be computed");
+        assert_eq!(complexity.cyclomatic, 1);
+        assert_eq!(complexity.cognitive, 0);
+    }
+
+    #[test]
+    fn nested_anonymous_function_gets_its_own_definition_and_scope() {
+        // The nested `function() ... end` passed as a callback must be its own
+        // Definition (not merged into the outer function's complexity).
+        let s = parse_lua(
+            "local function outer()\n  local cb = function()\n    if true then\n      return 1\n    end\n  end\n  return cb\nend",
+        );
+        let outer = s
+            .definitions
+            .iter()
+            .find(|d| d.name == "outer")
+            .expect("expected a Definition for outer");
+        let outer_complexity = outer.complexity.as_ref().expect("expected complexity");
+        // A nested function's branches still contribute to the enclosing
+        // function's score at increased nesting depth (matches the
+        // pre-existing JS `nested_function` test) — the key regression this
+        // guards is that `cb` now also gets its own separate Definition
+        // (asserted below), not that outer's total is unaffected.
+        assert_eq!(outer_complexity.cyclomatic, 2);
+        assert_eq!(outer_complexity.cognitive, 2);
+        assert_eq!(outer_complexity.max_nesting, 2);
+
+        let cb = s
+            .definitions
+            .iter()
+            .find(|d| d.name == "cb")
+            .expect("expected a Definition for cb");
+        let cb_complexity = cb.complexity.as_ref().expect("expected complexity");
+        assert_eq!(cb_complexity.cyclomatic, 2);
+        assert_eq!(cb_complexity.cognitive, 1);
     }
 }

--- a/src/ast-analysis/rules/b3.ts
+++ b/src/ast-analysis/rules/b3.ts
@@ -61,7 +61,16 @@ export const complexityLua: ComplexityRules = {
   logicalNodeTypes: new Set(['binary_expression']),
   optionalChainType: null,
   nestingNodes: new Set(['if_statement', 'for_statement', 'while_statement', 'repeat_statement']),
-  functionNodes: new Set(['function_declaration']),
+  // 'function_declaration' covers named forms (`function f() end`,
+  // `local function f() end`, `function M.foo() end`). 'function_definition'
+  // is the anonymous function *expression* node — the RHS of the common
+  // module-table idiom `local M = {}; M.foo = function(...) end` (issue
+  // #2036) as well as `local f = function() end` and any function literal
+  // passed as a callback argument. Both node types share the same
+  // parameters/body field shape, so every rule above (branch/nesting/
+  // Halstead scope detection) applies identically to either. Mirrors
+  // `LUA_RULES.function_nodes` in the native `complexity.rs`.
+  functionNodes: new Set(['function_declaration', 'function_definition']),
   ifNodeType: 'if_statement',
   elseNodeType: 'else_statement',
   elifNodeType: 'elseif_statement',

--- a/src/extractors/lua.ts
+++ b/src/extractors/lua.ts
@@ -220,6 +220,10 @@ function checkForRequire(node: TreeSitterNode, ctx: ExtractorOutput): void {
  * own assignment semantics — mixed variable kinds (`t.b, a = f, g`) do not
  * shift the pairing, since each side is indexed independently by position
  * rather than pre-filtered to identifiers first.
+ *
+ * Also detects anonymous `function(...) end` values assigned via a plain
+ * identifier/dotted target (issue #2036) — see
+ * `handleLuaFunctionExprAssignment` below.
  */
 function handleLuaAssignmentStatement(node: TreeSitterNode, ctx: ExtractorOutput): void {
   const variableList = findChild(node, 'variable_list');
@@ -234,6 +238,12 @@ function handleLuaAssignmentStatement(node: TreeSitterNode, ctx: ExtractorOutput
     const lhs = variables[i];
     const rhs = expressions[i];
     if (!lhs || !rhs) continue;
+
+    if (rhs.type === 'function_definition') {
+      handleLuaFunctionExprAssignment(lhs, rhs, ctx);
+      continue;
+    }
+
     if (lhs.type !== 'identifier' || rhs.type !== 'identifier') continue;
     if (!LUA_BUILTIN_GLOBALS.has(lhs.text) || LUA_BUILTIN_GLOBALS.has(rhs.text)) continue;
 
@@ -244,6 +254,58 @@ function handleLuaAssignmentStatement(node: TreeSitterNode, ctx: ExtractorOutput
       dynamicKind: 'value-ref',
     });
   }
+}
+
+/**
+ * Emit a Definition for the Lua module-table idiom `local M = {}; M.foo =
+ * function(...) end` — an anonymous `function_definition` assigned via a
+ * plain assignment (bare, or nested inside a `local` `variable_declaration`
+ * — both shapes dispatch through `handleLuaAssignmentStatement` since
+ * tree-sitter aliases the `local`-declared form to the same
+ * `assignment_statement` node), rather than the named `function M.foo() end`
+ * form `handleLuaFunctionDecl` already covers. Without this the RHS function
+ * has no Definition at all and silently gets zero complexity/Halstead data
+ * (issue #2036) — a fair portion of real Lua codebases use this
+ * module-table-of-functions idiom.
+ *
+ * Handles a plain identifier target (`local f = function() end`, kind
+ * 'function') and a dotted target (`M.foo = function() end`, kind
+ * 'method'), matching the two forms the named-declaration name field
+ * supports. Other LHS shapes (e.g. computed `M[k] = function() end`) are not
+ * handled here — see #2036 for the scope of this fix. Complexity/Halstead
+ * metrics are filled in later by the WASM complexity visitor (matched back
+ * to this Definition by line), mirroring the JS/TS `handleVarFnAssignment`
+ * split between extraction and analysis.
+ */
+function handleLuaFunctionExprAssignment(
+  lhs: TreeSitterNode,
+  rhs: TreeSitterNode,
+  ctx: ExtractorOutput,
+): void {
+  let name: string;
+  let kind: 'function' | 'method';
+
+  if (lhs.type === 'identifier') {
+    name = lhs.text;
+    kind = 'function';
+  } else if (lhs.type === 'dot_index_expression') {
+    const table = lhs.childForFieldName('table');
+    const field = lhs.childForFieldName('field');
+    if (!table || !field) return;
+    name = `${table.text}.${field.text}`;
+    kind = 'method';
+  } else {
+    return;
+  }
+
+  const params = extractLuaParams(rhs);
+  ctx.definitions.push({
+    name,
+    kind,
+    line: nodeStartLine(rhs),
+    endLine: nodeEndLine(rhs),
+    children: params.length > 0 ? params : undefined,
+  });
 }
 
 /**

--- a/tests/integration/issue-2036-lua-anonymous-function-complexity.test.ts
+++ b/tests/integration/issue-2036-lua-anonymous-function-complexity.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Integration test for #2036: Lua anonymous function expressions
+ * (`local M = {}; M.foo = function(...) end`, `local f = function() end`)
+ * were not tracked in complexity/Halstead metrics in either engine.
+ *
+ * Root cause: `function_nodes`/`functionNodes` for Lua only listed
+ * `function_declaration` (the named-declaration node type covering
+ * `function f() end`, `local function f() end`, `function M.foo() end`).
+ * The anonymous `function_definition` expression node — the RHS of the
+ * common module-table idiom `M.foo = function(...) end` and of
+ * `local f = function() end` — was never recognized as a function scope,
+ * and (more fundamentally) the extractor never created a `Definition` for
+ * it at all, so the function silently got zero complexity/Halstead data.
+ *
+ * Fix: both engines now (1) create a `Definition` for these
+ * identifier/dotted anonymous-function assignments (mirroring the
+ * `function M.foo() end` named-declaration handling), and (2) list
+ * `function_definition` alongside `function_declaration` in the
+ * complexity rules' function-node set, so nested anonymous functions get
+ * correct nesting-depth attribution too.
+ *
+ * This test builds the issue's own repro with both engines and asserts
+ * identical, real (non-zero-signal) complexity for both functions.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+import { isNativeAvailable } from '../../src/infrastructure/native.js';
+
+const LUA_SRC = `local M = {}
+
+M.foo = function(x)
+  if x then
+    return 1
+  else
+    return 2
+  end
+end
+
+local f = function(x)
+  return x + 1
+end
+`;
+
+const hasNative = isNativeAvailable();
+const requireParity = !!process.env.CODEGRAPH_PARITY;
+const describeNativeOrSkip = requireParity || hasNative ? describe : describe.skip;
+
+interface ComplexityRow {
+  name: string;
+  kind: string;
+  cognitive: number;
+  cyclomatic: number;
+  maxNesting: number;
+}
+
+function complexityRows(dbPath: string): ComplexityRow[] {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return db
+      .prepare(
+        `SELECT n.name AS name, n.kind AS kind, fc.cognitive AS cognitive,
+                fc.cyclomatic AS cyclomatic, fc.max_nesting AS maxNesting
+         FROM function_complexity fc
+         JOIN nodes n ON n.id = fc.node_id
+         WHERE n.file = 'repo.lua'
+         ORDER BY n.name`,
+      )
+      .all() as ComplexityRow[];
+  } finally {
+    db.close();
+  }
+}
+
+async function buildAndQuery(engine: 'wasm' | 'native'): Promise<ComplexityRow[]> {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2036-${engine}-`));
+  try {
+    fs.writeFileSync(path.join(tmpDir, 'repo.lua'), LUA_SRC);
+    await buildGraph(tmpDir, { engine, incremental: false, skipRegistry: true });
+    return complexityRows(path.join(tmpDir, '.codegraph', 'graph.db'));
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+describe('issue #2036: Lua anonymous function-expression complexity (WASM)', () => {
+  let rows: ComplexityRow[];
+
+  beforeAll(async () => {
+    rows = await buildAndQuery('wasm');
+  });
+
+  it('creates a method Definition with real complexity for the module-table idiom (M.foo = function() end)', () => {
+    const foo = rows.find((r) => r.name === 'M.foo');
+    expect(foo).toBeDefined();
+    expect(foo?.kind).toBe('method');
+    expect(foo?.cyclomatic).toBe(2);
+    expect(foo?.cognitive).toBe(2);
+    expect(foo?.maxNesting).toBe(1);
+  });
+
+  it('creates a function Definition with real complexity for a local anonymous function (local f = function() end)', () => {
+    const f = rows.find((r) => r.name === 'f');
+    expect(f).toBeDefined();
+    expect(f?.kind).toBe('function');
+    expect(f?.cyclomatic).toBe(1);
+    expect(f?.cognitive).toBe(0);
+  });
+});
+
+describeNativeOrSkip('issue #2036: Lua anonymous function-expression complexity (native)', () => {
+  let wasmRows: ComplexityRow[];
+  let nativeRows: ComplexityRow[];
+
+  beforeAll(async () => {
+    [wasmRows, nativeRows] = await Promise.all([buildAndQuery('wasm'), buildAndQuery('native')]);
+  });
+
+  it('produces identical complexity metrics to the WASM engine', () => {
+    expect(nativeRows).toEqual(wasmRows);
+  });
+
+  it('computes real (non-zero-signal) complexity for both functions natively', () => {
+    const foo = nativeRows.find((r) => r.name === 'M.foo');
+    const f = nativeRows.find((r) => r.name === 'f');
+    expect(foo?.cyclomatic).toBe(2);
+    expect(f?.cyclomatic).toBe(1);
+  });
+});

--- a/tests/parsers/lua.test.ts
+++ b/tests/parsers/lua.test.ts
@@ -46,6 +46,44 @@ end`);
     );
   });
 
+  // ── #2036: anonymous function-expression assignment Definitions ──────
+
+  it('extracts a Definition for the module-table function-assignment idiom (M.foo = function() end)', () => {
+    const symbols = parseLua(`local M = {}
+M.foo = function(x)
+  if x then
+    return 1
+  else
+    return 2
+  end
+end`);
+    expect(symbols.definitions).toContainEqual(
+      expect.objectContaining({ name: 'M.foo', kind: 'method' }),
+    );
+  });
+
+  it('extracts a Definition for a local anonymous function assignment (local f = function() end)', () => {
+    const symbols = parseLua(`local f = function(x)
+  return x + 1
+end`);
+    expect(symbols.definitions).toContainEqual(
+      expect.objectContaining({ name: 'f', kind: 'function' }),
+    );
+  });
+
+  it('extracts a separate Definition for a nested anonymous function passed as a callback', () => {
+    const symbols = parseLua(`local function outer()
+  local cb = function()
+    if true then
+      return 1
+    end
+  end
+  return cb
+end`);
+    expect(symbols.definitions).toContainEqual(expect.objectContaining({ name: 'outer' }));
+    expect(symbols.definitions).toContainEqual(expect.objectContaining({ name: 'cb' }));
+  });
+
   it('extracts require calls as imports', () => {
     const symbols = parseLua(`local json = require("cjson")`);
     expect(symbols.imports).toContainEqual(expect.objectContaining({ source: 'cjson' }));


### PR DESCRIPTION
## Summary

- Lua's `M.foo = function(...) end` module-table idiom and `local f = function() end` assign an anonymous `function_definition` node via a plain `assignment_statement`. Neither engine's extractor turned this into a `Definition`, and neither engine's complexity function-node list recognized `function_definition` as a function scope — so these functions silently got zero complexity/Halstead data.
- Added Definition-creation for identifier/dotted anonymous-function assignments in both extractors (`crates/codegraph-core/src/extractors/lua.rs`, `src/extractors/lua.ts`), mirroring the existing named `function_declaration` handling (plain identifier → kind `function`; dotted `dot_index_expression` → kind `method`).
- Added `function_definition` alongside `function_declaration` to `LUA_RULES.function_nodes` (native) and `complexityLua.functionNodes` (WASM), so nested anonymous functions (e.g. a callback literal passed as an argument) get correct scope/nesting attribution too — mirroring how JS already lists `arrow_function`/`function_expression`.

## Verification

Built the issue's own repro (`local M = {}; M.foo = function(x) if x then return 1 else return 2 end end` + `local f = function(x) return x + 1 end`) through the full `buildGraph` pipeline with both engines. Both now produce identical, real complexity:

- `M.foo` (method): cyclomatic=2, cognitive=2, maxNesting=1
- `f` (function): cyclomatic=1, cognitive=0

Closes #2036

## Test plan

- [x] `cargo test -p codegraph-core --lib` — 748 passed, including 3 new tests covering the module-table idiom, local anonymous assignment, and nested-callback scoping
- [x] `npx vitest run tests/parsers/lua.test.ts` — 26 passed, including 3 new extractor tests
- [x] `npx vitest run tests/integration/issue-2036-lua-anonymous-function-complexity.test.ts` — 4 passed (WASM + native dual-engine parity)
- [x] `npm test` — 273 files, 4422 tests passed
- [x] `npm run lint` — clean
- [x] `codegraph diff-impact --staged -T` — reviewed, scoped to the two new/changed functions