### PR TITLE
fix(extractors): distinguish static vs instance accessors in same-file registry

### DIFF
--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -1521,11 +1521,18 @@ fn handle_method_def(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 //      this file — emitted as a tagged candidate for the resolver's global
 //      accessor-kind filter to confirm once every file's accessors are known.
 
-/// Per-property record of which accessor kinds a same-file class declares.
+/// Per-property record of which accessor kinds a same-file class declares —
+/// instance and static accessors tracked separately (#2086). `this` inside
+/// an instance method never refers to the class/constructor object (where
+/// `static` members live) — only `this` inside a static method does — so a
+/// bare `this.prop` read must only ever match the bucket corresponding to
+/// its own calling context, never the other one.
 #[derive(Default, Clone, Copy)]
 struct LocalAccessorInfo {
     get: bool,
     set: bool,
+    static_get: bool,
+    static_set: bool,
 }
 
 /// `ClassName.propName` → which accessor kinds are declared, for this file only.
@@ -1551,6 +1558,46 @@ fn get_method_accessor_kind(meth_node: &Node) -> Option<&'static str> {
     None
 }
 
+/// True when `meth_node` (a method_definition) carries a `static` modifier —
+/// same unnamed-token-child shape `get_method_accessor_kind` scans for (#2086).
+fn is_static_method_definition(meth_node: &Node) -> bool {
+    let name_node = meth_node.child_by_field_name("name");
+    for i in 0..meth_node.child_count() {
+        let Some(child) = meth_node.child(i) else { continue };
+        if Some(child.id()) == name_node.map(|n| n.id()) {
+            break;
+        }
+        if child.kind() == "static" {
+            return true;
+        }
+    }
+    false
+}
+
+/// Walk up from `node` to the nearest enclosing `method_definition` and
+/// report whether it is static — determines whether a `this.prop` read's
+/// calling context refers to the class object (static) or an instance
+/// (#2086). Only meaningful once the caller has already confirmed (via
+/// `find_parent_class_for_this_binding`) that no this-rebinding boundary
+/// (#2085) sits between `node` and its enclosing class — an arrow function
+/// is transparent to both walks, so the nearest `method_definition` found
+/// here is the same function whose `this` binding actually governs `node`.
+///
+/// Returns false (instance) when `node` isn't inside any method_definition
+/// at all — e.g. a class field initializer or `static { }` block — which
+/// can misclassify a static field initializer's `this` as instance-context;
+/// not handled here (see #2085/#2086 follow-up discussion).
+fn is_enclosing_method_static(node: &Node) -> bool {
+    let mut current = node.parent();
+    while let Some(parent) = current {
+        if parent.kind() == "method_definition" {
+            return is_static_method_definition(&parent);
+        }
+        current = parent.parent();
+    }
+    false
+}
+
 /// Pre-scan pass: collect every ES6 get/set class-accessor declared in this
 /// file, keyed by its qualified `ClassName.propName` name — the same
 /// qualification `handle_method_def` already gives the accessor's own
@@ -1570,10 +1617,13 @@ fn collect_local_accessors(root: &Node, source: &[u8]) -> LocalAccessorRegistry 
                 {
                     let key = format!("{}.{}", class_name, prop_name);
                     let entry = registry.entry(key).or_default();
-                    if kind == "get" {
-                        entry.get = true;
-                    } else {
-                        entry.set = true;
+                    let is_static = is_static_method_definition(node);
+                    match (kind, is_static) {
+                        ("get", true) => entry.static_get = true,
+                        ("set", true) => entry.static_set = true,
+                        ("get", false) => entry.get = true,
+                        (_, false) => entry.set = true,
+                        _ => {}
                     }
                 }
             }
