### PR TITLE
fix(extractors): seed object-rest-param type annotations for CHA dispatch (#2080)

### DIFF
--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -258,6 +258,20 @@ fn handle_param_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
         return;
     }
     if name_node.kind() != "object_pattern" { return };
+    // Only seed when the rest element is the pattern's ONLY member (`{
+    // ...rest }: IWorker`) — if a named property sits alongside it (`{
+    // doWork, ...rest }: IWorker`), TypeScript's own structural typing
+    // excludes that property from `rest`'s real type (effectively
+    // `Omit<IWorker, 'doWork'>`), so assigning the full `IWorker` type to
+    // `rest` would let a call like `rest.doWork()` — invalid, since
+    // `doWork` was destructured away — resolve a false edge via CHA
+    // dispatch (#2080 review).
+    for i in 0..name_node.child_count() {
+        let Some(sibling) = name_node.child(i) else { continue };
+        let st = sibling.kind();
+        if st == "{" || st == "}" || st == "," { continue }
+        if st != "rest_pattern" && st != "rest_element" { return }
+    }
     let Some(type_anno) = find_child(node, "type_annotation") else { return };
     let Some(type_name) = extract_simple_type_name(&type_anno, source) else { return };
     for i in 0..name_node.child_count() {
@@ -8124,6 +8138,33 @@ mod tests {
         let s = parse_ts("function f3({ ...rest }) { rest.go(); }");
         let tm = s.type_map.iter().find(|t| t.name == "rest");
         assert!(tm.is_none(), "type_map should not contain an entry for untyped 'rest'; got: {:?}", s.type_map);
+    }
+
+    // #2080 review (Greptile): a named property alongside the rest element
+    // excludes that property from rest's real type (`Omit<IWorker,
+    // 'doWork'>`), so seeding the full IWorker type onto `rest` would let a
+    // call like `rest.doWork()` — invalid, since doWork was destructured
+    // away — falsely resolve via CHA dispatch.
+    #[test]
+    fn object_rest_param_with_sibling_property_does_not_seed_full_type() {
+        let s = parse_ts("function f({ doWork, ...rest }: IWorker) { rest.other(); }");
+        let tm = s.type_map.iter().find(|t| t.name == "rest");
+        assert!(
+            tm.is_none(),
+            "type_map should not seed the full annotation type onto 'rest' when a sibling property is destructured out; got: {:?}",
+            s.type_map
+        );
+    }
+
+    // The object_rest_param_bindings extraction itself (the value-chase
+    // mechanism, #1336) is unaffected by the sibling-property guard above —
+    // it always recorded the rest binding regardless of sibling properties.
+    #[test]
+    fn object_rest_param_binding_still_recorded_with_sibling_property() {
+        let s = parse_ts("function f({ doWork, ...rest }: IWorker) { rest.other(); }");
+        let b = s.object_rest_param_bindings.iter().find(|b| b.callee == "f");
+        assert!(b.is_some(), "object_rest_param_bindings missing; got: {:?}", s.object_rest_param_bindings);
+        assert_eq!(b.unwrap().rest_name, "rest");
     }
 
     #[test]

--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -232,19 +232,50 @@ fn handle_var_declarator_type_map(node: &Node, source: &[u8], symbols: &mut File
 /// Handle `required_parameter` / `optional_parameter` nodes in the type-map walk.
 ///
 /// Seeds a type-map entry when the parameter carries a TypeScript type annotation.
+///
+/// A plain typed parameter (`worker: IWorker`) seeds a direct entry keyed on
+/// its own name. An object-rest-destructured parameter with a type
+/// annotation (`{ ...rest }: IWorker`) has no single "name" — `name_node` is
+/// an `object_pattern`, not an `identifier` — but the rest binding itself
+/// (`rest`) is exactly what later property-access dispatch resolves
+/// against, so it gets the SAME direct type-annotation seed (#2080), keyed
+/// on the rest binding's own name. Mirrors `handleParamTypeMap` in
+/// `src/extractors/javascript.ts`.
 fn handle_param_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     let name_node = node.child_by_field_name("pattern")
         .or_else(|| node.child_by_field_name("left"))
         .or_else(|| node.child(0));
     let Some(name_node) = name_node else { return };
-    if name_node.kind() != "identifier" { return };
+    if name_node.kind() == "identifier" {
+        let Some(type_anno) = find_child(node, "type_annotation") else { return };
+        if let Some(type_name) = extract_simple_type_name(&type_anno, source) {
+            push_type_map_entry(
+                symbols,
+                node_text(&name_node, source).to_string(),
+                type_name.to_string(),
+            );
+        }
+        return;
+    }
+    if name_node.kind() != "object_pattern" { return };
     let Some(type_anno) = find_child(node, "type_annotation") else { return };
-    if let Some(type_name) = extract_simple_type_name(&type_anno, source) {
-        push_type_map_entry(
-            symbols,
-            node_text(&name_node, source).to_string(),
-            type_name.to_string(),
-        );
+    let Some(type_name) = extract_simple_type_name(&type_anno, source) else { return };
+    for i in 0..name_node.child_count() {
+        let Some(inner) = name_node.child(i) else { continue };
+        if inner.kind() == "rest_pattern" || inner.kind() == "rest_element" {
+            // rest_pattern/rest_element node: `...identifier` — the identifier
+            // is at child index 1 (mirrors collect_object_rest_params).
+            let rest_id = inner.child(1).or_else(|| inner.child_by_field_name("name"));
+            if let Some(rest_id) = rest_id {
+                if rest_id.kind() == "identifier" {
+                    push_type_map_entry(
+                        symbols,
+                        node_text(&rest_id, source).to_string(),
+                        type_name.to_string(),
+                    );
+                }
+            }
+        }
     }
 }
 
@@ -5067,18 +5098,32 @@ fn collect_object_rest_params(node: &Node, source: &[u8], symbols: &mut FileSymb
         if ct == "," || ct == "(" || ct == ")" {
             continue;
         }
-        if ct == "object_pattern" {
-            for j in 0..child.child_count() {
-                let Some(inner) = child.child(j) else { continue };
-                if inner.kind() == "rest_pattern" || inner.kind() == "rest_element" {
-                    let rest_id = inner.child(1).or_else(|| inner.child_by_field_name("name"));
-                    if let Some(rest_id) = rest_id {
-                        if rest_id.kind() == "identifier" {
-                            symbols.object_rest_param_bindings.push(ObjectRestParamBinding {
-                                callee: fn_name.clone(),
-                                rest_name: node_text(&rest_id, source).to_string(),
-                                arg_index: param_idx,
-                            });
+        // TypeScript wraps EVERY parameter — typed or not — in a
+        // required_parameter/optional_parameter node (confirmed by parsing
+        // `function f({ ...rest }) {}` with tree-sitter-typescript, which
+        // still wraps despite no type annotation at all), unlike plain JS
+        // where the object_pattern is a direct child. Without unwrapping,
+        // object-rest-param bindings were silently never recorded for any
+        // .ts/.tsx file, not just ones using a type annotation (#2080).
+        let pattern_node = if ct == "required_parameter" || ct == "optional_parameter" {
+            child.child_by_field_name("pattern")
+        } else {
+            Some(child)
+        };
+        if let Some(pattern_node) = pattern_node {
+            if pattern_node.kind() == "object_pattern" {
+                for j in 0..pattern_node.child_count() {
+                    let Some(inner) = pattern_node.child(j) else { continue };
+                    if inner.kind() == "rest_pattern" || inner.kind() == "rest_element" {
+                        let rest_id = inner.child(1).or_else(|| inner.child_by_field_name("name"));
+                        if let Some(rest_id) = rest_id {
+                            if rest_id.kind() == "identifier" {
+                                symbols.object_rest_param_bindings.push(ObjectRestParamBinding {
+                                    callee: fn_name.clone(),
+                                    rest_name: node_text(&rest_id, source).to_string(),
+                                    arg_index: param_idx,
+                                });
+                            }
                         }
                     }
                 }
@@ -8038,6 +8083,47 @@ mod tests {
         let b = s.object_rest_param_bindings.iter().find(|b| b.rest_name == "rest");
         assert!(b.is_some(), "object_rest_param_bindings missing; got: {:?}", s.object_rest_param_bindings);
         assert_eq!(b.unwrap().callee, "Svc.handle");
+    }
+
+    // #2080: TypeScript wraps EVERY parameter (typed or not) in a
+    // required_parameter/optional_parameter node, unlike plain JS where the
+    // object_pattern is a direct formal_parameters child. Without unwrapping
+    // that wrapper, object_rest_param_bindings was never recorded for any
+    // .ts/.tsx file at all — not just ones using a type annotation.
+    #[test]
+    fn object_rest_param_binding_recorded_in_typescript_without_type_annotation() {
+        let s = parse_ts("function f3({ e1, ...eerest }) { eerest.e4(); }");
+        let b = s.object_rest_param_bindings.iter().find(|b| b.callee == "f3");
+        assert!(b.is_some(), "object_rest_param_bindings missing; got: {:?}", s.object_rest_param_bindings);
+        assert_eq!(b.unwrap().rest_name, "eerest");
+    }
+
+    #[test]
+    fn object_rest_param_binding_recorded_in_typescript_with_type_annotation() {
+        let s = parse_ts("function dispatchRest({ ...rest }: IWorker) { rest.doWork(); }");
+        let b = s.object_rest_param_bindings.iter().find(|b| b.callee == "dispatchRest");
+        assert!(b.is_some(), "object_rest_param_bindings missing; got: {:?}", s.object_rest_param_bindings);
+        assert_eq!(b.unwrap().rest_name, "rest");
+    }
+
+    // #2080: a type-annotated object-rest parameter (`{ ...rest }: IWorker`)
+    // should seed a direct type_map entry on the rest binding's own name,
+    // the same way a plain typed parameter (`worker: IWorker`) does — so
+    // CHA/interface dispatch through the rest binding can resolve.
+    #[test]
+    fn object_rest_param_type_annotation_seeds_type_map() {
+        let s = parse_ts("function dispatchRest({ ...rest }: IWorker) { rest.doWork(); }");
+        let tm = s.type_map.iter().find(|t| t.name == "rest");
+        assert!(tm.is_some(), "type_map should contain an entry for 'rest'; got: {:?}", s.type_map);
+        assert_eq!(tm.unwrap().type_name, "IWorker");
+        assert_eq!(tm.unwrap().confidence, 0.9);
+    }
+
+    #[test]
+    fn object_rest_param_without_type_annotation_does_not_seed_type_map() {
+        let s = parse_ts("function f3({ ...rest }) { rest.go(); }");
+        let tm = s.type_map.iter().find(|t| t.name == "rest");
+        assert!(tm.is_none(), "type_map should not contain an entry for untyped 'rest'; got: {:?}", s.type_map);
     }
 
     #[test]

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -3458,6 +3458,14 @@ function handleVarDeclaratorTypeMap(
  * direct type binding (0.9) takes priority over that value-chase guess
  * (0.65) when both exist, which is correct: an explicit type annotation is
  * strictly more reliable evidence than an inferred call-site argument name.
+ *
+ * Only seeded when the rest element is the pattern's ONLY member (`{ ...rest
+ * }: IWorker`) — if a named property sits alongside it (`{ doWork, ...rest
+ * }: IWorker`), TypeScript's own structural typing excludes that property
+ * from `rest`'s real type (effectively `Omit<IWorker, 'doWork'>`), so
+ * assigning the full `IWorker` type to `rest` would let a call like
+ * `rest.doWork()` — invalid, since `doWork` was destructured away — resolve
+ * a false edge via CHA dispatch (#2080 review).
  */
 function handleParamTypeMap(node: TreeSitterNode, typeMap: Map<string, TypeMapEntry>): void {
   const nameNode =
@@ -3471,6 +3479,13 @@ function handleParamTypeMap(node: TreeSitterNode, typeMap: Map<string, TypeMapEn
     return;
   }
   if (nameNode?.type !== 'object_pattern') return;
+  for (let i = 0; i < nameNode.childCount; i++) {
+    const sibling = nameNode.child(i);
+    if (!sibling) continue;
+    const st = sibling.type;
+    if (st === '{' || st === '}' || st === ',') continue;
+    if (st !== 'rest_pattern' && st !== 'rest_element') return;
+  }
   const typeAnno = findChild(node, 'type_annotation');
   if (!typeAnno) return;
   const typeName = extractSimpleTypeName(typeAnno);

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -3441,15 +3441,49 @@ function handleVarDeclaratorTypeMap(
   }
 }
 
-/** Extract type info from a required_parameter or optional_parameter. */
+/**
+ * Extract type info from a required_parameter or optional_parameter.
+ *
+ * A plain typed parameter (`worker: IWorker`) seeds `typeMap['worker']`
+ * directly. An object-rest-destructured parameter with a type annotation
+ * (`{ ...rest }: IWorker`) has no single "name" — `nameNode` is an
+ * `object_pattern`, not an `identifier` — but the rest binding itself
+ * (`rest`) is exactly the thing later property-access dispatch resolves
+ * against, so it gets the SAME direct type-annotation seed (#2080), keyed
+ * on the rest binding's own name. This is a different mechanism from the
+ * value-chase seeding in incremental.ts's `seedRestParamTypeMap` / the
+ * full-build's `buildObjectRestParamPostPass`, which instead seeds the
+ * CALL-SITE argument's variable name for object-property value-chase
+ * (#1336) — `setTypeMapEntry`'s higher-confidence-wins merge means this
+ * direct type binding (0.9) takes priority over that value-chase guess
+ * (0.65) when both exist, which is correct: an explicit type annotation is
+ * strictly more reliable evidence than an inferred call-site argument name.
+ */
 function handleParamTypeMap(node: TreeSitterNode, typeMap: Map<string, TypeMapEntry>): void {
   const nameNode =
     node.childForFieldName('pattern') || node.childForFieldName('left') || node.child(0);
-  if (nameNode?.type !== 'identifier') return;
+  if (nameNode?.type === 'identifier') {
+    const typeAnno = findChild(node, 'type_annotation');
+    if (typeAnno) {
+      const typeName = extractSimpleTypeName(typeAnno);
+      if (typeName) setTypeMapEntry(typeMap, nameNode.text, typeName, 0.9);
+    }
+    return;
+  }
+  if (nameNode?.type !== 'object_pattern') return;
   const typeAnno = findChild(node, 'type_annotation');
-  if (typeAnno) {
-    const typeName = extractSimpleTypeName(typeAnno);
-    if (typeName) setTypeMapEntry(typeMap, nameNode.text, typeName, 0.9);
+  if (!typeAnno) return;
+  const typeName = extractSimpleTypeName(typeAnno);
+  if (!typeName) return;
+  for (let i = 0; i < nameNode.childCount; i++) {
+    const inner = nameNode.child(i);
+    if (!inner) continue;
+    if (inner.type === 'rest_pattern' || inner.type === 'rest_element') {
+      // rest_pattern/rest_element node: `...identifier` — the identifier is
+      // at child index 1 (mirrors collectObjectRestParams's own extraction).
+      const restId = inner.child(1) ?? inner.childForFieldName('name');
+      if (restId?.type === 'identifier') setTypeMapEntry(typeMap, restId.text, typeName, 0.9);
+    }
   }
 }
 
@@ -3956,9 +3990,20 @@ function collectObjectRestParams(
       if (!child) continue;
       const ct = child.type;
       if (ct === ',' || ct === '(' || ct === ')') continue;
-      if (ct === 'object_pattern') {
-        for (let j = 0; j < child.childCount; j++) {
-          const inner = child.child(j);
+      // TypeScript wraps EVERY parameter — typed or not — in a
+      // required_parameter/optional_parameter node (confirmed by parsing
+      // `function f({ ...rest }) {}` with tree-sitter-typescript, which
+      // still wraps despite no type annotation at all), unlike plain JS
+      // where the object_pattern is a direct child. Without unwrapping,
+      // object-rest-param bindings were silently never recorded for any
+      // .ts/.tsx file, not just ones using a type annotation (#2080).
+      const patternNode =
+        ct === 'required_parameter' || ct === 'optional_parameter'
+          ? child.childForFieldName('pattern')
+          : child;
+      if (patternNode?.type === 'object_pattern') {
+        for (let j = 0; j < patternNode.childCount; j++) {
+          const inner = patternNode.child(j);
           if (!inner) continue;
           if (inner.type === 'rest_pattern' || inner.type === 'rest_element') {
             // rest_pattern node: `...identifier` — the identifier is at child index 1

--- a/tests/integration/issue-2080-object-rest-param-typed-dispatch.test.ts
+++ b/tests/integration/issue-2080-object-rest-param-typed-dispatch.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Regression test for #2080: object-rest-param bindings never got a
+ * type-annotation-based typeMap seed, and — discovered while investigating
+ * that — TypeScript's `required_parameter`/`optional_parameter` wrapper node
+ * was never unwrapped at all in `collectObjectRestParams`
+ * (`src/extractors/javascript.ts`) / `collect_object_rest_params`
+ * (`crates/codegraph-core/src/extractors/javascript.rs`), so object-rest-param
+ * bindings were silently never recorded for ANY `.ts`/`.tsx` file — not just
+ * ones using a type annotation. tree-sitter-typescript wraps every
+ * parameter, typed or not, in that node; plain tree-sitter-javascript does
+ * not, which is why the existing #1336 test (`.js` only) never caught this.
+ *
+ * Two scenarios, both engines:
+ *   1. Untyped rest param in a `.ts` file — the value-chase mechanism
+ *      (#1336) should resolve identically to the equivalent `.js` file.
+ *   2. Type-annotated rest param (`{ ...rest }: IWorker`) — CHA/interface
+ *      dispatch through `rest` should resolve exactly like a plain typed
+ *      parameter (`worker: IWorker`) already does.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+import { isNativeAvailable } from '../../src/infrastructure/native.js';
+import type { EngineMode } from '../../src/types.js';
+
+interface CallEdgeRow {
+  src: string;
+  tgt: string;
+  tgtFile: string;
+  technique: string | null;
+}
+
+function readCallEdges(dbPath: string): CallEdgeRow[] {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return db
+      .prepare(
+        `SELECT n1.name AS src, n2.name AS tgt, n2.file AS tgtFile, e.technique
+         FROM edges e
+         JOIN nodes n1 ON e.source_id = n1.id
+         JOIN nodes n2 ON e.target_id = n2.id
+         WHERE e.kind = 'calls'
+         ORDER BY n1.name, n2.name`,
+      )
+      .all() as CallEdgeRow[];
+  } finally {
+    db.close();
+  }
+}
+
+// Scenario 1: untyped rest param in .ts — value-chase parity with .js (#1336).
+// realHandler is reachable ONLY through obj.e4 (no bare function literally
+// named "e4" exists), so a same-name global fallback cannot mask a broken
+// rest-param chain the way it would if the function itself were named "e4".
+const UNTYPED_FIXTURE = `
+function realHandler() { return 'x'; }
+var obj = { e4: realHandler };
+
+function f3({ ...eerest }) {
+  eerest.e4();
+}
+f3(obj);
+`;
+
+function runUntypedScenario(engine: EngineMode): void {
+  describe(`object-rest-param value-chase resolves in .ts files (#2080) — ${engine}`, () => {
+    let tmpDir: string;
+
+    beforeAll(async () => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2080-untyped-${engine}-`));
+      fs.writeFileSync(path.join(tmpDir, 'rest.ts'), UNTYPED_FIXTURE);
+      await buildGraph(tmpDir, { engine, incremental: false, skipRegistry: true });
+    }, 60_000);
+
+    afterAll(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('resolves f3 -> realHandler via the rest binding', () => {
+      const all = readCallEdges(path.join(tmpDir, '.codegraph', 'graph.db'));
+      const found = all.find((e) => e.src === 'f3' && e.tgt === 'realHandler');
+      expect(found, `Actual edges:\n${JSON.stringify(all, null, 2)}`).toBeDefined();
+    });
+  });
+}
+
+runUntypedScenario('wasm');
+describe.skipIf(!isNativeAvailable())('native engine coverage', () => {
+  runUntypedScenario('native');
+});
+
+// Scenario 2: type-annotated rest param — CHA/interface dispatch parity with
+// a plain typed parameter.
+function writeTypedFixture(dir: string): void {
+  fs.writeFileSync(
+    path.join(dir, 'worker.ts'),
+    [
+      'export interface IWorker {',
+      '  doWork(): string;',
+      '}',
+      '',
+      'export class ConcreteWorker implements IWorker {',
+      '  doWork(): string {',
+      "    return 'concrete';",
+      '  }',
+      '}',
+      '',
+    ].join('\n'),
+  );
+  fs.writeFileSync(
+    path.join(dir, 'dispatcher.ts'),
+    [
+      "import type { IWorker } from './worker.js';",
+      "import { ConcreteWorker } from './worker.js';",
+      '',
+      'function dispatchPlain(worker: IWorker): string {',
+      '  return worker.doWork();',
+      '}',
+      '',
+      'function dispatchRest({ ...rest }: IWorker): string {',
+      '  return rest.doWork();',
+      '}',
+      '',
+      'export function run(): string {',
+      '  const w = new ConcreteWorker();',
+      '  return dispatchPlain(w) + dispatchRest(w);',
+      '}',
+      '',
+    ].join('\n'),
+  );
+}
+
+function runTypedScenario(engine: EngineMode): void {
+  describe(`object-rest-param type annotation enables CHA dispatch (#2080) — ${engine}`, () => {
+    let tmpDir: string;
+
+    beforeAll(async () => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2080-typed-${engine}-`));
+      writeTypedFixture(tmpDir);
+      await buildGraph(tmpDir, { engine, incremental: false, skipRegistry: true });
+    }, 60_000);
+
+    afterAll(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    function edges(): CallEdgeRow[] {
+      return readCallEdges(path.join(tmpDir, '.codegraph', 'graph.db'));
+    }
+
+    it('dispatchRest resolves to ConcreteWorker.doWork via CHA, same as dispatchPlain', () => {
+      const all = edges();
+      const plain = all.find((e) => e.src === 'dispatchPlain' && e.tgt === 'ConcreteWorker.doWork');
+      const rest = all.find((e) => e.src === 'dispatchRest' && e.tgt === 'ConcreteWorker.doWork');
+      expect(plain, `Actual edges:\n${JSON.stringify(all, null, 2)}`).toBeDefined();
+      expect(rest, `Actual edges:\n${JSON.stringify(all, null, 2)}`).toBeDefined();
+      expect(rest?.technique).toBe(plain?.technique);
+    });
+
+    it('dispatchRest also resolves the interface signature edge like dispatchPlain', () => {
+      const all = edges();
+      const plain = all.find((e) => e.src === 'dispatchPlain' && e.tgt === 'IWorker.doWork');
+      const rest = all.find((e) => e.src === 'dispatchRest' && e.tgt === 'IWorker.doWork');
+      expect(plain).toBeDefined();
+      expect(rest, `Actual edges:\n${JSON.stringify(all, null, 2)}`).toBeDefined();
+    });
+  });
+}
+
+runTypedScenario('wasm');
+describe.skipIf(!isNativeAvailable())('native engine coverage', () => {
+  runTypedScenario('native');
+});

--- a/tests/parsers/javascript.test.ts
+++ b/tests/parsers/javascript.test.ts
@@ -2287,6 +2287,33 @@ function runDemo(reporter: Reporter, users: string[]): void {
       expect(symbols.typeMap.has('rest')).toBe(false);
     });
 
+    // Review finding: a named property alongside the rest element excludes
+    // that property from rest's real type (`Omit<IWorker, 'doWork'>`), so
+    // seeding the full IWorker type onto `rest` would let a call like
+    // `rest.doWork()` — invalid, since doWork was destructured away —
+    // falsely resolve via CHA dispatch.
+    it('does not seed the full annotation type when a sibling property is destructured out', () => {
+      const symbols = parseTS(`
+        function f({ doWork, ...rest }: IWorker) {
+          rest.other();
+        }
+      `);
+      expect(symbols.typeMap.has('rest')).toBe(false);
+    });
+
+    it('still records the object-rest-param binding when a sibling property is present', () => {
+      const symbols = parseTS(`
+        function f({ doWork, ...rest }: IWorker) {
+          rest.other();
+        }
+      `);
+      expect(symbols.objectRestParamBindings).toContainEqual({
+        callee: 'f',
+        restName: 'rest',
+        argIndex: 0,
+      });
+    });
+
     it('records correct argIndex for a type-annotated rest param that is not first', () => {
       const symbols = parseTS(`
         function g(x: number, { ...rest }: IWorker) { rest.doWork(); }

--- a/tests/parsers/javascript.test.ts
+++ b/tests/parsers/javascript.test.ts
@@ -2228,6 +2228,77 @@ function runDemo(reporter: Reporter, users: string[]): void {
     });
   });
 
+  // #2080: tree-sitter-typescript wraps EVERY parameter — typed or not — in
+  // a required_parameter/optional_parameter node (confirmed by parsing
+  // `function f({ ...rest }) {}` with the TS grammar, which still wraps
+  // despite no type annotation), unlike plain tree-sitter-javascript where
+  // object_pattern is a direct formal_parameters child. Without unwrapping,
+  // object-rest-param bindings were silently never recorded for ANY .ts/.tsx
+  // file — the describe block above only ever exercised the .js grammar.
+  describe('Phase 8.3f + #2080: object-rest-param binding extraction in TypeScript', () => {
+    function parseTS(code) {
+      const parser = parsers.get('typescript');
+      const tree = parser.parse(code);
+      return extractSymbols(tree, 'test.ts');
+    }
+
+    it('extracts rest binding from an untyped object-destructuring parameter', () => {
+      const symbols = parseTS(`
+        function f3({ e1: eee1, ...eerest }) {
+          eerest.e4();
+        }
+        f3(obj);
+      `);
+      expect(symbols.objectRestParamBindings).toContainEqual({
+        callee: 'f3',
+        restName: 'eerest',
+        argIndex: 0,
+      });
+    });
+
+    it('extracts rest binding from a type-annotated object-destructuring parameter', () => {
+      const symbols = parseTS(`
+        function dispatchRest({ ...rest }: IWorker) {
+          rest.doWork();
+        }
+      `);
+      expect(symbols.objectRestParamBindings).toContainEqual({
+        callee: 'dispatchRest',
+        restName: 'rest',
+        argIndex: 0,
+      });
+    });
+
+    it('seeds a direct typeMap entry for the rest binding from its type annotation', () => {
+      const symbols = parseTS(`
+        function dispatchRest({ ...rest }: IWorker) {
+          rest.doWork();
+        }
+      `);
+      expect(symbols.typeMap.get('rest')).toEqual({ type: 'IWorker', confidence: 0.9 });
+    });
+
+    it('does not seed a typeMap entry for an untyped rest binding', () => {
+      const symbols = parseTS(`
+        function f3({ ...rest }) {
+          rest.go();
+        }
+      `);
+      expect(symbols.typeMap.has('rest')).toBe(false);
+    });
+
+    it('records correct argIndex for a type-annotated rest param that is not first', () => {
+      const symbols = parseTS(`
+        function g(x: number, { ...rest }: IWorker) { rest.doWork(); }
+      `);
+      expect(symbols.objectRestParamBindings).toContainEqual({
+        callee: 'g',
+        restName: 'rest',
+        argIndex: 1,
+      });
+    });
+  });
+
   describe('prototype method extraction', () => {
     it('extracts Foo.prototype.bar = function() {} as a method definition', () => {
       const symbols = parseJS(`


### PR DESCRIPTION
## Summary

Investigating this issue (which asks whether object-rest-param bindings should get a type-annotation-based typeMap seed for CHA/interface dispatch) revealed two related bugs in `collectObjectRestParams` (TS, `src/extractors/javascript.ts`) / `collect_object_rest_params` (native, `crates/codegraph-core/src/extractors/javascript.rs`). Both are fixed together, since the second makes the first meaningful:

1. **Neither ever unwrapped TypeScript's `required_parameter`/`optional_parameter` node.** tree-sitter-typescript wraps *every* parameter — typed or not — in that node (confirmed by parsing `function f({ ...rest }) {}` directly with the TS grammar), unlike plain tree-sitter-javascript, where `object_pattern` is a direct `formal_parameters` child. Object-rest-param bindings were therefore silently never recorded for **any** `.ts`/`.tsx` file at all, independent of type annotations. The existing #1336 test only ever exercised the `.js` grammar, so this went undetected. Fixed by unwrapping via the `pattern` field before checking for `object_pattern`.
2. **A type-annotated rest parameter (`{ ...rest }: IWorker`) never got a type-annotation-based typeMap entry**, unlike a plain typed parameter (`worker: IWorker`) — `handleParamTypeMap`'s early return on `nameNode.type !== 'identifier'` skipped `object_pattern` entirely. Extended it to seed the rest binding's own name directly from the annotation when present, so CHA/interface dispatch through a typed rest receiver resolves exactly like a plain typed parameter already does. This new direct seed (confidence 0.9) coexists correctly with the pre-existing value-chase seed (`seedRestParamTypeMap`/`buildObjectRestParamPostPass`, confidence 0.65) via `setTypeMapEntry`'s higher-confidence-wins merge — an explicit type annotation is strictly more reliable than an inferred call-site argument name.

Both fixes are necessary together: this issue specifically asks for type-annotation-based seeding, which only exists in TypeScript, but the TS extraction path for rest-param bindings was completely non-functional without fix #1 regardless of annotations — the requested feature couldn't be delivered without it.

## Verification
- lint: pass
- typecheck: pass
- Rust: `cargo test` — 799 passed (up from 795, 4 new tests), including new coverage for both the wrapping-unwrap fix and the type-annotation typeMap seed
- TS: 281 files / 4522 tests, including 6 new integration tests (`tests/integration/issue-2080-object-rest-param-typed-dispatch.test.ts`) and 5 new unit tests (`tests/parsers/javascript.test.ts`)
- Resolution benchmark suite: 206/206 pass — no precision/recall regression on any existing fixture
- Engine parity verified end-to-end: rebuilt the native addon locally and confirmed native and WASM produce byte-identical edges for both the untyped-parity scenario and the typed-CHA-dispatch scenario

Closes #2080