### PR TITLE
fix(incremental): upgrade points-to edges to direct confidence (#2079)

### DIFF
--- a/src/domain/graph/builder/incremental.ts
+++ b/src/domain/graph/builder/incremental.ts
@@ -781,7 +781,11 @@ function getInsertCallEdgeExtStmt(db: BetterSqlite3Database): SqliteStatement {
   return _insertCallEdgeExtStmt!;
 }
 
-/** Insert a `calls` edge with an explicit technique and/or dynamic_kind. */
+/**
+ * Insert a `calls` edge with an explicit technique and/or dynamic_kind.
+ * Returns the inserted row's id so a caller-side map (e.g. `ptsEdgeRows`,
+ * #2079) can later upgrade this exact row in place.
+ */
 function insertCallEdgeExt(
   db: BetterSqlite3Database,
   sourceId: number,
@@ -790,8 +794,42 @@ function insertCallEdgeExt(
   dynamic: 0 | 1,
   technique: string | null,
   dynamicKind: string | null,
+): number | bigint {
+  return getInsertCallEdgeExtStmt(db).run(
+    sourceId,
+    targetId,
+    confidence,
+    dynamic,
+    technique,
+    dynamicKind,
+  ).lastInsertRowid;
+}
+
+// Lazily-cached prepared statement for upgrading a pts-resolved edge row to
+// direct-call confidence in place (#2079) — mirrors the full-build path's
+// `ptsEdgeRows` in-memory row mutation (stages/build-edges.ts), adapted for
+// the incremental path's per-row DB writes instead of a batched insert array.
+let _updateEdgeDb: BetterSqlite3Database | null = null;
+let _updateCallEdgeToDirectStmt: SqliteStatement | null = null;
+
+function getUpdateCallEdgeToDirectStmt(db: BetterSqlite3Database): SqliteStatement {
+  if (_updateEdgeDb !== db) {
+    _updateEdgeDb = db;
+    _updateCallEdgeToDirectStmt = db.prepare(
+      `UPDATE edges SET confidence = ?, dynamic = ?, technique = 'ts-native' WHERE id = ?`,
+    );
+  }
+  return _updateCallEdgeToDirectStmt!;
+}
+
+/** Upgrade a pts-resolved edge row to direct-call confidence/technique in place. */
+function upgradePtsEdgeToDirect(
+  db: BetterSqlite3Database,
+  rowId: number | bigint,
+  confidence: number,
+  dynamic: 0 | 1,
 ): void {
-  getInsertCallEdgeExtStmt(db).run(sourceId, targetId, confidence, dynamic, technique, dynamicKind);
+  getUpdateCallEdgeToDirectStmt(db).run(confidence, dynamic, rowId);
 }
 
 // ── Call edge building ──────────────────────────────────────────────────
@@ -938,6 +976,11 @@ function applyCallFallbacks(
  * Emit direct `calls` edges for the resolved targets of a single call site,
  * then emit a `receiver` edge when the call has a non-this/self/super receiver.
  * Returns the number of edges inserted.
+ *
+ * If a target pair was already claimed by a pts-resolved edge (`ptsEdgeRows`,
+ * #2079), that row is upgraded in place to direct-call confidence/technique
+ * instead of being skipped — mirroring the full-build path's
+ * `emitDirectCallEdgesForCall` (stages/build-edges.ts).
  */
 function emitIncrementalCallEdges(
   call: { name: string; receiver?: string | null; dynamic?: boolean },
@@ -949,16 +992,27 @@ function emitIncrementalCallEdges(
   lookup: CallNodeLookup,
   importedNames: Map<string, string>,
   seenCallEdges: Set<string>,
+  ptsEdgeRows: Map<string, number | bigint>,
   stmts: IncrementalStmts,
+  db: BetterSqlite3Database,
 ): number {
   let edgesAdded = 0;
 
   for (const t of targets) {
+    if (t.id === caller.id) continue;
     const edgeKey = `${caller.id}|${t.id}`;
-    if (t.id !== caller.id && !seenCallEdges.has(edgeKey)) {
+    if (seenCallEdges.has(edgeKey)) continue;
+
+    const confidence = computeConfidence(relPath, t.file, importedFrom ?? null);
+    const dynamic: 0 | 1 = call.dynamic ? 1 : 0;
+    const ptsRowId = ptsEdgeRows.get(edgeKey);
+    if (ptsRowId !== undefined) {
+      upgradePtsEdgeToDirect(db, ptsRowId, confidence, dynamic);
+      ptsEdgeRows.delete(edgeKey);
       seenCallEdges.add(edgeKey);
-      const confidence = computeConfidence(relPath, t.file, importedFrom ?? null);
-      stmts.insertEdge.run(caller.id, t.id, 'calls', confidence, call.dynamic ? 1 : 0);
+    } else {
+      seenCallEdges.add(edgeKey);
+      stmts.insertEdge.run(caller.id, t.id, 'calls', confidence, dynamic);
       edgesAdded++;
     }
   }
@@ -995,12 +1049,10 @@ function emitIncrementalCallEdges(
  * that function's docstring for the full case breakdown (dynamic calls,
  * scoped/module/flat pts keys).
  *
- * Unlike the full-build version, a pts edge here shares `seenCallEdges` with
- * direct-call edges rather than a separate `ptsEdgeRows` map, so a later
- * direct call to the same target in the same file is skipped (not upgraded
- * to the higher direct-call confidence) if a pts edge already claimed the
- * pair — a narrow, documented gap from full-build parity (tracked in #1852's
- * follow-up), not a missing edge.
+ * Pts edges are added to `ptsEdgeRows` (not `seenCallEdges`, #2079) so a
+ * later direct call to the same target in the same file upgrades this row
+ * in place (`emitIncrementalCallEdges`) instead of being silently dropped —
+ * mirroring the full-build path's `ptsEdgeRows` map exactly.
  */
 function emitIncrementalPtsNoReceiverEdges(
   db: BetterSqlite3Database,
@@ -1013,6 +1065,7 @@ function emitIncrementalPtsNoReceiverEdges(
   ptsMap: PointsToMap,
   fnRefBindingLhs: ReadonlySet<string>,
   seenCallEdges: Set<string>,
+  ptsEdgeRows: Map<string, number | bigint>,
   importedOriginalNames: ReadonlyMap<string, string> | undefined,
 ): number {
   const scopedPtsKey = caller.callerName != null ? `${caller.callerName}::${call.name}` : null;
@@ -1065,12 +1118,12 @@ function emitIncrementalPtsNoReceiverEdges(
         : aliasTargets;
     for (const t of sortedAliasTargets) {
       const edgeKey = `${caller.id}|${t.id}`;
-      if (t.id !== caller.id && !seenCallEdges.has(edgeKey)) {
+      if (t.id !== caller.id && !seenCallEdges.has(edgeKey) && !ptsEdgeRows.has(edgeKey)) {
         const conf =
           computeConfidence(relPath, t.file, aliasFrom ?? null) - PROPAGATION_HOP_PENALTY;
         if (conf > 0) {
-          seenCallEdges.add(edgeKey);
-          insertCallEdgeExt(db, caller.id, t.id, conf, isDynamic, 'points-to', null);
+          const rowId = insertCallEdgeExt(db, caller.id, t.id, conf, isDynamic, 'points-to', null);
+          ptsEdgeRows.set(edgeKey, rowId);
           edgesAdded++;
         }
       }
@@ -1083,6 +1136,9 @@ function emitIncrementalPtsNoReceiverEdges(
  * Phase 8.3f pts fallback for unresolved receiver calls via object-rest
  * param bindings (`rest.prop()`). Mirrors `emitPtsReceiverEdges`
  * (stages/build-edges.ts, full-build path).
+ *
+ * Pts edges are added to `ptsEdgeRows` (not `seenCallEdges`, #2079) — see
+ * `emitIncrementalPtsNoReceiverEdges`'s docstring for why.
  */
 function emitIncrementalPtsReceiverEdges(
   db: BetterSqlite3Database,
@@ -1094,6 +1150,7 @@ function emitIncrementalPtsReceiverEdges(
   typeMap: Map<string, unknown>,
   ptsMap: PointsToMap,
   seenCallEdges: Set<string>,
+  ptsEdgeRows: Map<string, number | bigint>,
   importedOriginalNames: ReadonlyMap<string, string> | undefined,
 ): number {
   const receiverKey = `${call.receiver}.${call.name}`;
@@ -1121,12 +1178,12 @@ function emitIncrementalPtsReceiverEdges(
         : aliasTargets;
     for (const t of sortedAliasTargets) {
       const edgeKey = `${caller.id}|${t.id}`;
-      if (t.id !== caller.id && !seenCallEdges.has(edgeKey)) {
+      if (t.id !== caller.id && !seenCallEdges.has(edgeKey) && !ptsEdgeRows.has(edgeKey)) {
         const conf =
           computeConfidence(relPath, t.file, aliasFrom ?? null) - PROPAGATION_HOP_PENALTY;
         if (conf > 0) {
-          seenCallEdges.add(edgeKey);
-          insertCallEdgeExt(db, caller.id, t.id, conf, isDynamic, 'points-to', null);
+          const rowId = insertCallEdgeExt(db, caller.id, t.id, conf, isDynamic, 'points-to', null);
+          ptsEdgeRows.set(edgeKey, rowId);
           edgesAdded++;
         }
       }
@@ -1174,6 +1231,10 @@ function buildCallEdges(
 ): number {
   const typeMap = buildIncrementalTypeMap(symbols);
   const seenCallEdges = new Set<string>();
+  // #2079: pts-resolved edges are tracked here (not seenCallEdges) so a later
+  // direct call to the same target in this file upgrades the row in place
+  // instead of being dropped by the seenCallEdges dedup guard.
+  const ptsEdgeRows = new Map<string, number | bigint>();
   const lookup = makeIncrementalLookup(db, stmts);
   // Phase 8.3 pts map (#1852) — same per-file construction the full-build
   // JS path uses (buildPointsToMapForFile, shared via resolver/points-to.js).
@@ -1242,7 +1303,9 @@ function buildCallEdges(
       lookup,
       importedNames,
       seenCallEdges,
+      ptsEdgeRows,
       stmts,
+      db,
     );
 
     // Phase 8.3/8.3c/8.3f pts fallback (#1852): only fires when the primary +
@@ -1260,6 +1323,7 @@ function buildCallEdges(
           ptsMap,
           fnRefBindingLhs,
           seenCallEdges,
+          ptsEdgeRows,
           importedOriginalNames,
         );
       } else if (
@@ -1278,6 +1342,7 @@ function buildCallEdges(
           typeMap,
           ptsMap,
           seenCallEdges,
+          ptsEdgeRows,
           importedOriginalNames,
         );
       }

--- a/tests/integration/issue-2079-pts-direct-confidence-upgrade.test.ts
+++ b/tests/integration/issue-2079-pts-direct-confidence-upgrade.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Regression test for #2079: the incremental single-file rebuild path
+ * (`buildCallEdges`/`emitIncrementalCallEdges`/`emitIncrementalPtsNoReceiverEdges`
+ * in `src/domain/graph/builder/incremental.ts`) used to share `seenCallEdges`
+ * between points-to-resolved edges and direct-call edges. If a points-to
+ * edge claimed a `(caller, target)` pair first (e.g. `const alias = handler;
+ * alias(x)`), a later direct call to the same target in the same file
+ * (`handler(y)`) was silently skipped instead of upgrading the row to the
+ * higher direct-call confidence/technique — leaving a lower-confidence
+ * `points-to` edge where a full rebuild of the identical source would
+ * produce the direct-resolution edge instead.
+ *
+ * The full-build path (`stages/build-edges.ts`) already gets this right via
+ * its own `ptsEdgeRows` map; this test proves the incremental path now
+ * matches it exactly.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { getNodeId as getNodeIdQuery, initSchema, openDb } from '../../src/db/index.js';
+import { rebuildFile } from '../../src/domain/graph/builder/incremental.js';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+import { isNativeAvailable } from '../../src/infrastructure/native.js';
+import type { EngineMode } from '../../src/types.js';
+
+function writeFixture(dir: string): void {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'handler.js'),
+    'export function handler(x) {\n  return x * 2;\n}\n',
+  );
+  // The alias call (pts-resolved) appears BEFORE the direct call to the same
+  // target in source order, so buildCallEdges's per-call loop processes the
+  // pts-resolved edge first — exactly the ordering #2079 depends on.
+  fs.writeFileSync(
+    path.join(dir, 'consumer.js'),
+    [
+      "import { handler } from './handler.js';",
+      '',
+      'export function processItems(items) {',
+      '  const alias = handler;',
+      '  alias(items[0]);',
+      '  return handler(items[1]);',
+      '}',
+      '',
+    ].join('\n'),
+  );
+}
+
+interface CallEdgeRow {
+  src: string;
+  tgt: string;
+  confidence: number;
+  technique: string | null;
+}
+
+function readCallEdges(dbPath: string): CallEdgeRow[] {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return db
+      .prepare(
+        `SELECT n1.name AS src, n2.name AS tgt, e.confidence, e.technique
+         FROM edges e
+         JOIN nodes n1 ON e.source_id = n1.id
+         JOIN nodes n2 ON e.target_id = n2.id
+         WHERE e.kind = 'calls'
+         ORDER BY n1.name, n2.name`,
+      )
+      .all() as CallEdgeRow[];
+  } finally {
+    db.close();
+  }
+}
+
+/** Build the prepared statements object that watcher.ts normally provides. */
+function makeStmts(db: ReturnType<typeof openDb>) {
+  return {
+    insertNode: db.prepare(
+      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
+    ),
+    getNodeId: {
+      get: (name: string, kind: string, file: string, line: number) => {
+        const id = getNodeIdQuery(db, name, kind, file, line);
+        return id != null ? { id } : undefined;
+      },
+    },
+    insertEdge: db.prepare(
+      'INSERT INTO edges (source_id, target_id, kind, confidence, dynamic) VALUES (?, ?, ?, ?, ?)',
+    ),
+    countNodes: db.prepare('SELECT COUNT(*) as c FROM nodes WHERE file = ?'),
+    countEdges: db.prepare(
+      'SELECT COUNT(*) as c FROM edges WHERE source_id IN (SELECT id FROM nodes WHERE file = ?)',
+    ),
+    findNodeInFile: db.prepare(
+      "SELECT id, kind, file FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant') AND file = ?",
+    ),
+    findNodeByName: db.prepare(
+      "SELECT id, file, kind FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
+    ),
+    listSymbols: db.prepare("SELECT name, kind, line FROM nodes WHERE file = ? AND kind != 'file'"),
+    upsertFileHash: db.prepare(
+      'INSERT OR REPLACE INTO file_hashes (file, hash, mtime, size) VALUES (?, ?, ?, ?)',
+    ),
+    deleteFileHash: db.prepare('DELETE FROM file_hashes WHERE file = ?'),
+  };
+}
+
+async function rebuildOneFile(dir: string, relFile: string, engine: EngineMode): Promise<void> {
+  const dbPath = path.join(dir, '.codegraph', 'graph.db');
+  const db = openDb(dbPath);
+  try {
+    initSchema(db);
+    const stmts = makeStmts(db);
+    await rebuildFile(db, dir, path.join(dir, relFile), stmts, { engine } as never, null);
+  } finally {
+    db.close();
+  }
+}
+
+function runScenario(engine: EngineMode): void {
+  describe(`codegraph watch (rebuildFile): pts edge upgrades to direct confidence (#2079) — ${engine}`, () => {
+    let tmpDir: string;
+
+    beforeAll(async () => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2079-pts-upgrade-${engine}-`));
+      writeFixture(tmpDir);
+      await buildGraph(tmpDir, { engine, incremental: false, skipRegistry: true });
+      // Re-run the exact same source through the incremental single-file
+      // rebuild path (mirrors what codegraph watch calls on a save event) so
+      // the pts-then-direct ordering inside one buildCallEdges call is
+      // exercised the same way a full build already exercises it.
+      await rebuildOneFile(tmpDir, 'consumer.js', engine);
+    }, 60_000);
+
+    afterAll(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    function edges(): CallEdgeRow[] {
+      return readCallEdges(path.join(tmpDir, '.codegraph', 'graph.db'));
+    }
+
+    it('upgrades the pts-resolved edge to direct-call confidence and technique', () => {
+      const all = edges();
+      const callsToHandler = all.filter((e) => e.src === 'processItems' && e.tgt === 'handler');
+      expect(callsToHandler, `Actual edges:\n${JSON.stringify(all, null, 2)}`).toHaveLength(1);
+      expect(callsToHandler[0].technique).toBe('ts-native');
+      expect(callsToHandler[0].confidence).toBe(1.0);
+    });
+
+    it('matches a full rebuild of the identical source state', async () => {
+      const refDir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2079-pts-upgrade-ref-${engine}-`));
+      try {
+        writeFixture(refDir);
+        await buildGraph(refDir, { engine, incremental: false, skipRegistry: true });
+        const reference = readCallEdges(path.join(refDir, '.codegraph', 'graph.db')).filter(
+          (e) => e.src === 'processItems',
+        );
+        const incremental = edges().filter((e) => e.src === 'processItems');
+        expect(incremental).toEqual(reference);
+      } finally {
+        fs.rmSync(refDir, { recursive: true, force: true });
+      }
+    });
+  });
+}
+
+runScenario('wasm');
+describe.skipIf(!isNativeAvailable())('native engine coverage', () => {
+  runScenario('native');
+});


### PR DESCRIPTION
## Summary

Fixes the gap deferred from PR #1997's review (never actually filed as its own tracked issue until now, despite being called out in `emitIncrementalPtsNoReceiverEdges`'s own doc comment since PR #1852).

`buildCallEdges` (incremental single-file rebuild path, `src/domain/graph/builder/incremental.ts`) shared `seenCallEdges` between points-to-resolved edges and direct-call edges. If a points-to edge claimed a `(caller, target)` pair first (e.g. `const alias = handler; alias(x)`), a later direct call to the same target in the same file (`handler(y)`) was silently skipped instead of upgrading the row to the higher direct-call confidence/technique — so a watch-mode rebuild could leave a lower-confidence `points-to` edge where a full rebuild of the identical source would have the direct-resolution edge instead.

**Fix:** mirrors the full-build path's `ptsEdgeRows` map (`stages/build-edges.ts`) exactly. Points-to edges are now tracked in their own `Map<edgeKey, rowId>` instead of `seenCallEdges`; a later direct-call match for the same key runs an `UPDATE` against that exact row (confidence, dynamic, technique) in place instead of being dropped by the dedup guard. `insertCallEdgeExt` now returns the inserted row's id to make this possible.

## Verification
- lint: pass
- typecheck: pass
- tests: pass (280 files / 4511 tests, including 4 new tests in `tests/integration/issue-2079-pts-direct-confidence-upgrade.test.ts`, covering both WASM and native engines)
- Confirmed the new test actually catches the bug: reverted the fix locally, re-ran the suite — all 4 new tests failed (edge stuck at `points-to`/0.9 confidence instead of `ts-native`/1.0); restored the fix and all 4 pass again.
- New test's "matches a full rebuild of the identical source state" case confirms the incremental and full-build paths now produce byte-identical edges for this scenario.

Closes #2079