### PR TITLE
fix(hooks): surface build failures in update-graph.sh instead of silently no-oping (#2074)

### DIFF
--- a/.claude/hooks/update-graph.sh
+++ b/.claude/hooks/update-graph.sh
@@ -92,12 +92,28 @@ else
   fi
 fi
 
-# Run the build
+# Run the build. Stderr is captured (not discarded) so a failure has a
+# diagnosable trail instead of silently no-oping — on a genuinely fresh
+# checkout `dist/cli.js` doesn't exist yet (before the first `npm run
+# build`), and even once it exists the native better-sqlite3 binding may
+# not be installed yet either. Both used to fail identically silent
+# (stderr -> /dev/null, exit code swallowed by `|| true`), giving a
+# contributor no signal that graph auto-rebuild isn't active (issue #2074).
 BUILD_OK=0
+BUILD_ERR=""
 if command -v codegraph &>/dev/null; then
-  codegraph build "$PROJECT_DIR" -d "$DB_PATH" $BUILD_FLAGS 2>/dev/null && BUILD_OK=1 || true
+  BUILD_ERR=$(codegraph build "$PROJECT_DIR" -d "$DB_PATH" $BUILD_FLAGS 2>&1 1>/dev/null) && BUILD_OK=1 || true
 else
-  node "${CLAUDE_PROJECT_DIR:-$PROJECT_DIR}/dist/cli.js" build "$PROJECT_DIR" -d "$DB_PATH" $BUILD_FLAGS 2>/dev/null && BUILD_OK=1 || true
+  CLI_ENTRY="${CLAUDE_PROJECT_DIR:-$PROJECT_DIR}/dist/cli.js"
+  if [ ! -f "$CLI_ENTRY" ]; then
+    echo "[codegraph] $CLI_ENTRY not found — run 'npm install' (or 'npm run build') to enable graph auto-rebuild" >&2
+    exit 0
+  fi
+  BUILD_ERR=$(node "$CLI_ENTRY" build "$PROJECT_DIR" -d "$DB_PATH" $BUILD_FLAGS 2>&1 1>/dev/null) && BUILD_OK=1 || true
+fi
+
+if [ "$BUILD_OK" -eq 0 ]; then
+  echo "[codegraph] graph rebuild failed — run 'npm run doctor' to diagnose (first line: $(printf '%s\n' "$BUILD_ERR" | head -1))" >&2
 fi
 
 # Update marker only if we did a full rebuild AND it succeeded

--- a/tests/unit/hook-fallback-build-path.test.ts
+++ b/tests/unit/hook-fallback-build-path.test.ts
@@ -26,6 +26,7 @@ describe('update-graph.sh hook fallback build path', () => {
   });
 
   it("invokes package.json's bin.codegraph entry point in the fallback branch", () => {
-    expect(script).toContain(`/${cliEntry}" build`);
+    expect(script).toContain(`/${cliEntry}"`);
+    expect(script).toContain('"$CLI_ENTRY" build');
   });
 });

