### PR TITLE
fix(extractors): extract rest/default bindings from destructured const decls

### DIFF
--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -3525,6 +3525,29 @@ fn extract_destructured_bindings(
                             content_hash: None,
                             accessor_kind: None,
                         });
+                    } else if value.kind() == "assignment_pattern" {
+                        // { original: renamed = defaultValue } — the local
+                        // binding is the assignment_pattern's left identifier
+                        // (Greptile follow-up to #2051, mirrors the identical
+                        // branch already in collect_object_pattern_names
+                        // since #1824).
+                        if let Some(left) = value.child_by_field_name("left") {
+                            if left.kind() == "identifier" {
+                                definitions.push(Definition {
+                                    name: node_text(&left, source).to_string(),
+                                    kind: "constant".to_string(),
+                                    line,
+                                    end_line: Some(end_line),
+                                    decorators: None,
+                                    complexity: None,
+                                    cfg: None,
+                                    children: None,
+                                    bodyless: None,
+                                    content_hash: None,
+                                    accessor_kind: None,
+                                });
+                            }
+                        }
                     }
                 }
             }
@@ -6703,6 +6726,23 @@ mod tests {
             assert_eq!(def.kind, "constant");
         }
         assert!(!s.definitions.iter().any(|d| d.name == "b"), "should not use the original key");
+    }
+
+    #[test]
+    fn extracts_constant_definition_for_renamed_binding_with_default_value() {
+        // Greptile follow-up: { key: local = fallback } nests an
+        // assignment_pattern under pair_pattern's value field — a distinct
+        // shape from the plain shorthand default ({ a = 1 }) case above.
+        // Without this branch the pair_pattern handler rejected the nested
+        // assignment_pattern and `local` never got a Definition at all.
+        let s = parse_js("const { key: local = fallback } = someValue;");
+        let def = s
+            .definitions
+            .iter()
+            .find(|d| d.name == "local")
+            .expect("should extract local definition");
+        assert_eq!(def.kind, "constant");
+        assert!(!s.definitions.iter().any(|d| d.name == "key"), "should not use the original key");
     }
 
     /// Regression test for issue #1271: native engine missing receiver edges.

--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -3475,6 +3475,12 @@ fn handle_instanceof_value_ref(node: &Node, source: &[u8], calls: &mut Vec<Call>
 /// destructured value (e.g. `const { dbPath } = workerData`). `constant`-kind
 /// nodes remain fully resolvable as call targets — call-target resolution is
 /// kind-agnostic — so callback-style destructured bindings still resolve.
+///
+/// Also handles a shorthand default value (`const { a = 1 } = value`, node
+/// kind `object_assignment_pattern`) and a rest element (`const { a, ...rest }
+/// = value`, node kind `rest_pattern`/`rest_element`) — both were previously
+/// dropped entirely, the same class of bug fixed for dynamic-import
+/// destructure extraction in #1920 (see `extract_rest_identifier`) (#2051).
 /// Mirrors the TS extractor's `extractDestructuredBindings`.
 fn extract_destructured_bindings(
     pattern: &Node,
@@ -3520,6 +3526,51 @@ fn extract_destructured_bindings(
                             accessor_kind: None,
                         });
                     }
+                }
+            }
+            "object_assignment_pattern" => {
+                // { a = defaultValue } — shorthand binding with a default
+                // value; the bound name is the left-hand identifier (#2051,
+                // mirrors #1920's fix to collect_object_pattern_names).
+                if let Some(left) = child.child_by_field_name("left") {
+                    if left.kind() == "shorthand_property_identifier_pattern"
+                        || left.kind() == "identifier"
+                    {
+                        definitions.push(Definition {
+                            name: node_text(&left, source).to_string(),
+                            kind: "constant".to_string(),
+                            line,
+                            end_line: Some(end_line),
+                            decorators: None,
+                            complexity: None,
+                            cfg: None,
+                            children: None,
+                            bodyless: None,
+                            content_hash: None,
+                            accessor_kind: None,
+                        });
+                    }
+                }
+            }
+            "rest_pattern" | "rest_element" => {
+                // { a, ...rest } — the rest binding was silently dropped
+                // entirely before (#2051, mirrors #1920).
+                let mut rest_names = Vec::new();
+                extract_rest_identifier(&child, source, &mut rest_names);
+                for name in rest_names {
+                    definitions.push(Definition {
+                        name,
+                        kind: "constant".to_string(),
+                        line,
+                        end_line: Some(end_line),
+                        decorators: None,
+                        complexity: None,
+                        cfg: None,
+                        children: None,
+                        bodyless: None,
+                        content_hash: None,
+                        accessor_kind: None,
+                    });
                 }
             }
             _ => {}
