### PR TITLE
fix(cycles): sort each Tarjan SCC's node array for deterministic order (#2064)

### DIFF
--- a/crates/codegraph-core/src/graph/algorithms/tarjan.rs
+++ b/crates/codegraph-core/src/graph/algorithms/tarjan.rs
@@ -81,6 +81,17 @@ fn strongconnect<'a>(
             }
         }
         if scc.len() > 1 {
+            // Canonicalize node order within the SCC before returning it. The
+            // adjacency map above is a HashMap, whose default hasher reseeds
+            // per construction — so the DFS entry point (and therefore the
+            // stack-pop order reconstructed here) is not stable across
+            // separate calls on the exact same logical graph, even though SCC
+            // *membership* always is. Sorting makes the returned node array a
+            // deterministic function of the SCC's member set alone, matching
+            // the JS/WASM fallback (see cycles.ts's tarjanFromEdges and
+            // graph/algorithms/tarjan.ts) so both engines agree byte-for-byte.
+            // See issues #2064, #2067, #2076.
+            scc.sort();
             state.sccs.push(scc);
         }
     }
@@ -166,5 +177,59 @@ mod tests {
         ];
         let cycles = detect_cycles(&edges);
         assert_eq!(cycles.len(), 2);
+    }
+
+    /// Regression test for issues #2064, #2067, #2076: the adjacency map is a
+    /// `HashMap`, whose default hasher reseeds per construction, so the DFS
+    /// entry point (and therefore the pre-sort stack-pop order) is not stable
+    /// across separate calls on the exact same logical graph. Each SCC's node
+    /// array must come back sorted regardless, so repeated calls agree
+    /// byte-for-byte and match the JS/WASM fallback's output.
+    #[test]
+    fn test_node_order_is_deterministic_across_repeated_calls() {
+        let edges = vec![
+            GraphEdge {
+                source: "src/math.js".to_string(),
+                target: "src/utils.js".to_string(),
+            },
+            GraphEdge {
+                source: "src/utils.js".to_string(),
+                target: "src/math.js".to_string(),
+            },
+        ];
+        let first = detect_cycles(&edges);
+        for _ in 0..25 {
+            assert_eq!(detect_cycles(&edges), first);
+        }
+        assert_eq!(
+            first,
+            vec![vec!["src/math.js".to_string(), "src/utils.js".to_string()]]
+        );
+    }
+
+    #[test]
+    fn test_scc_nodes_are_returned_sorted() {
+        let edges = vec![
+            GraphEdge {
+                source: "c".to_string(),
+                target: "a".to_string(),
+            },
+            GraphEdge {
+                source: "a".to_string(),
+                target: "b".to_string(),
+            },
+            GraphEdge {
+                source: "b".to_string(),
+                target: "c".to_string(),
+            },
+        ];
+        let cycles = detect_cycles(&edges);
+        assert_eq!(cycles.len(), 1);
+        let mut sorted = cycles[0].clone();
+        sorted.sort();
+        assert_eq!(
+            cycles[0], sorted,
+            "SCC node array must already be in sorted order"
+        );
     }
 }

--- a/src/domain/graph/cycles.ts
+++ b/src/domain/graph/cycles.ts
@@ -1,6 +1,7 @@
 import { getCallableNodes, getCallEdges, getFileNodesAll, getImportEdges } from '../../db/index.js';
 import { loadNative } from '../../infrastructure/native.js';
 import { isTestFile } from '../../infrastructure/test-filter.js';
+import { compareByCodePoint } from '../../shared/compare.js';
 import type { BetterSqlite3Database } from '../../types.js';
 
 type Edge = { source: string; target: string; speculative?: boolean };
@@ -227,7 +228,9 @@ function tarjanFromEdges(edges: Edge[]): string[][] {
         // but sorting keeps it byte-identical to the native engine's output
         // for the same logical graph regardless of either side's internal
         // traversal order. See issues #2064, #2067, #2076.
-        scc.sort();
+        // compareByCodePoint (not the default comparator) so supplementary-
+        // plane Unicode labels sort the same way Rust's UTF-8 byte order does.
+        scc.sort(compareByCodePoint);
         sccs.push(scc);
       }
     }

