### PR TITLE
fix(skills): housekeep branch pruning ignores squash merges; fixer never re-runs it after draining

### DIFF
--- a/.claude/skills/fixer/SKILL.md
+++ b/.claude/skills/fixer/SKILL.md
@@ -1338,7 +1338,19 @@ A reported line is not automatically a bug — `main` may have legitimately supe
 
 After the integrity check passes, re-run local verification and push, then re-evaluate the five gate conditions from Phase: Solve and Merge Loop before merging.
 
-**Exit condition:** Every PR listed in `parked.txt` is merged, or is reported as needing human review with a specific reason. No catch-up merge was pushed without a passing I4 integrity check. Every drain-phase merge's post-merge CI on `main` was confirmed green (I8) before the next merge in the pass. Drain stopped only once a pass merged nothing 3 times in a row, or the 15-pass safety cap was hit — never on a fixed pass count while merges were still happening.
+### Housekeep after the drain loop exits
+
+Every catch-up merge above cuts/checks-out a branch the same way Phase 2's Solve and Merge Loop does, so it leaves exactly the same kind of local-branch residue that Phase 3's step 3a runs `/housekeep` to clean up — but the drain loop has its own exit points (all merged, 3-stall, or 15-pass cap) separate from the batch loop, so nothing calls `/housekeep` again after it. Run it once, exactly like 3a, after the drain loop above has actually stopped (do not call it once per pass — it is idempotent, but there is nothing new to clean between passes that haven't yet merged anything):
+
+```bash
+mkdir -p .codegraph/fixer
+DRY_RUN=$(cat .codegraph/fixer/dry-run)
+echo "fixer: drain loop finished — running housekeeping before the final report"
+```
+
+Invoke the `housekeep` skill: `/housekeep --dry-run` if `DRY_RUN` is `true`, otherwise plain `/housekeep`. The same confirmation posture from 3a applies unchanged: confirm deletion only for local branches this run itself recorded as `merged` in `state.json` (drain-phase merges included — they are recorded exactly the same way as Phase 2 merges), decline every worktree-removal prompt including this run's own worktree, and decline everything else.
+
+**Exit condition:** Every PR listed in `parked.txt` is merged, or is reported as needing human review with a specific reason. No catch-up merge was pushed without a passing I4 integrity check. Every drain-phase merge's post-merge CI on `main` was confirmed green (I8) before the next merge in the pass. Drain stopped only once a pass merged nothing 3 times in a row, or the 15-pass safety cap was hit — never on a fixed pass count while merges were still happening. `/housekeep` has run once after the drain loop stopped, mirroring 3a.
 
 ---
 

--- a/.claude/skills/housekeep/SKILL.md
+++ b/.claude/skills/housekeep/SKILL.md
@@ -165,8 +165,9 @@ git worktree prune
 - If confirmed:
   ```bash
   git worktree remove "<path>"
-  git branch -d "<branch>"  # only if fully merged
+  git branch -D "<branch>"
   ```
+  `-D`, not `-d`: this worktree was already classified "stale" via Phase 1c's GitHub-PR-state check, not git ancestry, so `-d`'s own ancestry test would wrongly refuse a genuinely squash/rebase-merged branch here — see Phase 4d's identical fix for why `-d` is the wrong tool once a more authoritative source already confirmed the merge (issue #2309).
 
 **For bloated (non-stale) worktrees:**
 - List them with a per-artifact size breakdown
@@ -305,14 +306,20 @@ Flag any branches marked `[ahead N, behind M]` — these may need attention.
 
 ### 4a. Find merged branches
 
+> **Do not hand-roll this with `git branch --merged origin/main`** — same reason as Phase 1c: in a repo that **squash-merges** (confirmed live in this repo, issue #2309), a landed branch's tip is never an ancestor of the default branch, so `--merged` reports almost nothing as merged even right after a run that squash-merged a dozen PRs. Resolve merged-ness from GitHub PR state instead, exactly like Phase 1c/`gc-worktrees.sh` already do:
+
 ```bash
-git branch --merged origin/main
+git branch --format='%(refname:short)' | grep -vxF main > /tmp/housekeep-local-branches.txt
+gh pr list --state merged --limit 1000 --json headRefName --jq '.[].headRefName' > /tmp/housekeep-merged-heads.txt
+grep -xFf /tmp/housekeep-merged-heads.txt /tmp/housekeep-local-branches.txt
 ```
+
+This lists local branches whose head ref matches a PR GitHub reports as **merged** — true regardless of merge strategy (merge commit, squash, or rebase), unlike ancestry.
 
 ### 4b. Safe to delete
 
 Branches that are:
-- Fully merged into main
+- Confirmed merged via 4a's `gh pr list` check (not the ancestry test)
 - Not `main` itself
 - Not the current branch
 - Not a worktree branch (check `git worktree list`)
@@ -329,16 +336,16 @@ This removes local refs to branches that no longer exist on the remote.
 
 **If `DRY_RUN`:** List branches that would be deleted.
 
-**Otherwise:** For each merged branch, ask the user for confirmation before deleting:
+**Otherwise:** For each branch 4a confirmed merged, ask the user for confirmation before deleting:
 ```
 Delete merged branch '<branch>'? (y/n)
 ```
 If confirmed, delete the branch:
 ```bash
-git branch -d "<branch>"  # safe delete, only if fully merged
+git branch -D "<branch>"
 ```
 
-> **Never use `git branch -D`** (force delete). If `-d` fails, the branch has unmerged work — skip it.
+> **Use `-D` here, not `-d`.** This is not a blanket force-delete: 4a already established via authoritative GitHub PR state — not git's own ancestry heuristic — that this exact branch is merged. `-d`'s ancestry check is precisely the thing that's unreliable under squash/rebase merges (verified directly: it refuses a genuinely squash-merged branch once its stale remote-tracking ref has been pruned, e.g. by 4c), so requiring it to *also* agree before deleting is not an extra safety margin — it's reintroducing the exact bug 4a exists to fix. The safety boundary here is 4a's confirmed-merged check plus the per-branch confirmation prompt below, not `-d`'s ancestry test.
 > **Always confirm before deleting** — consistent with worktree removal in Phase 1c.
 
 **Exit condition:** every fully-merged, non-protected branch has had a confirmed delete decision (or been listed under `DRY_RUN`); stale remote-tracking refs have been pruned.
@@ -420,7 +427,7 @@ Status: CLEAN ✓
 
 ## Rules
 
-- **Never force-delete** anything — use safe deletes only (`git branch -d`, `git worktree remove`)
+- **Never delete a branch without first confirming it merged via `gh pr list` (GitHub PR state), not `git branch --merged`/`-d`'s ancestry test** — ancestry is unreliable under squash/rebase merges (issue #2309); `-D` is correct, not reckless, once the `gh`-based check confirms the merge (see Phase 1c and Phase 4)
 - **Never rebase** — sync with main via merge only (per project rules)
 - **Never delete tracked files** — only clean untracked/ignored dirt
 - **Never delete worktrees with uncommitted changes** — warn and skip

--- a/.claude/skills/housekeep/SKILL.md
+++ b/.claude/skills/housekeep/SKILL.md
@@ -167,7 +167,7 @@ git worktree prune
   git worktree remove "<path>"
   git branch -D "<branch>"
   ```
-  `-D`, not `-d`: this worktree was already classified "stale" via Phase 1c's GitHub-PR-state check, not git ancestry, so `-d`'s own ancestry test would wrongly refuse a genuinely squash/rebase-merged branch here — see Phase 4d's identical fix for why `-d` is the wrong tool once a more authoritative source already confirmed the merge (issue #2309).
+  `-D`, not `-d`: this worktree was already classified "stale" via Phase 1c's GitHub-PR-state check, not git ancestry, so `-d`'s own ancestry test would wrongly refuse a genuinely squash/rebase-merged branch here — see Phase 4d's identical fix for why `-d` is the wrong tool once a more authoritative source already confirmed the merge (issue #2309). Phase 1c's classifier currently matches by branch name only (not name-and-SHA the way Phase 4a now does), so this inherits the same reused-branch-name gap Phase 4a closed — tracked separately in issue #2310 since the fix belongs in `gc-worktrees.sh`, not here.
 
 **For bloated (non-stale) worktrees:**
 - List them with a per-artifact size breakdown
@@ -309,17 +309,26 @@ Flag any branches marked `[ahead N, behind M]` — these may need attention.
 > **Do not hand-roll this with `git branch --merged origin/main`** — same reason as Phase 1c: in a repo that **squash-merges** (confirmed live in this repo, issue #2309), a landed branch's tip is never an ancestor of the default branch, so `--merged` reports almost nothing as merged even right after a run that squash-merged a dozen PRs. Resolve merged-ness from GitHub PR state instead, exactly like Phase 1c/`gc-worktrees.sh` already do:
 
 ```bash
-git branch --format='%(refname:short)' | grep -vxF main > /tmp/housekeep-local-branches.txt
-gh pr list --state merged --limit 1000 --json headRefName --jq '.[].headRefName' > /tmp/housekeep-merged-heads.txt
-grep -xFf /tmp/housekeep-merged-heads.txt /tmp/housekeep-local-branches.txt
+# name + current tip SHA, not name alone: a branch name can be reused after its earlier
+# PR merged (a later /fixer-style run, or a human, creating a new branch of the same
+# name for unrelated work) — matching by name only would then classify that NEW, never-
+# merged work as "confirmed merged" and hand it straight to 4d's force-delete. Requiring
+# the local branch's CURRENT tip to equal the exact SHA GitHub recorded as the merged
+# PR's head closes that gap: any commit added since (a rename, a reused name, a new
+# unpushed commit) changes the tip SHA, so the pair no longer matches and 4d leaves the
+# branch alone instead of guessing (Greptile review, PR #2311).
+git branch --format='%(refname:short) %(objectname)' | grep -v '^main ' | sort > /tmp/housekeep-local-branches.txt
+gh pr list --state merged --limit 1000 --json headRefName,headRefOid \
+  --jq '.[] | "\(.headRefName) \(.headRefOid)"' | sort > /tmp/housekeep-merged-heads.txt
+comm -12 /tmp/housekeep-local-branches.txt /tmp/housekeep-merged-heads.txt
 ```
 
-This lists local branches whose head ref matches a PR GitHub reports as **merged** — true regardless of merge strategy (merge commit, squash, or rebase), unlike ancestry.
+This lists local branches whose name **and current commit** match a PR GitHub reports as **merged** — true regardless of merge strategy (merge commit, squash, or rebase), unlike ancestry, and immune to name reuse since it's pinned to the exact commit GitHub recorded at merge time.
 
 ### 4b. Safe to delete
 
 Branches that are:
-- Confirmed merged via 4a's `gh pr list` check (not the ancestry test)
+- Confirmed merged via 4a's name-**and**-SHA check against `gh pr list` (not the ancestry test, and not a name-only match)
 - Not `main` itself
 - Not the current branch
 - Not a worktree branch (check `git worktree list`)
@@ -427,7 +436,7 @@ Status: CLEAN ✓
 
 ## Rules
 
-- **Never delete a branch without first confirming it merged via `gh pr list` (GitHub PR state), not `git branch --merged`/`-d`'s ancestry test** — ancestry is unreliable under squash/rebase merges (issue #2309); `-D` is correct, not reckless, once the `gh`-based check confirms the merge (see Phase 1c and Phase 4)
+- **Never delete a branch without first confirming its *current tip commit* matches a merged PR's recorded head SHA via `gh pr list`** — not `git branch --merged`/`-d`'s ancestry test (unreliable under squash/rebase merges, issue #2309), and not a branch-*name* match alone (a reused name with new, never-merged commits would wrongly qualify, issue #2311). `-D` is correct, not reckless, once that name-and-SHA check confirms the exact commit was merged (see Phase 1c and Phase 4)
 - **Never rebase** — sync with main via merge only (per project rules)
 - **Never delete tracked files** — only clean untracked/ignored dirt
 - **Never delete worktrees with uncommitted changes** — warn and skip


### PR DESCRIPTION
## Summary

Two related bugs found while running \`/fixer\` end-to-end this session (issues #1923-#2077, 12 squash-merged PRs):

**1. `housekeep`'s Phase 4a ("Find merged branches") used `git branch --merged origin/main`** — ancestry-based, so a squash-merged branch's tip is never an ancestor of the new squash commit on \`main\`. Phase 1c already documents this exact failure mode and fixes it for worktree staleness (resolves merged-ness from GitHub PR state instead); Phase 4a never got the same fix.

Verified directly: after this run squash-merged 12 PRs, the ancestry check reported zero mergeable branches both times \`/fixer\` invoked \`/housekeep\`, while 10 of those branches sat locally unpruned.

Fixing detection alone isn't sufficient: \`git branch -d\`'s own internal check is the *same* ancestry test, so even a correctly \`gh pr list\`-confirmed-merged branch still gets refused by \`-d\` once stale remote-tracking refs are pruned (verified directly — reproduced this exact refusal on a real squash-merged branch from this run). Phase 4d and Phase 1e's worktree-branch cleanup now use \`-D\` for branches a GitHub PR-state check already confirmed merged — not a blanket force-delete, just deferring to a more authoritative signal than git's own unreliable-under-squash-merge heuristic.

**2. `fixer`'s Phase 3 (step 3a) runs `/housekeep` once per completed batch** specifically because branches accumulate during the Solve and Merge Loop — but Phase 4 (Drain Parked PRs) also cuts/merges branches via its catch-up-merge procedure, and nothing called `/housekeep` again after the drain loop's own exit conditions (all merged, 3-stall, or 15-pass cap). Added the same housekeep call, once, after the drain loop stops.

## Follow-up filed

#2310 — \`gc-worktrees.sh\` (a separate executable script, not a skill doc) has the identical \`-d\`-vs-ancestry bug at its own branch-deletion call site. Left for a separate PR since it's a script + its own test suite, not a doc change.

## Verification

- \`npm run lint\` clean
- \`tests/unit/docs-skills-mirror-sync.test.ts\` + \`tests/unit/docs-check-flags.test.ts\` pass (22/22) — confirms these skill docs aren't part of the public docs mirror set, so no mirror update needed
- Manually reproduced both halves of the bug on real branches from this run: \`git branch --merged origin/main\` returned empty against 10 genuinely-squash-merged branches; \`git branch -d\` on one of them refused with "not fully merged" once its stale remote-tracking ref was pruned

Closes #2309