@@ -6609,6 +6660,49 @@ mod tests {
         // kind is "constant" (#1773) — see comment on extracts_destructured_const_bindings.
         assert_eq!(renamed.kind, "constant");
         assert!(!s.definitions.iter().any(|d| d.name == "original"), "should not use the original key");
+    }
+
+    // Regression tests for #2051: extract_destructured_bindings's object_pattern
+    // branch only recognized shorthand_property_identifier_pattern and
+    // pair_pattern children, so a rest element (`...rest`) never got a
+    // Definition at all and a shorthand default (`{ a = 1 }`) produced no
+    // Definition either — the same class of bug fixed for dynamic-import
+    // destructure extraction in #1920, but for the generic
+    // destructured-const-binding path used by any object destructure.
+
+    #[test]
+    fn extracts_constant_definition_for_rest_binding_alongside_plain_names() {
+        let s = parse_js("const { a, ...rest } = someValue;");
+        let names: Vec<&str> = s.definitions.iter().map(|d| d.name.as_str()).collect();
+        assert!(names.contains(&"a"), "should extract a definition");
+        assert!(names.contains(&"rest"), "should extract rest definition");
+        let rest = s.definitions.iter().find(|d| d.name == "rest").unwrap();
+        assert_eq!(rest.kind, "constant");
+    }
+
+    #[test]
+    fn extracts_constant_definition_for_shorthand_default_value_binding() {
+        let s = parse_js("const { a = 1 } = someValue;");
+        let def = s
+            .definitions
+            .iter()
+            .find(|d| d.name == "a")
+            .expect("should extract a definition for the default-valued binding");
+        assert_eq!(def.kind, "constant");
+    }
+
+    #[test]
+    fn extracts_mixed_plain_renamed_default_and_rest_destructured_bindings() {
+        let s = parse_js("const { a, b: alias, c = 1, ...rest } = someValue;");
+        for expected in ["a", "alias", "c", "rest"] {
+            let def = s
+                .definitions
+                .iter()
+                .find(|d| d.name == expected)
+                .unwrap_or_else(|| panic!("should extract {expected} definition"));
+            assert_eq!(def.kind, "constant");
+        }
+        assert!(!s.definitions.iter().any(|d| d.name == "b"), "should not use the original key");
     }
 
     /// Regression test for issue #1271: native engine missing receiver edges.

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -1577,6 +1577,12 @@ function handleTypeAliasDecl(node: TreeSitterNode, ctx: ExtractorOutput): void {
  * (`TOP_LEVEL_BINDING_KINDS` in call-resolver.ts) — so callback-style
  * destructured bindings (`const { handleToken } = router; handleToken(req)`)
  * still resolve correctly.
+ *
+ * Also handles a shorthand default value (`const { a = 1 } = value`, node
+ * type `object_assignment_pattern`) and a rest element (`const { a, ...rest }
+ * = value`, node type `rest_pattern`/`rest_element`) — both were previously
+ * dropped entirely, the same class of bug fixed for dynamic-import destructure
+ * extraction in #1920 (see `extractRestPatternIdentifier`) (#2051).
  */
 function extractDestructuredBindings(
   pattern: TreeSitterNode,
@@ -1602,6 +1608,19 @@ function extractDestructuredBindings(
       ) {
         definitions.push({ name: value.text, kind: 'constant', line, endLine });
       }
+    } else if (child.type === 'object_assignment_pattern') {
+      // { a = defaultValue } — shorthand binding with a default value; the
+      // bound name is the left-hand identifier (#2051, mirrors #1920's fix
+      // to extractDynamicImportNames).
+      const left = child.childForFieldName('left');
+      if (left?.type === 'shorthand_property_identifier_pattern' || left?.type === 'identifier') {
+        definitions.push({ name: left.text, kind: 'constant', line, endLine });
+      }
+    } else if (child.type === 'rest_pattern' || child.type === 'rest_element') {
+      // { a, ...rest } — the rest binding was silently dropped entirely
+      // before (#2051, mirrors #1920).
+      const inner = extractRestPatternIdentifier(child);
+      if (inner) definitions.push({ name: inner, kind: 'constant', line, endLine });
     }
   }
 }

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -1607,6 +1607,15 @@ function extractDestructuredBindings(
         (value.type === 'identifier' || value.type === 'shorthand_property_identifier_pattern')
       ) {
         definitions.push({ name: value.text, kind: 'constant', line, endLine });
+      } else if (value?.type === 'assignment_pattern') {
+        // { original: renamed = defaultValue } — the local binding is the
+        // assignment_pattern's left-hand identifier (Greptile follow-up to
+        // #2051, mirrors the identical branch already in
+        // extractDynamicImportNames since #1824).
+        const left = value.childForFieldName('left');
+        if (left?.type === 'identifier') {
+          definitions.push({ name: left.text, kind: 'constant', line, endLine });
+        }
       }
     } else if (child.type === 'object_assignment_pattern') {
       // { a = defaultValue } — shorthand binding with a default value; the

--- a/tests/parsers/javascript.test.ts
+++ b/tests/parsers/javascript.test.ts
@@ -1548,6 +1548,19 @@ function runDemo(reporter: Reporter, users: string[]): void {
         }
         expect(symbols.definitions).not.toContainEqual(expect.objectContaining({ name: 'b' }));
       });
