### PR TITLE
fix(extractors): respect this-binding scope boundaries in call attribution

### DIFF
--- a/crates/codegraph-core/src/extractors/helpers.rs
+++ b/crates/codegraph-core/src/extractors/helpers.rs
@@ -120,11 +120,29 @@ pub fn find_parent_of_types<'a>(node: &Node<'a>, kinds: &[&str]) -> Option<Node<
 /// This replaces the duplicated `find_*_parent_class` helpers that existed in
 /// every language extractor with identical logic but different kind lists.
 pub fn find_enclosing_type_name(node: &Node, kinds: &[&str], source: &[u8]) -> Option<String> {
+    find_enclosing_type_name_with_boundary(node, kinds, source, |_| false)
+}
+
+/// Like `find_enclosing_type_name`, but `is_boundary` is checked against
+/// every ancestor before the `kinds` match — if it returns true, the walk
+/// stops immediately and returns `None` even though a matching ancestor
+/// might exist further up. Used by scope-respecting lookups (e.g. `this`
+/// binding: a plain function does not inherit the enclosing class's `this`,
+/// so the walk must not cross it — see JS's `find_parent_class_for_this_binding`).
+pub fn find_enclosing_type_name_with_boundary(
+    node: &Node,
+    kinds: &[&str],
+    source: &[u8],
+    is_boundary: impl Fn(&Node) -> bool,
+) -> Option<String> {
     let mut current = node.parent();
     while let Some(parent) = current {
         if kinds.contains(&parent.kind()) {
             return named_child_text(&parent, "name", source)
                 .map(|s| s.to_string());
+        }
+        if is_boundary(&parent) {
+            return None;
         }
         current = parent.parent();
     }

--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -1735,8 +1735,11 @@ fn handle_accessor_property_read(
     if obj.kind() == "this" {
         // `this`'s enclosing class is always declared in this same file —
         // the #1893 same-file registry is authoritative, so keep its exact
-        // semantics (including the ambiguous get+set skip) unchanged.
-        let Some(class_name) = find_parent_class(node, source) else { return };
+        // semantics (including the ambiguous get+set skip) unchanged. Uses
+        // the this-binding-boundary-respecting lookup (#2085): an
+        // intervening plain function between this read and its lexically
+        // enclosing class means `this` is not that class's instance.
+        let Some(class_name) = find_parent_class_for_this_binding(node, source) else { return };
         let key = format!("{}.{}", class_name, prop_name);
         let Some(accessor_info) = local_accessors.get(&key) else { return };
         if accessor_info.get && accessor_info.set {
@@ -3998,6 +4001,27 @@ fn extract_call_info(fn_node: &Node, call_node: &Node, source: &[u8]) -> Option<
                 }
             }
 
+            // #2085: `this.method()` where an intervening plain function
+            // breaks the `this`-binding chain to the lexically enclosing
+            // class (e.g. a bare `function` passed to
+            // `setTimeout`/`addEventListener`) — `this` is not guaranteed to
+            // be that class's instance at runtime, so resolving this as a
+            // same-class call would be a false positive. The real target is
+            // statically unknowable here, so this is flagged the same way
+            // other undecidable dynamic call shapes are, rather than
+            // guessed at.
+            if obj.as_ref().map(|o| o.kind()) == Some("this")
+                && this_rebinding_breaks_class_scope(fn_node, source)
+            {
+                return Some(Call {
+                    name: "<dynamic:unresolved>".to_string(),
+                    line: call_line,
+                    dynamic: Some(true),
+                    dynamic_kind: Some("unresolved-dynamic".to_string()),
+                    ..Default::default()
+                });
+            }
+
             let receiver = obj.as_ref().map(|o| extract_receiver_name(o, source));
             Some(Call {
                 name: prop_text.to_string(),
@@ -4219,6 +4243,91 @@ const JS_CLASS_KINDS: &[&str] = &["class_declaration", "abstract_class_declarati
 
 fn find_parent_class(node: &Node, source: &[u8]) -> Option<String> {
     find_enclosing_type_name(node, JS_CLASS_KINDS, source)
+}
+
+/// Plain (non-arrow) function scopes that do NOT inherit `this` lexically
+/// from their enclosing scope — JS/TS rebinds `this` at every ordinary
+/// function call unless the function is explicitly bound (see
+/// `is_bound_to_outer_this`). Arrow functions are deliberately excluded:
+/// they close over the enclosing scope's `this` rather than establishing
+/// their own, so they are transparent to a `this`-binding walk. Distinct
+/// from `JS_FN_SCOPE_KINDS` above, which serves an unrelated typeMap-reset
+/// purpose and also treats arrow functions and methods as boundaries.
+const JS_THIS_REBINDING_BOUNDARY_KINDS: &[&str] = &[
+    "function_declaration",
+    "function_expression",
+    "generator_function_declaration",
+    "generator_function",
+];
+
+/// True when `fn_node` (a function_declaration/function_expression/generator
+/// variant) is the direct receiver of an inline `.bind(this)` call —
+/// `function () { ... }.bind(this)` explicitly re-establishes the enclosing
+/// `this` at the point the function is created, so it does not rebind
+/// `this` away from the enclosing scope despite being a plain function.
+///
+/// Deliberately narrow: only the immediate `fn.bind(this)` shape is
+/// recognized. A named function referenced and bound elsewhere falls
+/// through to the conservative (boundary-respecting) treatment — a missed
+/// resolution, not an incorrect one. Mirrors `isBoundToOuterThis` in
+/// src/extractors/javascript.ts.
+fn is_bound_to_outer_this(fn_node: &Node, source: &[u8]) -> bool {
+    let Some(parent) = fn_node.parent() else { return false };
+    if parent.kind() != "member_expression" {
+        return false;
+    }
+    if parent.child_by_field_name("object").map(|o| o.id()) != Some(fn_node.id()) {
+        return false;
+    }
+    let Some(prop) = parent.child_by_field_name("property") else { return false };
+    if node_text(&prop, source) != "bind" {
+        return false;
+    }
+    let Some(call_expr) = parent.parent() else { return false };
+    if call_expr.kind() != "call_expression" {
+        return false;
+    }
+    if call_expr.child_by_field_name("function").map(|f| f.id()) != Some(parent.id()) {
+        return false;
+    }
+    let Some(args) = call_expr
+        .child_by_field_name("arguments")
+        .or_else(|| find_child(&call_expr, "arguments"))
+    else {
+        return false;
+    };
+    for i in 0..args.child_count() {
+        let Some(child) = args.child(i) else { continue };
+        match child.kind() {
+            "(" | ")" | "," => continue,
+            other => return other == "this",
+        }
+    }
+    false
+}
+
+fn is_this_rebinding_boundary(node: &Node, source: &[u8]) -> bool {
+    JS_THIS_REBINDING_BOUNDARY_KINDS.contains(&node.kind()) && !is_bound_to_outer_this(node, source)
+}
+
+/// Like `find_parent_class`, but stops (returning `None`) at an intervening
+/// plain function scope rather than walking through it — the scope-respecting
+/// lookup a `this`-qualified receiver's enclosing class needs (#2085). A
+/// non-arrow function does not inherit `this` from its enclosing method, so
+/// `this` inside it is not guaranteed to be that method's class instance.
+fn find_parent_class_for_this_binding(node: &Node, source: &[u8]) -> Option<String> {
+    find_enclosing_type_name_with_boundary(node, JS_CLASS_KINDS, source, |n| {
+        is_this_rebinding_boundary(n, source)
+    })
+}
+
+/// True when `node`'s enclosing class (if any) cannot be reached from `node`
+/// without crossing a `this`-rebinding boundary — i.e. there IS a lexically
+/// enclosing class, but an intervening plain function breaks the `this`
+/// chain to it (#2085). Returns false when there is no enclosing class at
+/// all, since there is nothing to falsely attribute `this` to in that case.
+fn this_rebinding_breaks_class_scope(node: &Node, source: &[u8]) -> bool {
+    find_parent_class(node, source).is_some() && find_parent_class_for_this_binding(node, source).is_none()
 }
 
 /// Like `find_parent_class` but stops at function scope boundaries.
@@ -8499,6 +8608,97 @@ mod tests {
         assert!(
             !s.calls.iter().any(|c| c.name == "unknownProp"),
             "a plain (non-accessor) this.field read must never produce a call, tagged or not; got: {:?}",
+            s.calls
+        );
+    }
+
+    // #2085: a plain (non-arrow) function does not inherit `this` lexically —
+    // `this.method()` inside one is not guaranteed to be the enclosing
+    // class's instance, so it must not resolve as a same-class call.
+
+    #[test]
+    fn flags_this_call_inside_plain_callback_as_unresolved() {
+        let s = parse_ts(
+            "class Session {\n\
+               isReady(): boolean { return true; }\n\
+               checkExplicit(): void {\n\
+                 setTimeout(function () {\n\
+                   return this.isReady();\n\
+                 }, 100);\n\
+               }\n\
+             }",
+        );
+        let call = s
+            .calls
+            .iter()
+            .find(|c| c.dynamic_kind.as_deref() == Some("unresolved-dynamic"))
+            .expect("expected the this.isReady() call to be flagged unresolved-dynamic");
+        assert_eq!(call.name, "<dynamic:unresolved>");
+        assert_eq!(call.dynamic, Some(true));
+        assert_eq!(call.dynamic_kind.as_deref(), Some("unresolved-dynamic"));
+        assert!(
+            call.receiver.is_none(),
+            "must not carry a 'this' receiver that would resolve to Session"
+        );
+    }
+
+    #[test]
+    fn still_resolves_this_call_inside_arrow_callback() {
+        let s = parse_ts(
+            "class Session {\n\
+               isReady(): boolean { return true; }\n\
+               checkArrow(): void {\n\
+                 setTimeout(() => {\n\
+                   return this.isReady();\n\
+                 }, 100);\n\
+               }\n\
+             }",
+        );
+        let call = s
+            .calls
+            .iter()
+            .find(|c| c.name == "isReady")
+            .expect("arrow callbacks are transparent to this-binding");
+        assert_eq!(call.receiver.as_deref(), Some("this"));
+    }
+
+    #[test]
+    fn still_resolves_this_call_inside_explicitly_bound_callback() {
+        let s = parse_ts(
+            "class Session {\n\
+               isReady(): boolean { return true; }\n\
+               checkBound(): void {\n\
+                 setTimeout(function () {\n\
+                   return this.isReady();\n\
+                 }.bind(this), 100);\n\
+               }\n\
+             }",
+        );
+        let call = s
+            .calls
+            .iter()
+            .find(|c| c.name == "isReady")
+            .expect(".bind(this) explicitly re-establishes the enclosing this");
+        assert_eq!(call.receiver.as_deref(), Some("this"));
+    }
+
+    #[test]
+    fn flags_this_accessor_read_inside_plain_callback_as_unconfirmed() {
+        let s = parse_ts(
+            "class Session {\n\
+               get ready(): boolean { return this._ready; }\n\
+               private _ready = true;\n\
+               checkExplicit(): void {\n\
+                 setTimeout(function () {\n\
+                   return this.ready;\n\
+                 }, 100);\n\
+               }\n\
+             }",
+        );
+        assert!(
+            !s.calls.iter().any(|c| c.name == "ready"),
+            "a this.field accessor read inside an unbound plain function must not \
+             resolve to the enclosing class's accessor; got: {:?}",
             s.calls
         );
     }

--- a/src/extractors/helpers.ts
+++ b/src/extractors/helpers.ts
@@ -155,12 +155,20 @@ export function rustVisibility(node: TreeSitterNode): 'public' | 'private' {
  * Walk up the parent chain to find an enclosing node whose type is in `typeNames`.
  * Returns the text of `nameField` (default `'name'`) on the matching ancestor, or null.
  *
+ * `isBoundary`, when passed, is checked against every ancestor before the
+ * `typeNames` match — if it returns true, the walk stops immediately and
+ * returns null even though a matching ancestor might exist further up. Used
+ * by callers that need a scope-respecting lookup (e.g. `this`-binding: a
+ * plain function does not inherit the enclosing class's `this`, so the walk
+ * must not cross it — see JS/TS's `findParentClassForThisBinding`).
+ *
  * Replaces per-language `findParentClass` / `findParentType` / `findCurrentImpl` helpers.
  */
 export function findParentNode(
   node: TreeSitterNode,
   typeNames: readonly string[],
   nameField: string = 'name',
+  isBoundary?: (n: TreeSitterNode) => boolean,
 ): string | null {
   let current = node.parent;
   while (current) {
@@ -168,6 +176,7 @@ export function findParentNode(
       const nameNode = current.childForFieldName(nameField);
       return nameNode ? nameNode.text : null;
     }
+    if (isBoundary?.(current)) return null;
     current = current.parent;
   }
   return null;

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -929,8 +929,10 @@ function collectAccessorPropertyRead(
     // (including the ambiguous get+set skip) unchanged. A #2030 cross-file
     // fallback would never have anything to add for `this`, and tagging
     // every plain `this.field` read would add unbounded extraction volume
-    // for zero benefit.
-    const className = findParentClass(node);
+    // for zero benefit. Uses the this-binding-boundary-respecting lookup
+    // (#2085): an intervening plain function between this read and its
+    // lexically enclosing class means `this` is not that class's instance.
+    const className = findParentClassForThisBinding(node);
     if (!className) return;
     const accessorInfo = localAccessors.get(`${className}.${propName}`);
     if (!accessorInfo || (accessorInfo.get && accessorInfo.set) || !accessorInfo[neededKind]) {
@@ -4354,6 +4356,23 @@ function extractMemberExprCallInfo(fn: TreeSitterNode, callNode: TreeSitterNode)
     }
   }
 
+  // #2085: `this.method()` where an intervening plain function breaks the
+  // `this`-binding chain to the lexically enclosing class (e.g. a bare
+  // `function` passed to `setTimeout`/`addEventListener`) — `this` is not
+  // guaranteed to be that class's instance at runtime, so resolving this as
+  // a same-class call would be a false positive. The real target is
+  // statically unknowable here (it depends on how the function ends up being
+  // invoked), so this is flagged the same way other undecidable dynamic call
+  // shapes are, rather than guessed at.
+  if (obj?.type === 'this' && thisRebindingBreaksClassScope(fn)) {
+    return {
+      name: '<dynamic:unresolved>',
+      line: callLine,
+      dynamic: true,
+      dynamicKind: 'unresolved-dynamic',
+    };
+  }
+
   const receiver = extractReceiverName(obj);
   return { name: propText, line: callLine, receiver };
 }
@@ -5263,6 +5282,80 @@ function extractSuperclass(heritage: TreeSitterNode): string | null {
 const JS_CLASS_TYPES = ['class_declaration', 'abstract_class_declaration', 'class'] as const;
 function findParentClass(node: TreeSitterNode): string | null {
   return findParentNode(node, JS_CLASS_TYPES);
+}
+
+/**
+ * Plain (non-arrow) function scopes that do NOT inherit `this` lexically from
+ * their enclosing scope — JS/TS rebinds `this` at every ordinary function
+ * call unless the function is explicitly bound (see `isBoundToOuterThis`).
+ * Arrow functions are deliberately excluded: they close over the enclosing
+ * scope's `this` rather than establishing their own, so they are transparent
+ * to a `this`-binding walk.
+ */
+const JS_THIS_REBINDING_BOUNDARY_TYPES: ReadonlySet<string> = new Set([
+  'function_declaration',
+  'function_expression',
+  'generator_function_declaration',
+  'generator_function',
+]);
+
+/**
+ * True when `fnNode` (a function_declaration/function_expression/generator
+ * variant) is the direct receiver of an inline `.bind(this)` call —
+ * `function () { ... }.bind(this)` explicitly re-establishes the enclosing
+ * `this` at the point the function is created, so it does not rebind `this`
+ * away from the enclosing scope despite being a plain function.
+ *
+ * Deliberately narrow: only the immediate `fn.bind(this)` shape is
+ * recognized. A named function referenced and bound elsewhere
+ * (`const f = function(){...}; el.on('x', f.bind(this))`) falls through to
+ * the conservative (boundary-respecting) treatment — a missed resolution,
+ * not an incorrect one.
+ */
+function isBoundToOuterThis(fnNode: TreeSitterNode): boolean {
+  const parent = fnNode.parent;
+  if (parent?.type !== 'member_expression') return false;
+  if (parent.childForFieldName('object')?.id !== fnNode.id) return false;
+  if (parent.childForFieldName('property')?.text !== 'bind') return false;
+  const callExpr = parent.parent;
+  if (callExpr?.type !== 'call_expression') return false;
+  if (callExpr.childForFieldName('function')?.id !== parent.id) return false;
+  const args = callExpr.childForFieldName('arguments') || findChild(callExpr, 'arguments');
+  if (!args) return false;
+  for (let i = 0; i < args.childCount; i++) {
+    const child = args.child(i);
+    if (!child) continue;
+    const t = child.type;
+    if (t === '(' || t === ')' || t === ',') continue;
+    return t === 'this';
+  }
+  return false;
+}
+
+function isThisRebindingBoundary(n: TreeSitterNode): boolean {
+  return JS_THIS_REBINDING_BOUNDARY_TYPES.has(n.type) && !isBoundToOuterThis(n);
+}
+
+/**
+ * Like `findParentClass`, but stops (returning null) at an intervening plain
+ * function scope rather than walking through it — the scope-respecting
+ * lookup a `this`-qualified receiver's enclosing class needs (#2085). A
+ * non-arrow function does not inherit `this` from its enclosing method, so
+ * `this` inside it is not guaranteed to be that method's class instance.
+ */
+function findParentClassForThisBinding(node: TreeSitterNode): string | null {
+  return findParentNode(node, JS_CLASS_TYPES, 'name', isThisRebindingBoundary);
+}
+
+/**
+ * True when `node`'s enclosing class (if any) cannot be reached from `node`
+ * without crossing a `this`-rebinding boundary — i.e. there IS a lexically
+ * enclosing class, but an intervening plain function breaks the `this`
+ * chain to it (#2085). Returns false when there is no enclosing class at
+ * all, since there is nothing to falsely attribute `this` to in that case.
+ */
+function thisRebindingBreaksClassScope(node: TreeSitterNode): boolean {
+  return findParentClass(node) !== null && findParentClassForThisBinding(node) === null;
 }
 
 /**

--- a/tests/parsers/javascript.test.ts
+++ b/tests/parsers/javascript.test.ts
@@ -3367,4 +3367,105 @@ function runDemo(reporter: Reporter, users: string[]): void {
       expect(symbols.calls).not.toContainEqual(expect.objectContaining({ name: 'unknownProp' }));
     });
   });
+
+  // #2085: a plain (non-arrow) function does not inherit `this` lexically —
+  // `this.method()`/`this.prop` inside one is not guaranteed to be the
+  // enclosing class's instance, so it must not resolve as a same-class call.
+  describe('this-binding scope boundaries for call/property-read attribution (#2085)', () => {
+    function parseTS(code) {
+      const parser = parsers.get('typescript');
+      const tree = parser.parse(code);
+      return extractSymbols(tree, 'test.ts');
+    }
+
+    it('flags a this.method() call inside an unbound plain-function callback as unresolved', () => {
+      const symbols = parseTS(`
+        class Session {
+          isReady(): boolean { return true; }
+          checkExplicit(): void {
+            setTimeout(function () {
+              return this.isReady();
+            }, 100);
+          }
+        }
+      `);
+      expect(symbols.calls).not.toContainEqual(
+        expect.objectContaining({ name: 'isReady', receiver: 'this' }),
+      );
+      expect(symbols.calls).toContainEqual(
+        expect.objectContaining({
+          name: '<dynamic:unresolved>',
+          dynamic: true,
+          dynamicKind: 'unresolved-dynamic',
+        }),
+      );
+    });
+
+    it('still resolves a this.method() call inside an arrow-function callback', () => {
+      const symbols = parseTS(`
+        class Session {
+          isReady(): boolean { return true; }
+          checkArrow(): void {
+            setTimeout(() => {
+              return this.isReady();
+            }, 100);
+          }
+        }
+      `);
+      expect(symbols.calls).toContainEqual(
+        expect.objectContaining({ name: 'isReady', receiver: 'this' }),
+      );
+    });
+
+    it('still resolves a this.method() call inside an explicitly `.bind(this)`-wrapped callback', () => {
+      const symbols = parseTS(`
+        class Session {
+          isReady(): boolean { return true; }
+          checkBound(): void {
+            setTimeout(function () {
+              return this.isReady();
+            }.bind(this), 100);
+          }
+        }
+      `);
+      expect(symbols.calls).toContainEqual(
+        expect.objectContaining({ name: 'isReady', receiver: 'this' }),
+      );
+    });
+
+    it('does not attribute a this.field accessor read inside an unbound plain-function callback', () => {
+      const symbols = parseTS(`
+        class Session {
+          get ready(): boolean { return this._ready; }
+          private _ready = true;
+          checkExplicit(): void {
+            setTimeout(function () {
+              return this.ready;
+            }, 100);
+          }
+        }
+      `);
+      expect(symbols.calls).not.toContainEqual(expect.objectContaining({ name: 'ready' }));
+    });
+
+    it('still resolves a nested plain function inside an arrow (boundary re-established)', () => {
+      const symbols = parseTS(`
+        class Session {
+          isReady(): boolean { return true; }
+          checkNested(): void {
+            const arrow = () => {
+              function inner() {
+                return this.isReady();
+              }
+              inner();
+            };
+            arrow();
+          }
+        }
+      `);
+      expect(symbols.calls).not.toContainEqual(
+        expect.objectContaining({ name: 'isReady', receiver: 'this' }),
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Closes #2085

A `this`-qualified call or property read (`this.method()` / `this.prop`) was always attributed to the nearest lexically enclosing class, even when a plain (non-arrow) function sat between the access site and that class. JS/TS does not bind `this` lexically through an ordinary function call, so:

```ts
class Session {
  isReady(): boolean { return this._ready; }
  private _ready = true;

  checkExplicit(): void {
    setTimeout(function () {
      return this.isReady(); // NOT the Session instance at runtime
    }, 100);
  }
}
```

previously produced a false `Session.checkExplicit -> Session.isReady` edge in both engines.

## Changes

- `src/extractors/helpers.ts`: `findParentNode` gains an optional `isBoundary` predicate — when it matches an ancestor before a type-name match is found, the walk stops and returns `null`.
- `src/extractors/javascript.ts`: adds `findParentClassForThisBinding` (stops at a plain `function_declaration`/`function_expression`/`generator_function_declaration`/`generator_function`, but treats `arrow_function` as transparent since it inherits `this` lexically). An inline `.bind(this)` wrapper (`function(){...}.bind(this)`) is recognized as re-establishing the outer `this` and is not treated as a boundary. Used by:
  - `collectAccessorPropertyRead`'s `this.field` accessor-read branch (#1893/#2030 same-file/cross-file accessor confirmation)
  - `extractMemberExprCallInfo`'s general `this.method()` call path — when the boundary is crossed, the call is now flagged `dynamic: true, dynamicKind: 'unresolved-dynamic'` instead of resolving to the wrong class (the true target is statically unknowable, same treatment as other undecidable dynamic call shapes)
- `crates/codegraph-core/src/extractors/helpers.rs`: mirrors `findParentNode`'s boundary support as `find_enclosing_type_name_with_boundary`.
- `crates/codegraph-core/src/extractors/javascript.rs`: mirrors `findParentClassForThisBinding`/`isBoundToOuterThis`/the call-site fix in `extract_call_info` and `handle_accessor_property_read`.
- Tests added on both sides covering: unbound plain-function callback (flagged), arrow-function callback (still resolves), `.bind(this)`-wrapped callback (still resolves), nested plain-function-inside-arrow (still flagged), and the accessor-read equivalent.

Verified end-to-end parity by rebuilding the native addon locally and comparing `codegraph query` output between `--engine native` and `--engine wasm` against the issue's repro — both now correctly report only `checkArrow`/`checkBound` as callers of `Session.isReady`, excluding `checkExplicit`.

Filed #2321 for an unrelated pre-existing artifact noticed during this investigation (`.bind()` called directly on an inline function expression emits a `Call` whose `receiver` is the entire function's raw source text) — out of scope for this fix.

## Test plan

- [x] `cargo test -p codegraph-core --lib` — 816 passed (including 4 new tests)
- [x] `npx vitest run tests/parsers/javascript.test.ts` — 308 passed (including 5 new tests)
- [x] `npm test` — full suite, 4542 passed
- [x] `npx tsc --noEmit` clean
- [x] `cargo build -p codegraph-core --lib` clean
- [x] Manual native-vs-wasm parity check via `codegraph build --engine native|wasm` + `codegraph query` on the issue's repro fixture
- [x] `codegraph diff-impact --staged -T` reviewed