--- a/tests/unit/hook-update-graph-diagnostics.test.ts
+++ b/tests/unit/hook-update-graph-diagnostics.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Regression guard for issue #2074: .claude/hooks/update-graph.sh's fallback
+ * build path (used when the `codegraph` binary isn't on PATH) invoked
+ * `node <project>/dist/cli.js build ...` with stderr redirected to
+ * /dev/null and its exit code swallowed by `|| true`. On a genuinely fresh
+ * checkout — before `npm run build` has ever produced dist/cli.js — the
+ * hook silently no-oped with no visible error, identical in symptom to the
+ * bug #1980 fixed (graph never rebuilds, contributor gets no feedback).
+ *
+ * The fix checks for dist/cli.js's existence up front (emitting a one-line
+ * hint pointing at `npm install` / `npm run build`) and, for any other
+ * build failure (e.g. the native better-sqlite3 binding not yet
+ * installed), surfaces the captured stderr instead of discarding it —
+ * while still always exiting 0 (informational only, never blocks).
+ */
+import { execFileSync, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const HOOK_PATH = path.join(REPO_ROOT, '.claude', 'hooks', 'update-graph.sh');
+
+function initRepo(dir: string): void {
+  fs.mkdirSync(dir, { recursive: true });
+  execFileSync('git', ['init', '-q'], { cwd: dir });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+  execFileSync('git', ['config', 'user.name', 'Test'], { cwd: dir });
+  // The hook exits early unless the graph DB already exists (project has
+  // been built/run at least once) — an empty file is enough to pass that guard.
+  fs.mkdirSync(path.join(dir, '.codegraph'), { recursive: true });
+  fs.writeFileSync(path.join(dir, '.codegraph', 'graph.db'), '');
+}
+
+/**
+ * A minimal PATH that provides node/git/bash (plus core POSIX utilities via
+ * /usr/bin and /bin) but deliberately excludes any directory that might
+ * also contain a globally installed `codegraph` binary, so the hook is
+ * forced down its dist/cli.js fallback branch exactly like a contributor
+ * who has never run `npm install -g @optave/codegraph`.
+ */
+function buildRestrictedPath(binDir: string): string {
+  for (const bin of ['node', 'git', 'bash']) {
+    const link = path.join(binDir, bin);
+    if (!fs.existsSync(link)) {
+      const real = execFileSync('which', [bin]).toString().trim();
+      fs.symlinkSync(real, link);
+    }
+  }
+  return `${binDir}:/usr/bin:/bin`;
+}
+
+function runHook(
+  filePath: string,
+  cwd: string,
+  restrictedBinDir: string,
+): { stdout: string; stderr: string; status: number | null } {
+  const toolInput = JSON.stringify({ tool_input: { file_path: filePath } });
+  const result = spawnSync('bash', [HOOK_PATH], {
+    cwd,
+    input: toolInput,
+    env: { PATH: buildRestrictedPath(restrictedBinDir) },
+    encoding: 'utf8',
+  });
+  return { stdout: result.stdout ?? '', stderr: result.stderr ?? '', status: result.status };
+}
+
+describe('update-graph.sh surfaces a diagnostic instead of silently no-oping', () => {
+  let tmpRoot: string;
+  let binDir: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'update-graph-test-')));
+    binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'update-graph-bin-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+    fs.rmSync(binDir, { recursive: true, force: true });
+  });
+
+  it('hints at npm install/build when dist/cli.js does not exist yet, and still exits 0', () => {
+    const repo = path.join(tmpRoot, 'fresh-checkout');
+    initRepo(repo);
+    // No dist/ directory at all — the state of a genuinely fresh clone
+    // before `npm run build` has ever produced dist/cli.js.
+    const targetFile = path.join(repo, 'src', 'thing.ts');
+    fs.mkdirSync(path.dirname(targetFile), { recursive: true });
+    fs.writeFileSync(targetFile, '// content\n');
+
+    const { stderr, status } = runHook(targetFile, repo, binDir);
+
+    expect(status).toBe(0);
+    expect(stderr).toMatch(/dist\/cli\.js not found/);
+    expect(stderr).toMatch(/npm install|npm run build/);
+  });
+
+  it('surfaces the captured build error (not /dev/null) when dist/cli.js exists but fails', () => {
+    const repo = path.join(tmpRoot, 'broken-build');
+    initRepo(repo);
+    // dist/cli.js exists but is not a working CLI (simulates, e.g., a
+    // missing native better-sqlite3 binding blowing up at require-time).
+    fs.mkdirSync(path.join(repo, 'dist'), { recursive: true });
+    fs.writeFileSync(
+      path.join(repo, 'dist', 'cli.js'),
+      "process.stderr.write('simulated native binding load failure\\n'); process.exit(1);\n",
+    );
+    const targetFile = path.join(repo, 'src', 'thing.ts');
+    fs.mkdirSync(path.dirname(targetFile), { recursive: true });
+    fs.writeFileSync(targetFile, '// content\n');
+
+    const { stderr, status } = runHook(targetFile, repo, binDir);
+
+    expect(status).toBe(0);
+    expect(stderr).toMatch(/graph rebuild failed/);
+    expect(stderr).toMatch(/npm run doctor/);
+    expect(stderr).toContain('simulated native binding load failure');
+  });
+});

