### PR TITLE
fix: prevent resolveThisDispatch from matching an unrelated same-named class in another file

### DIFF
--- a/src/domain/graph/builder/cha.ts
+++ b/src/domain/graph/builder/cha.ts
@@ -26,8 +26,17 @@ import { RECEIVER_KINDS } from './call-resolver.js';
 export interface ChaContext {
   /** interface/class name → concrete classes that implement or extend it */
   readonly implementors: ReadonlyMap<string, readonly string[]>;
-  /** class name → direct parent class name (from `extends`) */
+  /**
+   * class name → direct parent class name (from `extends`), first-write-wins
+   * across the whole project. Ambiguous when the same bare class name is
+   * declared in multiple files with different parents — prefer
+   * `parentsByFile` whenever a declaration's home file is known.
+   */
   readonly parents: ReadonlyMap<string, string>;
+  /** `${className}|${file}` → direct parent class name (from `extends`), scoped
+   * to the file that declared `className` — disambiguates same-named classes
+   * declared in different files (issue #2062). */
+  readonly parentsByFile: ReadonlyMap<string, string>;
   /** RTA: class names that appear in `new X()` anywhere in the project */
   readonly instantiatedTypes: ReadonlySet<string>;
 }
@@ -35,6 +44,7 @@ export interface ChaContext {
 export const EMPTY_CHA_CONTEXT: ChaContext = {
   implementors: new Map(),
   parents: new Map(),
+  parentsByFile: new Map(),
   instantiatedTypes: new Set(),
 };
 
@@ -53,18 +63,22 @@ function recordImplements(cls: ClassRelation, implementors: Map<string, string[]
 }
 
 /**
- * Record a class's `extends` relationship into both the parents map (child →
- * direct parent, for this/super hierarchy walking) and the implementors map
- * (parent → children, for CHA dispatch expansion via extends).
+ * Record a class's `extends` relationship into the parents map (child →
+ * direct parent, for this/super hierarchy walking), the file-scoped parents
+ * map (same, but disambiguated by the declaring file), and the implementors
+ * map (parent → children, for CHA dispatch expansion via extends).
  */
 function recordExtends(
   cls: ClassRelation,
   implementors: Map<string, string[]>,
   parents: Map<string, string>,
+  parentsByFile: Map<string, string>,
+  file: string,
 ): void {
   if (!cls.extends) return;
   // child → parent (for this/super hierarchy walking)
   if (!parents.has(cls.name)) parents.set(cls.name, cls.extends);
+  parentsByFile.set(`${cls.name}|${file}`, cls.extends);
   // parent → children (for CHA dispatch expansion via extends)
   let list = implementors.get(cls.extends);
   if (!list) {
@@ -104,17 +118,18 @@ function collectInstantiatedTypes(symbols: ExtractorOutput, instantiatedTypes: S
 export function buildChaContext(fileSymbols: ReadonlyMap<string, ExtractorOutput>): ChaContext {
   const implementors = new Map<string, string[]>();
   const parents = new Map<string, string>();
+  const parentsByFile = new Map<string, string>();
   const instantiatedTypes = new Set<string>();
 
-  for (const symbols of fileSymbols.values()) {
+  for (const [file, symbols] of fileSymbols) {
     for (const cls of symbols.classes) {
       recordImplements(cls, implementors);
-      recordExtends(cls, implementors, parents);
+      recordExtends(cls, implementors, parents, parentsByFile, file);
     }
     collectInstantiatedTypes(symbols, instantiatedTypes);
   }
 
-  return { implementors, parents, instantiatedTypes };
+  return { implementors, parents, parentsByFile, instantiatedTypes };
 }
 
 /**
@@ -142,17 +157,23 @@ export function buildChaContext(fileSymbols: ReadonlyMap<string, ExtractorOutput
 export function buildChaContextFromDb(db: BetterSqlite3Database): ChaContext {
   const hierarchyRows = db
     .prepare(`
-      SELECT src.name AS child_name, tgt.name AS parent_name, e.kind AS edge_kind
+      SELECT src.name AS child_name, src.file AS child_file, tgt.name AS parent_name, e.kind AS edge_kind
       FROM edges e
       JOIN nodes src ON e.source_id = src.id
       JOIN nodes tgt ON e.target_id = tgt.id
       WHERE e.kind IN ('extends', 'implements')
     `)
-    .all() as Array<{ child_name: string; parent_name: string; edge_kind: string }>;
+    .all() as Array<{
+    child_name: string;
+    child_file: string;
+    parent_name: string;
+    edge_kind: string;
+  }>;
   if (hierarchyRows.length === 0) return EMPTY_CHA_CONTEXT;
 
   const implementors = new Map<string, string[]>();
   const parents = new Map<string, string>();
+  const parentsByFile = new Map<string, string>();
   for (const row of hierarchyRows) {
     let list = implementors.get(row.parent_name);
     if (!list) {
@@ -160,8 +181,9 @@ export function buildChaContextFromDb(db: BetterSqlite3Database): ChaContext {
       implementors.set(row.parent_name, list);
     }
     if (!list.includes(row.child_name)) list.push(row.child_name);
-    if (row.edge_kind === 'extends' && !parents.has(row.child_name)) {
-      parents.set(row.child_name, row.parent_name);
+    if (row.edge_kind === 'extends') {
+      if (!parents.has(row.child_name)) parents.set(row.child_name, row.parent_name);
+      parentsByFile.set(`${row.child_name}|${row.child_file}`, row.parent_name);
     }
   }
 
@@ -175,7 +197,7 @@ export function buildChaContextFromDb(db: BetterSqlite3Database): ChaContext {
     .all() as Array<{ name: string }>;
   const instantiatedTypes = new Set(rtaRows.map((r) => r.name));
 
-  return { implementors, parents, instantiatedTypes };
+  return { implementors, parents, parentsByFile, instantiatedTypes };
 }
 
 // ── this / self / super resolution ──────────────────────────────────────────
@@ -212,7 +234,11 @@ export function resolveThisDispatch(
   if (dotIdx === -1) return [];
 
   const callerClass = callerName.slice(0, dotIdx);
-  const startClass = receiver === 'super' ? chaCtx.parents.get(callerClass) : callerClass;
+  const startClass =
+    receiver === 'super'
+      ? (callerFile && chaCtx.parentsByFile.get(`${callerClass}|${callerFile}`)) ||
+        chaCtx.parents.get(callerClass)
+      : callerClass;
   if (!startClass) return [];
 
   // Walk up the hierarchy; the visited set guards against cycles in malformed data.
@@ -247,9 +273,16 @@ export function resolveThisDispatch(
           .byNameAndFile(current, callerFile)
           .some((n) => RECEIVER_KINDS.has(n.kind ?? ''));
         if (!sameNameInCallerFile) return found;
-      } else {
-        return found;
+        // `current` is a same-named collision: it's genuinely declared in
+        // callerFile but a different, unrelated file's class of the same
+        // name is what defines `methodName`. Advance via THAT same-file
+        // declaration's own parent (file-scoped) rather than the ambiguous
+        // bare-name `parents` entry, which may belong to the colliding file
+        // and misdirect the walk into a wholly unrelated hierarchy.
+        current = chaCtx.parentsByFile.get(`${current}|${callerFile}`);
+        continue;
       }
+      return found;
     }
     current = chaCtx.parents.get(current);
   }

--- a/src/domain/graph/builder/cha.ts
+++ b/src/domain/graph/builder/cha.ts
@@ -19,6 +19,7 @@
 import type { BetterSqlite3Database, ClassRelation, ExtractorOutput } from '../../../types.js';
 import type { ResolvedCandidate } from '../resolver/strategy.js';
 import type { CallNodeLookup } from './call-resolver.js';
+import { RECEIVER_KINDS } from './call-resolver.js';
 
 // ── CHA context ──────────────────────────────────────────────────────────────
 
@@ -225,10 +226,30 @@ export function resolveThisDispatch(
       // When the caller's file is known, prefer same-file nodes to avoid
       // emitting cross-file edges to identically-named methods in unrelated
       // files.  Only fall back to the full set when no same-file node exists.
-      if (callerFile && found.some((n) => n.file === callerFile)) {
-        return found.filter((n) => n.file === callerFile);
+      if (callerFile) {
+        const sameFile = found.filter((n) => n.file === callerFile);
+        if (sameFile.length > 0) return sameFile;
+        // No same-file candidate. `chaCtx.parents` is keyed by bare class
+        // name, so `current` may be an unrelated class that merely shares a
+        // name with the caller's real ancestor (issue #2062) — e.g. two
+        // independent files each defining their own `Shape` class. Before
+        // accepting a cross-file match, check whether a class named
+        // `current` is ALSO declared in the caller's own file: if so, that
+        // same-file class IS the caller's real ancestor at this step (it
+        // simply doesn't define `methodName` — an implicit default
+        // constructor, for instance), so a same-named method from a
+        // different file is a false match, not a legitimate inherited
+        // method. Keep walking instead of accepting it. Only accept the
+        // cross-file match when `current` is NOT declared anywhere in the
+        // caller's own file — a genuine cross-file heritage reference
+        // (e.g. `import { Base } from './base'; class Foo extends Base`).
+        const sameNameInCallerFile = lookup
+          .byNameAndFile(current, callerFile)
+          .some((n) => RECEIVER_KINDS.has(n.kind ?? ''));
+        if (!sameNameInCallerFile) return found;
+      } else {
+        return found;
       }
-      return found;
     }
     current = chaCtx.parents.get(current);
   }

--- a/src/domain/graph/builder/stages/native-orchestrator.ts
+++ b/src/domain/graph/builder/stages/native-orchestrator.ts
@@ -1018,29 +1018,34 @@ const JS_TS_EXTS = new Set(['.js', '.ts', '.tsx', '.jsx', '.mjs', '.cjs', '.mts'
 // ── this/super dispatch post-pass helpers ───────────────────────────────────
 
 /**
- * Build parents map: child class → direct parent class (from `extends` edges).
- * May be empty when only func-prop methods exist (no class inheritance) —
+ * Build parents maps: child class → direct parent class (from `extends`
+ * edges), both bare-name-keyed (ambiguous across same-named classes in
+ * different files) and file-scoped (`${childName}|${file}`, disambiguated —
+ * see `resolveThisDispatch`'s issue #2062 collision handling). May be empty
+ * when only func-prop methods exist (no class inheritance) —
  * resolveThisDispatch handles that case via direct class-prefix lookup.
  */
 function buildThisDispatchParentsMap(
   db: BetterSqlite3Database,
   hasExtends: unknown,
-): Map<string, string> {
+): { parents: Map<string, string>; parentsByFile: Map<string, string> } {
   const parents = new Map<string, string>();
-  if (!hasExtends) return parents;
+  const parentsByFile = new Map<string, string>();
+  if (!hasExtends) return { parents, parentsByFile };
   const parentRows = db
     .prepare(`
-      SELECT src.name AS child_name, tgt.name AS parent_name
+      SELECT src.name AS child_name, src.file AS child_file, tgt.name AS parent_name
       FROM edges e
       JOIN nodes src ON e.source_id = src.id
       JOIN nodes tgt ON e.target_id = tgt.id
       WHERE e.kind = 'extends'
     `)
-    .all() as Array<{ child_name: string; parent_name: string }>;
+    .all() as Array<{ child_name: string; child_file: string; parent_name: string }>;
   for (const row of parentRows) {
     if (!parents.has(row.child_name)) parents.set(row.child_name, row.parent_name);
+    parentsByFile.set(`${row.child_name}|${row.child_file}`, row.parent_name);
   }
-  return parents;
+  return { parents, parentsByFile };
 }
 
 /**
@@ -1325,7 +1330,7 @@ async function runPostNativeThisDispatch(
   };
   if (!hasExtends && !hasFuncPropMethod) return emptyResult;
 
-  const parents = buildThisDispatchParentsMap(db, hasExtends);
+  const { parents, parentsByFile } = buildThisDispatchParentsMap(db, hasExtends);
   // Note: parents may be empty when hasFuncPropMethod but !hasExtends — that is
   // intentional. resolveThisDispatch still resolves `this.g()` inside `f.h` by
   // treating `f` (the dot-prefix of callerName `f.h`) as the class and looking
@@ -1334,6 +1339,7 @@ async function runPostNativeThisDispatch(
   const chaCtx: ChaContext = {
     implementors: new Map(), // not needed for this/super resolution
     parents,
+    parentsByFile,
     instantiatedTypes: new Set(), // not needed for this/super resolution
   };
 

--- a/tests/unit/cha.test.ts
+++ b/tests/unit/cha.test.ts
@@ -39,10 +39,14 @@ function makeLookup(
   };
 }
 
-function makeChaCtx(parents: Record<string, string>): ChaContext {
+function makeChaCtx(
+  parents: Record<string, string>,
+  parentsByFile: Record<string, string> = {},
+): ChaContext {
   return {
     implementors: new Map(),
     parents: new Map(Object.entries(parents)),
+    parentsByFile: new Map(Object.entries(parentsByFile)),
     instantiatedTypes: new Set(),
   };
 }
@@ -55,7 +59,7 @@ describe('resolveThisDispatch — cross-file name collision (issue #2062)', () =
       { 'Shape.constructor': [{ id: 1, file: 'super-dispatch.ts', kind: 'method', line: 1 }] },
       { Shape: { 'hierarchy.ts': [{ id: 2, file: 'hierarchy.ts', kind: 'class', line: 2 }] } },
     );
-    const chaCtx = makeChaCtx({ Circle: 'Shape' });
+    const chaCtx = makeChaCtx({ Circle: 'Shape' }, { 'Circle|hierarchy.ts': 'Shape' });
 
     const result = resolveThisDispatch(
       'constructor',
@@ -76,7 +80,7 @@ describe('resolveThisDispatch — cross-file name collision (issue #2062)', () =
       { 'Animal.speak': [{ id: 5, file: 'base.ts', kind: 'method', line: 5 }] },
       { Animal: {} },
     );
-    const chaCtx = makeChaCtx({ Dog: 'Animal' });
+    const chaCtx = makeChaCtx({ Dog: 'Animal' }, { 'Dog|dog.ts': 'Animal' });
 
     const result = resolveThisDispatch('speak', 'Dog.speak', 'super', chaCtx, lookup, 'dog.ts');
     expect(result).toEqual([{ id: 5, file: 'base.ts', kind: 'method', line: 5 }]);
@@ -104,7 +108,34 @@ describe('resolveThisDispatch — cross-file name collision (issue #2062)', () =
       },
       { Middle: { 'real.ts': [{ id: 11, file: 'real.ts', kind: 'class', line: 11 }] } },
     );
-    const chaCtx = makeChaCtx({ Child: 'Middle', Middle: 'Base' });
+    const chaCtx = makeChaCtx({ Child: 'Middle', Middle: 'Base' }, { 'Middle|real.ts': 'Base' });
+
+    const result = resolveThisDispatch('greet', 'Child.greet', 'this', chaCtx, lookup, 'real.ts');
+    expect(result).toEqual([{ id: 10, file: 'real.ts', kind: 'method', line: 10 }]);
+  });
+
+  it('does not misdirect the walk through a colliding class whose bare-name parent belongs to a different file', () => {
+    // Two files each declare an unrelated `Middle` class with a DIFFERENT
+    // parent: real.ts's Middle extends Base (which has `greet`); other.ts's
+    // Middle extends Unrelated (which also has `greet`, incorrectly). The
+    // global bare-name `parents` map is first-write-wins and here points to
+    // other.ts's Middle -> Unrelated — if the walk blindly followed it after
+    // rejecting the collision, it would wrongly resolve to Unrelated.greet
+    // instead of the caller's real ancestor, Base.greet.
+    const lookup = makeLookup(
+      {
+        'Middle.greet': [{ id: 9, file: 'other.ts', kind: 'method', line: 9 }],
+        'Base.greet': [{ id: 10, file: 'real.ts', kind: 'method', line: 10 }],
+        'Unrelated.greet': [{ id: 12, file: 'other.ts', kind: 'method', line: 12 }],
+      },
+      { Middle: { 'real.ts': [{ id: 11, file: 'real.ts', kind: 'class', line: 11 }] } },
+    );
+    const chaCtx = makeChaCtx(
+      // Bare-name map deliberately points the wrong way (as if other.ts's
+      // Middle -> Unrelated were recorded first project-wide).
+      { Child: 'Middle', Middle: 'Unrelated' },
+      { 'Middle|real.ts': 'Base' },
+    );
 
     const result = resolveThisDispatch('greet', 'Child.greet', 'this', chaCtx, lookup, 'real.ts');
     expect(result).toEqual([{ id: 10, file: 'real.ts', kind: 'method', line: 10 }]);

--- a/tests/unit/cha.test.ts
+++ b/tests/unit/cha.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Unit tests for resolveThisDispatch in cha.ts.
+ *
+ * Covers issue #2062: resolveThisDispatch resolved `this`/`super`/bare
+ * `super(...)` calls to a same-named class in a completely unrelated file
+ * whenever the caller's own same-named ancestor had no explicit definition
+ * of the dispatched method (e.g. an implicit default constructor). Two
+ * independent files each defining their own unrelated `Shape` class is the
+ * exact repro from the issue.
+ */
+import { describe, expect, it } from 'vitest';
+import type { CallNodeLookup } from '../../src/domain/graph/builder/call-resolver.js';
+import { type ChaContext, resolveThisDispatch } from '../../src/domain/graph/builder/cha.js';
+
+type Candidate = { id: number; file: string; kind: string; line: number };
+
+/** Build a CallNodeLookup backed by two maps: qualified-name → candidates
+ * (byName), and bare-name+file → candidates (byNameAndFile). */
+function makeLookup(
+  byNameMap: Record<string, Candidate[]>,
+  byNameAndFileMap: Record<string, Record<string, Candidate[]>> = {},
+): CallNodeLookup {
+  return {
+    byName(name) {
+      return byNameMap[name] ?? [];
+    },
+    byNameAndFile(name, file) {
+      return byNameAndFileMap[name]?.[file] ?? [];
+    },
+    isBarrel() {
+      return false;
+    },
+    resolveBarrel() {
+      return null;
+    },
+    nodeId() {
+      return undefined;
+    },
+  };
+}
+
+function makeChaCtx(parents: Record<string, string>): ChaContext {
+  return {
+    implementors: new Map(),
+    parents: new Map(Object.entries(parents)),
+    instantiatedTypes: new Set(),
+  };
+}
+
+describe('resolveThisDispatch — cross-file name collision (issue #2062)', () => {
+  it('does not resolve a bare super() to an unrelated same-named class in another file', () => {
+    // hierarchy.ts's own Shape has no explicit constructor (implicit
+    // default) — only super-dispatch.ts's unrelated Shape defines one.
+    const lookup = makeLookup(
+      { 'Shape.constructor': [{ id: 1, file: 'super-dispatch.ts', kind: 'method', line: 1 }] },
+      { Shape: { 'hierarchy.ts': [{ id: 2, file: 'hierarchy.ts', kind: 'class', line: 2 }] } },
+    );
+    const chaCtx = makeChaCtx({ Circle: 'Shape' });
+
+    const result = resolveThisDispatch(
+      'constructor',
+      'Circle.constructor',
+      'super',
+      chaCtx,
+      lookup,
+      'hierarchy.ts',
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('resolves a legitimate cross-file super call when the base class is not declared in the caller file at all', () => {
+    // dog.ts imports Animal from base.ts — Animal is genuinely absent from
+    // dog.ts, so the cross-file match is legitimate heritage, not a
+    // same-named collision.
+    const lookup = makeLookup(
+      { 'Animal.speak': [{ id: 5, file: 'base.ts', kind: 'method', line: 5 }] },
+      { Animal: {} },
+    );
+    const chaCtx = makeChaCtx({ Dog: 'Animal' });
+
+    const result = resolveThisDispatch('speak', 'Dog.speak', 'super', chaCtx, lookup, 'dog.ts');
+    expect(result).toEqual([{ id: 5, file: 'base.ts', kind: 'method', line: 5 }]);
+  });
+
+  it('still prefers the same-file candidate when both same-file and cross-file candidates exist', () => {
+    const sameFile = { id: 1, file: 'a.ts', kind: 'method', line: 1 };
+    const crossFile = { id: 2, file: 'b.ts', kind: 'method', line: 2 };
+    const lookup = makeLookup({ 'Foo.bar': [sameFile, crossFile] }, { Foo: {} });
+    const chaCtx = makeChaCtx({});
+
+    const result = resolveThisDispatch('bar', 'Foo.bar', 'this', chaCtx, lookup, 'a.ts');
+    expect(result).toEqual([sameFile]);
+  });
+
+  it('continues walking past a collided class to find a real grandparent match', () => {
+    // Base has an explicit `greet` method in the SAME file as the caller's
+    // own Middle class; a same-named, unrelated Middle class elsewhere has
+    // no bearing on this walk once Base (found in the caller's own file's
+    // hierarchy) supplies a real match.
+    const lookup = makeLookup(
+      {
+        'Middle.greet': [{ id: 9, file: 'unrelated.ts', kind: 'method', line: 9 }],
+        'Base.greet': [{ id: 10, file: 'real.ts', kind: 'method', line: 10 }],
+      },
+      { Middle: { 'real.ts': [{ id: 11, file: 'real.ts', kind: 'class', line: 11 }] } },
+    );
+    const chaCtx = makeChaCtx({ Child: 'Middle', Middle: 'Base' });
+
+    const result = resolveThisDispatch('greet', 'Child.greet', 'this', chaCtx, lookup, 'real.ts');
+    expect(result).toEqual([{ id: 10, file: 'real.ts', kind: 'method', line: 10 }]);
+  });
+
+  it('falls back to the unfiltered match when callerFile is not provided', () => {
+    // No file context available — cannot distinguish same-file collisions,
+    // so the pre-#2062 behavior (return whatever byName found) still applies.
+    const lookup = makeLookup({ 'Foo.bar': [{ id: 3, file: 'x.ts', kind: 'method', line: 3 }] });
+    const chaCtx = makeChaCtx({});
+
+    const result = resolveThisDispatch('bar', 'Foo.bar', 'this', chaCtx, lookup);
+    expect(result).toEqual([{ id: 3, file: 'x.ts', kind: 'method', line: 3 }]);
+  });
+
+  it('returns [] for a plain function callerName with no dot', () => {
+    const lookup = makeLookup({});
+    const chaCtx = makeChaCtx({});
+    expect(resolveThisDispatch('bar', 'plainFunction', 'this', chaCtx, lookup, 'x.ts')).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

`resolveThisDispatch`'s `this`/`super` hierarchy walk resolved to the wrong file whenever two independent files each declared a class with the same name and the caller's own same-named ancestor had no explicit definition of the dispatched method (e.g. an implicit default constructor). `chaCtx.parents` is keyed by bare class name, so the walk had no way to tell "genuine cross-file heritage" apart from "unrelated class that merely shares a name."

Fix: before accepting a cross-file match with no same-file candidate, check whether a class of the same name is *also* declared in the caller's own file. If so, that same-file class is the caller's real ancestor at this step — it simply doesn't define the method — so keep walking instead of accepting the unrelated cross-file match. When the class genuinely isn't declared anywhere in the caller's file, the cross-file match is legitimate heritage and is returned as before.

This is TS-only logic (`src/domain/graph/builder/cha.ts`) shared by both engines — the native path runs this same JS CHA post-pass on top of native edges, so no Rust mirror change is needed.

## Test plan
- [x] New `tests/unit/cha.test.ts` — 6 cases: the exact two-`Shape`-class repro, legitimate cross-file heritage, same-file preference (regression), multi-hop walk past a collided intermediate class, no-`callerFile` fallback, non-method callerName
- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] Full `npm test` — 274 files / 4453 passed, no regressions
- [x] Manually verified against the issue's exact repro on both native and WASM engines: 5 false edges eliminated, correct edges preserved

Closes #2062