### PR TITLE
fix: recognize .mts/.cts as TypeScript in both engines (#2073)

### DIFF
--- a/.claude/hooks/update-graph.sh
+++ b/.claude/hooks/update-graph.sh
@@ -46,7 +46,7 @@ if [ -f "$GENERATED_EXT_LIST" ]; then
   grep -qxF "$EXT" "$GENERATED_EXT_LIST" || exit 0
 else
   case "$EXT" in
-    .R|.bash|.c|.cc|.cjs|.clj|.cljc|.cljs|.cpp|.cs|.cu|.cuh|.cxx|.dart|.erl|.ex|.exs|.fs|.fsi|.fsx|.gemspec|.gleam|.go|.groovy|.gvy|.h|.hcl|.hpp|.hrl|.hs|.java|.jl|.js|.jsx|.kt|.kts|.lua|.m|.mjs|.ml|.mli|.php|.phtml|.py|.pyi|.r|.rake|.rb|.rs|.scala|.sh|.sol|.sv|.swift|.tf|.ts|.tsx|.v|.zig)
+    .R|.bash|.c|.cc|.cjs|.clj|.cljc|.cljs|.cpp|.cs|.cts|.cu|.cuh|.cxx|.dart|.erl|.ex|.exs|.fs|.fsi|.fsx|.gemspec|.gleam|.go|.groovy|.gvy|.h|.hcl|.hpp|.hrl|.hs|.java|.jl|.js|.jsx|.kt|.kts|.lua|.m|.mjs|.ml|.mli|.mts|.php|.phtml|.py|.pyi|.r|.rake|.rb|.rs|.scala|.sh|.sol|.sv|.swift|.tf|.ts|.tsx|.v|.zig)
       ;;
     *)
       exit 0