--- a/tests/unit/hook-update-graph-diagnostics.test.ts
+++ b/tests/unit/hook-update-graph-diagnostics.test.ts
@@ -68,55 +68,66 @@ function runHook(
   return { stdout: result.stdout ?? '', stderr: result.stderr ?? '', status: result.status };
 }
 
-describe('update-graph.sh surfaces a diagnostic instead of silently no-oping', () => {
-  let tmpRoot: string;
-  let binDir: string;
+// This suite proves the diagnostic fires by hiding a `codegraph` binary from
+// PATH and forcing the hook's fallback branch — a mechanism that only makes
+// sense against a POSIX-style, colon-delimited PATH and `/usr/bin`+`/bin`.
+// Skipped on win32 (CI's windows-2022 job runs `npm test` too): `which`,
+// `fs.symlinkSync`, and absolute POSIX paths are not reliably available
+// there (symlink creation needs elevated privileges without Developer Mode,
+// and there is no `/usr/bin`), so this harness would fail before ever
+// reaching its assertions rather than exercising the hook logic under test.
+describe.skipIf(process.platform === 'win32')(
+  'update-graph.sh surfaces a diagnostic instead of silently no-oping',
+  () => {
+    let tmpRoot: string;
+    let binDir: string;
 
-  beforeEach(() => {
-    tmpRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'update-graph-test-')));
-    binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'update-graph-bin-'));
-  });
+    beforeEach(() => {
+      tmpRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'update-graph-test-')));
+      binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'update-graph-bin-'));
+    });
 
-  afterEach(() => {
-    fs.rmSync(tmpRoot, { recursive: true, force: true });
-    fs.rmSync(binDir, { recursive: true, force: true });
-  });
+    afterEach(() => {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+      fs.rmSync(binDir, { recursive: true, force: true });
+    });
 
-  it('hints at npm install/build when dist/cli.js does not exist yet, and still exits 0', () => {
-    const repo = path.join(tmpRoot, 'fresh-checkout');
-    initRepo(repo);
-    // No dist/ directory at all — the state of a genuinely fresh clone
-    // before `npm run build` has ever produced dist/cli.js.
-    const targetFile = path.join(repo, 'src', 'thing.ts');
-    fs.mkdirSync(path.dirname(targetFile), { recursive: true });
-    fs.writeFileSync(targetFile, '// content\n');
+    it('hints at npm install/build when dist/cli.js does not exist yet, and still exits 0', () => {
+      const repo = path.join(tmpRoot, 'fresh-checkout');
+      initRepo(repo);
+      // No dist/ directory at all — the state of a genuinely fresh clone
+      // before `npm run build` has ever produced dist/cli.js.
+      const targetFile = path.join(repo, 'src', 'thing.ts');
+      fs.mkdirSync(path.dirname(targetFile), { recursive: true });
+      fs.writeFileSync(targetFile, '// content\n');
 
-    const { stderr, status } = runHook(targetFile, repo, binDir);
+      const { stderr, status } = runHook(targetFile, repo, binDir);
 
-    expect(status).toBe(0);
-    expect(stderr).toMatch(/dist\/cli\.js not found/);
-    expect(stderr).toMatch(/npm install|npm run build/);
-  });
+      expect(status).toBe(0);
+      expect(stderr).toMatch(/dist\/cli\.js not found/);
+      expect(stderr).toMatch(/npm install|npm run build/);
+    });
 
