### PR TITLE
fix: skip complexity/CFG for bodyless Rust trait methods (#2053)

### DIFF
--- a/crates/codegraph-core/src/extractors/rust_lang.rs
+++ b/crates/codegraph-core/src/extractors/rust_lang.rs
@@ -184,16 +184,31 @@ fn handle_trait_item(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                 continue;
             }
             if let Some(meth_name) = child.child_by_field_name("name") {
+                // function_signature_item is a required trait method with no
+                // default implementation (no body) — skip CFG and complexity
+                // to mirror the WASM extractor and avoid fabricating a
+                // trivial-but-meaningless complexity entry for a function
+                // with no body. function_item (default impl) still gets full
+                // metrics.
+                let is_bodyless = child.kind() == "function_signature_item";
                 symbols.definitions.push(Definition {
                     name: format!("{}.{}", trait_name, node_text(&meth_name, source)),
                     kind: "method".to_string(),
                     line: start_line(&child),
                     end_line: Some(end_line(&child)),
                     decorators: None,
-                    complexity: compute_all_metrics(&child, source, "rust"),
-                    cfg: build_function_cfg(&child, "rust", source),
+                    complexity: if is_bodyless {
+                        None
+                    } else {
+                        compute_all_metrics(&child, source, "rust")
+                    },
+                    cfg: if is_bodyless {
+                        None
+                    } else {
+                        build_function_cfg(&child, "rust", source)
+                    },
                     children: None,
-                    bodyless: Some(child.kind() == "function_signature_item"),
+                    bodyless: Some(is_bodyless),
                     content_hash: None,
                     accessor_kind: None,
                 });
@@ -644,6 +659,31 @@ mod tests {
 
         let find = s.definitions.iter().find(|d| d.name == "Repo.find").unwrap();
         assert_ne!(find.bodyless, Some(true));
+    }
+
+    /// Regression test for #2053: a bodyless trait method must not get a
+    /// fabricated complexity/CFG entry (WASM produces none for it, since
+    /// `function_signature_item` is excluded from `functionNodes`); a
+    /// default-implemented trait method must still get real metrics.
+    #[test]
+    fn trait_required_method_has_no_complexity_default_method_does() {
+        let s = parse_rust(
+            "trait Repo {\n\
+               fn save(&mut self, id: &str, value: i32) -> bool;\n\
+               fn find(&self, id: &str) -> Option<i32> {\n\
+                 if id.is_empty() { return None; }\n\
+                 for i in 0..3 { if i == 1 { return Some(i); } }\n\
+                 None\n\
+               }\n\
+             }\n",
+        );
+        let save = s.definitions.iter().find(|d| d.name == "Repo.save").unwrap();
+        assert!(save.complexity.is_none());
+        assert!(save.cfg.is_none());
+
+        let find = s.definitions.iter().find(|d| d.name == "Repo.find").unwrap();
+        assert!(find.complexity.is_some());
+        assert!(find.cfg.is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`handle_trait_item` in `crates/codegraph-core/src/extractors/rust_lang.rs` called `compute_all_metrics`/`build_function_cfg` unconditionally for every trait member, including `function_signature_item` (a required trait method with **no default implementation**, no body). This fabricated a trivial-but-meaningless complexity entry (`cyclomatic: 1, cognitive: 0`) that the WASM engine never produces, since `COMPLEXITY_RULES` for Rust (`src/ast-analysis/rules/rust.ts`) excludes `function_signature_item` from `functionNodes`.

Fix: gate `complexity`/`cfg` on the same bodyless check already used for the `Definition.bodyless` flag (added in #1922) — `function_signature_item` gets `None` for both, `function_item` (default impl, has a body) is unaffected. Mirrors `csharp.rs`'s `handle_interface_decl`, which already does this for C# interface methods.

## Verification

- `cargo test --lib` — 759/759 passed (including a new regression test for this fix)
- `npm run lint` — clean
- `npm test` — 273/273 test files, 4436 passed
- Native and WASM now produce **identical** `codegraph complexity` output on the issue's own repro:
  ```
  $ codegraph complexity --file repo.rs -T --json --engine native
  functions: 1   [ Repo.find ]
  $ codegraph complexity --file repo.rs -T --json --engine wasm
  functions: 1   [ Repo.find ]
  ```
  `Repo.save` is still correctly extracted as a symbol (`codegraph where` shows it), just without a fabricated complexity entry.

## Test plan

- [x] `cargo test --lib` in `crates/codegraph-core`
- [x] `npm run lint`
- [x] `npm test`
- [x] Native vs WASM diff on the issue's repro (identical output)

Closes #2053