### PR TITLE
fix: mark destructured const export bindings as exported (#2070)

### DIFF
--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -2373,6 +2373,14 @@ fn handle_export_declaration(node: &Node, decl: &Node, source: &[u8], symbols: &
 /// marks `exported = 1` by matching (name, kind, file, line) against
 /// already-inserted definition rows, so a mismatched kind here silently
 /// no-ops the UPDATE instead of marking the symbol exported (#1728).
+///
+/// `export const { a, b } = value` / `export const [a, b] = value` have no
+/// `identifier` name field either — the name is an `object_pattern`/
+/// `array_pattern` — so they walk `collect_object_pattern_names`/
+/// `collect_array_pattern_names`, the same name-collection `handle_var_decl`
+/// uses to build the matching Definitions, and push one "constant" ExportInfo
+/// per bound name. Restricted to `const` for the same reason the Definition
+/// side is (#2070).
 fn collect_exported_var_declarations(
     node: &Node,
     decl: &Node,
@@ -2390,20 +2398,34 @@ fn collect_exported_var_declarations(
         let name_n = declarator.child_by_field_name("name");
         let value_n = declarator.child_by_field_name("value");
         let (Some(name_n), Some(value_n)) = (name_n, value_n) else { continue };
-        if name_n.kind() != "identifier" { continue; }
-        let vt = value_n.kind();
-        if vt == "arrow_function" || vt == "function_expression" || vt == "function" || vt == "generator_function" {
-            symbols.exports.push(ExportInfo {
-                name: node_text(&name_n, source).to_string(),
-                kind: "function".to_string(),
-                line,
-            });
-        } else if is_const {
-            symbols.exports.push(ExportInfo {
-                name: node_text(&name_n, source).to_string(),
-                kind: "constant".to_string(),
-                line,
-            });
+        match name_n.kind() {
+            "identifier" => {
+                let vt = value_n.kind();
+                if vt == "arrow_function" || vt == "function_expression" || vt == "function" || vt == "generator_function" {
+                    symbols.exports.push(ExportInfo {
+                        name: node_text(&name_n, source).to_string(),
+                        kind: "function".to_string(),
+                        line,
+                    });
+                } else if is_const {
+                    symbols.exports.push(ExportInfo {
+                        name: node_text(&name_n, source).to_string(),
+                        kind: "constant".to_string(),
+                        line,
+                    });
+                }
+            }
+            "object_pattern" if is_const => {
+                for name in collect_object_pattern_names(&name_n, source, &mut Vec::new()) {
+                    symbols.exports.push(ExportInfo { name, kind: "constant".to_string(), line });
+                }
+            }
+            "array_pattern" if is_const => {
+                for name in collect_array_pattern_names(&name_n, source) {
+                    symbols.exports.push(ExportInfo { name, kind: "constant".to_string(), line });
+                }
+            }
+            _ => {}
         }
     }
 }
@@ -6643,6 +6665,49 @@ mod tests {
         let names: Vec<&str> = s.definitions.iter().map(|d| d.name.as_str()).collect();
         assert!(names.contains(&"handleToken"));
         assert!(names.contains(&"checkPermissions"));
+    }
+
+    #[test]
+    fn marks_exported_destructured_object_pattern_bindings_as_exports() {
+        // Regression guard for #2070: collect_exported_var_declarations used
+        // to skip any declarator whose name field wasn't a plain identifier,
+        // so `export const { a, b } = value` produced Definitions for a/b
+        // (see extracts_exported_destructured_const_bindings above) but no
+        // matching ExportInfo at all — the exported=1 UPDATE never fired.
+        let s = parse_js("export const { handleToken, checkPermissions } = initAuth(config);");
+        for name in ["handleToken", "checkPermissions"] {
+            assert!(
+                s.exports.iter().any(|e| e.name == name && e.kind == "constant"),
+                "{name} should be listed as an exported constant; got: {:?}",
+                s.exports
+            );
+        }
+    }
+
+    #[test]
+    fn marks_exported_destructured_array_pattern_bindings_as_exports() {
+        let s = parse_js("export const [a, b] = computePair();");
+        for name in ["a", "b"] {
+            assert!(
+                s.exports.iter().any(|e| e.name == name && e.kind == "constant"),
+                "{name} should be listed as an exported constant; got: {:?}",
+                s.exports
+            );
+        }
+    }
+
+    #[test]
+    fn does_not_export_let_var_destructured_bindings() {
+        // Mirrors skips_let_var_destructured_bindings below — the Export side
+        // must stay restricted to const too, never diverging from which
+        // bindings get a Definition in the first place (#2070).
+        let s = parse_js("export let { userId, email } = parseRequest(req);");
+        assert!(!s.exports.iter().any(|e| e.name == "userId"));
+        assert!(!s.exports.iter().any(|e| e.name == "email"));
+
+        let s2 = parse_js("export var [foo, bar] = getConfig();");
+        assert!(!s2.exports.iter().any(|e| e.name == "foo"));
+        assert!(!s2.exports.iter().any(|e| e.name == "bar"));
     }
 
     #[test]

--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -4368,7 +4368,30 @@ fn collect_array_pattern_names(pattern: &Node, source: &[u8]) -> Vec<String> {
                 }
             }
             "rest_pattern" | "rest_element" => {
-                extract_rest_identifier(&child, source, &mut names);
+                // `[...rest]` binds a plain identifier; `[...[a, b]]` nests
+                // another array pattern whose own bound names must each be
+                // collected too — plain `extract_rest_identifier` only ever
+                // extracts a single identifier, which left nested-rest names
+                // (created as Definitions by extract_array_pattern_bindings's
+                // own rest_pattern branch below) with no matching Export,
+                // diverging from the Definition side for e.g.
+                // `export const [x, ...[a, b]] = value` (#2070). Mirrors
+                // extract_array_pattern_bindings's rest_pattern handling
+                // instead of the plain-identifier-only extract_rest_identifier.
+                for j in 0..child.child_count() {
+                    let Some(inner) = child.child(j) else { continue };
+                    match inner.kind() {
+                        "identifier" => {
+                            names.push(node_text(&inner, source).to_string());
+                            break;
+                        }
+                        "array_pattern" => {
+                            names.extend(collect_array_pattern_names(&inner, source));
+                            break;
+                        }
+                        _ => {}
+                    }
+                }
             }
             _ => {}
         }
@@ -6688,6 +6711,25 @@ mod tests {
     fn marks_exported_destructured_array_pattern_bindings_as_exports() {
         let s = parse_js("export const [a, b] = computePair();");
         for name in ["a", "b"] {
+            assert!(
+                s.exports.iter().any(|e| e.name == name && e.kind == "constant"),
+                "{name} should be listed as an exported constant; got: {:?}",
+                s.exports
+            );
+        }
+    }
+
+    #[test]
+    fn marks_exported_nested_array_pattern_rest_bindings_as_exports() {
+        // Greptile review (#2070): collect_array_pattern_names's rest_pattern
+        // branch used to call the plain-identifier-only extract_rest_identifier,
+        // so a rest element that itself nests another array pattern
+        // (`...[a, b]`) got Definitions (see
+        // extracts_nested_array_pattern_rest_bindings_as_own_definitions) but no
+        // matching Export at all, diverging from the Definition side and from
+        // the TS engine (which already recursed here).
+        let s = parse_js("export const [x, ...[a, b]] = computeList();");
+        for name in ["x", "a", "b"] {
             assert!(
                 s.exports.iter().any(|e| e.name == name && e.kind == "constant"),
                 "{name} should be listed as an exported constant; got: {:?}",

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -215,6 +215,14 @@ const EXPORT_DECL_KIND: Record<string, string> = {
  * Definition-building one: the exported=1 UPDATE it feeds matches DB rows by
  * (name, kind, file, line), so a mismatched kind silently no-ops instead of
  * marking the symbol exported (#1728).
+ *
+ * `export const { a, b } = value` / `export const [a, b] = value` have no
+ * `identifier` name field either — the name is an `object_pattern`/
+ * `array_pattern` — so they walk `collectObjectPatternNames`/
+ * `collectArrayPatternNames`, the exact same name-collection `handleVariable-
+ * Declarator`'s object_pattern/array_pattern branches use to build the
+ * matching Definitions, and push one 'constant' Export per bound name.
+ * Restricted to `const` for the same reason the Definition side is (#2070).
  */
 function collectExportedDeclarations(
   decl: TreeSitterNode,
@@ -234,17 +242,27 @@ function collectExportedDeclarations(
     if (declarator?.type !== 'variable_declarator') continue;
     const nameN = declarator.childForFieldName('name');
     const valueN = declarator.childForFieldName('value');
-    if (nameN?.type !== 'identifier' || !valueN) continue;
-    const valType = valueN.type;
-    if (
-      valType === 'arrow_function' ||
-      valType === 'function_expression' ||
-      valType === 'function' ||
-      valType === 'generator_function'
-    ) {
-      exps.push({ name: nameN.text, kind: 'function', line: exportLine });
-    } else if (isConst) {
-      exps.push({ name: nameN.text, kind: 'constant', line: exportLine });
+    if (!nameN || !valueN) continue;
+    if (nameN.type === 'identifier') {
+      const valType = valueN.type;
+      if (
+        valType === 'arrow_function' ||
+        valType === 'function_expression' ||
+        valType === 'function' ||
+        valType === 'generator_function'
+      ) {
+        exps.push({ name: nameN.text, kind: 'function', line: exportLine });
+      } else if (isConst) {
+        exps.push({ name: nameN.text, kind: 'constant', line: exportLine });
+      }
+    } else if (isConst && nameN.type === 'object_pattern') {
+      for (const name of collectObjectPatternNames(nameN)) {
+        exps.push({ name, kind: 'constant', line: exportLine });
+      }
+    } else if (isConst && nameN.type === 'array_pattern') {
+      for (const name of collectArrayPatternNames(nameN)) {
+        exps.push({ name, kind: 'constant', line: exportLine });
+      }
     }
   }
 }
@@ -1590,6 +1608,24 @@ function extractDestructuredBindings(
   endLine: number,
   definitions: Definition[],
 ): void {
+  for (const name of collectObjectPatternNames(pattern)) {
+    definitions.push({ name, kind: 'constant', line, endLine });
+  }
+}
+
+/**
+ * Collect the bound local names from an object-destructuring pattern
+ * (`{ a, b: renamed, c = default, ...rest }`), in declaration order — the
+ * name-only core of `extractDestructuredBindings`'s per-property Definition
+ * building, shared with `collectExportedDeclarations` (#2070) so `export
+ * const { a, b } = value` walks exactly the same cases when deciding which
+ * names are exported that `extractDestructuredBindings` walks when creating
+ * their Definition rows. Any drift between the two would silently leave a
+ * genuinely exported binding unmarked — the exported=1 UPDATE matches DB rows
+ * by (name, kind, file, line), see #1728.
+ */
+function collectObjectPatternNames(pattern: TreeSitterNode): string[] {
+  const names: string[] = [];
   for (let i = 0; i < pattern.childCount; i++) {
     const child = pattern.child(i);
     if (!child) continue;
@@ -1598,7 +1634,7 @@ function extractDestructuredBindings(
       child.type === 'shorthand_property_identifier'
     ) {
       // { handleToken } — shorthand binding
-      definitions.push({ name: child.text, kind: 'constant', line, endLine });
+      names.push(child.text);
     } else if (child.type === 'pair_pattern' || child.type === 'pair') {
       // { original: renamed } — renamed binding, use the local alias
       const value = child.childForFieldName('value');
@@ -1606,7 +1642,7 @@ function extractDestructuredBindings(
         value &&
         (value.type === 'identifier' || value.type === 'shorthand_property_identifier_pattern')
       ) {
-        definitions.push({ name: value.text, kind: 'constant', line, endLine });
+        names.push(value.text);
       } else if (value?.type === 'assignment_pattern') {
         // { original: renamed = defaultValue } — the local binding is the
         // assignment_pattern's left-hand identifier (Greptile follow-up to
@@ -1614,7 +1650,7 @@ function extractDestructuredBindings(
         // extractDynamicImportNames since #1824).
         const left = value.childForFieldName('left');
         if (left?.type === 'identifier') {
-          definitions.push({ name: left.text, kind: 'constant', line, endLine });
+          names.push(left.text);
         }
       }
     } else if (child.type === 'object_assignment_pattern') {
@@ -1623,15 +1659,16 @@ function extractDestructuredBindings(
       // to extractDynamicImportNames).
       const left = child.childForFieldName('left');
       if (left?.type === 'shorthand_property_identifier_pattern' || left?.type === 'identifier') {
-        definitions.push({ name: left.text, kind: 'constant', line, endLine });
+        names.push(left.text);
       }
     } else if (child.type === 'rest_pattern' || child.type === 'rest_element') {
       // { a, ...rest } — the rest binding was silently dropped entirely
       // before (#2051, mirrors #1920).
       const inner = extractRestPatternIdentifier(child);
-      if (inner) definitions.push({ name: inner, kind: 'constant', line, endLine });
+      if (inner) names.push(inner);
     }
   }
+  return names;
 }
 
 /**
@@ -1650,17 +1687,31 @@ function extractArrayPatternBindings(
   endLine: number,
   definitions: Definition[],
 ): void {
+  for (const name of collectArrayPatternNames(pattern)) {
+    definitions.push({ name, kind: 'constant', line, endLine });
+  }
+}
+
+/**
+ * Collect the bound local names from an array-destructuring pattern
+ * (`[a, b = default, ...rest]`), in declaration order — the name-only core
+ * of `extractArrayPatternBindings`'s per-element Definition building, shared
+ * with `collectExportedDeclarations` (#2070) for the same reason
+ * `collectObjectPatternNames` is.
+ */
+function collectArrayPatternNames(pattern: TreeSitterNode): string[] {
+  const names: string[] = [];
   for (let i = 0; i < pattern.childCount; i++) {
     const child = pattern.child(i);
     if (!child) continue;
     if (child.type === 'identifier') {
       // [a, b] — plain positional binding
-      definitions.push({ name: child.text, kind: 'constant', line, endLine });
+      names.push(child.text);
     } else if (child.type === 'assignment_pattern') {
       // [a = defaultValue] — the bound name is the left-hand identifier
       const left = child.childForFieldName('left');
       if (left && left.type === 'identifier') {
-        definitions.push({ name: left.text, kind: 'constant', line, endLine });
+        names.push(left.text);
       }
     } else if (child.type === 'rest_pattern' || child.type === 'rest_element') {
       // `rest_pattern`/`rest_element` has no named fields at all (verified against
@@ -1675,17 +1726,18 @@ function extractArrayPatternBindings(
         const inner = child.child(j);
         if (!inner) continue;
         if (inner.type === 'identifier') {
-          definitions.push({ name: inner.text, kind: 'constant', line, endLine });
+          names.push(inner.text);
           break;
         } else if (inner.type === 'array_pattern') {
           // [...[a, b]] — recurse so the nested pattern's own bound
-          // identifiers each get their own Definition.
-          extractArrayPatternBindings(inner, line, endLine, definitions);
+          // identifiers each get their own name.
+          names.push(...collectArrayPatternNames(inner));
           break;
         }
       }
     }
   }
+  return names;
 }
 
 function handleVariableDecl(node: TreeSitterNode, ctx: ExtractorOutput): void {

--- a/tests/parsers/javascript.test.ts
+++ b/tests/parsers/javascript.test.ts
@@ -1462,6 +1462,44 @@ function runDemo(reporter: Reporter, users: string[]): void {
       );
     });
 
+    it('marks exported destructured object-pattern bindings as exports (#2070)', () => {
+      // Regression guard for #2070: collectExportedDeclarations used to skip
+      // any declarator whose name field wasn't a plain identifier, so
+      // `export const { a, b } = value` produced Definitions for a/b (above)
+      // but no matching Export entries at all — the exported=1 UPDATE never
+      // fired, leaving genuinely exported destructured bindings unmarked.
+      const symbols = parseJS(`export const { handleToken, checkPermissions } = initAuth(config);`);
+      expect(symbols.exports).toContainEqual(
+        expect.objectContaining({ name: 'handleToken', kind: 'constant', line: 1 }),
+      );
+      expect(symbols.exports).toContainEqual(
+        expect.objectContaining({ name: 'checkPermissions', kind: 'constant', line: 1 }),
+      );
+    });
+
+    it('marks exported destructured array-pattern bindings as exports (#2070)', () => {
+      const symbols = parseJS(`export const [a, b] = computePair();`);
+      expect(symbols.exports).toContainEqual(
+        expect.objectContaining({ name: 'a', kind: 'constant', line: 1 }),
+      );
+      expect(symbols.exports).toContainEqual(
+        expect.objectContaining({ name: 'b', kind: 'constant', line: 1 }),
+      );
+    });
+
+    it('does not export let/var destructured bindings (#2070)', () => {
+      // Mirrors "does not extract definitions from let/var destructured
+      // bindings" above — the Export side must stay restricted to const too,
+      // never diverging from which bindings get a Definition in the first place.
+      const letSymbols = parseJS(`export let { userId, email } = parseRequest(req);`);
+      expect(letSymbols.exports.some((e) => e.name === 'userId')).toBe(false);
+      expect(letSymbols.exports.some((e) => e.name === 'email')).toBe(false);
+
+      const varSymbols = parseJS(`export var [foo, bar] = getConfig();`);
+      expect(varSymbols.exports.some((e) => e.name === 'foo')).toBe(false);
+      expect(varSymbols.exports.some((e) => e.name === 'bar')).toBe(false);
+    });
+
     it('extracts non-renamed destructured const bindings with kind constant (#1773)', () => {
       // Regression guard for issue #1773: plain (non-renamed) destructured
       // bindings from a non-call RHS (e.g. `workerData`) must not default to

--- a/tests/parsers/javascript.test.ts
+++ b/tests/parsers/javascript.test.ts
@@ -1487,6 +1487,22 @@ function runDemo(reporter: Reporter, users: string[]): void {
       );
     });
 
+    it('marks exported nested array-pattern rest bindings as exports (#2070)', () => {
+      // Greptile review on the PR for #2070: a rest element that itself nests
+      // another array pattern (`...[a, b]`) must have its recursive names
+      // reach the Export side too, not just the Definition side (see
+      // "extracts nested array_pattern rest bindings as own definitions"
+      // elsewhere in this file) — the exported=1 UPDATE matches by
+      // (name, kind, file, line), so a name present only in one side never
+      // gets marked exported.
+      const symbols = parseJS(`export const [x, ...[a, b]] = computeList();`);
+      for (const name of ['x', 'a', 'b']) {
+        expect(symbols.exports).toContainEqual(
+          expect.objectContaining({ name, kind: 'constant', line: 1 }),
+        );
+      }
+    });
+
     it('does not export let/var destructured bindings (#2070)', () => {
       // Mirrors "does not extract definitions from let/var destructured
       // bindings" above — the Export side must stay restricted to const too,


### PR DESCRIPTION
## Summary
`export const { a, b } = value` and `export const [a, b] = value` never marked `a`/`b` as exported on either engine — `collectExportedDeclarations` (TS) and `collect_exported_var_declarations` (Rust) both skipped any declarator whose name field wasn't a plain `identifier`, so an `object_pattern`/`array_pattern` name field caused the declarator to be dropped entirely before pushing any `Export`. The matching `Definition` rows for `a`/`b` were created correctly by the sibling destructuring logic (`extractDestructuredBindings`/`extract_destructured_bindings`), so `codegraph exports`/dead-export analysis showed them as definitions but never as exports.

Both engines now walk the `object_pattern`/`array_pattern` name field the exact same way the Definition-building side already does, and push one `'constant'` `Export` per bound name:
- TS: extracted `collectObjectPatternNames`/`collectArrayPatternNames` name-only helpers out of `extractDestructuredBindings`/`extractArrayPatternBindings` (used by both, so they can never drift), and call them from `collectExportedDeclarations`.
- Rust: reused the existing `collect_object_pattern_names`/`collect_array_pattern_names` helpers (already shared elsewhere) from `collect_exported_var_declarations`.

Restricted to `const`, matching the Definition side's own let/var restriction — `export let { a } = ...` still does not produce a Definition, so it must not produce an Export either.

## Verification
- lint: pass (`npm run lint`)
- tests: pass (`npm test` — 275 files / 4470 tests; `cargo test -p codegraph-core --lib` — 780 tests)
- added regression tests on both engines for object-pattern exports, array-pattern exports, and the let/var non-export case
- `codegraph diff-impact --staged -T` confirms the change is contained to the destructuring/export helper family (5 functions, 14 callers, 1 file)

Closes #2070