### PR TITLE
fix(skills): replace zsh-unsafe for-in-$(...) loops with while/read (#2075)

### DIFF
--- a/.claude/skills/resolve/SKILL.md
+++ b/.claude/skills/resolve/SKILL.md
@@ -407,13 +407,20 @@ while IFS= read -r FILE; do
       if [ -f "$SOURCE_PR_FILE" ]; then
         # 2>/dev/null: suppress jq parse errors if the file was written as a stub {} — the || true means we skip this commit
         SOURCE_PR_NUMS=$(jq -r '.[].number' "$SOURCE_PR_FILE" 2>/dev/null || true)
-        for SOURCE_PR in $SOURCE_PR_NUMS; do
+        # while/read on a here-string, not `for SOURCE_PR in $SOURCE_PR_NUMS`: an unquoted
+        # multi-line variable only word-splits on newlines under bash's default IFS. zsh
+        # does NOT split unquoted expansions unless SH_WORD_SPLIT is set, so under zsh this
+        # would collapse every PR number into a single iteration where $SOURCE_PR is the
+        # whole multi-line blob instead of one number per iteration. while/read is portable
+        # across both shells; the empty-string guard handles SOURCE_PR_NUMS being empty.
+        while IFS= read -r SOURCE_PR; do
+          [ -z "$SOURCE_PR" ] && continue
           META=".codegraph/resolve/source-pr-diffs/$SOURCE_PR.json"
           if [ -f "$META" ]; then
             echo "  Source PR #$SOURCE_PR: $(jq -r '.title // "(no title)"' "$META")"
             echo "  Purpose: $(jq -r '.body // "(no description)"' "$META" | head -5)"
           fi
-        done
+        done <<< "$SOURCE_PR_NUMS"
       fi
     done < "$COMMIT_FILE"
   else

--- a/.claude/skills/sweep/SKILL.md
+++ b/.claude/skills/sweep/SKILL.md
@@ -329,17 +329,22 @@ If `trigger_count` is under 50, proceed:
 # Step 0: Verify every Greptile inline comment has at least one reply from us
 all_comments=$(gh api repos/<repo>/pulls/<number>/comments --paginate)
 
-greptile_comment_ids=$(echo "$all_comments" \
-  | jq -r '[.[] | select(.user.login == "greptile-apps[bot]" and .in_reply_to_id == null)] | .[].id')
-
+# while/read on a process substitution, not `for cid in $(...)`: an unquoted multi-line
+# command substitution only word-splits on newlines under bash's default IFS. zsh does
+# NOT split unquoted expansions unless SH_WORD_SPLIT is set, so under zsh `for cid in
+# $greptile_comment_ids` collapses every id into a single iteration where $cid is the
+# whole multi-line blob — the subsequent jq call then fails to parse, reply_count comes
+# back empty, and the numeric comparison below silently fails open, reporting "all
+# comments answered" even when none are. while/read is portable across both shells.
 unanswered=()
-for cid in $greptile_comment_ids; do
+while IFS= read -r cid; do
+  [ -z "$cid" ] && continue
   reply_count=$(echo "$all_comments" \
     | jq -s "[.[][] | select(.in_reply_to_id == $cid and .user.login != \"greptile-apps[bot]\")] | length")
   if [ "$reply_count" -eq 0 ]; then
     unanswered+=("$cid")
   fi
-done
+done < <(echo "$all_comments" | jq -r '[.[] | select(.user.login == "greptile-apps[bot]" and .in_reply_to_id == null)] | .[].id')
 
 if [ ${#unanswered[@]} -gt 0 ]; then
   echo "BLOCKED — ${#unanswered[@]} Greptile comments have no reply: ${unanswered[*]}"


### PR DESCRIPTION
## Summary
The `sweep` skill's Step 2g Greptile-reply verification, and `resolve`'s source-PR context lookup, both iterated a multi-line command-substitution result with `for x in $multiline_var`. bash word-splits an unquoted expansion on newlines by default, but zsh does not (unless `SH_WORD_SPLIT` is set) — under zsh the loop collapses to a single iteration where the loop variable holds the *entire* multi-line blob instead of one item per line.

This repo's default shell is zsh, and the Claude Code Bash tool used to run these skills is confirmed to execute under zsh in this environment, so the bug is live, not theoretical. In `sweep`, this meant the safety check whose entire purpose is to block a premature Greptile re-trigger could report "all comments answered" when they were not — reproduced directly in issue #2075 while resolving PR #1982 (a visible `jq: parse error` on stderr, yet the check still concluded it was safe to re-trigger).

Fixed both loops to use a portable `while IFS= read -r ...; do ... done < <(...)` (or `<<<` here-string where the value was already captured in a variable) instead of `for x in $(...)`/`for x in $var`. Verified the bug reproduces and the fix resolves it directly in a zsh shell:

```
# buggy pattern: 1 iteration instead of 3, cid holds the whole blob
multiline_var=$(printf "111\n222\n333\n")
for cid in $multiline_var; do echo "[$cid]"; done
# => 1 iteration: [111
#      222
#      333]

# fixed pattern: 3 iterations, one id per line, portable across bash and zsh
while IFS= read -r cid; do echo "[$cid]"; done < <(printf "111\n222\n333\n")
```

Audited both skill files for the same pattern (per the issue's ask) — only these two occurrences were found; other `for x in ...` loops in these files iterate literal word lists or glob expansions, which are unaffected.

## Verification
- lint: pass (`npm run lint`)
- tests: pass (277 files, 4480 tests — unaffected by this docs-only change, run per skill instructions)
- diff-impact: no function-level changes (markdown-only)
- manually reproduced the bug and confirmed the fix under an actual zsh shell (see snippet above)

Closes #2075