--- a/README.md
+++ b/README.md
@@ -501,7 +501,7 @@ A user-level config file at `~/.config/codegraph/config.json` (XDG) or `~/.codeg
 | Language | Extensions | Imports | Exports | Call Sites | Heritage¹ | Type Inference² | Dataflow |
 |---|---|:---:|:---:|:---:|:---:|:---:|:---:|
 | ![JavaScript](https://img.shields.io/badge/-JavaScript-F7DF1E?style=flat-square&logo=javascript&logoColor=black) | `.js`, `.jsx`, `.mjs`, `.cjs` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| ![TypeScript](https://img.shields.io/badge/-TypeScript-3178C6?style=flat-square&logo=typescript&logoColor=white) | `.ts`, `.tsx` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| ![TypeScript](https://img.shields.io/badge/-TypeScript-3178C6?style=flat-square&logo=typescript&logoColor=white) | `.ts`, `.tsx`, `.mts`, `.cts` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | ![Python](https://img.shields.io/badge/-Python-3776AB?style=flat-square&logo=python&logoColor=white) | `.py`, `.pyi` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | ![Go](https://img.shields.io/badge/-Go-00ADD8?style=flat-square&logo=go&logoColor=white) | `.go` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | ![Rust](https://img.shields.io/badge/-Rust-000000?style=flat-square&logo=rust&logoColor=white) | `.rs` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |

--- a/crates/codegraph-core/src/domain/graph/builder/stages/collect_files.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/collect_files.rs
@@ -47,11 +47,11 @@ const DEFAULT_IGNORE_DIRS: &[&str] = &[
 ///   vs MATLAB keywords like `function`/`classdef`).
 /// - `.h` (C vs Objective-C) is unambiguous here — routed to C parser.
 const SUPPORTED_EXTENSIONS: &[&str] = &[
-    "js", "jsx", "mjs", "cjs", "ts", "tsx", "d.ts", "py", "pyi", "go", "rs", "java", "cs", "rb",
-    "rake", "gemspec", "php", "phtml", "tf", "hcl", "c", "h", "cpp", "cc", "cxx", "hpp", "cu",
-    "cuh", "kt", "kts", "swift", "scala", "sh", "bash", "ex", "exs", "lua", "dart", "zig", "hs",
-    "ml", "mli", "fs", "fsx", "fsi", "m", "jl", "gleam", "clj", "cljs", "cljc", "erl", "hrl",
-    "groovy", "gvy", "sol",
+    "js", "jsx", "mjs", "cjs", "ts", "tsx", "mts", "cts", "d.ts", "py", "pyi", "go", "rs", "java",
+    "cs", "rb", "rake", "gemspec", "php", "phtml", "tf", "hcl", "c", "h", "cpp", "cc", "cxx",
+    "hpp", "cu", "cuh", "kt", "kts", "swift", "scala", "sh", "bash", "ex", "exs", "lua", "dart",
+    "zig", "hs", "ml", "mli", "fs", "fsx", "fsi", "m", "jl", "gleam", "clj", "cljs", "cljc", "erl",
+    "hrl", "groovy", "gvy", "sol",
     // R is case-sensitive: both `.r` and `.R` are conventional.
     "r", "R", "v", "sv",
 ];
@@ -407,6 +407,36 @@ mod tests {
 
         assert!(names.contains("main.ts"));
         assert!(names.contains("util.js"));
+        assert!(!names.contains("readme.md"));
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn collect_finds_mts_and_cts_files() {
+        // .mts/.cts are TypeScript's ESM/CJS module extensions — they must be
+        // walked exactly like .ts, not silently skipped (#2073).
+        let tmp = std::env::temp_dir().join("codegraph_collect_mts_cts_test");
+        let _ = fs::remove_dir_all(&tmp);
+        let src = tmp.join("src");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(src.join("esm.mts"), "export const x = 1;").unwrap();
+        fs::write(src.join("cjs.cts"), "export const y = 2;").unwrap();
+        fs::write(src.join("readme.md"), "# Hello").unwrap();
+
+        let result = collect_files(tmp.to_str().unwrap(), &[], &[], &[]);
+        let names: HashSet<String> = result
+            .files
+            .iter()
+            .filter_map(|f| {
+                Path::new(f)
+                    .file_name()
+                    .map(|n| n.to_str().unwrap().to_string())
+            })
+            .collect();
+
+        assert!(names.contains("esm.mts"));
+        assert!(names.contains("cjs.cts"));
         assert!(!names.contains("readme.md"));
 
         let _ = fs::remove_dir_all(&tmp);

--- a/crates/codegraph-core/src/domain/parser.rs
+++ b/crates/codegraph-core/src/domain/parser.rs
@@ -95,7 +95,11 @@ impl LanguageKind {
         if file_path.ends_with(".tsx") {
             return Some(Self::Tsx);
         }
-        if file_path.ends_with(".d.ts") || ext == "ts" {
+        // .mts/.cts are TypeScript's ESM/CJS module extensions — same
+        // LanguageKind as .ts (TS forbids JSX in both, so neither routes to
+        // Tsx). Mirrors the 'typescript' entry in LANGUAGE_REGISTRY
+        // (src/domain/parser.ts) (#2073).
+        if file_path.ends_with(".d.ts") || ext == "ts" || ext == "mts" || ext == "cts" {
             return Some(Self::TypeScript);
         }
         match ext {
@@ -332,6 +336,36 @@ mod tests {
             EXPECTED_LEN,
             "A LanguageKind variant is in the exhaustive match but missing from \
              `all()` (or vice-versa). Update `all()` and bump EXPECTED_LEN.",
+        );
+    }
+
+    /// .mts/.cts are TypeScript's ESM/CJS module extensions — they must
+    /// resolve to `LanguageKind::TypeScript` (same grammar as `.ts`, since TS
+    /// forbids JSX in both), not fall through to `None` and be dropped by
+    /// the file collector (#2073).
+    #[test]
+    fn from_extension_recognizes_mts_and_cts() {
+        assert_eq!(
+            LanguageKind::from_extension("src/module.mts"),
+            Some(LanguageKind::TypeScript)
+        );
+        assert_eq!(
+            LanguageKind::from_extension("src/module.cts"),
+            Some(LanguageKind::TypeScript)
+        );
+        // Declaration-file variants must also resolve, mirroring `.d.ts`.
+        assert_eq!(
+            LanguageKind::from_extension("src/module.d.mts"),
+            Some(LanguageKind::TypeScript)
+        );
+        assert_eq!(
+            LanguageKind::from_extension("src/module.d.cts"),
+            Some(LanguageKind::TypeScript)
+        );
+        // Must not be misrouted to the JSX-capable Tsx grammar.
+        assert_ne!(
+            LanguageKind::from_extension("src/module.mts"),
+            Some(LanguageKind::Tsx)
         );
     }
 }

--- a/src/domain/parser.ts
+++ b/src/domain/parser.ts
@@ -499,6 +499,8 @@ export const NATIVE_SUPPORTED_EXTENSIONS: ReadonlySet<string> = new Set([
   '.cjs',
   '.ts',
   '.tsx',
+  '.mts',
+  '.cts',
   '.py',
   '.pyi',
   '.tf',
@@ -823,7 +825,14 @@ export const LANGUAGE_REGISTRY: LanguageRegistryEntry[] = [
   },
   {
     id: 'typescript',
-    extensions: ['.ts'],
+    // .mts/.cts are TypeScript's ESM/CJS module extensions — same grammar as
+    // .ts (tree-sitter-typescript, not tsx), since TS forbids JSX in both
+    // (#2073). Downstream extension-aware logic (TYPESCRIPT_EXTENSIONS,
+    // NATIVE_SUPPORTED_EXTENSIONS, resolver/strategy.ts,
+    // resolver/ts-resolver.ts, native-orchestrator.ts) already anticipates
+    // these extensions; this registry entry was the missing gate that kept
+    // .mts/.cts files from ever being walked or parsed.
+    extensions: ['.ts', '.mts', '.cts'],
     grammarFile: 'tree-sitter-typescript.wasm',
     extractor: extractSymbols,
     required: true,

--- a/src/domain/wasm-worker-entry.ts
+++ b/src/domain/wasm-worker-entry.ts
@@ -159,7 +159,9 @@ const LANGUAGE_REGISTRY: LanguageRegistryEntry[] = [
   },
   {
     id: 'typescript',
-    extensions: ['.ts'],
+    // .mts/.cts are TypeScript's ESM/CJS module extensions — mirrors the
+    // 'typescript' entry in domain/parser.ts's LANGUAGE_REGISTRY (#2073).
+    extensions: ['.ts', '.mts', '.cts'],
     grammarFile: 'tree-sitter-typescript.wasm',
     extractor: extractSymbols,
     required: true,

--- a/tests/builder/collect-files.test.ts
+++ b/tests/builder/collect-files.test.ts
@@ -16,6 +16,8 @@ beforeAll(() => {
   fs.mkdirSync(path.join(tmpDir, 'src'));
   fs.writeFileSync(path.join(tmpDir, 'src', 'a.js'), 'export const a = 1;');
   fs.writeFileSync(path.join(tmpDir, 'src', 'b.ts'), 'export const b = 2;');
+  fs.writeFileSync(path.join(tmpDir, 'src', 'c.mts'), 'export const c = 3;');
+  fs.writeFileSync(path.join(tmpDir, 'src', 'd.cts'), 'export const d = 4;');
   fs.writeFileSync(path.join(tmpDir, 'src', 'style.css'), 'body {}');
 });
 
@@ -32,10 +34,14 @@ describe('collectFiles stage', () => {
 
     await collectFiles(ctx);
 
-    expect(ctx.allFiles.length).toBe(2); // a.js + b.ts, not style.css
+    expect(ctx.allFiles.length).toBe(4); // a.js + b.ts + c.mts + d.cts, not style.css
     const basenames = ctx.allFiles.map((f) => path.basename(f));
     expect(basenames).toContain('a.js');
     expect(basenames).toContain('b.ts');
+    // .mts/.cts are TypeScript's ESM/CJS module extensions — must be walked
+    // like any other TypeScript file, not silently skipped (#2073).
+    expect(basenames).toContain('c.mts');
+    expect(basenames).toContain('d.cts');
     expect(basenames).not.toContain('style.css');
     expect(ctx.discoveredDirs).toBeInstanceOf(Set);
     expect(ctx.discoveredDirs.size).toBeGreaterThan(0);

--- a/tests/unit/constants.test.ts
+++ b/tests/unit/constants.test.ts
@@ -20,6 +20,8 @@ describe('EXTENSIONS', () => {
       '.jsx',
       '.ts',
       '.tsx',
+      '.mts',
+      '.cts',
       '.mjs',
       '.cjs',
       '.tf',

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -9,6 +9,8 @@ import {
   computeDeclarationHashes,
   isWasmAvailable,
   LANGUAGE_REGISTRY,
+  NATIVE_SUPPORTED_EXTENSIONS,
+  SUPPORTED_EXTENSIONS,
 } from '../../src/domain/parser.js';
 import type { Definition } from '../../src/types.js';
 
@@ -63,6 +65,32 @@ describe('isWasmAvailable', () => {
     for (const call of spy.mock.calls) {
       expect(call[0]).toContain('grammars');
     }
+  });
+});
+
+// ─── .mts/.cts recognition (#2073) ──────────────────────────────────────
+
+describe('.mts/.cts TypeScript extension recognition', () => {
+  it('LANGUAGE_REGISTRY routes .mts and .cts to the typescript entry', () => {
+    const tsEntry = LANGUAGE_REGISTRY.find((e) => e.id === 'typescript');
+    expect(tsEntry).toBeDefined();
+    expect(tsEntry!.extensions).toContain('.mts');
+    expect(tsEntry!.extensions).toContain('.cts');
+    // .mts/.cts forbid JSX just like .ts — they must not be routed to the
+    // tsx grammar entry.
+    const tsxEntry = LANGUAGE_REGISTRY.find((e) => e.id === 'tsx');
+    expect(tsxEntry!.extensions).not.toContain('.mts');
+    expect(tsxEntry!.extensions).not.toContain('.cts');
+  });
+
+  it('SUPPORTED_EXTENSIONS (derived from LANGUAGE_REGISTRY) includes .mts and .cts', () => {
+    expect(SUPPORTED_EXTENSIONS.has('.mts')).toBe(true);
+    expect(SUPPORTED_EXTENSIONS.has('.cts')).toBe(true);
+  });
+
+  it('NATIVE_SUPPORTED_EXTENSIONS includes .mts and .cts', () => {
+    expect(NATIVE_SUPPORTED_EXTENSIONS.has('.mts')).toBe(true);
+    expect(NATIVE_SUPPORTED_EXTENSIONS.has('.cts')).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

`.mts` (TypeScript ESM) and `.cts` (TypeScript CJS) files were never recognized by either engine — silently skipped at file-collection time and never entered the graph at all, despite being increasingly common in real-world dual ESM/CJS TypeScript packages.

Root cause: `LANGUAGE_REGISTRY`'s `typescript` entry in `src/domain/parser.ts` only listed `.ts`, and the mirrored Rust `LanguageKind::from_extension` in `crates/codegraph-core/src/domain/parser.rs` had no `mts`/`cts` match arm. Since `EXTENSIONS` (TS/WASM) and the native file collector's gate both derive from these two single sources of truth, adding the extensions there is the complete fix — most downstream extension-aware logic (`TYPESCRIPT_EXTENSIONS`, `resolver/strategy.ts`'s `MODULE_SCOPED_BARE_CALL_EXTENSIONS`/`CONSTRUCTOR_LOCAL_NAME_BY_EXTENSION`, `resolver/ts-resolver.ts`, `native-orchestrator.ts`'s `JS_TS_EXTS`, and their Rust mirrors in `build_edges.rs`/`resolve.rs`) already anticipated `.mts`/`.cts` — this PR closes the one remaining gate that kept them from ever reaching that logic.

## Changes

- `src/domain/parser.ts`: add `.mts`, `.cts` to the `typescript` `LANGUAGE_REGISTRY` entry and to `NATIVE_SUPPORTED_EXTENSIONS`. `.mts`/`.cts` route to the same grammar as `.ts` (not `tsx`), since TypeScript forbids JSX in both.
- `src/domain/wasm-worker-entry.ts`: same change to its worker-thread-safe duplicate `LANGUAGE_REGISTRY` copy (kept separate from `parser.ts`'s to avoid sharing process-wide parser caches across worker threads).
- `crates/codegraph-core/src/domain/parser.rs`: add `mts`/`cts` to `LanguageKind::from_extension`'s TypeScript branch.
- `crates/codegraph-core/src/domain/graph/builder/stages/collect_files.rs`: add `mts`/`cts` to `SUPPORTED_EXTENSIONS` for consistency with `from_extension`.
- `.claude/hooks/update-graph.sh`: sync its hand-maintained fallback extension allowlist — caught by its own pre-existing drift-guard test (`tests/unit/hook-extensions.test.ts`).
- `README.md`: update the language-support table's TypeScript extensions.
- Tests: `tests/unit/parser.test.ts` (LANGUAGE_REGISTRY/SUPPORTED_EXTENSIONS/NATIVE_SUPPORTED_EXTENSIONS assertions), `tests/unit/constants.test.ts`, `tests/builder/collect-files.test.ts` (file-collection walk test), plus Rust unit tests in `parser.rs` (`from_extension_recognizes_mts_and_cts`, including `.d.mts`/`.d.cts`) and `collect_files.rs` (`collect_finds_mts_and_cts_files`).

## Verification

Manually built a 3-file fixture (`.mts`/`.cts`) with both `--engine native` and `--engine wasm`: both now walk and parse all 3 files identically (9 nodes, 11 edges in each), confirming dual-engine parity.

- lint: pass
- tests: pass (JS/TS: 276 files, 4478 tests; Rust: 787 tests — includes the pre-existing `NATIVE_SUPPORTED_EXTENSIONS`↔Rust and `LANGUAGE_REGISTRY`↔`NATIVE_SUPPORTED_EXTENSIONS` drift guards, both of which pass with the new extensions in sync)

## Note: follow-up filed

While verifying this fix end-to-end, I found that import resolution doesn't remap `.mjs`/`.cjs` specifiers to `.mts`/`.cts` sources (the ESM/CJS equivalent of the existing `.js`→`.ts`/`.tsx` remap in `remapJsToTs`/`probe_js_to_ts_remap`), which is TypeScript's required specifier convention for `NodeNext`/`Node16` resolution of these files. That's a distinct bug from file recognition (this PR) — filed as #2299 rather than expanding this PR's scope.

Closes #2073