### PR TITLE
fix: clear stale deleted-export advisories on full builds, not just incremental

### DIFF
--- a/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
@@ -224,6 +224,17 @@ fn save_and_purge_changed(
     if change_result.is_full_build {
         let has_embeddings = detect_changes::has_embeddings(conn);
         detect_changes::clear_all_graph_data(conn, has_embeddings);
+        // A full rebuild re-parses every currently-existing file from
+        // scratch, so none of them are "deleted" — clear any stale advisory
+        // left over from a prior removal at these paths before this build's
+        // fresh parse reinserts them. Without this, a file that was deleted
+        // (capturing an advisory), reappeared with fewer/no exports, and is
+        // later deleted again would resurface the OLD (pre-reappearance)
+        // advisory snapshot instead of a fresh one, misattributing a stale
+        // violation (#1938). Mirrors the TS `handleFullBuild` fix.
+        let changed_paths: Vec<String> =
+            parse_changes.iter().map(|c| c.rel_path.clone()).collect();
+        detect_changes::clear_deleted_export_advisories(conn, &changed_paths);
         return (
             saved_reverse_dep_edges,
             saved_sibling_groups,

--- a/src/domain/graph/builder/stages/detect-changes.ts
+++ b/src/domain/graph/builder/stages/detect-changes.ts
@@ -629,7 +629,7 @@ function handleScopedBuild(ctx: PipelineContext): void {
 }
 
 function handleFullBuild(ctx: PipelineContext): void {
-  const { db } = ctx;
+  const { db, rootDir } = ctx;
   const hasEmbeddings = detectHasEmbeddings(db, ctx.nativeDb);
   ctx.hasEmbeddings = hasEmbeddings;
   const deletions =
@@ -639,6 +639,17 @@ function handleFullBuild(ctx: PipelineContext): void {
       ? `${deletions.replace('PRAGMA foreign_keys = ON;', '')} DELETE FROM embeddings; PRAGMA foreign_keys = ON;`
       : deletions,
   );
+  // A full rebuild re-parses every currently-existing file from scratch, so
+  // none of them are "deleted" — clear any stale advisory left over from a
+  // prior removal at these paths before this build's fresh parse reinserts
+  // them. Without this, a file that was deleted (capturing an advisory),
+  // reappeared with fewer/no exports, and is later deleted again would
+  // resurface the OLD (pre-reappearance) advisory snapshot instead of a
+  // fresh one, misattributing a stale violation (#1938).
+  const changePaths = ctx.parseChanges.map(
+    (item) => item.relPath || normalizePath(path.relative(rootDir, item.file)),
+  );
+  clearDeletedExportAdvisories(db, changePaths);
 }
 
 function handleIncrementalBuild(ctx: PipelineContext): void {

--- a/tests/integration/check.test.ts
+++ b/tests/integration/check.test.ts
@@ -992,7 +992,16 @@ describe('checkNoDeletedExportsInUse', () => {
 // snapshot (captured by that rebuild, before the purge) is what
 // `checkNoDeletedExportsInUse` must fall back to.
 
-function insertAdvisory(db, file, name, kind, line, consumerName, consumerFile, consumerLine) {
+function insertAdvisory(
+  db: Database.Database,
+  file: string,
+  name: string,
+  kind: string,
+  line: number,
+  consumerName: string,
+  consumerFile: string,
+  consumerLine: number,
+): void {
   db.prepare(
     `INSERT INTO deleted_export_advisories
        (file, name, kind, line, consumer_name, consumer_file, consumer_line, deleted_at)

--- a/tests/integration/issue-1938-deleted-export-advisory-persistence.test.ts
+++ b/tests/integration/issue-1938-deleted-export-advisory-persistence.test.ts
@@ -245,6 +245,50 @@ function runScenario(engine: 'wasm' | 'native'): void {
       expect(violation.reason).toBe('file-deleted');
       expect(violation.consumers.map((c) => c.file)).toContain('src/consumer.js');
     }, 60_000);
+
+    it('clears the advisory on a full (non-incremental) rebuild once the deleted file reappears', async () => {
+      // Regression test for the gap Greptile flagged on #2103: the
+      // full-rebuild path wiped nodes/edges/file_hashes but never cleared
+      // `deleted_export_advisories`, so a file that reappeared with fewer/no
+      // exports and was later deleted again would resurface the STALE
+      // pre-reappearance snapshot instead of a fresh (empty) one.
+      const projectDir = mkTmp(`cg-1938-fullbuild-${engine}-`);
+      fs.mkdirSync(path.join(projectDir, 'src'), { recursive: true });
+      fs.writeFileSync(
+        path.join(projectDir, 'package.json'),
+        JSON.stringify({ name: 'test-1938-fullbuild', version: '1.0.0', type: 'module' }),
+      );
+      fs.writeFileSync(
+        path.join(projectDir, 'src', 'shared.js'),
+        'export function sharedHelper() {\n  return 1;\n}\n',
+      );
+      fs.writeFileSync(
+        path.join(projectDir, 'src', 'consumer.js'),
+        "import { sharedHelper } from './shared.js';\nexport function useShared() {\n  return sharedHelper();\n}\n",
+      );
+
+      await buildGraph(projectDir, { engine, incremental: false, skipRegistry: true });
+
+      // Delete shared.js, rebuild (purges + captures the advisory for
+      // sharedHelper), then bring it back with NO exports at all — but this
+      // time reinsert it via a FULL rebuild instead of an incremental one.
+      fs.rmSync(path.join(projectDir, 'src', 'shared.js'));
+      await buildGraph(projectDir, { engine, skipRegistry: true });
+
+      fs.writeFileSync(path.join(projectDir, 'src', 'shared.js'), '// no exports here\n');
+      await buildGraph(projectDir, { engine, incremental: false, skipRegistry: true });
+
+      const dbPath = path.join(projectDir, '.codegraph', 'graph.db');
+      const verifyDb = new Database(dbPath, { readonly: true });
+      try {
+        const advisoryRows = verifyDb
+          .prepare("SELECT * FROM deleted_export_advisories WHERE file = 'src/shared.js'")
+          .all();
+        expect(advisoryRows).toEqual([]);
+      } finally {
+        verifyDb.close();
+      }
+    }, 60_000);
   });
 }
 


### PR DESCRIPTION
## Summary
#1938 fixed `deleted_export_advisories` persistence for the incremental rebuild path (`handleIncrementalBuild`/`clearDeletedExportAdvisories`), but the full-build path (`handleFullBuild` / Rust's `save_and_purge_changed` full-build branch) never called the equivalent clear, so a full rebuild after a delete-then-recreate cycle could leave stale advisory rows behind, causing `codegraph check` to report a false-positive removed-export warning that a full build should have cleared.

This fix recovered from an orphaned worktree (found during `/housekeep`) — the work was done, verified, and never turned into a PR. Independently re-verified before landing: confirmed not superseded by any later independent fix, confirmed clean merge onto current `origin/main` (zero conflicts), and re-ran the full relevant test suite (both engines) from a fresh branch.

## Verification
- `npx vitest run tests/integration/check.test.ts tests/integration/issue-1938-deleted-export-advisory-persistence.test.ts`: 68/68 pass (wasm + native)
- `cargo test --release` (codegraph-core): 753/753 pass
- `npm run lint`: clean
- `codegraph diff-impact origin/main -T`: 1 function changed (`handleFullBuild`), 3 transitive callers, 2 files — scoped as expected

Closes #2232