+
+      it('extracts a constant Definition for a renamed binding with a default value', () => {
+        // Greptile follow-up: { key: local = fallback } nests an
+        // assignment_pattern under pair_pattern's value field — a distinct
+        // shape from the plain shorthand default ({ a = 1 }) case above.
+        // Without this branch the pair_pattern handler rejected the nested
+        // assignment_pattern and `local` never got a Definition at all.
+        const symbols = parseJS(`const { key: local = fallback } = someValue;`);
+        expect(symbols.definitions).toContainEqual(
+          expect.objectContaining({ name: 'local', kind: 'constant' }),
+        );
+        expect(symbols.definitions).not.toContainEqual(expect.objectContaining({ name: 'key' }));
+      });
     });
 
     // let/var object-literal method definitions

--- a/tests/parsers/javascript.test.ts
+++ b/tests/parsers/javascript.test.ts
@@ -1513,6 +1513,43 @@ function runDemo(reporter: Reporter, users: string[]): void {
       );
     });
 
+    describe('destructured const binding rest/default definitions (#2051)', () => {
+      // extractDestructuredBindings's object_pattern branch only recognized
+      // shorthand_property_identifier_pattern and pair_pattern children, so a
+      // rest element (`...rest`) never got a Definition at all and a shorthand
+      // default (`{ a = 1 }`) produced no Definition either — the same class of
+      // bug fixed for dynamic-import destructure extraction in #1920, but for
+      // the generic destructured-const-binding path used by any object
+      // destructure, not just dynamic imports.
+
+      it('extracts a constant Definition for a rest binding alongside plain names', () => {
+        const symbols = parseJS(`const { a, ...rest } = someValue;`);
+        expect(symbols.definitions).toContainEqual(
+          expect.objectContaining({ name: 'a', kind: 'constant' }),
+        );
+        expect(symbols.definitions).toContainEqual(
+          expect.objectContaining({ name: 'rest', kind: 'constant' }),
+        );
+      });
+
+      it('extracts a constant Definition for a shorthand default-value binding', () => {
+        const symbols = parseJS(`const { a = 1 } = someValue;`);
+        expect(symbols.definitions).toContainEqual(
+          expect.objectContaining({ name: 'a', kind: 'constant' }),
+        );
+      });
+
+      it('extracts a mix of plain, renamed, default, and rest bindings', () => {
+        const symbols = parseJS(`const { a, b: alias, c = 1, ...rest } = someValue;`);
+        for (const name of ['a', 'alias', 'c', 'rest']) {
+          expect(symbols.definitions).toContainEqual(
+            expect.objectContaining({ name, kind: 'constant' }),
+          );
+        }
+        expect(symbols.definitions).not.toContainEqual(expect.objectContaining({ name: 'b' }));
+      });
+    });
+
     // let/var object-literal method definitions
     it('extracts qualified definitions from var object-literal arrow functions', () => {
       // `var x = { a: function() {} }` — native produces `x.a`, WASM must too.


### PR DESCRIPTION
## Summary
- `extractDestructuredBindings` (TS/WASM) and its mirror `extract_destructured_bindings` (native) only recognized `shorthand_property_identifier_pattern` and `pair_pattern` children when creating `constant`-kind `Definition`s for a plain object-destructuring `const` declaration, so:
  - `const { a, ...rest } = someValue;` never got a `Definition` for `rest`.
  - `const { a = 1 } = someValue;` never got a `Definition` for `a` at all.
- Verified present identically in both engines — a genuine parity-preserving gap, not a WASM-only bug.
- Fixed by adding `object_assignment_pattern` (default value) and `rest_pattern`/`rest_element` branches to both engines, mirroring the equivalent fix already landed for `extractDynamicImportNames`/`extract_dynamic_import_names` in #1920 (PR #2052). The TS side reuses the existing shared `extractRestPatternIdentifier` helper; the Rust side reuses the existing `extract_rest_identifier` helper.
- Both the walk-based and query-based paths call the same shared `extractDestructuredBindings`/`extract_destructured_bindings` function, so both are fixed by this one change.
- Checked the array-pattern counterpart (`extractArrayPatternBindings`/`extract_array_pattern_bindings`) for the same class of bug per the issue's broader "destructured-binding" title — it already correctly handles both `assignment_pattern` (default) and `rest_pattern`/`rest_element` in both engines (added in #1901), so no change was needed there.

## Repro (issue's own example)
```js
const { a, ...rest } = someValue;
// before: definitions contains `a` but not `rest`
// after:  definitions contains both `a` and `rest`, kind 'constant'

const { a = 1 } = someValue;
// before: definitions does not contain `a` at all
// after:  definitions contains `a`, kind 'constant'
```
Confirmed via a real `buildGraph()` run against a small fixture on both `engine: 'wasm'` and `engine: 'native'` (native addon rebuilt + codesigned locally) — both produce identical `constant` definitions: `a`, `d`, `rest`, `someValue`.

## Test plan
- `npx vitest run tests/parsers/javascript.test.ts` — 291 passed (3 new, covering rest/default/mixed bindings in object-pattern destructured const declarations)
- `cargo test --lib javascript` (crates/codegraph-core) — 216 passed (3 new, mirroring the TS cases)
- Rebuilt and codesigned the native addon locally (`npx napi build --platform --release` + `codesign --sign - --force`) so the fix was exercised by the real native engine
- `npm test` — full suite: 273 files, 4427 passed, 30 skipped, 2 todo, 0 failed
- `npm run lint` — clean
- `node scripts/parity-compare.mjs --langs javascript,typescript,tsx,pts-javascript,dynamic-javascript,dynamic-typescript --hybrid` — PARITY OK, all engines identical across all 6 JS/TS-related fixtures
- `npx vitest run tests/benchmarks/resolution/resolution-benchmark.test.ts` — 206 passed, javascript/typescript/pts-javascript all at 100% precision/recall
- `codegraph diff-impact --staged -T` — confirms the change is scoped to exactly `extractDestructuredBindings`, 6 transitive callers, all within the JS/TS extractor

Closes #2051