@@ -1742,13 +1792,19 @@ fn handle_accessor_property_read(
         let Some(class_name) = find_parent_class_for_this_binding(node, source) else { return };
         let key = format!("{}.{}", class_name, prop_name);
         let Some(accessor_info) = local_accessors.get(&key) else { return };
-        if accessor_info.get && accessor_info.set {
+        // #2086: `this` only reaches the class/constructor object (where
+        // static members live) from inside a static method — match only the
+        // bucket corresponding to the read site's own calling context.
+        let is_static_context = is_enclosing_method_static(node);
+        let relevant_get = if is_static_context { accessor_info.static_get } else { accessor_info.get };
+        let relevant_set = if is_static_context { accessor_info.static_set } else { accessor_info.set };
+        if relevant_get && relevant_set {
             return;
         }
-        if needed_get && !accessor_info.get {
+        if needed_get && !relevant_get {
             return;
         }
-        if !needed_get && !accessor_info.set {
+        if !needed_get && !relevant_set {
             return;
         }
         symbols.calls.push(Call {
@@ -8465,6 +8521,62 @@ mod tests {
         assert!(
             s.calls.iter().any(|c| c.name == "version" && c.receiver.as_deref() == Some("this")),
             "expected a call to version via this; got: {:?}",
+            s.calls
+        );
+    }
+
+    // ── Accessor registry static vs instance distinction (#2086) ──
+
+    #[test]
+    fn does_not_attribute_instance_context_this_read_to_a_static_only_accessor() {
+        let s = parse_js(
+            "class Config {\n\
+               static get version() { return Config._v; }\n\
+               static _v = '1.0';\n\
+               describe() { return this.version; }\n\
+             }",
+        );
+        assert!(
+            !s.calls.iter().any(|c| c.name == "version"),
+            "this.version inside an INSTANCE method must not resolve to a \
+             static-only accessor — `this` there is the instance, not the \
+             class object; got: {:?}",
+            s.calls
+        );
+    }
+
+    #[test]
+    fn does_not_attribute_static_context_this_read_to_an_instance_only_accessor() {
+        let s = parse_js(
+            "class Widget {\n\
+               get value() { return this._v; }\n\
+               _v = 1;\n\
+               static describe() { return this.value; }\n\
+             }",
+        );
+        assert!(
+            !s.calls.iter().any(|c| c.name == "value"),
+            "this.value inside a STATIC method must not resolve to an \
+             instance-only accessor — `this` there is the class object, not \
+             an instance; got: {:?}",
+            s.calls
+        );
+    }
+
+    #[test]
+    fn still_attributes_instance_context_this_read_to_an_instance_accessor() {
+        let s = parse_js(
+            "class Widget {\n\
+               get value() { return this._v; }\n\
+               _v = 1;\n\
+               useOther() { return this.value; }\n\
+             }",
+        );
+        assert!(
+            s.calls
+                .iter()
+                .any(|c| c.name == "value" && c.receiver.as_deref() == Some("this")),
+            "instance-to-instance accessor attribution must keep working; got: {:?}",
             s.calls
         );
     }

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -717,10 +717,19 @@ function buildMethodDefinition(node: TreeSitterNode, name: string): Definition {
 // reads (the accessor's class declared in a different file than the read
 // site) are not yet covered — see #2030.
 
-/** Per-property record of which accessor kinds a same-file class declares. */
+/**
+ * Per-property record of which accessor kinds a same-file class declares —
+ * instance and static accessors tracked separately (#2086). `this` inside an
+ * instance method never refers to the class/constructor object (where
+ * `static` members live) — only `this` inside a static method does — so a
+ * bare `this.prop` read must only ever match the bucket corresponding to its
+ * own calling context, never the other one.
+ */
 interface LocalAccessorInfo {
   get: boolean;
   set: boolean;
+  staticGet: boolean;
+  staticSet: boolean;
 }
 
 /** `ClassName.propName` → which accessor kinds are declared, for this file only. */
@@ -748,6 +757,44 @@ function getMethodAccessorKind(methNode: TreeSitterNode): 'get' | 'set' | null {
 }
 
 /**
+ * True when `methNode` (a method_definition) carries a `static` modifier —
+ * same unnamed-token-child shape `getMethodAccessorKind` scans for (#2086).
+ */
+function isStaticMethodDefinition(methNode: TreeSitterNode): boolean {
+  const nameNode = methNode.childForFieldName('name');
+  for (let i = 0; i < methNode.childCount; i++) {
+    const child = methNode.child(i);
+    if (!child || child.id === nameNode?.id) break;
+    if (child.type === 'static') return true;
+  }
+  return false;
+}
+
+/**
+ * Walk up from `node` to the nearest enclosing `method_definition` and
+ * report whether it is static — determines whether a `this.prop` read's
+ * calling context refers to the class object (static) or an instance
+ * (#2086). Only meaningful once the caller has already confirmed (via
+ * `findParentClassForThisBinding`) that no this-rebinding boundary (#2085)
+ * sits between `node` and its enclosing class — an arrow function is
+ * transparent to both walks, so the nearest `method_definition` found here
+ * is the same function whose `this` binding actually governs `node`.
+ *
+ * Returns false (instance) when `node` isn't inside any method_definition at
+ * all — e.g. a class field initializer or `static { }` block — which can
+ * misclassify a static field initializer's `this` as instance-context; not
+ * handled here (see #2085/#2086 follow-up discussion).
+ */
+function isEnclosingMethodStatic(node: TreeSitterNode): boolean {
+  let current = node.parent;
+  while (current) {
+    if (current.type === 'method_definition') return isStaticMethodDefinition(current);
+    current = current.parent;
+  }
+  return false;
+}
+
+/**
  * Pre-scan pass: collect every ES6 get/set class-accessor declared in this
  * file, keyed by its qualified `ClassName.propName` name — the same
  * qualification `buildMethodDefinition`'s caller already gives the accessor's
@@ -767,8 +814,18 @@ function collectLocalAccessors(rootNode: TreeSitterNode): LocalAccessorRegistry 
         const propName = nameNode ? resolveMethodDefinitionName(nameNode) : '';
         if (className && propName) {
           const key = `${className}.${propName}`;
-          const entry = registry.get(key) ?? { get: false, set: false };
-          entry[accessorKind] = true;
+          const entry = registry.get(key) ?? {
+            get: false,
+            set: false,
+            staticGet: false,
+            staticSet: false,
+          };
+          const bucketKey = isStaticMethodDefinition(node)
+            ? accessorKind === 'get'
+              ? 'staticGet'
+              : 'staticSet'
+            : accessorKind;
+          entry[bucketKey] = true;
           registry.set(key, entry);
         }
       }
@@ -935,7 +992,15 @@ function collectAccessorPropertyRead(
     const className = findParentClassForThisBinding(node);
     if (!className) return;
     const accessorInfo = localAccessors.get(`${className}.${propName}`);
-    if (!accessorInfo || (accessorInfo.get && accessorInfo.set) || !accessorInfo[neededKind]) {
+    if (!accessorInfo) return;
+    // #2086: `this` only reaches the class/constructor object (where static
+    // members live) from inside a static method — match only the bucket
+    // corresponding to the read site's own calling context.
+    const isStaticContext = isEnclosingMethodStatic(node);
+    const relevantGet = isStaticContext ? accessorInfo.staticGet : accessorInfo.get;
+    const relevantSet = isStaticContext ? accessorInfo.staticSet : accessorInfo.set;
+    const relevantForKind = neededKind === 'get' ? relevantGet : relevantSet;
+    if ((relevantGet && relevantSet) || !relevantForKind) {
       return;
     }
     valueRefCalls.push({ name: propName, receiver: 'this', line: nodeStartLine(node) });

--- a/tests/parsers/javascript.test.ts
+++ b/tests/parsers/javascript.test.ts
@@ -3250,6 +3250,51 @@ function runDemo(reporter: Reporter, users: string[]): void {
         expect.objectContaining({ name: 'version', receiver: 'this' }),
       );
     });
+
+    // #2086: `this` inside an instance method never refers to the
+    // class/constructor object (where static members live) — only `this`
+    // inside a static method does — so the registry must not conflate the
+    // two when matching a bare `this.prop` read.
+    it('does not attribute an instance-context this read to a static-only accessor', () => {
+      const symbols = parseJS(`
+        class Config {
+          static get version() { return Config._v; }
+          static _v = '1.0';
+          describe() {
+            return this.version;
+          }
+        }
+      `);
+      expect(symbols.calls).not.toContainEqual(expect.objectContaining({ name: 'version' }));
+    });
+
+    it('does not attribute a static-context this read to an instance-only accessor', () => {
+      const symbols = parseJS(`
+        class Widget {
+          get value() { return this._v; }
+          _v = 1;
+          static describe() {
+            return this.value;
+          }
+        }
+      `);
+      expect(symbols.calls).not.toContainEqual(expect.objectContaining({ name: 'value' }));
+    });
+
+    it('still attributes an instance-context this read to an instance accessor', () => {
+      const symbols = parseJS(`
+        class Widget {
+          get value() { return this._v; }
+          _v = 1;
+          useOther() {
+            return this.value;
+          }
+        }
+      `);
+      expect(symbols.calls).toContainEqual(
+        expect.objectContaining({ name: 'value', receiver: 'this' }),
+      );
+    });
   });
 
   describe('ES6 getter/setter cross-file property-read call attribution (#2030)', () => {


### PR DESCRIPTION
## Summary

Closes #2086

Deferred from #2031's review (Greptile 5/5, one open note): `collectLocalAccessors`/`collect_local_accessors`'s same-file ES6 get/set accessor registry keyed purely by `ClassName.propName -> {get, set}`, with no static/instance distinction. `this` inside an **instance** method never refers to the class/constructor object (where `static` members live) — only `this` inside a **static** method does. If a class declared only a `static get X()` (no instance accessor of that name), a bare `this.X` read inside an **instance** method matched against the static accessor and produced a false-positive `calls` edge (and the mirror case — an instance-only accessor read from a static method — had the same gap in reverse):

```ts
export class Config {
  static get version(): string { return Config._v; }
  static _v = '1.0';

  // this refers to the Config INSTANCE here — this.version does not invoke
  // the static getter at runtime — yet codegraph reported
  // Config.describe -> Config.version.
  describe(): string {
    return this.version;
  }
}
```

## Changes

- `src/extractors/javascript.ts` / `crates/codegraph-core/src/extractors/javascript.rs`: `LocalAccessorInfo` gains `staticGet`/`staticSet` fields alongside the existing `get`/`set` (now unambiguously instance-only). `collectLocalAccessors`/`collect_local_accessors` routes each declared accessor into the correct bucket via a new `isStaticMethodDefinition`/`is_static_method_definition` check.
- A new `isEnclosingMethodStatic`/`is_enclosing_method_static` walks up from a `this.prop` read to the nearest enclosing `method_definition` and reports whether it's static — that determines which bucket (`static*` vs instance) the read must match against. Only meaningful once `findParentClassForThisBinding` (#2085) has already confirmed no this-rebinding boundary sits in between; an arrow function is transparent to both walks.
- The `varName.prop` (non-`this`) branch is untouched: it already only needs the instance bucket, since typeMap never records a variable holding the class object itself — so unifying `get`/`set` to mean "instance" for free fixes that branch's equivalent gap too (an instance-typed variable reading a static-only accessor).
- Tests added on both sides for all four combinations: instance-context reading a static-only accessor (no edge), static-context reading an instance-only accessor (no edge), and confirming the pre-existing static-to-static and instance-to-instance cases still pass.

Known narrow gap left out of scope (matches the issue's stated boundary): a class field initializer or `static { }` block isn't inside any `method_definition`, so `isEnclosingMethodStatic` defaults to instance-context there — a static field initializer's own `this.prop` read could still misclassify. Not handled here; flagged in code comments for anyone extending this further.

## Test plan

- [x] `cargo test -p codegraph-core --lib` — 822 passed (including 3 new tests)
- [x] `npx vitest run tests/parsers/javascript.test.ts` — 311 passed (including 3 new tests)
- [x] `npm test` — full suite, 4545 passed
- [x] `npx tsc --noEmit` clean
- [x] `cargo build -p codegraph-core --lib` clean
- [x] Manual native-vs-wasm parity check via `codegraph build --engine native|wasm` + `codegraph query` against the issue's repro (both engines agree: `Config.version` has no callers, `Widget.value` is called only by the instance method, not the static one)
- [x] `codegraph diff-impact --staged -T` reviewed