--- a/src/domain/graph/cycles.ts
+++ b/src/domain/graph/cycles.ts
@@ -219,7 +219,17 @@ function tarjanFromEdges(edges: Edge[]): string[][] {
         onStack.delete(w);
         scc.push(w);
       } while (w !== v);
-      if (scc.length > 1) sccs.push(scc);
+      if (scc.length > 1) {
+        // Canonicalize node order within the SCC before returning it — see
+        // the matching comment in crates/codegraph-core/src/graph/algorithms/
+        // tarjan.rs. `allNodes` here is a Set built from edge insertion order,
+        // so this JS path is already deterministic call-to-call in isolation,
+        // but sorting keeps it byte-identical to the native engine's output
+        // for the same logical graph regardless of either side's internal
+        // traversal order. See issues #2064, #2067, #2076.
+        scc.sort();
+        sccs.push(scc);
+      }
     }
   }
 

--- a/src/graph/algorithms/tarjan.ts
+++ b/src/graph/algorithms/tarjan.ts
@@ -1,3 +1,4 @@
+import { compareByCodePoint } from '../../shared/compare.js';
 import type { CodeGraph } from '../model.js';
 
 /**
@@ -51,7 +52,9 @@ export function tarjan(graph: CodeGraph): string[][] {
         // separate calls on the same logical graph. Sorting makes the
         // returned array a deterministic function of SCC membership alone,
         // so both engines agree byte-for-byte. See issues #2064, #2067, #2076.
-        scc.sort();
+        // compareByCodePoint (not the default comparator) so supplementary-
+        // plane Unicode labels sort the same way Rust's UTF-8 byte order does.
+        scc.sort(compareByCodePoint);
         sccs.push(scc);
       }
     }

--- a/src/graph/algorithms/tarjan.ts
+++ b/src/graph/algorithms/tarjan.ts
@@ -43,7 +43,17 @@ export function tarjan(graph: CodeGraph): string[][] {
         scc.push(w);
       } while (w !== v);
       // Only report non-trivial SCCs (length > 1 = a real cycle)
-      if (scc.length > 1) sccs.push(scc);
+      if (scc.length > 1) {
+        // Canonicalize node order within the SCC — mirrors the native Rust
+        // implementation (crates/codegraph-core/src/graph/algorithms/
+        // tarjan.rs), whose HashMap-backed adjacency map makes its DFS entry
+        // point (and therefore stack-pop order) non-deterministic across
+        // separate calls on the same logical graph. Sorting makes the
+        // returned array a deterministic function of SCC membership alone,
+        // so both engines agree byte-for-byte. See issues #2064, #2067, #2076.
+        scc.sort();
+        sccs.push(scc);
+      }
     }
   }
 

--- a/src/shared/compare.ts
+++ b/src/shared/compare.ts
@@ -1,0 +1,24 @@
+/**
+ * Compare two strings by Unicode code point, not UTF-16 code unit — the
+ * ordering `Array.prototype.sort()` uses with no comparator. For
+ * supplementary-plane characters (code point > U+FFFF, encoded in UTF-16 as
+ * a surrogate pair), code-unit order can diverge from code-point order,
+ * which in turn diverges from Rust's `str`/`String` ordering (UTF-8 byte
+ * order, which always matches code-point order). Use this wherever a JS/TS
+ * sort result must agree byte-for-byte with the native engine's Rust string
+ * sort on identical input (e.g. Tarjan SCC node arrays, issue #2292).
+ */
+export function compareByCodePoint(a: string, b: string): number {
+  const aIter = a[Symbol.iterator]();
+  const bIter = b[Symbol.iterator]();
+  while (true) {
+    const aNext = aIter.next();
+    const bNext = bIter.next();
+    if (aNext.done && bNext.done) return 0;
+    if (aNext.done) return -1;
+    if (bNext.done) return 1;
+    const aCp = aNext.value.codePointAt(0) as number;
+    const bCp = bNext.value.codePointAt(0) as number;
+    if (aCp !== bCp) return aCp - bCp;
+  }
+}