-  it('surfaces the captured build error (not /dev/null) when dist/cli.js exists but fails', () => {
-    const repo = path.join(tmpRoot, 'broken-build');
-    initRepo(repo);
-    // dist/cli.js exists but is not a working CLI (simulates, e.g., a
-    // missing native better-sqlite3 binding blowing up at require-time).
-    fs.mkdirSync(path.join(repo, 'dist'), { recursive: true });
-    fs.writeFileSync(
-      path.join(repo, 'dist', 'cli.js'),
-      "process.stderr.write('simulated native binding load failure\\n'); process.exit(1);\n",
-    );
-    const targetFile = path.join(repo, 'src', 'thing.ts');
-    fs.mkdirSync(path.dirname(targetFile), { recursive: true });
-    fs.writeFileSync(targetFile, '// content\n');
+    it('surfaces the captured build error (not /dev/null) when dist/cli.js exists but fails', () => {
+      const repo = path.join(tmpRoot, 'broken-build');
+      initRepo(repo);
+      // dist/cli.js exists but is not a working CLI (simulates, e.g., a
+      // missing native better-sqlite3 binding blowing up at require-time).
+      fs.mkdirSync(path.join(repo, 'dist'), { recursive: true });
+      fs.writeFileSync(
+        path.join(repo, 'dist', 'cli.js'),
+        "process.stderr.write('simulated native binding load failure\\n'); process.exit(1);\n",
+      );
+      const targetFile = path.join(repo, 'src', 'thing.ts');
+      fs.mkdirSync(path.dirname(targetFile), { recursive: true });
+      fs.writeFileSync(targetFile, '// content\n');
 
-    const { stderr, status } = runHook(targetFile, repo, binDir);
+      const { stderr, status } = runHook(targetFile, repo, binDir);
 
-    expect(status).toBe(0);
-    expect(stderr).toMatch(/graph rebuild failed/);
-    expect(stderr).toMatch(/npm run doctor/);
-    expect(stderr).toContain('simulated native binding load failure');
-  });
-});
+      expect(status).toBe(0);
+      expect(stderr).toMatch(/graph rebuild failed/);
+      expect(stderr).toMatch(/npm run doctor/);
+      expect(stderr).toContain('simulated native binding load failure');
+    });
+  },
+);


### PR DESCRIPTION
## Summary
- `.claude/hooks/update-graph.sh`'s fallback build path (used when the `codegraph` binary isn't on PATH) invoked `node <project>/dist/cli.js build ...` with stderr redirected to `/dev/null` and its exit code swallowed by `|| true`. On a genuinely fresh checkout — before `npm run build` has ever produced `dist/cli.js` — this silently no-oped with no visible error, the same symptom #1980 fixed for the stale-path bug.
- The fallback branch now checks for `dist/cli.js`'s existence up front and prints a one-line hint (`run 'npm install' (or 'npm run build')`) to stderr before exiting — still non-blocking (exit 0).
- For any other build failure (e.g. the native `better-sqlite3` binding not yet installed, or any other invocation failure in either branch), stderr is now captured instead of discarded and surfaced with a `npm run doctor` hint plus the first line of the actual error, so a contributor always gets a diagnosable trail instead of silence.
- Added `tests/unit/hook-update-graph-diagnostics.test.ts`, which actually executes the hook (via a restricted `PATH` that hides `codegraph` and a fresh temp git repo) to verify both new diagnostic paths fire and the hook still always exits 0.
- Updated the existing `tests/unit/hook-fallback-build-path.test.ts` regression test for the new `CLI_ENTRY` variable indirection.

Filed two out-of-scope findings hit while working this issue rather than folding them in here:
- #2301 — `guard-git.sh`'s `git checkout --` guard false-positives on `--detach` and any other double-dash flag.
- #2302 — `docs/examples/claude-code-hooks/update-graph.sh` (the external-consumer template) has the same silent-swallow pattern in its `npx` fallback branch.

## Verification
- lint: pass
- tests: pass (277 files / 4480 tests)

Closes #2074