### PR TITLE
fix(lua): tag literal-key bracket-index calls as computed-literal

### DIFF
--- a/crates/codegraph-core/src/extractors/lua.rs
+++ b/crates/codegraph-core/src/extractors/lua.rs
@@ -296,11 +296,23 @@ fn handle_lua_function_call(node: &Node, source: &[u8], symbols: &mut FileSymbol
             }
             if let Some(k) = key {
                 if k.kind() == "string" || k.kind() == "string_literal" {
+                    // t["handler"]() — literal-key bracket index; statically
+                    // resolvable to the same target as t.handler(), so it still
+                    // resolves to a normal edge. Tagged `computed-literal` (ADR-002
+                    // Track A) to match JS's extractSubscriptCallInfo convention for
+                    // obj["method"]() and make the call visible to dynamic_kind-based
+                    // queries — see issue #2042. Lua table indexing has no structural
+                    // difference from JS member access here: both `t.handler()` and
+                    // `t["handler"]()` are equally subject to metatable `__index`
+                    // redirection, so there's no Lua-specific reason the literal-key
+                    // form should be treated as more "static" than JS's equivalent.
                     let raw = node_text(&k, source);
                     let call_name = raw.trim_matches(|c| c == '\'' || c == '"').to_string();
                     symbols.calls.push(Call {
                         name: call_name,
                         line: start_line(node),
+                        dynamic: Some(true),
+                        dynamic_kind: Some("computed-literal".to_string()),
                         receiver: table.map(|t| node_text(&t, source).to_string()),
                         ..Default::default()
                     });
@@ -464,20 +476,23 @@ mod tests {
 
     #[test]
     fn resolves_bracket_index_call_with_string_literal_key_directly() {
+        // Resolves to the same target as `t.handler()`, but tagged Track A
+        // `computed-literal` (#2042) to match JS's `obj["method"]()` convention
+        // instead of looking identical to a static `t.handler()` call.
         let s = parse_lua("t[\"handler\"]()");
-        assert!(s
-            .calls
-            .iter()
-            .any(|c| c.name == "handler" && c.receiver.as_deref() == Some("t") && c.dynamic.is_none()));
+        assert!(s.calls.iter().any(|c| c.name == "handler"
+            && c.receiver.as_deref() == Some("t")
+            && c.dynamic == Some(true)
+            && c.dynamic_kind.as_deref() == Some("computed-literal")));
     }
 
     #[test]
     fn resolves_bracket_index_call_with_single_quoted_string_literal_key_directly() {
         let s = parse_lua("t['handler']()");
-        assert!(s
-            .calls
-            .iter()
-            .any(|c| c.name == "handler" && c.receiver.as_deref() == Some("t")));
+        assert!(s.calls.iter().any(|c| c.name == "handler"
+            && c.receiver.as_deref() == Some("t")
+            && c.dynamic == Some(true)
+            && c.dynamic_kind.as_deref() == Some("computed-literal")));
     }
 
     #[test]

--- a/src/extractors/lua.ts
+++ b/src/extractors/lua.ts
@@ -371,11 +371,22 @@ function handleLuaFunctionCall(node: TreeSitterNode, ctx: ExtractorOutput): void
     // (undecidable statically — flagged `computed-key`). Mirrors
     // handle_lua_function_call's `bracket_index_expression` arm in
     // crates/codegraph-core/src/extractors/lua.rs.
+    //
+    // The literal-key case (`t["handler"]()`) is tagged `computed-literal`
+    // (ADR-002 Track A — resolvable) to match JS's extractSubscriptCallInfo
+    // convention for `obj["method"]()`, making it visible to dynamic_kind-
+    // based queries instead of looking identical to a static `t.handler()`
+    // call (issue #2042). Lua table indexing is not structurally different
+    // from JS member access here — both `t.handler()` and `t["handler"]()`
+    // are equally subject to metatable `__index` redirection — so there is
+    // no Lua-specific reason to diverge from JS's convention.
     const table = nameNode.childForFieldName('table');
     const key = nameNode.childForFieldName('field');
     if (key) {
       if (LUA_STRING_NODE_TYPES.has(key.type)) {
         call.name = key.text.replace(/^['"]|['"]$/g, '');
+        call.dynamic = true;
+        call.dynamicKind = 'computed-literal';
         if (table) call.receiver = table.text;
       } else {
         const dynamicCall: Call = {

--- a/tests/parsers/lua.test.ts
+++ b/tests/parsers/lua.test.ts
@@ -216,18 +216,31 @@ string.format("%s", name)`);
       );
     });
 
-    it('resolves a bracket-index call with a string-literal key directly', () => {
+    it('resolves a bracket-index call with a string-literal key directly, tagged computed-literal', () => {
+      // Resolves to the same target as `t.handler()`, but tagged Track A
+      // `computed-literal` (#2042) to match JS's `obj["method"]()` convention
+      // instead of looking identical to a static `t.handler()` call.
       const symbols = parseLua(`t["handler"]()`);
       expect(symbols.calls).toContainEqual(
-        expect.objectContaining({ name: 'handler', receiver: 't' }),
+        expect.objectContaining({
+          name: 'handler',
+          receiver: 't',
+          dynamic: true,
+          dynamicKind: 'computed-literal',
+        }),
       );
       expect(symbols.calls.some((c) => c.dynamicKind === 'computed-key')).toBe(false);
     });
 
-    it('resolves a bracket-index call with a single-quoted string-literal key directly', () => {
+    it('resolves a bracket-index call with a single-quoted string-literal key directly, tagged computed-literal', () => {
       const symbols = parseLua(`t['handler']()`);
       expect(symbols.calls).toContainEqual(
-        expect.objectContaining({ name: 'handler', receiver: 't' }),
+        expect.objectContaining({
+          name: 'handler',
+          receiver: 't',
+          dynamic: true,
+          dynamicKind: 'computed-literal',
+        }),
       );
     });
 


### PR DESCRIPTION
## Design decision

Issue #2042 asked me to decide whether Lua's `t["handler"]()` (bracket-index call with a string-literal key) should be tagged `dynamicKind: 'computed-literal'` to match JS's convention, or whether the existing plain/untagged resolution is intentional and should be documented as a deliberate divergence.

**Decision: align with JS's convention.** I found no structural reason for Lua to diverge:

- ADR-002's `DynamicKind` taxonomy is explicitly meant to be language-agnostic — `computed-literal` covers any "key is a literal string" call, Track A (statically resolvable).
- JS's `extractSubscriptCallInfo` already tags `obj["method"]()` this way, resolving to a normal edge while still surfacing the call's dynamic-dispatch *shape* via the tag.
- Lua table indexing (`t["handler"]` vs `t.handler`) is not structurally different from JS member access (`obj["method"]` vs `obj.method`) in any way that would make the tag misleading. Both languages' literal-bracket and dot forms are equally subject to runtime interception (Lua's `__index` metamethod, JS's proxies/getters) — neither is "more static" than the other, so there's no genuine Lua-specific reason to leave it untagged while every other language in the taxonomy tags it.

So: tag it, in both engines, matching JS's exact convention (`dynamic: true, dynamicKind: 'computed-literal'`, real resolved `name`/`receiver`, no `keyExpr` — `keyExpr` is reserved for the unresolved `computed-key` case).

## Changes

- `crates/codegraph-core/src/extractors/lua.rs` — `handle_lua_function_call`'s `bracket_index_expression` string-literal arm now sets `dynamic: Some(true), dynamic_kind: Some("computed-literal".to_string())`.
- `src/extractors/lua.ts` — `handleLuaFunctionCall`'s `bracket_index_expression` string-literal branch now sets `call.dynamic = true; call.dynamicKind = 'computed-literal';`.
- Updated the two existing Rust tests and two existing TS tests asserting the old untagged behavior; added doc comments in both extractors explaining the decision.

The call still resolves to the same target (`t.handler`) at full confidence — only the classification metadata changes. Both engines were re-verified to agree via `scripts/parity-compare.mjs --langs lua`.

## Verification

Repro (`t["handler"]()` calling a real `t.handler` definition), both engines:

- Native and WASM both resolve `run -> t.handler` at `confidence=1, dynamic=1`, identical output.
- `codegraph roles --dynamic` reports "No flagged dynamic calls found" for **both** Lua and an equivalent hand-built JS `obj["foo"]()` fixture — this is not a regression: I traced it to a pre-existing, cross-language gap (filed as #2270) where `dynamic_kind` is never persisted onto *resolved* edges in either engine's edge-emission code (`emitDirectCallEdgesForCall` / `emit_call_edges` hardcode the DB column to `null`; only flag-only sink edges write it). Lua now matches JS's real observed behavior exactly, end to end.

## Tests

- `cargo test --lib` — 749 passed (20 Lua-specific).
- `npm test` — 4424 passed, 273 files.
- `npx vitest run tests/parsers/lua.test.ts` — 26 passed.
- `npx vitest run tests/benchmarks/resolution/resolution-benchmark.test.ts` — 206 passed (incl. Lua fixture).
- `node scripts/parity-compare.mjs --langs lua` — native/wasm identical (27 nodes, 37 edges).
- `npm run lint` — clean.
- `codegraph diff-impact --staged -T` — 1 function changed (`handleLuaFunctionCall`), 2 transitive callers, low blast radius.

## Follow-up

Filed #2270 for the pre-existing `dynamic_kind`-not-persisted-on-resolved-edges gap discovered during verification — affects all languages, not Lua-specific, out of scope here.