--- a/tests/graph/algorithms/tarjan.test.ts
+++ b/tests/graph/algorithms/tarjan.test.ts
@@ -74,4 +74,19 @@ describe('tarjan', () => {
       expect(tarjan(g)).toEqual(first);
     }
   });
+
+  it('sorts supplementary-plane Unicode node labels by code point, not UTF-16 code unit (#2292)', () => {
+    // U+FFFF (BMP) vs U+1F600 (supplementary plane, surrogate pair). By code
+    // point, U+FFFF < U+1F600 — matching Rust's UTF-8-byte-order string sort.
+    // The default Array.sort() comparator (UTF-16 code unit order) gets this
+    // pair backwards, which is exactly the cross-engine divergence Greptile
+    // flagged when this fix's `.sort()` calls had no comparator.
+    const bmp = '\uFFFF';
+    const supplementary = '\u{1F600}';
+    const g = new CodeGraph();
+    g.addEdge(supplementary, bmp);
+    g.addEdge(bmp, supplementary);
+    const sccs = tarjan(g);
+    expect(sccs).toEqual([[bmp, supplementary]]);
+  });
 });

--- a/tests/graph/algorithms/tarjan.test.ts
+++ b/tests/graph/algorithms/tarjan.test.ts
@@ -58,4 +58,20 @@ describe('tarjan', () => {
     g.addNode('a');
     expect(tarjan(g)).toHaveLength(0);
   });
+
+  it('returns byte-identical node order within a cycle across repeated calls (#2064, #2067, #2076)', () => {
+    // Regression coverage: SCC node order must be a deterministic function of
+    // the cycle's member set alone, not of incidental traversal order. Mirrors
+    // the same guarantee added to the native Rust implementation
+    // (crates/codegraph-core/src/graph/algorithms/tarjan.rs) and to the
+    // edge-list-based JS fallback (src/domain/graph/cycles.ts).
+    const g = new CodeGraph();
+    g.addEdge('a', 'b');
+    g.addEdge('b', 'c');
+    g.addEdge('c', 'a');
+    const first = tarjan(g);
+    for (let i = 0; i < 25; i++) {
+      expect(tarjan(g)).toEqual(first);
+    }
+  });
 });

--- a/tests/graph/cycles.test.ts
+++ b/tests/graph/cycles.test.ts
@@ -391,3 +391,60 @@ describe.skipIf(!hasNative)('Cycle detection: native vs JS parity', () => {
     db.close();
   });
 });
+
+// ── Deterministic node order within a cycle (#2064, #2067, #2076) ─────────
+
+describe('Cycle detection: node order is deterministic across repeated calls', () => {
+  // Regression coverage: Tarjan's SCC node order within a cycle must be a
+  // deterministic function of the cycle's member set alone. Before this fix,
+  // the native engine's HashMap-backed adjacency map reseeds its hasher per
+  // construction, so the DFS entry point — and therefore the stack-pop order
+  // reconstructed into each SCC's node array — varied across separate calls
+  // on the exact same logical graph. That is what made the "excludeSpeculative
+  // has no effect..." test above flaky: two back-to-back calls on identical
+  // input reported the same cycle with a different node order.
+  const twoNodeEdges = [
+    { source: 'src/math.js', target: 'src/utils.js' },
+    { source: 'src/utils.js', target: 'src/math.js' },
+  ];
+  const threeNodeEdges = [
+    { source: 'a.js', target: 'b.js' },
+    { source: 'b.js', target: 'c.js' },
+    { source: 'c.js', target: 'a.js' },
+  ];
+
+  it.each([
+    ['2-node cycle', twoNodeEdges],
+    ['3-node cycle', threeNodeEdges],
+  ])(
+    'findCyclesJS returns byte-identical node order across repeated calls (%s)',
+    (_label, edges) => {
+      const first = findCyclesJS(edges);
+      for (let i = 0; i < 25; i++) {
+        expect(findCyclesJS(edges)).toEqual(first);
+      }
+    },
+  );
+
+  it.skipIf(!hasNative).each([
+    ['2-node cycle', twoNodeEdges],
+    ['3-node cycle', threeNodeEdges],
+  ])(
+    'native detectCycles returns byte-identical node order across repeated calls (%s)',
+    (_label, edges) => {
+      const native = loadNative()!;
+      const first = native.detectCycles(edges);
+      for (let i = 0; i < 25; i++) {
+        expect(native.detectCycles(edges)).toEqual(first);
+      }
+    },
+  );
+
+  it.skipIf(!hasNative).each([
+    ['2-node cycle', twoNodeEdges],
+    ['3-node cycle', threeNodeEdges],
+  ])('native and JS engines agree on node order, not just membership (%s)', (_label, edges) => {
+    const native = loadNative()!;
+    expect(native.detectCycles(edges)).toEqual(findCyclesJS(edges));
+  });
+});

