### PR TITLE
fix: preserve barrel-renamed declared name for CJS require() imports (#2071)

### DIFF
--- a/src/domain/graph/builder/call-resolver.ts
+++ b/src/domain/graph/builder/call-resolver.ts
@@ -603,6 +603,13 @@ export function resolveCallTargets(
  *    or no same-file node exists at all, fall back to global candidates filtered
  *    by RECEIVER_KINDS.  This preserves the pre-#1539 behaviour for cases where
  *    an imported name appears as kind='function' in the importer file.
+ *
+ * `importedNames` is only ever probed with `.has()` here — the classification
+ * only needs key presence, never the value — so callers may pass either the
+ * plain ESM `importedNames` map (`string` values) or the richer per-name
+ * `BarrelExportResolution` map `buildImportArtifactNames` builds for CJS
+ * `require()` bindings (#2071). The value type is intentionally untyped
+ * (`unknown`) to reflect that.
  */
 export function resolveReceiverEdge(
   lookup: CallNodeLookup,
@@ -611,7 +618,7 @@ export function resolveReceiverEdge(
   relPath: string,
   typeMap: Map<string, unknown>,
   seenCallEdges: Set<string>,
-  importedNames: ReadonlyMap<string, string>,
+  importedNames: ReadonlyMap<string, unknown>,
 ): { callerId: number; receiverId: number; confidence: number } | null {
   const typeEntry = typeMap.get(call.receiver);
   const typeName = typeEntry

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -62,7 +62,13 @@ import {
   runChaPostPass,
 } from '../helpers.js';
 import { importNamePairs } from '../import-utils.js';
-import { getResolved, isBarrelFile, resolveBarrelExportCached } from './resolve-imports.js';
+import type { BarrelExportResolution } from './resolve-imports.js';
+import {
+  getResolved,
+  isBarrelFile,
+  resolveBarrelExportCached,
+  traceBarrelTarget,
+} from './resolve-imports.js';
 
 // ── Local types ──────────────────────────────────────────────────────────
 
@@ -1009,6 +1015,7 @@ function buildCallEdgesJS(
     // import shadows — does NOT affect call-target resolution or DB edges (#1661).
     const importArtifactNames = buildImportArtifactNames(
       importedNames,
+      importedOriginalNames,
       symbols,
       ctx,
       relPath,
@@ -1063,18 +1070,12 @@ function buildImportedNamesMap(
   const importedOriginalNames = new Map<string, string>();
   // Phase 8.4: trace through barrel files so that symbol names map to their
   // actual definition file, not the re-exporting barrel. Mirrors the tracing
-  // already done in buildImportedNamesForNative (the native path).
-  const traceBarrel = (
-    resolvedPath: string,
-    originalName: string,
-  ): { file: string; name: string } => {
-    if (!isBarrelFile(ctx, resolvedPath)) return { file: resolvedPath, name: originalName };
-    const resolved = resolveBarrelExportCached(ctx, resolvedPath, originalName);
-    return resolved ?? { file: resolvedPath, name: originalName };
-  };
+  // already done in buildImportedNamesForNative (the native path), and
+  // shares its implementation with buildImportArtifactNames's CJS require
+  // path via traceBarrelTarget (#2071).
   const addImportNames = (imp: (typeof symbols.imports)[number], resolvedPath: string) => {
     for (const { local, original } of importNamePairs(imp)) {
-      const { file, name } = traceBarrel(resolvedPath, original);
+      const { file, name } = traceBarrelTarget(ctx, resolvedPath, original);
       importedNames.set(local, file);
       if (name !== local) importedOriginalNames.set(local, name);
     }
@@ -1102,26 +1103,37 @@ function buildImportedNamesMap(
  * bindings (`const { X } = require('./path')`). Used exclusively by resolveReceiverEdge
  * to classify same-file function-kind nodes as import artifacts vs. local definitions.
  * Does NOT affect call resolution or DB edge creation (#1661).
+ *
+ * Values carry both the resolved target file and the name actually declared
+ * there, post barrel-tracing (`BarrelExportResolution`, mirroring
+ * `buildImportedNamesMap`'s `importedNames`/`importedOriginalNames` pair) —
+ * a CJS require() binding that flows through a renamed barrel re-export
+ * (`export { real as friendly } from './x'`) traces via the same
+ * `traceBarrelTarget` helper as the ESM path, so it resolves to the correct
+ * declared name instead of the barrel's external rename (#2071). No current
+ * caller reads the `name` field (only `.has()`, for artifact classification),
+ * but keeping it correct here means a future consumer that needs the
+ * declared name — not just the target file — gets the right value instead of
+ * silently inheriting this asymmetry.
  */
 function buildImportArtifactNames(
   importedNames: Map<string, string>,
+  importedOriginalNames: ReadonlyMap<string, string>,
   symbols: ExtractorOutput,
   ctx: PipelineContext,
   relPath: string,
   rootDir: string,
-): ReadonlyMap<string, string> {
-  if (!symbols.cjsRequireBindings?.length) return importedNames;
-  const combined = new Map(importedNames);
-  const traceBarrel = (resolvedPath: string, cleanName: string): string => {
-    if (!isBarrelFile(ctx, resolvedPath)) return resolvedPath;
-    const resolved = resolveBarrelExportCached(ctx, resolvedPath, cleanName);
-    return resolved?.file ?? resolvedPath;
-  };
+): ReadonlyMap<string, BarrelExportResolution> {
+  const combined = new Map<string, BarrelExportResolution>();
+  for (const [name, file] of importedNames) {
+    combined.set(name, { file, name: importedOriginalNames.get(name) ?? name });
+  }
+  if (!symbols.cjsRequireBindings?.length) return combined;
   for (const binding of symbols.cjsRequireBindings) {
     const resolvedPath = getResolved(ctx, path.join(rootDir, relPath), binding.source);
     for (const name of binding.names) {
       if (!combined.has(name)) {
-        combined.set(name, traceBarrel(resolvedPath, name));
+        combined.set(name, traceBarrelTarget(ctx, resolvedPath, name));
       }
     }
   }
@@ -1690,7 +1702,7 @@ function buildFileCallEdges(
   invokedPropertyNames: ReadonlySet<string>,
   ptsMap?: PointsToMap | null,
   chaCtx?: ChaContext,
-  importArtifactNames?: ReadonlyMap<string, string>,
+  importArtifactNames?: ReadonlyMap<string, BarrelExportResolution>,
   importedOriginalNames?: ReadonlyMap<string, string>,
 ): void {
   // Tracks edges that were inserted by the pts fallback (edgeKey → allEdgeRows index).

--- a/src/domain/graph/builder/stages/resolve-imports.ts
+++ b/src/domain/graph/builder/stages/resolve-imports.ts
@@ -206,6 +206,32 @@ export function resolveBarrelExportCached(
 }
 
 /**
+ * Resolve `symbolName` through a possible barrel hop at `resolvedPath` to
+ * the file that actually declares it and the name declared there. Falls
+ * back to `resolvedPath`/`symbolName` unchanged when `resolvedPath` isn't a
+ * barrel, or when barrel resolution finds nothing.
+ *
+ * Single source of truth for this fallback (#2071). Before this helper
+ * existed, `buildImportedNamesMap` (ESM imports) and `buildImportArtifactNames`
+ * (CJS `require()` destructuring) in build-edges.ts each maintained their own
+ * copy of this exact pattern under the same local name (`traceBarrel`), and
+ * the copies silently diverged: the CJS copy kept only `resolved.file`,
+ * dropping `resolved.name` (the declared name after a barrel-rename
+ * translation, e.g. `export { real as friendly } from './x'`), while the
+ * ESM copy correctly threaded both through. Both call sites now share this
+ * implementation so they can never drift apart again.
+ */
+export function traceBarrelTarget(
+  ctx: PipelineContext,
+  resolvedPath: string,
+  symbolName: string,
+): BarrelExportResolution {
+  if (!isBarrelFile(ctx, resolvedPath)) return { file: resolvedPath, name: symbolName };
+  const resolved = resolveBarrelExportCached(ctx, resolvedPath, symbolName);
+  return resolved ?? { file: resolvedPath, name: symbolName };
+}
+
+/**
  * Persist barrel re-export rename pairs (`export { X as Y } from …`) from
  * `ctx.reexportMap` into the `reexport_renames` table (#1967).
  *

--- a/tests/unit/trace-barrel-target.test.ts
+++ b/tests/unit/trace-barrel-target.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for traceBarrelTarget (#2071).
+ *
+ * `traceBarrelTarget` is the single shared implementation of "resolve a name
+ * through a possible barrel hop to the file and declared name that actually
+ * own it" — extracted so `buildImportedNamesMap` (ESM imports) and
+ * `buildImportArtifactNames` (CJS `require()` destructuring), both in
+ * build-edges.ts, can no longer maintain divergent private copies.
+ *
+ * Before this fix, `buildImportArtifactNames`'s own copy of this logic kept
+ * only the resolved file and silently dropped the resolved *name*, so a CJS
+ * `require()` binding traced through a barrel that renames on re-export
+ * (`export { realName as friendlyName } from './underlying'`) would report
+ * the barrel's external alias instead of the name actually declared in the
+ * underlying file — asymmetric with the ESM import path, which always got
+ * this right. No current consumer reads that value (only key presence via
+ * `.has()`), which is exactly why the divergence went unnoticed; these tests
+ * pin the shared helper's behavior directly so it can't regress silently
+ * again, for either caller.
+ */
+import { describe, expect, it } from 'vitest';
+import { PipelineContext } from '../../src/domain/graph/builder/context.js';
+import { traceBarrelTarget } from '../../src/domain/graph/builder/stages/resolve-imports.js';
+import type { ExtractorOutput, Import } from '../../src/types.js';
+
+function makeCtx(): PipelineContext {
+  const ctx = new PipelineContext();
+  ctx.fileSymbols = new Map();
+  ctx.reexportMap = new Map();
+  return ctx;
+}
+
+function stubSymbols(overrides: Partial<ExtractorOutput> = {}): ExtractorOutput {
+  return {
+    definitions: [],
+    calls: [],
+    imports: [],
+    classes: [],
+    exports: [],
+    typeMap: new Map(),
+    ...overrides,
+  };
+}
+
+function reexportImport(source: string, names: string[]): Import {
+  return { source, names, line: 1, reexport: true };
+}
+
+describe('traceBarrelTarget (#2071)', () => {
+  it('returns the path/name unchanged when the target is not a barrel file', () => {
+    const ctx = makeCtx();
+    // Not registered in fileSymbols at all — isBarrelFile treats that as "not a barrel".
+    expect(traceBarrelTarget(ctx, 'plain.js', 'x')).toEqual({ file: 'plain.js', name: 'x' });
+  });
+
+  it('traces through a barrel re-export with no rename', () => {
+    const ctx = makeCtx();
+    ctx.fileSymbols.set(
+      'underlying.js',
+      stubSymbols({ definitions: [{ name: 'realName', kind: 'function', line: 1 }] }),
+    );
+    ctx.fileSymbols.set(
+      'barrel.js',
+      stubSymbols({ imports: [reexportImport('underlying.js', ['realName'])] }),
+    );
+    ctx.reexportMap.set('barrel.js', [
+      { source: 'underlying.js', names: ['realName'], wildcardReexport: false, renames: [] },
+    ]);
+
+    expect(traceBarrelTarget(ctx, 'barrel.js', 'realName')).toEqual({
+      file: 'underlying.js',
+      name: 'realName',
+    });
+  });
+
+  it('traces through a barrel-renamed re-export to the name actually declared in the underlying file (#2071)', () => {
+    const ctx = makeCtx();
+    ctx.fileSymbols.set(
+      'underlying.js',
+      stubSymbols({ definitions: [{ name: 'realName', kind: 'function', line: 1 }] }),
+    );
+    ctx.fileSymbols.set(
+      'barrel.js',
+      stubSymbols({ imports: [reexportImport('underlying.js', ['realName'])] }),
+    );
+    // `export { realName as friendlyName } from './underlying'`.
+    ctx.reexportMap.set('barrel.js', [
+      {
+        source: 'underlying.js',
+        names: ['realName'],
+        wildcardReexport: false,
+        renames: [{ local: 'friendlyName', imported: 'realName' }],
+      },
+    ]);
+
+    // A CJS consumer does `const { friendlyName } = require('./barrel')` — the
+    // requested name is the barrel's external alias. The resolved name must be
+    // the underlying declaration ('realName'), never the alias itself.
+    expect(traceBarrelTarget(ctx, 'barrel.js', 'friendlyName')).toEqual({
+      file: 'underlying.js',
+      name: 'realName',
+    });
+  });
+
+  it('falls back to the barrel file/name unchanged when barrel resolution finds nothing', () => {
+    const ctx = makeCtx();
+    ctx.fileSymbols.set(
+      'barrel.js',
+      stubSymbols({ imports: [reexportImport('missing.js', ['other'])] }),
+    );
+    // No matching reexportMap entry for 'barrel.js'.
+
+    expect(traceBarrelTarget(ctx, 'barrel.js', 'nonexistent')).toEqual({
+      file: 'barrel.js',
+      name: 'nonexistent',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
`buildImportArtifactNames`'s local barrel-tracing helper (`traceBarrel`) resolved through barrel chains via `resolveBarrelExportCached` but kept only `resolved.file`, discarding `resolved.name` — the declared name after a barrel-rename translation (`export { realName as friendlyName } from './underlying'`). This was asymmetric with the ESM import path's own `traceBarrel` in `buildImportedNamesMap` (same file), which correctly threads `.name` through.

No consumer currently reads the dropped value — `resolveReceiverEdge`, the sole consumer of `importArtifactNames`, only calls `.has()` for import-artifact classification, never `.get()` — so this was latent, not an observed bug. But if a future consumer needs the correct declared name (mirroring how the ESM path already works), the CJS-through-a-renamed-barrel case would have silently carried the wrong name with no test coverage catching it.

## Fix
Extracted a single shared `traceBarrelTarget(ctx, resolvedPath, name)` helper into `resolve-imports.ts` — the module that already owns `isBarrelFile`/`resolveBarrelExportCached`/`BarrelExportResolution`. Both `buildImportedNamesMap` (ESM) and `buildImportArtifactNames` (CJS `require()`) now call this one implementation instead of maintaining separate private copies, so they can no longer silently diverge the way they did here.

`buildImportArtifactNames`'s return type widened from `Map<string,string>` (name -> file) to `ReadonlyMap<string, BarrelExportResolution>` (name -> {file, name}), matching the fix sketch from the issue. `resolveReceiverEdge`'s `importedNames` parameter type widened to `ReadonlyMap<string, unknown>` since it only ever checks `.has()` and is fed either the plain ESM map or the richer artifact map.

No native-engine changes — the issue confirms there's no native equivalent of `buildImportArtifactNames` to diverge from.

## Verification
- lint: pass
- tests: pass (full suite: 276 files, 4475 tests)
- typecheck: pass
- Added `tests/unit/trace-barrel-target.test.ts` unit-testing `traceBarrelTarget` directly (the previously-buggy logic), including the exact barrel-rename scenario from the issue. Since the fixed value has no current consumer, this is the only way to make the bug observable — no integration/DB-level assertion can distinguish fixed from buggy today.
- `codegraph diff-impact --staged` impact matches expectations exactly: the touched functions and their transitive callers, nothing else.

Filed #2295 for a related but out-of-scope cleanup: three other inline barrel-trace call sites in build-edges.ts duplicate the same fallback pattern but are already correct, so consolidating them onto `traceBarrelTarget` too was left for a follow-up.

Closes #2071