### PR TITLE
fix(tests): use POSIX [[:space:]] in go-tracer.sh main() regex for BSD sed

### DIFF
--- a/tests/benchmarks/resolution/tracer/go-tracer.sh
+++ b/tests/benchmarks/resolution/tracer/go-tracer.sh
@@ -139,11 +139,11 @@ for gofile in "$TMP_DIR"/*.go; do
 
     # Use sed to inject traceCall() after function opening braces
     # Match: func ... { at end of line -> add traceCall() on next line
-    sedi -E 's/^(func [^{]*\{)\s*$/\1\n\ttraceCall()/' "$gofile"
+    sedi -E 's/^(func [^{]*\{)[[:space:]]*$/\1\n\ttraceCall()/' "$gofile"
 done
 
 # Inject defer dumpTrace() at start of main()
-sedi -E '/^func main\(\)\s*\{/{
+sedi -E '/^func main\(\)[[:space:]]*\{/{
     a\	defer dumpTrace()
 }' "$TMP_DIR/main.go"
 # Suppress any os.Exit calls that would skip deferred dumpTrace


### PR DESCRIPTION
## Summary

- `\s` is a GNU-only regex escape; BSD sed (macOS) does not treat it as whitespace, so the `main()` address `/^func main\(\)\s*\{/` never matches idiomatic gofmt'd Go code (`func main() {`), and the `defer dumpTrace()` injection silently never fires on BSD sed hosts.
- Replaces `\(\)\s*\{` with the POSIX-portable `\(\)[[:space:]]*\{`, matching the fix already applied to the 8 sites in #1913 (BSD-incompatible sed injection in jvm-tracer.sh/native-tracer.sh).
- Also updates the second, currently-benign `\s*$` occurrence (per-function trailing-whitespace match) to `[[:space:]]*$` for consistency with the blanket fix style from #1913, even though gofmt already strips trailing whitespace there.

Closes #2046

## Test plan

- [x] Repro from the issue: `sed -E -n '/^func main\(\)\s*\{/p' main_test.go` prints nothing on BSD sed (macOS); with the fix (`[[:space:]]`), it correctly prints the `func main() {` line.
- [x] `npx vitest run tests/benchmarks/resolution/tracer/tracer-validation.test.ts tests/benchmarks/resolution/tracer/tracer-common.test.ts` — 47/47 passed.
- [x] `npm run lint` — clean.
- [x] `npm test` — 273 test files, 4424 passed, 30 skipped, 2 todo, 0 failed.