### PR TITLE
fix(tests): exclude control-flow keywords from jvm-tracer traceCall injection

### DIFF
--- a/tests/benchmarks/resolution/tracer/jvm-tracer.sh
+++ b/tests/benchmarks/resolution/tracer/jvm-tracer.sh
@@ -142,7 +142,16 @@ case "$LANG" in
             # Match lines like: public void method(...) {
             # The first sed pass matches all method/constructor opening braces,
             # so a second pass is unnecessary (it would double-inject traceCall).
-            sedi_append_unless '/\)[[:space:]]*\{$/' '/class |interface /' \
+            # The negate pattern also excludes control-flow constructs that share
+            # the same "...) {" shape as a method signature (if/else if, while,
+            # for, switch, catch, synchronized, try-with-resources) -- see #2045.
+            # Unlike kotlin/scala, which anchor on the `fun `/`def ` keyword,
+            # java/groovy method signatures have no single leading keyword
+            # (`<modifiers> <returnType> <name>(...) {`), so a positive anchor
+            # isn't practical here; excluding the known control-flow keywords is
+            # the pragmatic option, matching how class/interface are already
+            # excluded below.
+            sedi_append_unless '/\)[[:space:]]*\{$/' '/class |interface |if |while |for |switch |catch |synchronized |try /' \
                 '        CallTracer.traceCall();' "$javafile"
         done
 
@@ -222,8 +231,10 @@ case "$LANG" in
         done
 
         # Inject CallTracer.traceCall() into every method body
+        # (see the java branch above for why the negate pattern also excludes
+        # control-flow keywords -- #2045)
         for grfile in "$TMP_DIR"/*.groovy; do
-            sedi_append_unless '/\)[[:space:]]*\{[[:space:]]*$/' '/class |interface /' \
+            sedi_append_unless '/\)[[:space:]]*\{[[:space:]]*$/' '/class |interface |if |while |for |switch |catch |synchronized |try /' \
                 '        CallTracer.traceCall();' "$grfile"
         done
 

--- a/tests/benchmarks/resolution/tracer/jvm-tracer.sh
+++ b/tests/benchmarks/resolution/tracer/jvm-tracer.sh
@@ -151,7 +151,7 @@ case "$LANG" in
             # isn't practical here; excluding the known control-flow keywords is
             # the pragmatic option, matching how class/interface are already
             # excluded below.
-            sedi_append_unless '/\)[[:space:]]*\{$/' '/class |interface |if |while |for |switch |catch |synchronized |try /' \
+            sedi_append_unless '/\)[[:space:]]*\{$/' '/class[[:space:]]|interface[[:space:]]|if[[:space:]]|while[[:space:]]|for[[:space:]]|switch[[:space:]]|catch[[:space:]]|synchronized[[:space:]]|try[[:space:]]/' \
                 '        CallTracer.traceCall();' "$javafile"
         done
 
@@ -234,7 +234,7 @@ case "$LANG" in
         # (see the java branch above for why the negate pattern also excludes
         # control-flow keywords -- #2045)
         for grfile in "$TMP_DIR"/*.groovy; do
-            sedi_append_unless '/\)[[:space:]]*\{[[:space:]]*$/' '/class |interface |if |while |for |switch |catch |synchronized |try /' \
+            sedi_append_unless '/\)[[:space:]]*\{[[:space:]]*$/' '/class[[:space:]]|interface[[:space:]]|if[[:space:]]|while[[:space:]]|for[[:space:]]|switch[[:space:]]|catch[[:space:]]|synchronized[[:space:]]|try[[:space:]]/' \
                 '        CallTracer.traceCall();' "$grfile"
         done
 


### PR DESCRIPTION
## Summary

`tests/benchmarks/resolution/tracer/jvm-tracer.sh`'s per-method `traceCall()` injection for java/groovy matched any line ending in `) {` that wasn't a `class `/`interface ` declaration — including `if`/`while`/`for`/`switch`/`catch` blocks. Unlike kotlin/scala (which anchor on `fun `/`def `), java/groovy had no such anchor.

Currently harmless at runtime: `CallTracer.traceCall()` always records `stack[3]` (the enclosing method) as the edge source regardless of where inside the method it's called from, and the `seen` Set dedup in `CallTracer.java`/`CallTracer.groovy` silently absorbs the spurious duplicate. Still worth fixing since it's fragile and does redundant work.

## Fix

Extended the negate pattern to also exclude `if `, `while `, `for `, `switch `, `catch `, `synchronized `, and `try ` (covers try-with-resources, which also has parens before `{`; `else if` is already caught since `if ` is a substring match). `try {` without resources has no `)` so it was never affected.

**Why negate-list over positive anchoring:** kotlin/scala anchor on the `fun `/`def ` keyword because every function declaration starts with it. Java/groovy method signatures have no single leading keyword (`<modifiers> <returnType> <name>(...) {`), so there's nothing comparable to anchor on positively. Extending the negate list — the same strategy already used for `class `/`interface ` — is the pragmatic, minimal-risk choice here.

## Repro / verification

Applied the old vs. new pattern to a copy of `tests/benchmarks/resolution/fixtures/java/UserService.java` (the exact example from #2045):

- **Old pattern:** injects `CallTracer.traceCall();` right after `if (!valid) {` — the bug.
- **New pattern:** only injects at true method-body entry points; the `if` block is untouched.

Same result verified on the groovy fixture's `if (found) {` in `Main.groovy`.

## Test plan

- [x] `npx vitest run tests/benchmarks/resolution/tracer/` — 47/47 pass (includes the `#1913` GNU/BSD sed regression guard, which still finds zero single-line `a\`/`i\` shortcuts in `jvm-tracer.sh`)
- [x] `npx vitest run tests/benchmarks/resolution/tracer/tracer-validation.test.ts -t java` / `-t groovy` — pass (groovyc unavailable locally, skips gracefully; javac present but no JDK runtime in this sandbox — pre-existing environment limitation, not caused by this change)
- [x] `npm run lint` — clean
- [x] `npm test` — 273 files / 4424 tests pass, 0 failures

## Notes

Filed #2272 for a related-but-distinct latent over-match (anonymous class bodies / Groovy trailing-closure calls ending in `) {`) discovered while auditing this pattern — no current fixture exercises it, so it's out of scope here.

Closes #2045