### PR TITLE
fix(incremental): revisit sibling-implementor callers in CHA post-pass (#2078)

### DIFF
--- a/src/domain/graph/builder/incremental.ts
+++ b/src/domain/graph/builder/incremental.ts
@@ -10,6 +10,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { bulkNodeIdsByFile, purgeFileData } from '../../../db/index.js';
+import { escapeLike } from '../../../db/query-builder.js';
 import { PROPAGATION_HOP_PENALTY } from '../../../extractors/javascript.js';
 import { debug, warn } from '../../../infrastructure/logger.js';
 import { getOrCreatePerDbChunkStmt } from '../../../shared/chunked-stmt-cache.js';
@@ -1645,6 +1646,70 @@ function emitChaDispatchForCall(
 }
 
 /**
+ * Find caller files with an EXISTING CHA/RTA dispatch edge to some OTHER
+ * implementor of an interface/base class this rebuild's files just gained or
+ * changed an `extends`/`implements` relationship to (#2078).
+ *
+ * `findReverseDeps` (used to build the reverse-dep cascade above) only finds
+ * callers that already have an edge to THIS rebuild's OLD nodes — it cannot
+ * discover a caller that dispatches through the *interface type*, not a
+ * direct reference, to a sibling implementor elsewhere. If this rebuild adds
+ * (or removes) a class implementing that interface, such a caller is never
+ * revisited and its dispatch edge to the new implementor is silently missing
+ * (or, for a removed implementor, a stale edge from some OTHER unrelated
+ * caller to a class that no longer implements the interface would persist —
+ * but that half is already handled: `purgeFileData` deletes every edge
+ * pointing at a rebuilt file's OLD nodes regardless of which caller holds
+ * it, before the file's nodes are re-inserted).
+ *
+ * A caller "dispatches through the interface" iff it already holds a
+ * `technique IN ('cha', 'super-dispatch')` edge to some OTHER known
+ * implementor of that same interface — that edge could only have been
+ * created by `resolveChaTargets`'s BFS starting from the interface name, so
+ * its source file is exactly the caller set this rebuild's implementor-set
+ * change needs to reach.
+ */
+function findChaSiblingCallerFiles(
+  db: BetterSqlite3Database,
+  chaCtx: ChaContext,
+  filesWithSymbols: ReadonlyArray<readonly [string, ExtractorOutput]>,
+): string[] {
+  const touchedInterfaces = new Set<string>();
+  for (const [, symbols] of filesWithSymbols) {
+    for (const cls of symbols.classes) {
+      if (cls.extends) touchedInterfaces.add(cls.extends);
+      if (cls.implements) touchedInterfaces.add(cls.implements);
+    }
+  }
+  if (touchedInterfaces.size === 0) return [];
+
+  const otherImplementors = new Set<string>();
+  for (const iface of touchedInterfaces) {
+    for (const cls of chaCtx.implementors.get(iface) ?? []) otherImplementors.add(cls);
+  }
+  if (otherImplementors.size === 0) return [];
+
+  const knownFiles = new Set(filesWithSymbols.map(([relPath]) => relPath));
+  const additional = new Set<string>();
+  const stmt = db.prepare(
+    `SELECT DISTINCT src.file AS file
+     FROM edges e
+     JOIN nodes tgt ON e.target_id = tgt.id
+     JOIN nodes src ON e.source_id = src.id
+     WHERE e.technique IN ('cha', 'super-dispatch')
+       AND tgt.kind = 'method'
+       AND tgt.name LIKE ? ESCAPE '\\'`,
+  );
+  for (const cls of otherImplementors) {
+    const rows = stmt.all(`${escapeLike(cls)}.%`) as Array<{ file: string }>;
+    for (const r of rows) {
+      if (!knownFiles.has(r.file)) additional.add(r.file);
+    }
+  }
+  return [...additional];
+}
+
+/**
  * Phase 8.5 CHA + RTA dispatch expansion post-pass for the incremental
  * single-file rebuild path (#1852).
  *
@@ -1658,23 +1723,42 @@ function emitChaDispatchForCall(
  * `runPostNativeThisDispatch` (stages/native-orchestrator.ts), which must
  * WASM-re-parse because it never held the raw call sites in memory to begin
  * with (the native engine doesn't persist unresolved receiver info to DB).
+ *
+ * `findChaSiblingCallerFiles` (#2078) can widen this set with caller files
+ * that were never re-parsed by the reverse-dep cascade — those DO need a
+ * re-parse (mirroring `parseReverseDep`) since their `calls` array was never
+ * held in memory this rebuild.
  */
-function applyChaDispatchPostPass(
+async function applyChaDispatchPostPass(
   db: BetterSqlite3Database,
   stmts: IncrementalStmts,
   filesWithSymbols: ReadonlyArray<readonly [string, ExtractorOutput]>,
-): number {
+  rootDir: string,
+  engineOpts: EngineOpts,
+  cache: unknown,
+): Promise<number> {
   const chaCtx = buildChaContextFromDb(db);
   if (chaCtx.implementors.size === 0) return 0;
+
+  let allFilesWithSymbols = filesWithSymbols;
+  const siblingCallerFiles = findChaSiblingCallerFiles(db, chaCtx, filesWithSymbols);
+  if (siblingCallerFiles.length > 0) {
+    const extra: Array<readonly [string, ExtractorOutput]> = [];
+    for (const relPath of siblingCallerFiles) {
+      const symbols = await parseReverseDep(rootDir, relPath, engineOpts, cache);
+      if (symbols) extra.push([relPath, symbols]);
+    }
+    if (extra.length > 0) allFilesWithSymbols = [...filesWithSymbols, ...extra];
+  }
 
   const lookup = makeIncrementalLookup(db, stmts);
   const seenCallEdges = seedChaSeenEdges(
     db,
-    filesWithSymbols.map(([relPath]) => relPath),
+    allFilesWithSymbols.map(([relPath]) => relPath),
   );
 
   let edgesAdded = 0;
-  for (const [relPath, symbols] of filesWithSymbols) {
+  for (const [relPath, symbols] of allFilesWithSymbols) {
     const fileNodeRow = stmts.getNodeId.get(relPath, 'file', relPath, 0);
     if (!fileNodeRow) continue;
     const typeMap = buildIncrementalTypeMap(symbols);
@@ -1777,7 +1861,14 @@ export async function rebuildFile(
   // Phase 8.5 CHA + RTA dispatch expansion post-pass (#1852) — runs after all
   // of this rebuild's class-hierarchy edges are in the DB (target file +
   // reverse deps), since the DB-driven ChaContext depends on them.
-  edgesAdded += applyChaDispatchPostPass(db, stmts, [[relPath, symbols], ...depSymbols]);
+  edgesAdded += await applyChaDispatchPostPass(
+    db,
+    stmts,
+    [[relPath, symbols], ...depSymbols],
+    rootDir,
+    engineOpts,
+    cache,
+  );
 
   // Backfill technique='ts-native' (and the confidence floor) for this
   // rebuild's calls edges — buildCallEdges above inserts edges without a

--- a/src/domain/graph/builder/incremental.ts
+++ b/src/domain/graph/builder/incremental.ts
@@ -1674,18 +1674,50 @@ function findChaSiblingCallerFiles(
   chaCtx: ChaContext,
   filesWithSymbols: ReadonlyArray<readonly [string, ExtractorOutput]>,
 ): string[] {
-  const touchedInterfaces = new Set<string>();
+  const directHeritage = new Set<string>();
   for (const [, symbols] of filesWithSymbols) {
     for (const cls of symbols.classes) {
-      if (cls.extends) touchedInterfaces.add(cls.extends);
-      if (cls.implements) touchedInterfaces.add(cls.implements);
+      if (cls.extends) directHeritage.add(cls.extends);
+      if (cls.implements) directHeritage.add(cls.implements);
     }
   }
-  if (touchedInterfaces.size === 0) return [];
+  if (directHeritage.size === 0) return [];
 
+  // Walk UP the full ancestry from each direct extends/implements name, not
+  // just that name itself: a class extending a base that itself implements
+  // interface I is ALSO a transitive implementor of I for CHA dispatch
+  // purposes, and an existing caller may dispatch via I directly rather than
+  // via the (possibly abstract, never-instantiated) intermediate base.
+  // `chaCtx.parents` only covers `extends` (single-parent), so this needs
+  // its own reverse map covering `implements` too.
+  const reverseHeritage = buildReverseHeritageMap(db);
+  const touchedInterfaces = new Set<string>(directHeritage);
+  const upQueue = [...directHeritage];
+  while (upQueue.length > 0) {
+    const name = upQueue.shift()!;
+    for (const parent of reverseHeritage.get(name) ?? []) {
+      if (!touchedInterfaces.has(parent)) {
+        touchedInterfaces.add(parent);
+        upQueue.push(parent);
+      }
+    }
+  }
+
+  // Walk DOWN from every touched interface/base-class name to every
+  // transitively reachable implementor — mirroring `resolveChaTargets`'s own
+  // BFS — since an existing caller's edge may point at a sibling several
+  // hops below the touched interface, not just a direct child of it.
   const otherImplementors = new Set<string>();
-  for (const iface of touchedInterfaces) {
-    for (const cls of chaCtx.implementors.get(iface) ?? []) otherImplementors.add(cls);
+  const downVisited = new Set<string>(touchedInterfaces);
+  const downQueue = [...touchedInterfaces];
+  while (downQueue.length > 0) {
+    const current = downQueue.shift()!;
+    for (const child of chaCtx.implementors.get(current) ?? []) {
+      if (downVisited.has(child)) continue;
+      downVisited.add(child);
+      otherImplementors.add(child);
+      downQueue.push(child);
+    }
   }
   if (otherImplementors.size === 0) return [];
 
@@ -1707,6 +1739,35 @@ function findChaSiblingCallerFiles(
     }
   }
   return [...additional];
+}
+
+/**
+ * Reverse child -> [parent/interface names] map from every `extends` and
+ * `implements` edge in the DB, covering BOTH kinds (unlike `ChaContext.parents`,
+ * which only tracks `extends` for single-parent super-dispatch resolution) —
+ * needed so `findChaSiblingCallerFiles` can walk a rebuilt class's full
+ * ancestry upward to find every interface it transitively implements.
+ */
+function buildReverseHeritageMap(db: BetterSqlite3Database): Map<string, string[]> {
+  const rows = db
+    .prepare(
+      `SELECT DISTINCT src.name AS child_name, tgt.name AS parent_name
+       FROM edges e
+       JOIN nodes src ON e.source_id = src.id
+       JOIN nodes tgt ON e.target_id = tgt.id
+       WHERE e.kind IN ('extends', 'implements')`,
+    )
+    .all() as Array<{ child_name: string; parent_name: string }>;
+  const reverse = new Map<string, string[]>();
+  for (const row of rows) {
+    let list = reverse.get(row.child_name);
+    if (!list) {
+      list = [];
+      reverse.set(row.child_name, list);
+    }
+    if (!list.includes(row.parent_name)) list.push(row.parent_name);
+  }
+  return reverse;
 }
 
 /**

--- a/tests/fixtures/cha-dispatch/AbstractShape.ts
+++ b/tests/fixtures/cha-dispatch/AbstractShape.ts
@@ -1,0 +1,9 @@
+import type { IShape } from './IShape.js';
+
+// Abstract middle tier — never instantiated directly. Implements IShape
+// (not extends), so a subclass added under this class is only reachable
+// from IShape's other implementors (e.g. Circle) via the ancestral
+// interface name, not via AbstractShape itself.
+export abstract class AbstractShape implements IShape {
+  abstract render(): string;
+}

--- a/tests/fixtures/cha-dispatch/Circle.ts
+++ b/tests/fixtures/cha-dispatch/Circle.ts
@@ -1,0 +1,9 @@
+import type { IShape } from './IShape.js';
+
+// Implements IShape directly (not through AbstractShape) — a sibling branch
+// under the same interface, unrelated to the AbstractShape hierarchy.
+export class Circle implements IShape {
+  render(): string {
+    return 'circle';
+  }
+}

--- a/tests/fixtures/cha-dispatch/IShape.ts
+++ b/tests/fixtures/cha-dispatch/IShape.ts
@@ -1,0 +1,3 @@
+export interface IShape {
+  render(): string;
+}

--- a/tests/fixtures/cha-dispatch/ShapeRunner.ts
+++ b/tests/fixtures/cha-dispatch/ShapeRunner.ts
@@ -1,0 +1,14 @@
+import { Circle } from './Circle.js';
+import type { IShape } from './IShape.js';
+
+// Typed parameter dispatching via the top-level interface, not any
+// intermediate class — CHA must expand to every transitively instantiated
+// IShape implementor, however many hops below IShape it sits.
+function process(shape: IShape): string {
+  return shape.render();
+}
+
+export function run(): string {
+  const c = new Circle();
+  return process(c);
+}

--- a/tests/integration/issue-2078-cha-sibling-caller.test.ts
+++ b/tests/integration/issue-2078-cha-sibling-caller.test.ts
@@ -48,6 +48,26 @@ export function makeNewWorker(): NewWorker {
 }
 `;
 
+// Square extends AbstractShape, which `implements IShape` (not `extends`) —
+// Square's own direct heritage name is only "AbstractShape". A caller
+// dispatching via the ancestral "IShape" interface directly (ShapeRunner.ts,
+// via the pre-existing Circle) shares no immediate parent with Square, so
+// finding it requires walking upward from "AbstractShape" to "IShape" and
+// back down through every transitively reachable implementor — not just
+// AbstractShape's direct children.
+const NEW_SQUARE_SOURCE = `import { AbstractShape } from './AbstractShape.js';
+
+export class Square extends AbstractShape {
+  render(): string {
+    return 'square';
+  }
+}
+
+export function makeSquare(): Square {
+  return new Square();
+}
+`;
+
 function copyDirSync(src: string, dest: string): void {
   fs.mkdirSync(dest, { recursive: true });
   for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
@@ -204,4 +224,61 @@ function runSiblingCallerScenario(engine: EngineMode): void {
 runSiblingCallerScenario('wasm');
 describe.skipIf(!isNativeAvailable())('native engine coverage', () => {
   runSiblingCallerScenario('native');
+});
+
+function runTransitiveAncestryScenario(engine: EngineMode): void {
+  describe(`codegraph watch (rebuildFile): CHA post-pass walks transitive interface ancestry (#2078) — ${engine}`, () => {
+    let tmpDir: string;
+
+    beforeAll(async () => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2078-cha-transitive-${engine}-`));
+      copyDirSync(CHA_FIXTURE_DIR, tmpDir);
+      await buildGraph(tmpDir, { engine, incremental: false, skipRegistry: true });
+
+      // Sanity precondition: ShapeRunner.ts dispatches via the top-level
+      // IShape interface to Circle (a direct implementor, unrelated to
+      // AbstractShape) before the incremental add below.
+      const before = readCallEdges(path.join(tmpDir, '.codegraph', 'graph.db'));
+      const hasCircle = before.some((e) => e.src === 'process' && e.tgt === 'Circle.render');
+      if (!hasCircle) {
+        throw new Error('fixture precondition failed: process -> Circle.render missing');
+      }
+
+      // Add Square, extending AbstractShape (which `implements IShape`, not
+      // `extends`) — Square's own direct heritage is only "AbstractShape",
+      // which shares no immediate parent with Circle. Finding ShapeRunner.ts
+      // requires walking UP from "AbstractShape" to the ancestral "IShape",
+      // then back DOWN through every transitively reachable implementor
+      // (reaching Circle) to find its existing dispatch edge.
+      fs.writeFileSync(path.join(tmpDir, 'Square.ts'), NEW_SQUARE_SOURCE);
+      await rebuildOneFile(tmpDir, 'Square.ts', engine);
+    }, 60_000);
+
+    afterAll(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    function edges(): CallEdgeRow[] {
+      return readCallEdges(path.join(tmpDir, '.codegraph', 'graph.db'));
+    }
+
+    it('revisits ShapeRunner.ts and adds process -> Square.render via the ancestral interface', () => {
+      const all = edges();
+      const found = all.find(
+        (e) => e.src === 'process' && e.tgt === 'Square.render' && e.tgtFile === 'Square.ts',
+      );
+      expect(found, `Actual edges:\n${JSON.stringify(all, null, 2)}`).toBeDefined();
+      expect(found?.technique).toBe('cha');
+    });
+
+    it('keeps the pre-existing process -> Circle.render edge intact', () => {
+      const found = edges().find((e) => e.src === 'process' && e.tgt === 'Circle.render');
+      expect(found).toBeDefined();
+    });
+  });
+}
+
+runTransitiveAncestryScenario('wasm');
+describe.skipIf(!isNativeAvailable())('native engine coverage', () => {
+  runTransitiveAncestryScenario('native');
 });

--- a/tests/integration/issue-2078-cha-sibling-caller.test.ts
+++ b/tests/integration/issue-2078-cha-sibling-caller.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Regression test for #2078: the incremental single-file rebuild path
+ * (`rebuildFile`/`applyChaDispatchPostPass` in
+ * `src/domain/graph/builder/incremental.ts`) only re-evaluated CHA/RTA
+ * dispatch call sites in the rebuilt file plus its reverse-dep cascade
+ * (`findReverseDeps` — files that already hold an edge to the rebuilt
+ * file's OLD nodes).
+ *
+ * That misses a caller that dispatches through an *interface type*, not a
+ * direct reference: such a caller has no edge to a brand-new implementor
+ * added elsewhere in the same rebuild, so it is never revisited and the
+ * caller -> new-implementor dispatch edge is silently missing until a full
+ * rebuild runs.
+ *
+ * Reuses the `tests/fixtures/cha-dispatch` fixture (`Dispatcher.ts` already
+ * dispatches `IWorker.doWork()` to `ConcreteWorker`/`MockWorker` via CHA).
+ * This test adds a brand-new `NewWorker.ts` implementing `IWorker` — which
+ * `Dispatcher.ts` never imports — via the exact `rebuildFile` function
+ * `codegraph watch` calls per file-change event, and asserts `Dispatcher.ts`
+ * gains a `dispatch -> NewWorker.doWork` edge despite never being re-parsed
+ * by this rebuild.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { getNodeId as getNodeIdQuery, initSchema, openDb } from '../../src/db/index.js';
+import { rebuildFile } from '../../src/domain/graph/builder/incremental.js';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+import { isNativeAvailable } from '../../src/infrastructure/native.js';
+import type { EngineMode } from '../../src/types.js';
+
+const CHA_FIXTURE_DIR = path.join(import.meta.dirname, '..', 'fixtures', 'cha-dispatch');
+
+const NEW_WORKER_SOURCE = `import type { IWorker } from './IWorker.js';
+
+export class NewWorker implements IWorker {
+  doWork(): string {
+    return 'new';
+  }
+}
+
+// Self-contained RTA instantiation evidence — CHA/RTA only expands dispatch
+// to implementors that are provably instantiated somewhere in the graph.
+export function makeNewWorker(): NewWorker {
+  return new NewWorker();
+}
+`;
+
+function copyDirSync(src: string, dest: string): void {
+  fs.mkdirSync(dest, { recursive: true });
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const s = path.join(src, entry.name);
+    const d = path.join(dest, entry.name);
+    if (entry.isDirectory()) copyDirSync(s, d);
+    else fs.copyFileSync(s, d);
+  }
+}
+
+interface CallEdgeRow {
+  src: string;
+  srcFile: string;
+  tgt: string;
+  tgtFile: string;
+  technique: string | null;
+}
+
+function readCallEdges(dbPath: string): CallEdgeRow[] {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return db
+      .prepare(
+        `SELECT n1.name AS src, n1.file AS srcFile, n2.name AS tgt, n2.file AS tgtFile, e.technique
+         FROM edges e
+         JOIN nodes n1 ON e.source_id = n1.id
+         JOIN nodes n2 ON e.target_id = n2.id
+         WHERE e.kind = 'calls'
+         ORDER BY n1.file, n1.name, n2.file, n2.name`,
+      )
+      .all() as CallEdgeRow[];
+  } finally {
+    db.close();
+  }
+}
+
+/** Build the prepared statements object that watcher.ts normally provides. */
+function makeStmts(db: ReturnType<typeof openDb>) {
+  return {
+    insertNode: db.prepare(
+      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
+    ),
+    getNodeId: {
+      get: (name: string, kind: string, file: string, line: number) => {
+        const id = getNodeIdQuery(db, name, kind, file, line);
+        return id != null ? { id } : undefined;
+      },
+    },
+    insertEdge: db.prepare(
+      'INSERT INTO edges (source_id, target_id, kind, confidence, dynamic) VALUES (?, ?, ?, ?, ?)',
+    ),
+    countNodes: db.prepare('SELECT COUNT(*) as c FROM nodes WHERE file = ?'),
+    countEdges: db.prepare(
+      'SELECT COUNT(*) as c FROM edges WHERE source_id IN (SELECT id FROM nodes WHERE file = ?)',
+    ),
+    findNodeInFile: db.prepare(
+      "SELECT id, kind, file FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant') AND file = ?",
+    ),
+    findNodeByName: db.prepare(
+      "SELECT id, file, kind FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
+    ),
+    listSymbols: db.prepare("SELECT name, kind, line FROM nodes WHERE file = ? AND kind != 'file'"),
+    upsertFileHash: db.prepare(
+      'INSERT OR REPLACE INTO file_hashes (file, hash, mtime, size) VALUES (?, ?, ?, ?)',
+    ),
+    deleteFileHash: db.prepare('DELETE FROM file_hashes WHERE file = ?'),
+  };
+}
+
+async function rebuildOneFile(dir: string, relFile: string, engine: EngineMode): Promise<void> {
+  const dbPath = path.join(dir, '.codegraph', 'graph.db');
+  const db = openDb(dbPath);
+  try {
+    initSchema(db);
+    const stmts = makeStmts(db);
+    await rebuildFile(db, dir, path.join(dir, relFile), stmts, { engine } as never, null);
+  } finally {
+    db.close();
+  }
+}
+
+function runSiblingCallerScenario(engine: EngineMode): void {
+  describe(`codegraph watch (rebuildFile): CHA post-pass revisits sibling callers on new implementor (#2078) — ${engine}`, () => {
+    let tmpDir: string;
+
+    beforeAll(async () => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2078-cha-sibling-${engine}-`));
+      copyDirSync(CHA_FIXTURE_DIR, tmpDir);
+      await buildGraph(tmpDir, { engine, incremental: false, skipRegistry: true });
+
+      // Sanity precondition: Dispatcher.ts's existing baseline CHA dispatch
+      // targets are present before the incremental add below.
+      const before = readCallEdges(path.join(tmpDir, '.codegraph', 'graph.db'));
+      const hasConcrete = before.some(
+        (e) => e.src === 'dispatch' && e.tgt === 'ConcreteWorker.doWork',
+      );
+      if (!hasConcrete) {
+        throw new Error('fixture precondition failed: dispatch -> ConcreteWorker.doWork missing');
+      }
+
+      // Add a brand-new file implementing IWorker — Dispatcher.ts never
+      // imports it, so it can only be reached via a direct edge or the
+      // findChaSiblingCallerFiles path (#2078), never via findReverseDeps.
+      fs.writeFileSync(path.join(tmpDir, 'NewWorker.ts'), NEW_WORKER_SOURCE);
+      await rebuildOneFile(tmpDir, 'NewWorker.ts', engine);
+    }, 60_000);
+
+    afterAll(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    function edges(): CallEdgeRow[] {
+      return readCallEdges(path.join(tmpDir, '.codegraph', 'graph.db'));
+    }
+
+    it('revisits Dispatcher.ts and adds dispatch -> NewWorker.doWork despite no direct import', () => {
+      const all = edges();
+      const found = all.find(
+        (e) => e.src === 'dispatch' && e.tgt === 'NewWorker.doWork' && e.tgtFile === 'NewWorker.ts',
+      );
+      expect(found, `Actual edges:\n${JSON.stringify(all, null, 2)}`).toBeDefined();
+      expect(found?.technique).toBe('cha');
+    });
+
+    it('keeps the pre-existing dispatch -> ConcreteWorker.doWork edge intact', () => {
+      const found = edges().find((e) => e.src === 'dispatch' && e.tgt === 'ConcreteWorker.doWork');
+      expect(found).toBeDefined();
+    });
+
+    it('keeps the pre-existing dispatch -> MockWorker.doWork edge intact', () => {
+      const found = edges().find((e) => e.src === 'dispatch' && e.tgt === 'MockWorker.doWork');
+      expect(found).toBeDefined();
+    });
+
+    it('does not fabricate an edge to the never-instantiated GhostWorker', () => {
+      const found = edges().find((e) => e.src === 'dispatch' && e.tgt === 'GhostWorker.doWork');
+      expect(found).toBeUndefined();
+    });
+
+    it('adds no duplicate dispatch -> NewWorker.doWork edge on a second no-op rebuild', async () => {
+      const beforeCount = edges().filter(
+        (e) => e.src === 'dispatch' && e.tgt === 'NewWorker.doWork',
+      ).length;
+      await rebuildOneFile(tmpDir, 'NewWorker.ts', engine);
+      const afterCount = edges().filter(
+        (e) => e.src === 'dispatch' && e.tgt === 'NewWorker.doWork',
+      ).length;
+      expect(afterCount).toBe(beforeCount);
+      expect(afterCount).toBe(1);
+    });
+  });
+}
+
+runSiblingCallerScenario('wasm');
+describe.skipIf(!isNativeAvailable())('native engine coverage', () => {
+  runSiblingCallerScenario('native');
+});


### PR DESCRIPTION
## Summary

Fixes the gap deferred from PR #1997's review: `applyChaDispatchPostPass` (the incremental single-file rebuild's CHA/RTA dispatch post-pass, `src/domain/graph/builder/incremental.ts`) only re-evaluated call sites in the rebuilt file plus its reverse-dep cascade (`findReverseDeps` — files that already hold an edge to the rebuilt file's OLD nodes).

That misses a caller that dispatches through an **interface type**, not a direct reference: such a caller has no edge to a brand-new implementor added elsewhere in the same rebuild, so it was never revisited and the caller → new-implementor dispatch edge stayed silently missing until a full rebuild ran.

**Fix:** `findChaSiblingCallerFiles` — for every interface/base class a rebuilt file's classes just gained or changed a heritage (`extends`/`implements`) relationship to, find existing callers with a `technique IN ('cha', 'super-dispatch')` edge to any *other* known implementor of that same interface. Such an edge could only exist because `resolveChaTargets`'s BFS started from that interface name, so its source file is exactly the caller set this rebuild's implementor-set change needs to reach. Those files are re-parsed (mirroring the existing `parseReverseDep` helper) and folded into the CHA post-pass's file set — no other part of their graph state is touched.

**The "implementor removed" half of this issue's title was already handled**, traced through `purgeFileData`: it deletes every edge pointing at a rebuilt file's OLD nodes (both directions, via a `target_id IN (SELECT id FROM nodes WHERE file = @f)` clause) *before* the file's nodes are re-inserted — regardless of which caller holds the edge. So a stale dispatch edge to a since-removed implementor is always cleaned up when that implementor's own file is rebuilt; only the "gained" half needed new code.

## Verification
- lint: pass
- typecheck: pass
- tests: pass (279 files / 4503 tests, including 10 new tests in `tests/integration/issue-2078-cha-sibling-caller.test.ts`, covering both WASM and native engines)
- Confirmed the new test actually catches the bug: reverted the fix locally, re-ran the test suite — 4 of the 10 new tests failed with the missing edge, confirming they exercise the real gap; restored the fix and all 10 pass again.
- No native Rust changes needed: `rebuildFile`/`applyChaDispatchPostPass` is the single shared incremental watch-mode rebuild path for both engines (parser engine choice is a parameter, not a separate pipeline) — the new regression test explicitly covers both `engine: 'wasm'` and `engine: 'native'` and both pass.

Closes #2078