### PR TITLE
fix(types): widen CommandContext.outputResult data param from any to object

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -3127,7 +3127,7 @@ export interface CommandContext {
   resolveNoTests: (opts: any) => boolean;
   resolveQueryOpts: (opts: any) => any;
   formatSize: (bytes: number) => string;
-  outputResult: (data: any, key: string, opts: any) => boolean;
+  outputResult: (data: object, key: string, opts: any) => boolean;
   program: import('commander').Command;
 }
 


### PR DESCRIPTION
## Summary
`CommandContext.outputResult` in `src/types.ts` still typed its `data` parameter as `any`, predating PR #1933, which widened the real `outputResult` function (`src/presentation/result-formatter.ts`) from `data: Record<string, any>` to `data: object`. This widens the DI-shape type to match, closing the documentation/consistency gap. Purely a type annotation change — no behavior change.

Closes #2048

## Test plan
- [x] `npm run typecheck` passes with no errors
- [x] `npm run lint` passes
- [x] `npm test` — 273 test files / 4424 tests pass