--- a/tests/graph/cycles.test.ts
+++ b/tests/graph/cycles.test.ts
@@ -349,6 +349,25 @@ describe.skipIf(!hasNative)('Cycle detection: native vs JS parity', () => {
     expect(sortCycles(nativeResult)).toEqual(sortCycles(jsResult));
   });
 
+  it('supplementary-plane Unicode node labels sort identically on both engines, without re-sorting (#2292)', () => {
+    // Unlike the tests above, this compares raw (not test-re-sorted) output —
+    // `sortCycles`'s own default-comparator re-sort would mask exactly the
+    // UTF-16-vs-code-point divergence this test exists to catch. U+FFFF (BMP)
+    // sorts before U+1F600 (supplementary plane) by code point, matching
+    // Rust's UTF-8-byte-order string sort; the default JS comparator gets
+    // this pair backwards.
+    const bmp = '\uFFFF';
+    const supplementary = '\u{1F600}';
+    const edges = [
+      { source: supplementary, target: bmp },
+      { source: bmp, target: supplementary },
+    ];
+    const jsResult = findCyclesJS(edges);
+    const nativeResult = native.detectCycles(edges);
+    expect(jsResult).toEqual([[bmp, supplementary]]);
+    expect(nativeResult).toEqual([[bmp, supplementary]]);
+  });
+
   it('speculative classification agrees between native and JS Tarjan backends', () => {
     // Same fixture as the "excludeSpeculative" unit test above, run through
     // findCycles() so both the full and filtered Tarjan passes exercise

--- a/tests/unit/compare.test.ts
+++ b/tests/unit/compare.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { compareByCodePoint } from '../../src/shared/compare.js';
+
+describe('compareByCodePoint', () => {
+  it('orders plain ASCII strings the same as the default comparator', () => {
+    const input = ['banana', 'apple', 'cherry'];
+    expect([...input].sort(compareByCodePoint)).toEqual([...input].sort());
+  });
+
+  it('orders a supplementary-plane character after a BMP character near the surrogate range', () => {
+    // U+FFFF (BMP, single UTF-16 code unit 0xFFFF) vs U+1F600 (supplementary
+    // plane, surrogate pair 0xD83D 0xDE00). By code point, U+FFFF (65535) <
+    // U+1F600 (128512). By UTF-16 code unit (the default Array.sort() comparator),
+    // the high surrogate 0xD83D (55357) < 0xFFFF, so the default comparator gets
+    // this backwards relative to code-point order — exactly the divergence from
+    // Rust's UTF-8-byte-order string sort that issue #2292's Greptile review
+    // flagged for the un-comparatored `.sort()` calls this fix replaces.
+    const bmp = '\uFFFF';
+    const supplementary = '\u{1F600}';
+    expect(compareByCodePoint(bmp, supplementary)).toBeLessThan(0);
+    expect(compareByCodePoint(supplementary, bmp)).toBeGreaterThan(0);
+    expect([supplementary, bmp].sort(compareByCodePoint)).toEqual([bmp, supplementary]);
+    // The default comparator gets this pair backwards — proof the two disagree.
+    expect([supplementary, bmp].sort()).toEqual([supplementary, bmp]);
+  });
+
+  it('returns 0 for identical strings, including identical supplementary-plane strings', () => {
+    expect(compareByCodePoint('abc', 'abc')).toBe(0);
+    expect(compareByCodePoint('\u{1F600}', '\u{1F600}')).toBe(0);
+  });
+
+  it('orders a prefix before a longer string that extends it', () => {
+    expect(compareByCodePoint('ab', 'abc')).toBeLessThan(0);
+    expect(compareByCodePoint('abc', 'ab')).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

`checkNoNewCycles`'s `excludeSpeculative has no effect on cycles formed
entirely of static import edges` test was flaky: two back-to-back Tarjan
runs on the exact same fixture reported the same cycle (`src/math.js` <->
`src/utils.js`) with a different node order.

Root cause: the native engine's Tarjan implementation
(`crates/codegraph-core/src/graph/algorithms/tarjan.rs`) builds its
adjacency map as a `HashMap<&str, Vec<&str>>`. Rust's default hasher
(`RandomState`) reseeds per `HashMap` construction, so the DFS entry point
selected from `graph.keys()` — and therefore the stack-pop order collected
into each returned SCC — is not stable across separate `detect_cycles`
calls on the exact same logical graph, even though SCC *membership* is
always correct.

This was previously worked around only in the one test that hit it
(sorting both sides before comparing), which papered over the symptom
without fixing the underlying non-determinism — the exact "don't document
a bug as expected behavior" anti-pattern this repo's CLAUDE.md calls out.
Three duplicate issues (#2064, #2067, #2076) independently reported the
same root cause, and #2076 explicitly names the fix that lands here: sort
each returned SCC's node array by convention at the runTarjan/detectCycles
boundary, in both engines, so callers never need to think about it.

## What changed

Sort each SCC's node array (canonical, `Vec::sort`/`Array.sort`) at the
point where it's collected — right where Tarjan closes out a component —
in all three Tarjan implementations this repo has:

- `crates/codegraph-core/src/graph/algorithms/tarjan.rs` — native
  `detect_cycles`, exposed via napi as `detectCycles`, the one consumers
  reach through `domain/graph/cycles.ts`'s `runTarjan()`.
- `src/domain/graph/cycles.ts`'s `tarjanFromEdges` — the WASM/JS fallback
  used when native isn't loaded, and mirrors of the above.
- `src/graph/algorithms/tarjan.ts`'s `tarjan()` — the `CodeGraph`-based
  implementation that the native module's own doc comment names as its
  mirror partner.

This makes each cycle's node order a deterministic function of its member
set alone, independent of adjacency-map/traversal iteration order, so
repeated calls agree byte-for-byte and both engines produce identical
output for the same input — the repo's standing "both engines must produce
identical results" invariant, applied to this primitive's own output.

Node order within a returned `Cycle.nodes` array was never a rigorously
guaranteed edge-by-edge traversal path for non-trivial (3+ node, branchy)
SCCs to begin with — Tarjan identifies SCC *membership*, not a Hamiltonian
cycle through it — so canonicalizing to alphabetical order doesn't regress
any tested or documented guarantee; it only replaces one arbitrary order
with a stable one.

## Verification

- lint: pass
- tests: pass (full suite, 274 files / 4461 tests, native engine active)
- Added regression tests asserting byte-identical node order across 25
  repeated calls, for both the native and JS/WASM paths, and cross-engine
  agreement (`tests/graph/cycles.test.ts`, `tests/graph/algorithms/tarjan.test.ts`).
- Added a Rust unit test asserting the sorted invariant directly plus a
  25-call determinism loop (`crates/codegraph-core/src/graph/algorithms/tarjan.rs`).
- Confirmed the fix empirically: called the rebuilt native `detectCycles`
  20x in a loop on the reported fixture — pre-fix this flips order
  intermittently (as reported), post-fix every call returns
  `["src/math.js","src/utils.js"]`.

Closes #2064
Closes #2067
Closes #2076