### PR TITLE
fix(extractors): extract CJS require() rest binding in TS/WASM engine

### DIFF
--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -5684,6 +5684,19 @@ mod tests {
         assert_eq!(dyn_imports[0].names, vec!["a".to_string(), "rest".to_string()]);
     }
 
+    /// Regression test for #2037: the native `require()` destructuring path
+    /// reuses `collect_object_pattern_names` (already fixed for #1920), so a
+    /// rest binding must come through correctly here — this locks in parity
+    /// with the WASM/TS `extractCjsRequireBinding` fix for the same issue.
+    #[test]
+    fn finds_cjs_require_with_object_rest_destructuring() {
+        let s = parse_js("const { a, ...rest } = require('./mod');");
+        let cjs_imports: Vec<_> = s.imports.iter().filter(|i| i.cjs_require == Some(true)).collect();
+        assert_eq!(cjs_imports.len(), 1);
+        assert_eq!(cjs_imports[0].source, "./mod");
+        assert_eq!(cjs_imports[0].names, vec!["a".to_string(), "rest".to_string()]);
+    }
+
     #[test]
     fn finds_dynamic_import_with_shorthand_default_destructuring() {
         let s = parse_js("const { a = 1 } = await import('./mod.js');");

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -1093,6 +1093,13 @@ function extractCjsRequireBinding(
       if (val?.type === 'identifier' || val?.type === 'shorthand_property_identifier_pattern') {
         names.push(val.text);
       }
+    } else if (prop.type === 'rest_pattern' || prop.type === 'rest_element') {
+      // { a, ...rest } = require(...) — without this branch the rest binding
+      // was silently dropped from the CJS-require import-artifact classification
+      // (issue #2037), a parity gap with Rust's collect_object_pattern_names
+      // (which the native require() path already reuses correctly).
+      const inner = extractRestPatternIdentifier(prop);
+      if (inner) names.push(inner);
     }
   }
   if (names.length === 0) return null;

--- a/tests/parsers/javascript.test.ts
+++ b/tests/parsers/javascript.test.ts
@@ -414,6 +414,25 @@ describe('JavaScript parser', () => {
     });
   });
 
+  describe('CJS require() destructuring rest binding (#2037)', () => {
+    // `extractCjsRequireBinding`'s object-pattern loop only recognized
+    // shorthand_property_identifier_pattern and pair_pattern children, so a
+    // rest element (`...rest`) was silently dropped from the CJS-require
+    // import-artifact classification (#1661) — a parity gap with Rust's
+    // collect_object_pattern_names, which the native require() path already
+    // reuses correctly (#2037).
+
+    it('includes the rest binding in cjsRequireBindings alongside plain names', () => {
+      const symbols: any = parseJS(`const { a, ...rest } = require('./mod');`);
+      expect(symbols.cjsRequireBindings).toEqual([{ names: ['a', 'rest'], source: './mod' }]);
+    });
+
+    it('includes a rest binding mixed with a renamed pair', () => {
+      const symbols: any = parseJS(`const { a: b, ...rest } = require('./mod');`);
+      expect(symbols.cjsRequireBindings).toEqual([{ names: ['b', 'rest'], source: './mod' }]);
+    });
+  });
+
   it('extracts call expressions', () => {
     const symbols = parseJS(`import { foo } from './bar'; foo(); baz();`);
     expect(symbols.calls).toContainEqual(expect.objectContaining({ name: 'foo' }));


### PR DESCRIPTION
## Summary

Issue #2037 diagnosed a wrong-child-index bug in both engines' rest-pattern
identifier extraction for dynamic-`import()`/CJS-`require()` name
collection: `rest_pattern`'s `child(0)` is the `...` token, not the bound
identifier, so `const [a, ...rest] = fn()`-style destructures silently
dropped `rest`.

**By the time this was investigated, the exact locations #2037 cited had
already been fixed** — PR #2052 (merged 2026-07-11, closing #1920) fixed
`extract_rest_identifier` (Rust) and `extractDynamicImportNames` (TS) for
both array- and object-pattern **dynamic `import()`** destructures, in both
engines, three days after #2037 was filed. Verified via `cargo test`/
`vitest` (all existing `#1920` regression tests pass) and a direct repro:
`const [a, ...rest] = await import('./mod.js')` already extracts
`["a", "rest"]` in both engines.

**What was still actually broken**, discovered while chasing #2037's own
CJS-`require()` repro (`const { a, ...rest } = require('./mod')`): the
*Rust* `require()` path reuses the already-fixed `collect_object_pattern_names`
helper directly, so it was already correct — but the *TS/WASM* `require()`
path uses a **separate**, never-fixed function, `extractCjsRequireBinding`,
whose object-pattern loop only recognized `shorthand_property_identifier_pattern`
and `pair_pattern` children. It had no `rest_pattern`/`rest_element` branch
at all, so `rest` was silently dropped from `cjsRequireBindings` (the
CJS-require import-artifact classification, #1661) — a genuine, currently
existing engine-parity gap.

## Fix

- `src/extractors/javascript.ts`: added a `rest_pattern`/`rest_element`
  branch to `extractCjsRequireBinding`, reusing the existing
  `extractRestPatternIdentifier` helper (the same one `extractDynamicImportNames`
  already uses) — mirrors Rust's `collect_object_pattern_names` behavior.
- `crates/codegraph-core/src/extractors/javascript.rs`: no logic change
  needed (already correct) — added a regression test locking in the
  already-correct native behavior for the same repro, to prevent
  future regressions and keep the two engines' test coverage symmetric.
- `tests/parsers/javascript.test.ts`: added `#2037` coverage for the
  CJS-require rest-binding case (plain + renamed-pair mixes).

## Repro confirmation

Both engines now agree for both of the issue's repros:

```
const [a, ...rest] = await import('./mod.js')   -> names: ["a", "rest"]   (already correct, both engines)
const { a, ...rest } = require('./mod')         -> names: ["a", "rest"]   (native already correct; WASM fixed here)
```

Verified via `codegraph diff-impact --staged -T` — change is scoped to
`extractCjsRequireBinding` (6 transitive callers, 1 file).

## Test plan

- `npx vitest run tests/parsers/javascript.test.ts` — 290 passed
- `npm test` — 273 files, 4424 passed, 30 skipped, 2 todo, 0 failed
- `cargo test --lib` (crates/codegraph-core) — 749 passed, 0 failed
- `npm run lint` — clean
- `node scripts/parity-compare.mjs --langs javascript,typescript` — PARITY OK, wasm vs native identical for both fixtures
- `npx vitest run tests/benchmarks/resolution/resolution-benchmark.test.ts` — 206 passed

## Follow-up

Filed #2268 for an out-of-scope finding discovered during investigation:
both engines' CJS-require import-artifact classification only handles
object-pattern destructures, never array-pattern ones (symmetric gap, not
a parity divergence).

Closes #2037