### PR TITLE
fix(dart): extract bare calls, fix endLine truncation, bodyless members (#2082)

### DIFF
--- a/crates/codegraph-core/src/extractors/dart.rs
+++ b/crates/codegraph-core/src/extractors/dart.rs
@@ -34,6 +34,7 @@ fn match_dart_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth
         "constructor_invocation" | "new_expression" => handle_dart_constructor_call(node, source, symbols),
         "type_alias" => handle_dart_type_alias(node, source, symbols),
         "selector" => handle_dart_selector(node, source, symbols),
+        "call_expression" => handle_dart_call_expression(node, source, symbols),
         _ => {}
     }
 }
@@ -133,20 +134,42 @@ fn extract_dart_class_methods(body: &Node, class_name: &str, source: &[u8], symb
                                 None => continue,
                             }
                         }
-                        None => continue,
+                        None => {
+                            // A bodyless (semicolon-only) member — `Foo();` (a
+                            // constructor, the short form idiomatic Dart uses
+                            // throughout) or `double area();` (an abstract
+                            // method with no implementation) — wraps its
+                            // constructor_signature/function_signature in a
+                            // `declaration` node instead of the
+                            // `method_declaration` a block-bodied member uses
+                            // (confirmed by parsing both forms with
+                            // tree-sitter-dart 0.2; #2082). Check for that
+                            // shape before skipping — otherwise every
+                            // fixture/codebase using this idiomatic form
+                            // silently loses its constructors/abstract methods.
+                            let bodyless_sig = find_child(&member, "declaration").and_then(|d| {
+                                find_child(&d, "constructor_signature")
+                                    .or_else(|| find_child(&d, "method_signature"))
+                                    .or_else(|| find_child(&d, "function_signature"))
+                            });
+                            match bodyless_sig {
+                                Some(s) => s,
+                                None => continue,
+                            }
+                        }
                     }
                 }
                 // Direct signatures at the top of the class body (some grammar versions)
                 _ => member,
             };
             match sig.kind() {
-                "method_signature" | "function_signature" => {
+                "method_signature" | "function_signature" | "constructor_signature" => {
                     if let Some(fn_name) = extract_dart_fn_name(&sig, source) {
                         symbols.definitions.push(Definition {
                             name: format!("{}.{}", class_name, fn_name),
                             kind: "method".to_string(),
                             line: start_line(&sig),
-                            end_line: Some(end_line(&sig)),
+                            end_line: Some(dart_function_end_line(&sig)),
                             decorators: None,
                             complexity: compute_all_metrics(&sig, source, "dart"),
                             cfg: build_function_cfg(&sig, "dart", source),
@@ -172,6 +195,39 @@ fn find_dart_signature_child<'a>(node: &Node<'a>) -> Option<Node<'a>> {
         }
     }
     None
+}
+
+/// Compute the true end line for a function/method whose grammar splits the
+/// signature and body into SIBLING nodes — `function_signature`/
+/// `method_signature` followed by a separate `function_body` sibling under
+/// the SAME parent — rather than nesting the body inside the signature node
+/// (confirmed by parsing multi-line top-level functions and class methods
+/// with tree-sitter-dart 0.2; #2082, and the same root cause tracked for
+/// complexity/dataflow purposes in #2182). Using the signature node's own
+/// span alone truncates `end_line` to the signature line, so any call
+/// inside a multi-line body falls outside `[line, end_line]` and
+/// enclosing-function caller-attribution during graph build silently
+/// misses it. Mirrors `dartFunctionEndLine` in `src/extractors/dart.ts`.
+///
+/// Falls back to the signature node's own span when the next sibling is a
+/// bare `;` (an abstract/interface method signature with no body at all)
+/// or doesn't exist.
+fn dart_function_end_line(signature_node: &Node) -> u32 {
+    if let Some(parent) = signature_node.parent() {
+        for i in 0..parent.child_count() {
+            if let Some(child) = parent.child(i) {
+                if child.id() == signature_node.id() {
+                    if let Some(next) = parent.child(i + 1) {
+                        if next.kind() != ";" {
+                            return end_line(&next);
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+    }
+    end_line(signature_node)
 }
 
 fn extract_dart_fn_name(node: &Node, source: &[u8]) -> Option<String> {
@@ -266,7 +322,7 @@ fn handle_dart_function_sig(node: &Node, source: &[u8], symbols: &mut FileSymbol
         name: node_text(&name_node, source).to_string(),
         kind: "function".to_string(),
         line: start_line(node),
-        end_line: Some(end_line(node)),
+        end_line: Some(dart_function_end_line(node)),
         decorators: None,
         complexity: compute_all_metrics(node, source, "dart"),
         cfg: build_function_cfg(node, "dart", source),
@@ -380,6 +436,57 @@ fn handle_dart_selector(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     push_simple_call(symbols, node, method_name);
 }
 
+/// Handles `call_expression` nodes — the shape tree-sitter-dart 0.2
+/// (crates.io, the native engine's grammar) uses for EVERY function/method
+/// call, bare or chained (`helper()`, `Foo()`, `obj.method()`,
+/// `obj.method1().method2()`), confirmed by parsing sample calls with this
+/// crate version and inspecting `src/node-types.json`. This is a
+/// structurally different (and simpler) shape than the `selector`/
+/// `unconditional_assignable_selector` chain `handle_dart_selector` targets
+/// for older grammar versions — a `call_expression` node never appeared in
+/// the parse tree for any of these calls, so `handle_dart_selector` alone
+/// left every native Dart call unextracted (#2082).
+///
+/// `function` field: `identifier` for a bare call (the callee's own name),
+/// or `member_expression` for a chained/property call (`property` field is
+/// the invoked method name — the chain's earlier `call_expression`s, e.g.
+/// `obj.method1()` inside `obj.method1().method2()`, are visited separately
+/// by the tree walk's own recursion, so no manual recursion is needed here).
+fn handle_dart_call_expression(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
+    let Some(func) = node.child_by_field_name("function") else { return };
+    match func.kind() {
+        "identifier" => {
+            let name = node_text(&func, source).to_string();
+            push_simple_call(symbols, node, name);
+        }
+        "member_expression" => {
+            let Some(property) = func.child_by_field_name("property") else { return };
+            let method_name = node_text(&property, source).to_string();
+
+            // Function.apply(fn, positionalArgs, namedArgs) — dynamic
+            // higher-order dispatch, mirrors handle_dart_selector's own
+            // Function.apply special case for the older grammar shape.
+            if method_name == "apply" {
+                if let Some(object) = func.child_by_field_name("object") {
+                    if object.kind() == "identifier" && node_text(&object, source) == "Function" {
+                        symbols.calls.push(Call {
+                            name: "<dynamic:unresolved>".to_string(),
+                            line: start_line(node),
+                            dynamic: Some(true),
+                            dynamic_kind: Some("unresolved-dynamic".to_string()),
+                            ..Default::default()
+                        });
+                        return;
+                    }
+                }
+            }
+
+            push_simple_call(symbols, node, method_name);
+        }
+        _ => {}
+    }
+}
+
 fn is_inside_class(node: &Node) -> bool {
     let mut current = node.parent();
     while let Some(parent) = current {
@@ -395,3 +502,138 @@ fn is_inside_class(node: &Node) -> bool {
     false
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tree_sitter::Parser;
+
+    fn parse_dart(code: &str) -> FileSymbols {
+        let mut parser = Parser::new();
+        parser.set_language(&tree_sitter_dart::LANGUAGE.into()).unwrap();
+        let tree = parser.parse(code, None).unwrap();
+        DartExtractor.extract(&tree, code.as_bytes(), "test.dart")
+    }
+
+    // #2082: tree-sitter-dart 0.2 (the native engine's grammar) represents
+    // EVERY function/method call — bare or chained — as a `call_expression`
+    // node, a structurally different shape from the `selector`-based one
+    // `handle_dart_selector` targets for older grammar versions. Without a
+    // dispatch case for `call_expression`, no native Dart call was ever
+    // extracted at all.
+    mod call_expression_extraction {
+        use super::*;
+
+        #[test]
+        fn extracts_a_bare_plain_function_call() {
+            let s = parse_dart("void main() {\n  helper();\n}");
+            assert!(
+                s.calls.iter().any(|c| c.name == "helper"),
+                "expected a call named 'helper'; got: {:?}",
+                s.calls
+            );
+        }
+
+        #[test]
+        fn extracts_a_bare_constructor_call() {
+            let s = parse_dart("void main() {\n  var w = Foo();\n}");
+            assert!(
+                s.calls.iter().any(|c| c.name == "Foo"),
+                "expected a call named 'Foo'; got: {:?}",
+                s.calls
+            );
+        }
+
+        #[test]
+        fn resolves_each_call_in_a_chained_sequence_to_its_own_name() {
+            let s = parse_dart("void main() {\n  obj.method1().method2();\n}");
+            let names: Vec<&str> = s.calls.iter().map(|c| c.name.as_str()).collect();
+            assert!(names.contains(&"method1"), "missing method1; got: {:?}", names);
+            assert!(names.contains(&"method2"), "missing method2; got: {:?}", names);
+        }
+
+        #[test]
+        fn flags_function_apply_as_unresolved_dynamic() {
+            let s = parse_dart("void g() {\n  var r = Function.apply(callback, []);\n}");
+            assert!(
+                s.calls.iter().any(|c| c.name == "<dynamic:unresolved>" && c.dynamic == Some(true)),
+                "expected an unresolved-dynamic call; got: {:?}",
+                s.calls
+            );
+        }
+    }
+
+    // #2082: function_signature/method_signature and function_body are
+    // SIBLING nodes in tree-sitter-dart, not parent-child, so end_line must
+    // be measured through to the sibling body.
+    mod end_line {
+        use super::*;
+
+        #[test]
+        fn spans_a_multiline_top_level_function_through_its_closing_brace() {
+            let s = parse_dart("Foo makeWaldo() {\n  return Foo();\n}");
+            let def = s.definitions.iter().find(|d| d.name == "makeWaldo");
+            assert!(def.is_some(), "missing makeWaldo definition; got: {:?}", s.definitions);
+            let def = def.unwrap();
+            assert_eq!(def.line, 1);
+            assert_eq!(def.end_line, Some(3));
+        }
+
+        #[test]
+        fn spans_a_multiline_class_method_through_its_closing_brace() {
+            let s = parse_dart(
+                "class UserService {\n  User getUser(String id) {\n    return User(id);\n  }\n}",
+            );
+            let def = s.definitions.iter().find(|d| d.name == "UserService.getUser");
+            assert!(def.is_some(), "missing UserService.getUser; got: {:?}", s.definitions);
+            let def = def.unwrap();
+            assert_eq!(def.line, 2);
+            assert_eq!(def.end_line, Some(4));
+        }
+
+        #[test]
+        fn does_not_extend_past_the_signature_for_an_abstract_method() {
+            let s = parse_dart("abstract class Shape {\n  double area();\n}");
+            let def = s.definitions.iter().find(|d| d.name == "Shape.area");
+            assert!(def.is_some(), "missing Shape.area; got: {:?}", s.definitions);
+            assert_eq!(def.unwrap().end_line, Some(2));
+        }
+    }
+
+    // #2082: a bodyless (semicolon-only) constructor — `Foo();`, the short
+    // form idiomatic Dart uses throughout — wraps its constructor_signature
+    // in a `declaration` node instead of the `method_declaration` a
+    // block-bodied constructor uses.
+    mod bodyless_members {
+        use super::*;
+
+        #[test]
+        fn extracts_a_semicolon_only_constructor() {
+            let s = parse_dart("class Waldo {\n  Waldo();\n}");
+            assert!(
+                s.definitions.iter().any(|d| d.name == "Waldo.Waldo" && d.kind == "method"),
+                "missing Waldo.Waldo method; got: {:?}",
+                s.definitions
+            );
+        }
+
+        #[test]
+        fn extracts_a_semicolon_only_constructor_with_this_shorthand_params() {
+            let s = parse_dart("class User {\n  final String id;\n  User(this.id);\n}");
+            assert!(
+                s.definitions.iter().any(|d| d.name == "User.User" && d.kind == "method"),
+                "missing User.User method; got: {:?}",
+                s.definitions
+            );
+        }
+
+        #[test]
+        fn still_extracts_a_block_bodied_constructor() {
+            let s = parse_dart("class Waldo {\n  Waldo() {\n    print('hi');\n  }\n}");
+            assert!(
+                s.definitions.iter().any(|d| d.name == "Waldo.Waldo" && d.kind == "method"),
+                "missing Waldo.Waldo method; got: {:?}",
+                s.definitions
+            );
+        }
+    }
+}

--- a/crates/codegraph-core/src/extractors/dart.rs
+++ b/crates/codegraph-core/src/extractors/dart.rs
@@ -217,7 +217,26 @@ fn dart_function_end_line(signature_node: &Node) -> u32 {
         for i in 0..parent.child_count() {
             if let Some(child) = parent.child(i) {
                 if child.id() == signature_node.id() {
-                    if let Some(next) = parent.child(i + 1) {
+                    // A `comment` can appear as its own intervening sibling
+                    // BETWEEN the signature and its body (confirmed by
+                    // parsing a signature followed by a same-line-or-not
+                    // `//` comment then `{ ... }` — Greptile review on
+                    // #2082), since tree-sitter-dart's comment rule is an
+                    // `extra` production that can surface anywhere in the
+                    // tree, not just a token folded into an adjacent node.
+                    // Skip past any number of them to find the real next
+                    // sibling. Mirrors `dartFunctionEndLine` in
+                    // `src/extractors/dart.ts`.
+                    let mut j = i + 1;
+                    let mut next = parent.child(j);
+                    while let Some(n) = next {
+                        if n.kind() != "comment" {
+                            break;
+                        }
+                        j += 1;
+                        next = parent.child(j);
+                    }
+                    if let Some(next) = next {
                         if next.kind() != ";" {
                             return end_line(&next);
                         }
@@ -596,6 +615,22 @@ mod tests {
             let def = s.definitions.iter().find(|d| d.name == "Shape.area");
             assert!(def.is_some(), "missing Shape.area; got: {:?}", s.definitions);
             assert_eq!(def.unwrap().end_line, Some(2));
+        }
+
+        // Review finding: a comment between the signature and its body is
+        // its own intervening SIBLING node (tree-sitter-dart's comment rule
+        // is an `extra` production, not folded into an adjacent node),
+        // which the naive "next sibling" lookup mistook for the body itself.
+        #[test]
+        fn skips_a_comment_between_the_signature_and_its_body() {
+            let s = parse_dart(
+                "Foo makeWaldo()\n// a comment between signature and body\n{\n  return Foo();\n}",
+            );
+            let def = s.definitions.iter().find(|d| d.name == "makeWaldo");
+            assert!(def.is_some(), "missing makeWaldo; got: {:?}", s.definitions);
+            let def = def.unwrap();
+            assert_eq!(def.line, 1);
+            assert_eq!(def.end_line, Some(5));
         }
     }
 

--- a/src/extractors/dart.ts
+++ b/src/extractors/dart.ts
@@ -98,10 +98,35 @@ function extractDartClassMembers(
           name: `${className}.${fnName}`,
           kind: 'method',
           line: member.startPosition.row + 1,
-          endLine: nodeEndLine(member),
+          endLine: dartFunctionEndLine(member),
         });
       }
     } else if (member.type === 'declaration') {
+      // A bodyless (semicolon-only) member — `Foo();` (a constructor, the
+      // short form idiomatic Dart uses throughout) or `double area();` (an
+      // abstract method with no implementation) — wraps its
+      // constructor_signature/function_signature/method_signature in a
+      // `declaration` node instead of the `method_signature` a block-bodied
+      // member uses (confirmed by parsing both forms with tree-sitter-dart;
+      // #2082). Check for that shape before falling back to plain
+      // field-declaration detection, which would otherwise silently find no
+      // `identifier` child here and drop the member entirely.
+      const bodylessSig =
+        findChild(member, 'constructor_signature') ||
+        findChild(member, 'method_signature') ||
+        findChild(member, 'function_signature');
+      if (bodylessSig) {
+        const fnName = extractDartFunctionName(member);
+        if (fnName) {
+          ctx.definitions.push({
+            name: `${className}.${fnName}`,
+            kind: 'method',
+            line: member.startPosition.row + 1,
+            endLine: nodeEndLine(member),
+          });
+        }
+        continue;
+      }
       // Field declarations
       for (let j = 0; j < member.childCount; j++) {
         const decl = member.child(j);
@@ -116,6 +141,35 @@ function extractDartClassMembers(
       }
     }
   }
+}
+
+/**
+ * Compute the true end line for a function/method whose grammar splits the
+ * signature and body into SIBLING nodes — `function_signature`/
+ * `method_signature` followed by a separate `function_body` sibling under
+ * the SAME parent — rather than nesting the body inside the signature node
+ * (confirmed by parsing multi-line top-level functions and class methods
+ * with tree-sitter-dart; #2082). Using the signature node's own span alone
+ * truncates `endLine` to the signature line, so any call inside a
+ * multi-line body falls outside `[line, endLine]` and enclosing-function
+ * caller-attribution during graph build silently misses it.
+ *
+ * Falls back to the signature node's own span when the next sibling is a
+ * bare `;` (an abstract/interface method signature with no body at all) or
+ * doesn't exist.
+ */
+function dartFunctionEndLine(signatureNode: TreeSitterNode): number {
+  const parent = signatureNode.parent;
+  if (parent) {
+    for (let i = 0; i < parent.childCount; i++) {
+      if (parent.child(i)?.id === signatureNode.id) {
+        const next = parent.child(i + 1);
+        if (next && next.type !== ';') return nodeEndLine(next);
+        break;
+      }
+    }
+  }
+  return nodeEndLine(signatureNode);
 }
 
 function extractDartFunctionName(node: TreeSitterNode): string | null {
@@ -186,7 +240,7 @@ function handleDartFunction(node: TreeSitterNode, ctx: ExtractorOutput): void {
     name: nameNode.text,
     kind: 'function',
     line: node.startPosition.row + 1,
-    endLine: nodeEndLine(node),
+    endLine: dartFunctionEndLine(node),
   });
 }
 
@@ -199,7 +253,7 @@ function handleDartMethodSig(node: TreeSitterNode, ctx: ExtractorOutput): void {
     name: fnName,
     kind: 'function',
     line: node.startPosition.row + 1,
-    endLine: nodeEndLine(node),
+    endLine: dartFunctionEndLine(node),
   });
 }
 
@@ -291,10 +345,17 @@ function handleDartSelector(node: TreeSitterNode, ctx: ExtractorOutput): void {
 }
 
 // Look for the identifier this selector belongs to.
-// Two layouts are possible depending on grammar version:
+// Three layouts are possible depending on grammar version and call shape:
 //   A) selector has both unconditional_assignable_selector + argument_part (same node)
 //   B) one selector node holds unconditional_assignable_selector (.method),
 //      the next holds argument_part (the call args) — method name is in the previous sibling
+//   C) a bare (keyword-less) call — `helper()`, `Foo()` — has no preceding
+//      `.method`-style selector at all; the callee is a plain identifier
+//      (or type_identifier, for a bare constructor call) sitting directly
+//      before this selector in the SAME parent (confirmed by parsing
+//      `helper();` and `var w = Foo();` with tree-sitter-dart: the tree is
+//      `identifier "helper"` followed by a SIBLING `selector` node, not a
+//      wrapping call_expression — #2082).
 function resolveDartSelectorMethodName(node: TreeSitterNode): string | null {
   const unconditional = findChild(node, 'unconditional_assignable_selector');
   if (unconditional) {
@@ -302,23 +363,37 @@ function resolveDartSelectorMethodName(node: TreeSitterNode): string | null {
     return id ? id.text : null;
   }
 
-  // Layout B: look at the previous sibling selector for the method name
   const parent = node.parent;
   if (!parent) return null;
 
-  let methodName: string | null = null;
+  // Find the sibling immediately preceding this selector node — Dart's
+  // grammar places exactly the callee there, whether that's another
+  // `selector` in a chained-access call (Layout B) or a bare identifier
+  // (Layout C). Compares by `.id`, not `===`: web-tree-sitter returns a
+  // fresh wrapper object from every `.child()` call, so two accessors for
+  // the SAME underlying node are never reference-equal — only `.id` is
+  // stable (confirmed empirically; `.child(i) === .child(i)` is false but
+  // `.child(i).id === .child(i).id` is true). A `===` comparison here would
+  // never break the loop, silently falling through to the LAST sibling in
+  // the parent instead of the one immediately before this selector (#2082).
+  let prevSibling: TreeSitterNode | null = null;
   for (let i = 0; i < parent.childCount; i++) {
     const sibling = parent.child(i);
-    if (sibling === node) break;
-    if (sibling?.type === 'selector') {
-      const unc2 = findChild(sibling, 'unconditional_assignable_selector');
-      if (unc2) {
-        const id2 = findChild(unc2, 'identifier');
-        if (id2) methodName = id2.text;
-      }
-    }
+    if (sibling?.id === node.id) break;
+    prevSibling = sibling;
   }
-  return methodName;
+  if (!prevSibling) return null;
+
+  if (prevSibling.type === 'selector') {
+    const unc2 = findChild(prevSibling, 'unconditional_assignable_selector');
+    return unc2 ? (findChild(unc2, 'identifier')?.text ?? null) : null;
+  }
+
+  if (prevSibling.type === 'identifier' || prevSibling.type === 'type_identifier') {
+    return prevSibling.text;
+  }
+
+  return null;
 }
 
 // Detects `Function.apply(...)` calls: true when a sibling selector's text is

--- a/src/extractors/dart.ts
+++ b/src/extractors/dart.ts
@@ -163,7 +163,19 @@ function dartFunctionEndLine(signatureNode: TreeSitterNode): number {
   if (parent) {
     for (let i = 0; i < parent.childCount; i++) {
       if (parent.child(i)?.id === signatureNode.id) {
-        const next = parent.child(i + 1);
+        // A `comment` can appear as its own intervening sibling BETWEEN the
+        // signature and its body (confirmed by parsing a signature followed
+        // by a same-line-or-not `//` comment then `{ ... }` — Greptile
+        // review on #2082), since tree-sitter-dart's comment rule is an
+        // `extra` production that can surface anywhere in the tree, not
+        // just a token folded into an adjacent node. Skip past any number
+        // of them to find the real next sibling.
+        let j = i + 1;
+        let next = parent.child(j);
+        while (next && next.type === 'comment') {
+          j++;
+          next = parent.child(j);
+        }
         if (next && next.type !== ';') return nodeEndLine(next);
         break;
       }

--- a/tests/benchmarks/resolution/resolution-benchmark.test.ts
+++ b/tests/benchmarks/resolution/resolution-benchmark.test.ts
@@ -206,7 +206,17 @@ const THRESHOLDS: Record<string, { precision: number; recall: number }> = {
   //   matching what the Elixir extractor emits. Same-module bare calls (display_user → get_user)
   //   are not yet resolved — tracked as FNs. Precision 1.0 acts as ratchet against future FPs.
   elixir: { precision: 1.0, recall: 0.8 },
-  dart: { precision: 0.0, recall: 0.0 },
+  // dart: fixed three extractor bugs (#2082) that left recall at a genuine 0%
+  // floor — bare/keyword-less calls were never extracted at all, multi-line
+  // function/method endLine was truncated to the signature line (breaking
+  // enclosing-function caller-attribution for any call inside the body), and
+  // bodyless (semicolon-only) constructors were never extracted as
+  // definitions. Now 100% precision, 61.9% recall (13/21). The remaining
+  // FNs are all receiver-typed calls (`_repo.save(user)` where `_repo`'s
+  // type comes from a constructor `this.field` parameter) — Dart has no
+  // typeMap population for field/parameter types yet, tracked separately
+  // in #2319. Ratcheted below the exact achieved value to avoid flakiness.
+  dart: { precision: 1.0, recall: 0.6 },
   zig: { precision: 0.0, recall: 0.0 },
   fsharp: { precision: 0.0, recall: 0.0 },
   gleam: { precision: 0.0, recall: 0.0 },

--- a/tests/parsers/dart.test.ts
+++ b/tests/parsers/dart.test.ts
@@ -46,9 +46,9 @@ import 'package:flutter/material.dart';`);
 
   it('extracts constructor calls', () => {
     const symbols = parseDart(`var user = User("Alice");`);
-    // Constructor calls may or may not be detected depending on the grammar
-    // This test verifies the parser doesn't crash on constructor syntax
-    expect(symbols).toBeDefined();
+    // Bare (keyword-less) constructor call, #2082 — resolved via the
+    // identifier immediately preceding the call's `selector` node.
+    expect(symbols.calls).toContainEqual(expect.objectContaining({ name: 'User' }));
   });
 
   it('flags Function.apply as unresolved-dynamic', () => {
@@ -62,5 +62,128 @@ import 'package:flutter/material.dart';`);
         dynamicKind: 'unresolved-dynamic',
       }),
     );
+  });
+
+  // #2082: bare (keyword-less) calls — modern Dart permits omitting `new`
+  // for both plain function calls and constructor invocations.
+  describe('#2082: bare (keyword-less) call extraction', () => {
+    it('extracts a bare plain function call', () => {
+      const symbols = parseDart(`void main() {
+  helper();
+}`);
+      expect(symbols.calls).toContainEqual(expect.objectContaining({ name: 'helper' }));
+    });
+
+    it('extracts a bare constructor call assigned to a variable', () => {
+      const symbols = parseDart(`void main() {
+  var w = Foo();
+}`);
+      expect(symbols.calls).toContainEqual(expect.objectContaining({ name: 'Foo' }));
+    });
+
+    it('extracts a bare constructor call in a return statement', () => {
+      const symbols = parseDart(`Foo makeWaldo() {
+  return Foo();
+}`);
+      expect(symbols.calls).toContainEqual(expect.objectContaining({ name: 'Foo' }));
+    });
+
+    it('still resolves an explicit `new` constructor call alongside a bare one', () => {
+      const symbols = parseDart(`void main() {
+  var a = Foo();
+  var b = new Foo();
+}`);
+      expect(symbols.calls.filter((c) => c.name === 'Foo')).toHaveLength(2);
+    });
+
+    it('resolves each call in a chained method-call sequence to its own name (not the last one)', () => {
+      // Regression guard for the underlying root cause: web-tree-sitter
+      // returns a fresh wrapper object from every `.child()` call, so a
+      // `===` reference comparison between two accessors for the SAME node
+      // is always false. Before switching to `.id` comparison, this caused
+      // EVERY selector in a chain to resolve to whichever selector was
+      // encountered last while scanning past it — obj.method1() would
+      // silently resolve as "method2" instead of "method1".
+      const symbols = parseDart(`void main() {
+  obj.method1().method2();
+}`);
+      const names = symbols.calls.map((c) => c.name);
+      expect(names).toContain('method1');
+      expect(names).toContain('method2');
+    });
+  });
+
+  // #2082: multi-line function/method endLine truncation — tree-sitter-dart
+  // splits a function's signature and body into SIBLING nodes
+  // (function_signature/method_signature + function_body), not a
+  // parent-child relationship, so endLine must be measured through to the
+  // sibling body, not just the signature node's own span.
+  describe('#2082: multi-line function/method endLine', () => {
+    it('spans a multi-line top-level function through its closing brace', () => {
+      const symbols = parseDart(`Foo makeWaldo() {
+  return Foo();
+}`);
+      const def = symbols.definitions.find((d) => d.name === 'makeWaldo');
+      expect(def).toBeDefined();
+      expect(def!.line).toBe(1);
+      expect(def!.endLine).toBe(3);
+    });
+
+    it('spans a multi-line class method through its closing brace', () => {
+      const symbols = parseDart(`class UserService {
+  User getUser(String id) {
+    return User(id);
+  }
+}`);
+      const def = symbols.definitions.find((d) => d.name === 'UserService.getUser');
+      expect(def).toBeDefined();
+      expect(def!.line).toBe(2);
+      expect(def!.endLine).toBe(4);
+    });
+
+    it('does not extend past the signature for an abstract method with no body', () => {
+      const symbols = parseDart(`abstract class Shape {
+  double area();
+}`);
+      const def = symbols.definitions.find((d) => d.name === 'Shape.area');
+      expect(def).toBeDefined();
+      expect(def!.endLine).toBe(2);
+    });
+  });
+
+  // #2082: bodyless (semicolon-only) constructors — the idiomatic short
+  // form Dart codebases use throughout (`Foo();`) — parse under a
+  // `declaration` wrapper, not the `method_signature` a block-bodied
+  // constructor uses, so they were silently dropped entirely.
+  describe('#2082: bodyless constructor extraction', () => {
+    it('extracts a semicolon-only constructor as a method definition', () => {
+      const symbols = parseDart(`class Waldo {
+  Waldo();
+}`);
+      expect(symbols.definitions).toContainEqual(
+        expect.objectContaining({ name: 'Waldo.Waldo', kind: 'method' }),
+      );
+    });
+
+    it('extracts a semicolon-only constructor with this-shorthand parameters', () => {
+      const symbols = parseDart(`class User {
+  final String id;
+  User(this.id);
+}`);
+      expect(symbols.definitions).toContainEqual(
+        expect.objectContaining({ name: 'User.User', kind: 'method' }),
+      );
+    });
+
+    it('still extracts a block-bodied constructor (pre-existing behavior)', () => {
+      const symbols = parseDart(`class Waldo {
+  Waldo() {
+    print('hi');
+  }
+}`);
+      expect(symbols.definitions).toContainEqual(
+        expect.objectContaining({ name: 'Waldo.Waldo', kind: 'method' }),
+      );
+    });
   });
 });

--- a/tests/parsers/dart.test.ts
+++ b/tests/parsers/dart.test.ts
@@ -149,6 +149,34 @@ import 'package:flutter/material.dart';`);
       expect(def).toBeDefined();
       expect(def!.endLine).toBe(2);
     });
+
+    // Review finding: a comment between the signature and its body is its
+    // own intervening SIBLING node (tree-sitter-dart's comment rule is an
+    // `extra` production, not folded into an adjacent node), which the
+    // naive "next sibling" lookup mistook for the body itself.
+    it('skips a comment between the signature and its body', () => {
+      const symbols = parseDart(`Foo makeWaldo()
+// a comment between signature and body
+{
+  return Foo();
+}`);
+      const def = symbols.definitions.find((d) => d.name === 'makeWaldo');
+      expect(def).toBeDefined();
+      expect(def!.line).toBe(1);
+      expect(def!.endLine).toBe(5);
+    });
+
+    it('skips multiple consecutive comments between the signature and its body', () => {
+      const symbols = parseDart(`Foo makeWaldo()
+// comment one
+// comment two
+{
+  return Foo();
+}`);
+      const def = symbols.definitions.find((d) => d.name === 'makeWaldo');
+      expect(def).toBeDefined();
+      expect(def!.endLine).toBe(6);
+    });
   });
 
   // #2082: bodyless (semicolon-only) constructors — the idiomatic short


### PR DESCRIPTION
## Summary

Three pre-existing Dart extractor bugs, discovered together while adding Dart constructor-call attribution test coverage. Fixed in both engines (WASM `src/extractors/dart.ts` and native `crates/codegraph-core/src/extractors/dart.rs`):

1. **Bare (keyword-less) calls never extracted.** Modern Dart permits omitting `new`/parens-only calls (`helper()`, `var w = Foo()`). WASM's `resolveDartSelectorMethodName` only handled a preceding `.method` selector (chained access); native had **no dispatch case for `call_expression` at all** — tree-sitter-dart 0.2 represents every call (bare or chained) as `call_expression`, a completely different shape from the older `selector`-based grammar the existing code targeted. Every native Dart call was silently unextracted, not just bare ones.
2. **Multi-line function/method `endLine` truncated to the signature line.** `function_signature`/`method_signature` and `function_body` are SIBLING nodes in tree-sitter-dart (confirmed in both grammar versions), not parent-child. Any call inside a multi-line body fell outside `[line, endLine]`, so enclosing-function caller-attribution during graph build silently misattributed it to file scope.
3. **Bodyless (semicolon-only) constructors and abstract methods** (`Foo();`, `double area();`) — the idiomatic short form Dart codebases use throughout — were never extracted as definitions. They wrap their signature in a `declaration` node instead of the `method_signature`/`method_declaration` a block-bodied member uses, which the field-detection fallback silently swallowed.

**Also fixed, found while implementing #1:** a `===` node-reference comparison bug in the WASM sibling-walk. web-tree-sitter returns a fresh wrapper object from every `.child()` call, so two accessors for the same underlying node are never reference-equal — only `.id` is stable. This silently broke the **pre-existing** chained-method-call case too: `obj.method1().method2()` resolved **both** calls to `"method2"` (whichever selector the broken loop scanned last), not their own names — not just the new bare-call path this PR adds.

Together these took Dart's resolution-benchmark recall from a genuine **0% floor to 100% precision / 61.9% recall (13/21)**. The remaining false negatives are all receiver-typed calls needing typeMap population for Dart fields/parameters — filed as #2319 rather than expanding this PR's scope. Complexity/CFG metrics still use the signature-only node for AST walking (a separate, already-tracked issue, #2182) and are untouched here.

## Verification
- lint: pass
- typecheck: pass
- Rust: `cargo test` — 811 passed (up from 801, 10 new tests)
- TS: 281 files / 4535 tests, including 11 new unit tests (`tests/parsers/dart.test.ts`)
- Engine parity verified end-to-end: rebuilt the native addon locally and confirmed native and WASM produce byte-identical `calls`/`definitions` for every fix scenario (bare calls, chained calls, multi-line endLine, bodyless constructors/methods)
- Resolution-benchmark threshold updated to reflect the new achieved baseline (ratcheted below the exact value to avoid flakiness)

Closes #2082