### PR TITLE
fix(incremental): thread configured pointsToMaxIterations through watch-mode points-to map (#2077)

### DIFF
--- a/src/domain/graph/builder/incremental.ts
+++ b/src/domain/graph/builder/incremental.ts
@@ -246,6 +246,8 @@ function rebuildReverseDepEdges(
   symbols: ExtractorOutput,
   stmts: IncrementalStmts,
   skipBarrel: boolean,
+  // #2077: forwarded to buildCallEdges — see its own param doc.
+  maxIterations?: number,
 ): number {
   const fileNodeRow = stmts.getNodeId.get(depRelPath, 'file', depRelPath, 0);
   if (!fileNodeRow) return 0;
@@ -281,6 +283,7 @@ function rebuildReverseDepEdges(
     fileNodeRow,
     importedNames,
     importedOriginalNames,
+    maxIterations,
   );
   edgesAdded += buildClassHierarchyEdges(
     db,
@@ -1162,13 +1165,18 @@ function buildCallEdges(
   fileNodeRow: { id: number },
   importedNames: Map<string, string>,
   importedOriginalNames?: ReadonlyMap<string, string>,
+  // #2077: resolved from EngineOpts.pointsToMaxIterations (itself sourced
+  // from config.analysis.pointsToMaxIterations) so a .codegraphrc.json
+  // override applies to watch-mode rebuilds, not just full builds.
+  // Undefined falls back to buildPointsToMapForFile's own default parameter.
+  maxIterations?: number,
 ): number {
   const typeMap = buildIncrementalTypeMap(symbols);
   const seenCallEdges = new Set<string>();
   const lookup = makeIncrementalLookup(db, stmts);
   // Phase 8.3 pts map (#1852) — same per-file construction the full-build
   // JS path uses (buildPointsToMapForFile, shared via resolver/points-to.js).
-  const ptsMap = buildPointsToMapForFile(symbols, importedNames);
+  const ptsMap = buildPointsToMapForFile(symbols, importedNames, maxIterations);
   const fnRefBindingLhs = new Set(symbols.fnRefBindings?.map((b) => b.lhs) ?? []);
   // #1895: scoped to this file's own calls only — see collectInvokedPropertyNames
   // doc comment (call-resolver.ts) for why incremental rebuilds use a narrower,
@@ -1400,6 +1408,8 @@ function rebuildEdgesForTargetFile(
   symbols: ExtractorOutput,
   fileNodeRow: { id: number },
   rootDir: string,
+  // #2077: forwarded to buildCallEdges — see its own param doc.
+  maxIterations?: number,
 ): number {
   // #1967: keep this file's persisted barrel rename table current if it's
   // itself a barrel — independent of the edges rebuilt below.
@@ -1424,6 +1434,7 @@ function rebuildEdgesForTargetFile(
     fileNodeRow,
     importedNames,
     importedOriginalNames,
+    maxIterations,
   );
   edgesAdded += buildClassHierarchyEdges(
     db,
@@ -1527,7 +1538,15 @@ async function runReverseDepCascade(
   let edgesAdded = 0;
   // Pass 1: direct edges only (no barrel resolution) — creates reexports edges
   for (const [depRelPath, symbols_] of depSymbols) {
-    edgesAdded += rebuildReverseDepEdges(db, rootDir, depRelPath, symbols_, stmts, true);
+    edgesAdded += rebuildReverseDepEdges(
+      db,
+      rootDir,
+      depRelPath,
+      symbols_,
+      stmts,
+      true,
+      engineOpts.pointsToMaxIterations,
+    );
   }
   // Pass 2: add barrel import edges (reexports edges now exist)
   edgesAdded += emitBarrelImportEdgesForReverseDeps(db, stmts, depSymbols, rootDir);
@@ -1739,7 +1758,15 @@ export async function rebuildFile(
       edgesBefore,
     };
 
-  let edgesAdded = rebuildEdgesForTargetFile(db, stmts, relPath, symbols, fileNodeRow, rootDir);
+  let edgesAdded = rebuildEdgesForTargetFile(
+    db,
+    stmts,
+    relPath,
+    symbols,
+    fileNodeRow,
+    rootDir,
+    engineOpts.pointsToMaxIterations,
+  );
   const {
     edgesAdded: cascadeEdges,
     reverseDepsEdgesBefore,

--- a/src/domain/graph/builder/pipeline.ts
+++ b/src/domain/graph/builder/pipeline.ts
@@ -67,6 +67,11 @@ function initializeEngine(ctx: PipelineContext): void {
     engine: ctx.opts.engine ?? ctx.config.build.engine ?? 'auto',
     dataflow: ctx.opts.dataflow !== false,
     ast: ctx.opts.ast !== false,
+    // Full builds already pass ctx.config.analysis.pointsToMaxIterations
+    // directly to buildPointsToMapForFile (stages/build-edges.ts); this keeps
+    // ctx.engineOpts itself consistent rather than leaving the field
+    // permanently unset on this construction path (#2077).
+    pointsToMaxIterations: ctx.config.analysis.pointsToMaxIterations,
     // nativeDb and WAL callbacks are set later when NativeDatabase is opened
     // (deferred to skip overhead on no-op rebuilds).
     nativeDb: undefined,

--- a/src/domain/graph/watcher.ts
+++ b/src/domain/graph/watcher.ts
@@ -210,6 +210,10 @@ function setupWatcher(rootDir: string, opts: { engine?: string; dbPath?: string 
     engine: (opts.engine || 'auto') as import('../../types.js').EngineMode,
     dataflow: false,
     ast: false,
+    // #2077: without this, incremental rebuilds fell back to
+    // buildPointsToMapForFile's own default parameter instead of honoring a
+    // .codegraphrc.json override, diverging from the full-build path below.
+    pointsToMaxIterations: config.analysis.pointsToMaxIterations,
   };
   const { name: engineName, version: engineVersion } = getActiveEngine(engineOpts);
   info(`Watch mode using ${engineName} engine${engineVersion ? ` (v${engineVersion})` : ''}`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1290,6 +1290,16 @@ export interface EngineOpts {
   engine: EngineMode;
   dataflow: boolean;
   ast: boolean;
+  /**
+   * Fixed-point iteration cap for the JS points-to solver (Phase 8.3),
+   * resolved from `config.analysis.pointsToMaxIterations`. Threaded through
+   * incremental/watch-mode rebuilds (`rebuildFile` → `buildCallEdges` →
+   * `buildPointsToMapForFile`) so a `.codegraphrc.json` override applies
+   * identically to `codegraph watch` and a full build (#2077). When omitted,
+   * `buildPointsToMapForFile` falls back to its own default parameter
+   * (`DEFAULTS.analysis.pointsToMaxIterations`).
+   */
+  pointsToMaxIterations?: number;
   /** Persistent NativeDatabase connection for build writes (Phase 6.15). */
   nativeDb?: NativeDatabase;
   /**

--- a/tests/integration/issue-2077-watch-points-to-max-iterations.test.ts
+++ b/tests/integration/issue-2077-watch-points-to-max-iterations.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Regression test for issue #2077 — thread the configured
+ * `pointsToMaxIterations` through watch-mode's points-to map construction.
+ *
+ * `buildCallEdges` in `src/domain/graph/builder/incremental.ts` used to call
+ * `buildPointsToMapForFile(symbols, importedNames)` with only 2 arguments, so
+ * the points-to solver's fixed-point iteration cap silently fell back to
+ * `buildPointsToMapForFile`'s own default parameter
+ * (`DEFAULTS.analysis.pointsToMaxIterations`) instead of the resolved
+ * `config.analysis.pointsToMaxIterations` that the full-build path
+ * (`stages/build-edges.ts`) passes explicitly. A `.codegraphrc.json` override
+ * therefore had no effect on `codegraph watch`'s incremental rebuilds.
+ *
+ * This reuses the 8-hop function-alias chain fixture from
+ * `issue-1753-points-to-max-iterations.test.ts` (that issue fixed full-build
+ * threading; this one covers the incremental/watch-mode path) and calls
+ * `rebuildFile` directly with an explicit `EngineOpts.pointsToMaxIterations`
+ * override, exercising both call paths that feed `buildPointsToMapForFile`:
+ *   - `rebuildEdgesForTargetFile` — the file that changed itself
+ *   - `rebuildReverseDepEdges` — files that depend on the one that changed
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterAll, describe, expect, it } from 'vitest';
+import { getNodeId as getNodeIdQuery, initSchema, openDb } from '../../src/db/index.js';
+import { rebuildFile } from '../../src/domain/graph/builder/incremental.js';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+
+// 8-hop alias chain: a0 requires exactly 8 fixed-point iterations to resolve
+// to `handler` (one hop propagates per solver iteration).
+const CHAIN_LENGTH = 8;
+
+const HANDLER_JS = `
+export function handler(item) {
+  return item * 2;
+}
+`.trimStart();
+
+function buildConsumerSource(): string {
+  const lines = [
+    "import { handler } from './handler.js';",
+    '',
+    'export function processItems(items) {',
+  ];
+  for (let i = 0; i < CHAIN_LENGTH - 1; i++) {
+    lines.push(`  const a${i} = a${i + 1};`);
+  }
+  lines.push(`  const a${CHAIN_LENGTH - 1} = handler;`);
+  lines.push('  return items.map(a0);');
+  lines.push('}');
+  return `${lines.join('\n')}\n`;
+}
+
+const CONSUMER_JS = buildConsumerSource();
+
+const dirsToClean: string[] = [];
+
+function writeFixture(dir: string): void {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'handler.js'), HANDLER_JS);
+  fs.writeFileSync(path.join(dir, 'consumer.js'), CONSUMER_JS);
+}
+
+function makeStmts(db: ReturnType<typeof openDb>) {
+  return {
+    insertNode: db.prepare(
+      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
+    ),
+    getNodeId: {
+      get: (name: string, kind: string, file: string, line: number) => {
+        const id = getNodeIdQuery(db, name, kind, file, line);
+        return id != null ? { id } : undefined;
+      },
+    },
+    insertEdge: db.prepare(
+      'INSERT OR IGNORE INTO edges (source_id, target_id, kind, confidence, dynamic) VALUES (?, ?, ?, ?, ?)',
+    ),
+    countNodes: db.prepare('SELECT COUNT(*) as c FROM nodes WHERE file = ?'),
+    countEdges: db.prepare(
+      'SELECT COUNT(*) as c FROM edges WHERE source_id IN (SELECT id FROM nodes WHERE file = ?)',
+    ),
+    findNodeInFile: db.prepare(
+      "SELECT id, kind, file FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant') AND file = ?",
+    ),
+    findNodeByName: db.prepare(
+      "SELECT id, file, kind FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
+    ),
+    listSymbols: db.prepare("SELECT name, kind, line FROM nodes WHERE file = ? AND kind != 'file'"),
+    upsertFileHash: db.prepare(
+      'INSERT OR REPLACE INTO file_hashes (file, hash, mtime, size) VALUES (?, ?, ?, ?)',
+    ),
+    deleteFileHash: db.prepare('DELETE FROM file_hashes WHERE file = ?'),
+  };
+}
+
+function hasAliasChainEdge(dbPath: string): boolean {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    const rows = db
+      .prepare(
+        `SELECT n1.name AS src, n2.name AS tgt
+         FROM edges e
+         JOIN nodes n1 ON e.source_id = n1.id
+         JOIN nodes n2 ON e.target_id = n2.id
+         WHERE e.kind = 'calls'`,
+      )
+      .all() as Array<{ src: string; tgt: string }>;
+    return rows.some((r) => r.src === 'processItems' && r.tgt === 'handler');
+  } finally {
+    db.close();
+  }
+}
+
+afterAll(() => {
+  for (const dir of dirsToClean) {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+});
+
+describe('Incremental buildCallEdges honors EngineOpts.pointsToMaxIterations (#2077)', () => {
+  it('suppresses the alias-chain edge on an incremental rebuild of the changed file itself', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-2077-target-'));
+    dirsToClean.push(dir);
+    writeFixture(dir);
+
+    await buildGraph(dir, { engine: 'wasm', incremental: false, skipRegistry: true });
+    const dbPath = path.join(dir, '.codegraph', 'graph.db');
+    // Sanity check: the default cap (50) resolves the 8-hop chain.
+    expect(hasAliasChainEdge(dbPath)).toBe(true);
+
+    const consumerFile = path.join(dir, 'consumer.js');
+    fs.appendFileSync(consumerFile, '\n// touch\n');
+
+    const db = openDb(dbPath);
+    initSchema(db);
+    await rebuildFile(
+      db,
+      dir,
+      consumerFile,
+      makeStmts(db),
+      { engine: 'wasm', pointsToMaxIterations: 3 },
+      null,
+    );
+    db.close();
+
+    expect(
+      hasAliasChainEdge(dbPath),
+      'rebuildEdgesForTargetFile must forward pointsToMaxIterations to buildPointsToMapForFile',
+    ).toBe(false);
+  }, 60_000);
+
+  it('suppresses the alias-chain edge via the reverse-dep cascade when a dependency changes', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-2077-revdep-'));
+    dirsToClean.push(dir);
+    writeFixture(dir);
+
+    await buildGraph(dir, { engine: 'wasm', incremental: false, skipRegistry: true });
+    const dbPath = path.join(dir, '.codegraph', 'graph.db');
+    expect(hasAliasChainEdge(dbPath)).toBe(true);
+
+    // Touch handler.js (the dependency), NOT consumer.js — consumer.js is
+    // rebuilt as a reverse dep, exercising rebuildReverseDepEdges rather than
+    // rebuildEdgesForTargetFile.
+    const handlerFile = path.join(dir, 'handler.js');
+    fs.appendFileSync(handlerFile, '\n// touch\n');
+
+    const db = openDb(dbPath);
+    initSchema(db);
+    await rebuildFile(
+      db,
+      dir,
+      handlerFile,
+      makeStmts(db),
+      { engine: 'wasm', pointsToMaxIterations: 3 },
+      null,
+    );
+    db.close();
+
+    expect(
+      hasAliasChainEdge(dbPath),
+      'rebuildReverseDepEdges must forward pointsToMaxIterations to buildPointsToMapForFile',
+    ).toBe(false);
+  }, 60_000);
+
+  it('still resolves the alias-chain edge when the override cap is high enough', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-2077-cap-ok-'));
+    dirsToClean.push(dir);
+    writeFixture(dir);
+
+    await buildGraph(dir, { engine: 'wasm', incremental: false, skipRegistry: true });
+    const dbPath = path.join(dir, '.codegraph', 'graph.db');
+
+    const consumerFile = path.join(dir, 'consumer.js');
+    fs.appendFileSync(consumerFile, '\n// touch\n');
+
+    const db = openDb(dbPath);
+    initSchema(db);
+    await rebuildFile(
+      db,
+      dir,
+      consumerFile,
+      makeStmts(db),
+      { engine: 'wasm', pointsToMaxIterations: CHAIN_LENGTH },
+      null,
+    );
+    db.close();
+
+    expect(hasAliasChainEdge(dbPath)).toBe(true);
+  }, 60_000);
+});


### PR DESCRIPTION
## Summary

`buildCallEdges` in `src/domain/graph/builder/incremental.ts` called
`buildPointsToMapForFile(symbols, importedNames)` with only 2 arguments, so
the points-to solver's fixed-point iteration cap silently fell back to
`buildPointsToMapForFile`'s own default parameter
(`DEFAULTS.analysis.pointsToMaxIterations`) instead of the resolved
`config.analysis.pointsToMaxIterations` that the full-build path
(`stages/build-edges.ts`) already passes explicitly. For most users (no
`.codegraphrc.json` override) this was a no-op, but any project that
explicitly overrides `pointsToMaxIterations` got a `codegraph watch`
incremental rebuild that silently used a different iteration cap than a full
build of the same files.

Fixed by threading the resolved config value through the whole watch-mode
call chain, as the issue's deferred-fix note described:

- Added `EngineOpts.pointsToMaxIterations?: number` (`src/types.ts`), with a
  doc comment on why it exists and where it flows.
- Populated it wherever `EngineOpts` is constructed — `setupWatcher`
  (`watcher.ts`, watch-mode) and `initializeEngine` (`pipeline.ts`, full
  build) — so the field is never silently stale on either construction path.
- Threaded it through `rebuildFile` -> `rebuildEdgesForTargetFile` /
  `runReverseDepCascade` -> `rebuildReverseDepEdges` -> `buildCallEdges` ->
  `buildPointsToMapForFile`, covering both the changed file itself and its
  reverse-dep cascade.

## Verification
- lint: pass
- tests: pass (278 files, 4483 tests)
- New regression test
  (`tests/integration/issue-2077-watch-points-to-max-iterations.test.ts`)
  reuses the 8-hop alias-chain fixture from
  `issue-1753-points-to-max-iterations.test.ts` and calls `rebuildFile`
  directly with an explicit low `pointsToMaxIterations` override, covering
  both the direct-target-file path and the reverse-dep cascade path. Verified
  these tests fail without the fix (temporarily reverted the core line,
  confirmed 2/3 tests fail, restored).
- `codegraph diff-impact --staged -T`: 8 functions changed, 14 transitive
  callers affected — all within the expected optional-parameter threading
  chain, no unexpected blast radius.

Closes #2077