### PR TITLE
fix(incremental): persist invoked-property-name evidence across builds

### DIFF
--- a/crates/codegraph-core/src/db/connection.rs
+++ b/crates/codegraph-core/src/db/connection.rs
@@ -477,6 +477,31 @@ const MIGRATIONS: &[Migration] = &[
         ON edges(source_id, target_id, kind, confidence, dynamic, COALESCE(dynamic_kind, ''), COALESCE(technique, ''));
     "#,
     },
+    Migration {
+        // #2087: durable, per-file record of every property/method name ever
+        // invoked via member-call syntax (`x.name(...)`) — the "one hop
+        // further" liveness evidence the #1895 object-literal-property
+        // value-ref check needs (collect_invoked_property_names /
+        // collectInvokedPropertyNames). A full build sees every file at
+        // once, so it was always exact; a `codegraph watch` single-file
+        // incremental rebuild (JS-only, domain/graph/builder/incremental.ts)
+        // only sees the one file being rebuilt, so a consumer's
+        // `.resolve(...)` call living in an untouched file was invisible.
+        // Populated once per full or incremental build (both engines — the
+        // native orchestrator mirrors the JS pipeline's write via
+        // import_edges::persist_invoked_property_names) so the incremental
+        // path has a durable, whole-graph view to query. Mirrors
+        // src/db/migrations.ts v29.
+        version: 29,
+        up: r#"
+      CREATE TABLE IF NOT EXISTS invoked_property_names (
+        file TEXT NOT NULL,
+        name TEXT NOT NULL,
+        PRIMARY KEY (file, name)
+      );
+      CREATE INDEX IF NOT EXISTS idx_invoked_property_names_name ON invoked_property_names(name);
+    "#,
+    },
 ];
 
 // ── napi types ──────────────────────────────────────────────────────────

--- a/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
@@ -1821,7 +1821,32 @@ fn build_and_insert_call_edges(
         });
     }
 
-    let computed_edges = build_call_edges(file_entries, all_nodes, builtin_receivers, max_iterations);
+    // #2087: persist per-file invoked-property-name evidence before
+    // `file_entries` is moved into `build_call_edges` below — gives
+    // `codegraph watch`'s JS-only incremental rebuild a durable, whole-graph
+    // view for repos built with the native engine too.
+    import_edges::persist_invoked_property_names(conn, &file_entries)
+        .map_err(|e| format!("invoked property name persistence failed: {e}"))?;
+
+    // Read back the now-current whole-graph view (includes the fresh rows
+    // just written above) so this pass's own call-edge resolution sees
+    // evidence from files outside `file_entries` too — `file_entries` alone
+    // is exact on a full build but narrower on an incremental one (#2087).
+    let extra_invoked_property_names: Vec<String> = conn
+        .prepare("SELECT DISTINCT name FROM invoked_property_names")
+        .and_then(|mut stmt| {
+            stmt.query_map([], |row| row.get::<_, String>(0))
+                .map(|rows| rows.filter_map(|r| r.ok()).collect())
+        })
+        .unwrap_or_default();
+
+    let computed_edges = build_call_edges(
+        file_entries,
+        all_nodes,
+        builtin_receivers,
+        max_iterations,
+        Some(extra_invoked_property_names),
+    );
     insert_call_edge_rows(conn, &computed_edges)
 }
 

--- a/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
@@ -180,9 +180,13 @@ struct EdgeContext<'a> {
     builtin_set: HashSet<&'a str>,
     receiver_kinds: HashSet<&'a str>,
     /// Property/method names ever invoked via member-call syntax
-    /// (`x.name(...)`) across every file in this build pass — see
-    /// `collect_invoked_property_names` for the #1895 liveness rationale.
-    invoked_property_names: HashSet<&'a str>,
+    /// (`x.name(...)`) across every file in this build pass, unioned with
+    /// `extra_invoked_property_names` (#2087 — durable cross-pass evidence
+    /// for a scoped incremental build; empty on a full build, which is
+    /// already exact) — see `collect_invoked_property_names` for the #1895
+    /// liveness rationale. Owned (not borrowed) since the extra evidence
+    /// comes from outside `files`' own lifetime.
+    invoked_property_names: HashSet<String>,
     /// CHA + RTA typed-dispatch context (#1949): interface/class name →
     /// concrete classes that implement or extend it, built once per build
     /// pass from every file's `classes` (`extends`/`implements`). Used by
@@ -206,6 +210,7 @@ impl<'a> EdgeContext<'a> {
         all_nodes: &'a [NodeInfo],
         builtin_receivers: &'a [String],
         files: &'a [FileEdgeInput],
+        extra_invoked_property_names: &[String],
     ) -> Self {
         let mut nodes_by_name: HashMap<&str, Vec<&NodeInfo>> = HashMap::new();
         let mut nodes_by_name_and_file: HashMap<(&str, &str), Vec<&NodeInfo>> = HashMap::new();
@@ -224,7 +229,7 @@ impl<'a> EdgeContext<'a> {
             nodes_by_name_and_file,
             builtin_set,
             receiver_kinds,
-            invoked_property_names: collect_invoked_property_names(files),
+            invoked_property_names: collect_invoked_property_names(files, extra_invoked_property_names),
             cha_implementors: build_cha_implementors_map(files),
             cha_instantiated_types: collect_cha_instantiated_types(files),
         }
@@ -328,26 +333,32 @@ fn resolve_cha_dispatch<'a>(
 /// somewhere, actually invokes a `.resolve(...)`-shaped call — otherwise the
 /// property is wired up but never read, and `someFn` is genuinely dead.
 ///
-/// Scope matches whatever `files` the caller passes to `build_call_edges`:
-/// the full codebase for a full build, or just the changed file(s) on an
-/// incremental one. The incremental case is a narrower, same-build-pass view
-/// (a cross-file consumer added in an untouched file won't be seen until the
-/// next full rebuild) — the same scoping trade-off already accepted
-/// elsewhere in this codebase's incremental classification
-/// (`has_active_file_siblings` and exported-via-reexport both recompute from
-/// the affected file set only, not the whole graph, in
-/// `graph/classifiers/roles.rs`'s incremental path — median fan-in/out is a
-/// separate case, deliberately kept as a whole-graph statistic even on the
-/// incremental path, for classification-threshold consistency). Mirrors
-/// `collectInvokedPropertyNames` in `src/domain/graph/builder/call-resolver.ts`.
-fn collect_invoked_property_names(files: &[FileEdgeInput]) -> HashSet<&str> {
+/// Scope matches whatever `files` the caller passes to `build_call_edges`,
+/// unioned with `extra` (#2087) — durable per-file evidence persisted into
+/// `invoked_property_names` from a prior build pass, letting a scoped
+/// incremental build see evidence contributed by a file it isn't currently
+/// reprocessing. `files` alone is exact on a full build (it IS the whole
+/// codebase) and narrower on an incremental one (just the changed file(s) —
+/// a cross-file consumer added in an untouched file won't be seen without
+/// `extra`) — the same scoping trade-off already accepted elsewhere in this
+/// codebase's incremental classification (`has_active_file_siblings` and
+/// exported-via-reexport both recompute from the affected file set only, not
+/// the whole graph, in `graph/classifiers/roles.rs`'s incremental path —
+/// median fan-in/out is a separate case, deliberately kept as a whole-graph
+/// statistic even on the incremental path, for classification-threshold
+/// consistency). Mirrors `collectInvokedPropertyNames` in
+/// `src/domain/graph/builder/call-resolver.ts`.
+fn collect_invoked_property_names(files: &[FileEdgeInput], extra: &[String]) -> HashSet<String> {
     let mut names = HashSet::new();
     for file in files {
         for call in &file.calls {
             if call.receiver.is_some() {
-                names.insert(call.name.as_str());
+                names.insert(call.name.clone());
             }
         }
+    }
+    for name in extra {
+        names.insert(name.clone());
     }
     names
 }
@@ -640,14 +651,24 @@ fn emit_pts_alias_edges<'a>(
 /// `max_iterations` caps the Phase 8.3 points-to solver's fixed-point loop —
 /// callers pass `ctx.config.analysis.pointsToMaxIterations` (resolved from
 /// `.codegraphrc.json`, defaulting to `DEFAULTS.analysis.pointsToMaxIterations`).
+///
+/// `extra_invoked_property_names` (#2087) is durable cross-pass
+/// invoked-property-name evidence from the `invoked_property_names` table —
+/// callers on a scoped incremental build (where `files` is narrower than the
+/// whole codebase) should pass every name persisted for files NOT in this
+/// pass, so the #1895 liveness check doesn't lose evidence contributed by an
+/// untouched consumer. `None`/empty is correct for a full build, where
+/// `files` already covers everything.
 #[napi]
 pub fn build_call_edges(
     files: Vec<FileEdgeInput>,
     all_nodes: Vec<NodeInfo>,
     builtin_receivers: Vec<String>,
     max_iterations: u32,
+    extra_invoked_property_names: Option<Vec<String>>,
 ) -> Vec<ComputedEdge> {
-    let ctx = EdgeContext::new(&all_nodes, &builtin_receivers, &files);
+    let extra_names = extra_invoked_property_names.unwrap_or_default();
+    let ctx = EdgeContext::new(&all_nodes, &builtin_receivers, &files, &extra_names);
     let mut edges = Vec::new();
 
     for file_input in &files {
@@ -3414,7 +3435,7 @@ mod call_edge_tests {
             vec![],
         )];
 
-        let edges = build_call_edges(files, all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+        let edges = build_call_edges(files, all_nodes, vec![], MAX_SOLVER_ITERATIONS, None);
 
         let receiver_edge = edges.iter().find(|e| e.kind == "receiver");
         assert!(
@@ -3450,7 +3471,7 @@ mod call_edge_tests {
             vec![],
         )];
 
-        let edges = build_call_edges(files, all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+        let edges = build_call_edges(files, all_nodes, vec![], MAX_SOLVER_ITERATIONS, None);
 
         let call_edge = edges.iter().find(|e| e.kind == "calls");
         assert!(
@@ -3482,7 +3503,7 @@ mod call_edge_tests {
             vec![],
         )];
 
-        let edges = build_call_edges(files, all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+        let edges = build_call_edges(files, all_nodes, vec![], MAX_SOLVER_ITERATIONS, None);
 
         assert!(
             !edges.iter().any(|e| e.kind == "calls"),
@@ -3512,7 +3533,7 @@ mod call_edge_tests {
             vec![],
         )];
 
-        let edges = build_call_edges(files, all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+        let edges = build_call_edges(files, all_nodes, vec![], MAX_SOLVER_ITERATIONS, None);
 
         let call_edges: Vec<_> = edges.iter().filter(|e| e.kind == "calls").collect();
         assert_eq!(
@@ -3558,7 +3579,7 @@ mod call_edge_tests {
             imported: Some("SqliteRepository".to_string()),
         }];
 
-        let edges = build_call_edges(vec![file], all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+        let edges = build_call_edges(vec![file], all_nodes, vec![], MAX_SOLVER_ITERATIONS, None);
 
         let call_edges: Vec<_> = edges.iter().filter(|e| e.kind == "calls").collect();
         assert_eq!(
@@ -3599,7 +3620,7 @@ mod call_edge_tests {
             imported: None,
         }];
 
-        let edges = build_call_edges(vec![file], all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+        let edges = build_call_edges(vec![file], all_nodes, vec![], MAX_SOLVER_ITERATIONS, None);
 
         let call_edges: Vec<_> = edges.iter().filter(|e| e.kind == "calls").collect();
         assert_eq!(
@@ -3636,7 +3657,7 @@ mod call_edge_tests {
             imported: None,
         }];
 
-        let edges = build_call_edges(vec![file], all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+        let edges = build_call_edges(vec![file], all_nodes, vec![], MAX_SOLVER_ITERATIONS, None);
 
         assert!(
             !edges.iter().any(|e| e.kind == "calls"),
@@ -3695,6 +3716,7 @@ mod call_edge_tests {
             all_nodes,
             vec![],
             MAX_SOLVER_ITERATIONS,
+            None,
         );
 
         let calls_never_read = edges.iter().any(|e| e.kind == "calls" && e.target_id == 2);
@@ -3739,7 +3761,7 @@ mod call_edge_tests {
         // same-file kind="function" node as an import artifact and falls through.
         file.imported_names = vec![ImportedName { name: "Calculator".to_string(), file: "utils.js".to_string(), imported: None }];
 
-        let edges = build_call_edges(vec![file], all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+        let edges = build_call_edges(vec![file], all_nodes, vec![], MAX_SOLVER_ITERATIONS, None);
 
         let receiver_edge = edges.iter().find(|e| e.kind == "receiver");
         assert!(
@@ -3773,7 +3795,7 @@ mod call_edge_tests {
             vec![],
         )];
 
-        let edges = build_call_edges(files, all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+        let edges = build_call_edges(files, all_nodes, vec![], MAX_SOLVER_ITERATIONS, None);
 
         let receiver_edge = edges.iter().find(|e| e.kind == "receiver");
         assert!(
@@ -3803,7 +3825,7 @@ mod call_edge_tests {
             vec![],
         )];
 
-        let edges = build_call_edges(files, all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+        let edges = build_call_edges(files, all_nodes, vec![], MAX_SOLVER_ITERATIONS, None);
 
         let receiver_edge = edges.iter().find(|e| e.kind == "receiver");
         assert!(
@@ -3831,7 +3853,7 @@ mod call_edge_tests {
             vec![],
         )];
 
-        let edges = build_call_edges(files, all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+        let edges = build_call_edges(files, all_nodes, vec![], MAX_SOLVER_ITERATIONS, None);
 
         let receiver_edge = edges.iter().find(|e| e.kind == "receiver");
         assert!(
@@ -3860,7 +3882,7 @@ mod call_edge_tests {
             vec![type_map_entry("UserService.logger", "Logger", 1.0)],
             vec![],
         )];
-        let edges = build_call_edges(files, all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+        let edges = build_call_edges(files, all_nodes, vec![], MAX_SOLVER_ITERATIONS, None);
         assert!(
             edges.iter().any(|e| e.kind == "calls" && e.source_id == 1 && e.target_id == 2),
             "expected calls edge UserService.create → Logger.error; got: {:?}",
@@ -3884,7 +3906,7 @@ mod call_edge_tests {
             vec![type_map_entry("useRest::eerest", "E4", 0.85)],
             vec![],
         )];
-        let edges = build_call_edges(files, all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+        let edges = build_call_edges(files, all_nodes, vec![], MAX_SOLVER_ITERATIONS, None);
         assert!(
             edges.iter().any(|e| e.kind == "calls" && e.source_id == 1 && e.target_id == 2),
             "expected calls edge useRest → E4.e4 via rest-param key; got: {:?}",
@@ -3908,7 +3930,7 @@ mod call_edge_tests {
             vec![],
             vec![],
         )];
-        let edges = build_call_edges(files, all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+        let edges = build_call_edges(files, all_nodes, vec![], MAX_SOLVER_ITERATIONS, None);
         assert!(
             !edges.iter().any(|e| e.kind == "calls" && e.source_id == 1 && e.target_id == 2),
             "bare call must not resolve to same-class sibling in a module-scoped language"
@@ -3931,7 +3953,7 @@ mod call_edge_tests {
             vec![],
             vec![],
         )];
-        let edges = build_call_edges(files, all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+        let edges = build_call_edges(files, all_nodes, vec![], MAX_SOLVER_ITERATIONS, None);
         assert!(
             edges.iter().any(|e| e.kind == "calls" && e.source_id == 1 && e.target_id == 2),
             "bare sibling call must resolve in a class-scoped language; got: {:?}",
@@ -3956,7 +3978,7 @@ mod call_edge_tests {
             vec![],
             vec![],
         )];
-        let edges = build_call_edges(files, all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+        let edges = build_call_edges(files, all_nodes, vec![], MAX_SOLVER_ITERATIONS, None);
         assert!(
             edges.iter().any(|e| e.kind == "calls" && e.source_id == 1 && e.target_id == 2),
             "expected Geo.Shape.describe → Shape.area via bare class segment; got: {:?}",
@@ -3985,7 +4007,7 @@ mod call_edge_tests {
             vec![],
             vec![],
         )];
-        let edges = build_call_edges(files, all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+        let edges = build_call_edges(files, all_nodes, vec![], MAX_SOLVER_ITERATIONS, None);
         assert!(
             !edges.iter().any(|e| e.kind == "calls" && e.source_id == 1),
             "ambiguous same-confidence candidates must not fan out into calls edges; got: {:?}",
@@ -4014,7 +4036,7 @@ mod call_edge_tests {
             vec![],
             vec![],
         )];
-        let edges = build_call_edges(files, all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+        let edges = build_call_edges(files, all_nodes, vec![], MAX_SOLVER_ITERATIONS, None);
         let call_edges: Vec<_> = edges.iter().filter(|e| e.kind == "calls" && e.source_id == 1).collect();
         assert_eq!(
             call_edges.len(),
@@ -4043,7 +4065,7 @@ mod call_edge_tests {
             vec![type_map_entry("calc", "Calculator", 0.85)],
             vec![],
         )];
-        let edges = build_call_edges(files, all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+        let edges = build_call_edges(files, all_nodes, vec![], MAX_SOLVER_ITERATIONS, None);
         let re = edges.iter().find(|e| e.kind == "receiver").expect("receiver edge");
         assert!(
             (re.confidence - 0.85).abs() < 1e-9,
@@ -4070,7 +4092,7 @@ mod call_edge_tests {
             vec![],
         )];
 
-        let edges = build_call_edges(files, all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+        let edges = build_call_edges(files, all_nodes, vec![], MAX_SOLVER_ITERATIONS, None);
 
         let receiver_edge = edges.iter().find(|e| e.kind == "receiver");
         assert!(receiver_edge.is_some(), "expected receiver edge for direct class-name receiver");
@@ -4116,7 +4138,7 @@ mod call_edge_tests {
             vec![class_info("NativeDbProxy", None, Some("BetterSqlite3Database"))],
         );
 
-        let edges = build_call_edges(vec![caller_file, impl_file], all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+        let edges = build_call_edges(vec![caller_file, impl_file], all_nodes, vec![], MAX_SOLVER_ITERATIONS, None);
 
         // The interface's own qualified method (id 2) must NOT receive an edge —
         // computeConfidence(helpers.ts, types.ts) is well below the 0.5 gate.
@@ -4170,7 +4192,7 @@ mod call_edge_tests {
             vec![class_info("NativeDbProxy", None, Some("BetterSqlite3Database"))],
         );
 
-        let edges = build_call_edges(vec![caller_file, impl_file], all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+        let edges = build_call_edges(vec![caller_file, impl_file], all_nodes, vec![], MAX_SOLVER_ITERATIONS, None);
 
         let calls_edges: Vec<_> = edges.iter().filter(|e| e.kind == "calls").collect();
         assert!(
@@ -4211,7 +4233,7 @@ mod call_edge_tests {
             vec![class_info("LocalImpl", None, Some("ILocal"))],
         );
 
-        let edges = build_call_edges(vec![caller_file, impl_file], all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+        let edges = build_call_edges(vec![caller_file, impl_file], all_nodes, vec![], MAX_SOLVER_ITERATIONS, None);
 
         let calls_edges: Vec<_> = edges.iter().filter(|e| e.kind == "calls").collect();
         assert_eq!(
@@ -4272,6 +4294,7 @@ mod call_edge_tests {
             all_nodes,
             vec![],
             MAX_SOLVER_ITERATIONS,
+            None,
         );
 
         let to_real = edges.iter().find(|e| e.kind == "calls" && e.target_id == 5);
@@ -4321,7 +4344,7 @@ mod call_edge_tests {
             arg_name: "target".to_string(),
         }]);
 
-        let edges = build_call_edges(vec![file], all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+        let edges = build_call_edges(vec![file], all_nodes, vec![], MAX_SOLVER_ITERATIONS, None);
 
         assert!(
             edges.iter().any(|e| e.source_id == 1 && e.target_id == 2 && e.kind == "calls"),
@@ -4368,7 +4391,7 @@ mod call_edge_tests {
             f
         };
 
-        let edges = build_call_edges(vec![file], all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+        let edges = build_call_edges(vec![file], all_nodes, vec![], MAX_SOLVER_ITERATIONS, None);
 
         let pts_edge = edges
             .iter()
@@ -4422,7 +4445,7 @@ mod call_edge_tests {
             f
         };
 
-        let edges = build_call_edges(vec![file], all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+        let edges = build_call_edges(vec![file], all_nodes, vec![], MAX_SOLVER_ITERATIONS, None);
 
         let hof_to_target: Vec<_> =
             edges.iter().filter(|e| e.source_id == 1 && e.target_id == 2 && e.kind == "calls").collect();
@@ -4471,7 +4494,7 @@ mod call_edge_tests {
             this_arg: "handler".to_string(),
         }]);
 
-        let edges = build_call_edges(vec![file], all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+        let edges = build_call_edges(vec![file], all_nodes, vec![], MAX_SOLVER_ITERATIONS, None);
 
         assert!(
             edges.iter().any(|e| e.source_id == 1 && e.target_id == 2 && e.kind == "calls"),
@@ -4517,7 +4540,7 @@ mod call_edge_tests {
             enclosing_func: "iterPlain".to_string(),
         }]);
 
-        let edges = build_call_edges(vec![file], all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+        let edges = build_call_edges(vec![file], all_nodes, vec![], MAX_SOLVER_ITERATIONS, None);
 
         for target in [1u32, 2u32] {
             assert!(
@@ -4567,7 +4590,7 @@ mod call_edge_tests {
             value_name: "e4".to_string(),
         }]);
 
-        let edges = build_call_edges(vec![file], all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+        let edges = build_call_edges(vec![file], all_nodes, vec![], MAX_SOLVER_ITERATIONS, None);
 
         assert!(
             edges.iter().any(|e| e.source_id == 1 && e.target_id == 2 && e.kind == "calls"),
@@ -4609,7 +4632,7 @@ mod call_edge_tests {
             start_index: 0,
         }]);
 
-        let edges = build_call_edges(vec![file], all_nodes, vec![], MAX_SOLVER_ITERATIONS);
+        let edges = build_call_edges(vec![file], all_nodes, vec![], MAX_SOLVER_ITERATIONS, None);
 
         assert!(
             edges.iter().any(|e| e.source_id == 1 && e.target_id == 2 && e.kind == "calls"),

--- a/crates/codegraph-core/src/domain/graph/builder/stages/detect_changes.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/detect_changes.rs
@@ -1114,6 +1114,11 @@ pub fn purge_changed_files(
         // file never leaves stale rows behind for the JS watch path's
         // `resolveBarrelTarget` to read later.
         ("DELETE FROM reexport_renames WHERE barrel_file = ?1", false),
+        // #2087: invoked-property-name evidence keyed by the file it was
+        // observed in — cleared so a deleted (or no-longer-matching) file
+        // never leaves stale rows behind for the incremental #1895 liveness
+        // check to read later.
+        ("DELETE FROM invoked_property_names WHERE file = ?1", false),
         // Core tables (errors logged)
         ("DELETE FROM edges WHERE source_id IN (SELECT id FROM nodes WHERE file = ?1) OR target_id IN (SELECT id FROM nodes WHERE file = ?1)", true),
         ("DELETE FROM nodes WHERE file = ?1", true),
@@ -1160,7 +1165,8 @@ pub fn clear_all_graph_data(conn: &Connection, has_embeddings: bool) {
         "PRAGMA foreign_keys = OFF; \
          DELETE FROM cfg_edges; DELETE FROM cfg_blocks; DELETE FROM node_metrics; \
          DELETE FROM edges; DELETE FROM function_complexity; DELETE FROM dataflow; \
-         DELETE FROM ast_nodes; DELETE FROM reexport_renames; DELETE FROM nodes; DELETE FROM file_hashes;",
+         DELETE FROM ast_nodes; DELETE FROM reexport_renames; DELETE FROM invoked_property_names; \
+         DELETE FROM nodes; DELETE FROM file_hashes;",
     );
     if has_embeddings {
         sql.push_str(" DELETE FROM embeddings;");

--- a/crates/codegraph-core/src/domain/graph/builder/stages/import_edges.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/import_edges.rs
@@ -279,6 +279,54 @@ pub fn persist_reexport_renames(
     Ok(())
 }
 
+/// Persist per-file invoked-property-name evidence (#2087) into
+/// `invoked_property_names` — the native orchestrator's counterpart of
+/// `persistInvokedPropertyNames` in `resolve-imports.ts` (JS pipeline). A
+/// property/method name counts as "invoked" for a file when some call in
+/// that file's own `calls` carries a receiver (`x.name(...)` member-call
+/// syntax, regardless of whether the receiver itself resolves).
+///
+/// Called once per native-orchestrated build (full or incremental) so
+/// `codegraph watch`'s JS-only single-file rebuild
+/// (`collectInvokedPropertyNames` in `domain/graph/builder/incremental.ts`)
+/// has a durable, whole-graph view to query instead of only the file it is
+/// currently rebuilding — see #2087 for the false-negative this closes.
+///
+/// Deletes and re-inserts per file so a file whose invoked names changed (or
+/// were removed entirely) never leaves stale rows behind for it.
+pub fn persist_invoked_property_names(
+    conn: &Connection,
+    files: &[super::build_edges::FileEdgeInput],
+) -> Result<(), String> {
+    if files.is_empty() {
+        return Ok(());
+    }
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|e| format!("persist_invoked_property_names: failed to start transaction: {e}"))?;
+    {
+        let mut delete_stmt = tx
+            .prepare("DELETE FROM invoked_property_names WHERE file = ?1")
+            .map_err(|e| e.to_string())?;
+        let mut insert_stmt = tx
+            .prepare("INSERT OR IGNORE INTO invoked_property_names (file, name) VALUES (?1, ?2)")
+            .map_err(|e| e.to_string())?;
+        for file in files {
+            delete_stmt.execute([&file.file]).map_err(|e| e.to_string())?;
+            let mut seen: HashSet<&str> = HashSet::new();
+            for call in &file.calls {
+                if call.receiver.is_some() && seen.insert(call.name.as_str()) {
+                    insert_stmt
+                        .execute(rusqlite::params![file.file, call.name])
+                        .map_err(|e| e.to_string())?;
+                }
+            }
+        }
+    }
+    tx.commit().map_err(|e| format!("persist_invoked_property_names: commit failed: {e}"))?;
+    Ok(())
+}
+
 /// Detect which of `candidate_paths` are barrel-only (reexport count >=
 /// definition count).
 ///

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -515,6 +515,35 @@ export const MIGRATIONS: Migration[] = [
         ON edges(source_id, target_id, kind, confidence, dynamic, COALESCE(dynamic_kind, ''), COALESCE(technique, ''));
     `,
   },
+  {
+    // #2087: durable, per-file record of every property/method name ever
+    // invoked via member-call syntax (`x.name(...)`) — the "one hop further"
+    // liveness evidence #1895's object-literal-property value-ref check
+    // needs (collectInvokedPropertyNames / collect_invoked_property_names).
+    // A full build sees every file at once, so it was always exact; a
+    // `codegraph watch` single-file incremental rebuild
+    // (domain/graph/builder/incremental.ts) only sees the one file being
+    // rebuilt, so a consumer's `.resolve(...)` call living in an untouched
+    // file was invisible and a same-named object-literal property in the
+    // rebuilt file could be misclassified as dead. Persisting this table
+    // once per full or incremental build (both engines — the native
+    // orchestrator mirrors this via
+    // import_edges::persist_invoked_property_names in Rust) gives the
+    // incremental path a durable, whole-graph view to query instead of only
+    // the current file's own evidence.
+    //
+    // Deletes and re-inserts per file so a file whose invoked names changed
+    // (or were removed entirely) never leaves stale rows behind for it.
+    version: 29,
+    up: `
+      CREATE TABLE IF NOT EXISTS invoked_property_names (
+        file TEXT NOT NULL,
+        name TEXT NOT NULL,
+        PRIMARY KEY (file, name)
+      );
+      CREATE INDEX IF NOT EXISTS idx_invoked_property_names_name ON invoked_property_names(name);
+    `,
+  },
 ];
 
 interface PragmaColumnInfo {

--- a/src/db/repository/build-stmts.ts
+++ b/src/db/repository/build-stmts.ts
@@ -20,6 +20,10 @@ interface PurgeStmts {
    *  leaves stale rows behind for `resolveBarrelTarget` (incremental.ts) to
    *  read later. */
   reexportRenames: SqliteStatement | null;
+  /** #2087: invoked-property-name evidence keyed by the file it was observed
+   *  in — cleared so a deleted (or no-longer-matching) file never leaves
+   *  stale rows behind for the incremental #1895 liveness check to read. */
+  invokedPropertyNames: SqliteStatement | null;
 }
 
 interface PurgeOpts {
@@ -87,6 +91,7 @@ function preparePurgeStmts(db: BetterSqlite3Database): PurgeStmts {
     nodes: db.prepare('DELETE FROM nodes WHERE file = ?'),
     fileHashes: tryPrepare('DELETE FROM file_hashes WHERE file = ?'),
     reexportRenames: tryPrepare('DELETE FROM reexport_renames WHERE barrel_file = ?'),
+    invokedPropertyNames: tryPrepare('DELETE FROM invoked_property_names WHERE file = ?'),
   };
 }
 
@@ -120,6 +125,7 @@ function runPurge(stmts: PurgeStmts, file: string, opts: PurgeOpts = {}): void {
   stmts.nodeMetrics?.run(file);
   stmts.astNodes?.run(file);
   stmts.reexportRenames?.run(file);
+  stmts.invokedPropertyNames?.run(file);
 
   // Core tables
   stmts.edges.run({ f: file });

--- a/src/domain/graph/builder/incremental.ts
+++ b/src/domain/graph/builder/incremental.ts
@@ -378,6 +378,82 @@ function isBarrelFile(db: BetterSqlite3Database, relPath: string): boolean {
   return (reexportCount || 0) > 0;
 }
 
+// Lazily-cached prepared statements for the #2087 invoked-property-name registry.
+let _invokedPropDb: BetterSqlite3Database | null = null;
+let _invokedPropOtherFilesStmt: SqliteStatement | null = null;
+let _invokedPropDeleteStmt: SqliteStatement | null = null;
+let _invokedPropInsertStmt: SqliteStatement | null = null;
+
+function getInvokedPropertyStmts(db: BetterSqlite3Database): {
+  otherFilesStmt: SqliteStatement;
+  deleteStmt: SqliteStatement;
+  insertStmt: SqliteStatement;
+} {
+  if (_invokedPropDb !== db) {
+    _invokedPropDb = db;
+    _invokedPropOtherFilesStmt = db.prepare(
+      'SELECT DISTINCT name FROM invoked_property_names WHERE file != ?',
+    );
+    _invokedPropDeleteStmt = db.prepare('DELETE FROM invoked_property_names WHERE file = ?');
+    _invokedPropInsertStmt = db.prepare(
+      'INSERT OR IGNORE INTO invoked_property_names (file, name) VALUES (?, ?)',
+    );
+  }
+  return {
+    otherFilesStmt: _invokedPropOtherFilesStmt!,
+    deleteStmt: _invokedPropDeleteStmt!,
+    insertStmt: _invokedPropInsertStmt!,
+  };
+}
+
+/**
+ * Graph-wide invoked-property-name evidence for the #1895 liveness check
+ * (#2087): this file's own freshly-computed names, unioned with every other
+ * file's persisted evidence from `invoked_property_names` — the durable
+ * counterpart of the full-build path's whole-`fileSymbols` computation
+ * (`collectInvokedPropertyNames` in call-resolver.ts). Excludes this file's
+ * OWN persisted rows (not just its fresh ones) since those are about to be
+ * replaced by `persistInvokedPropertyNamesForFile` below; querying them here
+ * would only ever match what `ownNames` already provides directly.
+ */
+function collectGraphWideInvokedPropertyNames(
+  db: BetterSqlite3Database,
+  relPath: string,
+  ownNames: ReadonlySet<string>,
+): Set<string> {
+  const { otherFilesStmt } = getInvokedPropertyStmts(db);
+  const names = new Set(ownNames);
+  for (const row of otherFilesStmt.all(relPath) as Array<{ name: string }>) {
+    names.add(row.name);
+  }
+  return names;
+}
+
+/**
+ * Persist this file's invoked-property-name evidence (#2087) into
+ * `invoked_property_names` — the durable counterpart of
+ * `persistInvokedPropertyNames` in `resolve-imports.ts`/`build-edges.ts`
+ * (full-build path), needed here because `codegraph watch`'s single-file
+ * rebuild never goes through that stage. Always deletes this file's existing
+ * rows first (even when it invokes nothing via member-call syntax anymore)
+ * so a file that changed to stop invoking a property never leaves stale
+ * rows behind.
+ *
+ * Called for both the primary rebuilt file and each reverse-dep, mirroring
+ * `persistReexportRenamesForFile`.
+ */
+function persistInvokedPropertyNamesForFile(
+  db: BetterSqlite3Database,
+  relPath: string,
+  ownNames: ReadonlySet<string>,
+): void {
+  const { deleteStmt, insertStmt } = getInvokedPropertyStmts(db);
+  deleteStmt.run(relPath);
+  for (const name of ownNames) {
+    insertStmt.run(relPath, name);
+  }
+}
+
 /**
  * Persist this file's barrel re-export rename pairs (`export { X as Y } from
  * …`) into `reexport_renames` (#1967) — the durable counterpart of
@@ -1240,10 +1316,17 @@ function buildCallEdges(
   // JS path uses (buildPointsToMapForFile, shared via resolver/points-to.js).
   const ptsMap = buildPointsToMapForFile(symbols, importedNames, maxIterations);
   const fnRefBindingLhs = new Set(symbols.fnRefBindings?.map((b) => b.lhs) ?? []);
-  // #1895: scoped to this file's own calls only — see collectInvokedPropertyNames
-  // doc comment (call-resolver.ts) for why incremental rebuilds use a narrower,
-  // same-file view rather than a full-codebase one.
-  const invokedPropertyNames = collectInvokedPropertyNames([symbols.calls]);
+  // #2087: this file's own calls, unioned with every other file's persisted
+  // evidence (invoked_property_names) — closes the false-negative window
+  // that scoping purely to `symbols.calls` left open, where a consumer's
+  // `.resolve(...)` call living in an untouched file was invisible to this
+  // rebuild.
+  const ownInvokedPropertyNames = collectInvokedPropertyNames([symbols.calls]);
+  const invokedPropertyNames = collectGraphWideInvokedPropertyNames(
+    db,
+    relPath,
+    ownInvokedPropertyNames,
+  );
   let edgesAdded = 0;
 
   for (const call of symbols.calls) {
@@ -1353,6 +1436,10 @@ function buildCallEdges(
       edgesAdded += emitDynamicSinkEdge(db, call, caller, fileNodeRow, seenCallEdges);
     }
   }
+  // #2087: keep this file's persisted invoked-property-name evidence current
+  // for future rebuilds of OTHER files, regardless of what this rebuild
+  // itself needed it for.
+  persistInvokedPropertyNamesForFile(db, relPath, ownInvokedPropertyNames);
   return edgesAdded;
 }
 

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -705,11 +705,21 @@ function buildCallEdgesNative(
   const nativeNodes = allNodes.map((n) =>
     n.accessorKind == null ? { ...n, accessorKind: undefined } : n,
   );
+  // #2087: whole-graph invoked-property-name evidence (persistInvokedPropertyNames
+  // already wrote this pass's own fresh rows before buildCallEdgesPhase branched
+  // here) — closes the same false-negative window buildCallEdgesJS's read
+  // side closes, for the native fast path.
+  const extraInvokedPropertyNames = (
+    ctx.db.prepare('SELECT DISTINCT name FROM invoked_property_names').all() as Array<{
+      name: string;
+    }>
+  ).map((row) => row.name);
   const nativeEdges = native.buildCallEdges(
     nativeFiles,
     nativeNodes,
     [...BUILTIN_RECEIVERS],
     ctx.config.analysis.pointsToMaxIterations,
+    extraInvokedPropertyNames,
   ) as NativeEdge[];
   for (const e of nativeEdges) {
     allEdgeRows.push([
@@ -946,6 +956,38 @@ function buildImportedNamesForNative(
   return importedNames;
 }
 
+/**
+ * Persist per-file invoked-property-name evidence (#2087) into
+ * `invoked_property_names` — the durable counterpart of
+ * `persistInvokedPropertyNamesForFile` in `domain/graph/builder/incremental.ts`
+ * (codegraph watch's single-file path). Called once per `buildCallEdgesPhase`
+ * invocation regardless of which sub-path (native or JS fallback) resolves
+ * this pass's edges, so `codegraph watch`'s narrower same-file view always
+ * has a durable, whole-graph view to fall back on — see #2087 for the
+ * false-negative this closes.
+ *
+ * Deletes and re-inserts per file so a file whose invoked names changed (or
+ * were removed entirely) never leaves stale rows behind for it.
+ */
+function persistInvokedPropertyNames(ctx: PipelineContext): void {
+  const { db, fileSymbols } = ctx;
+  const deleteStmt = db.prepare('DELETE FROM invoked_property_names WHERE file = ?');
+  const insertStmt = db.prepare(
+    'INSERT OR IGNORE INTO invoked_property_names (file, name) VALUES (?, ?)',
+  );
+
+  const tx = db.transaction(() => {
+    for (const [relPath, symbols] of fileSymbols) {
+      deleteStmt.run(relPath);
+      const names = collectInvokedPropertyNames([symbols.calls]);
+      for (const name of names) {
+        insertStmt.run(relPath, name);
+      }
+    }
+  });
+  tx();
+}
+
 // ── Call edges (JS fallback) ────────────────────────────────────────────
 
 function buildCallEdgesJS(
@@ -954,14 +996,25 @@ function buildCallEdgesJS(
   allEdgeRows: EdgeRowTuple[],
   chaCtx?: ChaContext,
 ): void {
-  const { fileSymbols, barrelOnlyFiles, rootDir } = ctx;
+  const { db, fileSymbols, barrelOnlyFiles, rootDir } = ctx;
   const lookup = makeContextLookup(ctx, getNodeIdStmt);
-  // #1895: computed once from every file in this build pass (all files on a
-  // full build, just the affected files on an incremental one) — see
-  // collectInvokedPropertyNames doc comment for the scoping rationale.
-  const invokedPropertyNames = collectInvokedPropertyNames(
-    Array.from(fileSymbols.values(), (s) => s.calls),
+  // #1895 / #2087: this build pass's own files, unioned with every other
+  // file's persisted evidence (invoked_property_names) — on a full build the
+  // in-memory set is already exact (fileSymbols IS the whole codebase), but
+  // on a scoped incremental `codegraph build` (ctx.fileSymbols narrowed to
+  // the changed files + reverse-deps) the persisted table is what closes the
+  // false-negative window a purely in-memory computation would leave open
+  // for a consumer living in an untouched file. persistInvokedPropertyNames
+  // (called just before this in buildCallEdgesPhase) has already written
+  // this pass's own fresh rows, so this query already reflects them.
+  const invokedPropertyNames = new Set(
+    collectInvokedPropertyNames(Array.from(fileSymbols.values(), (s) => s.calls)),
   );
+  for (const row of db.prepare('SELECT DISTINCT name FROM invoked_property_names').all() as Array<{
+    name: string;
+  }>) {
+    invokedPropertyNames.add(row.name);
+  }
 
   for (const [relPath, symbols] of fileSymbols) {
     if (barrelOnlyFiles.has(relPath)) continue;
@@ -2455,6 +2508,10 @@ function buildCallEdgesPhase(
   native: NativeAddon | null,
   chaCtx: ChaContext,
 ): void {
+  // #2087: persist once per pass regardless of which sub-path below resolves
+  // this build's edges — see persistInvokedPropertyNames doc comment.
+  persistInvokedPropertyNames(ctx);
+
   // Skip native call-edge path for small incremental builds: napi-rs
   // marshaling overhead for allNodes exceeds Rust computation savings.
   const useNativeCallEdges =

--- a/src/domain/graph/builder/stages/detect-changes.ts
+++ b/src/domain/graph/builder/stages/detect-changes.ts
@@ -633,7 +633,7 @@ function handleFullBuild(ctx: PipelineContext): void {
   const hasEmbeddings = detectHasEmbeddings(db, ctx.nativeDb);
   ctx.hasEmbeddings = hasEmbeddings;
   const deletions =
-    'PRAGMA foreign_keys = OFF; DELETE FROM cfg_edges; DELETE FROM cfg_blocks; DELETE FROM node_metrics; DELETE FROM edges; DELETE FROM function_complexity; DELETE FROM dataflow; DELETE FROM ast_nodes; DELETE FROM reexport_renames; DELETE FROM nodes; DELETE FROM file_hashes; PRAGMA foreign_keys = ON;';
+    'PRAGMA foreign_keys = OFF; DELETE FROM cfg_edges; DELETE FROM cfg_blocks; DELETE FROM node_metrics; DELETE FROM edges; DELETE FROM function_complexity; DELETE FROM dataflow; DELETE FROM ast_nodes; DELETE FROM reexport_renames; DELETE FROM invoked_property_names; DELETE FROM nodes; DELETE FROM file_hashes; PRAGMA foreign_keys = ON;';
   db.exec(
     hasEmbeddings
       ? `${deletions.replace('PRAGMA foreign_keys = ON;', '')} DELETE FROM embeddings; PRAGMA foreign_keys = ON;`

--- a/src/types.ts
+++ b/src/types.ts
@@ -2517,6 +2517,14 @@ export interface NativeAddon {
     nodes: unknown[],
     builtinReceivers: string[],
     maxIterations: number,
+    /**
+     * #2087: durable cross-pass invoked-property-name evidence
+     * (`invoked_property_names` table) — needed on a scoped incremental
+     * build, where `files` is narrower than the whole codebase, so the
+     * #1895 liveness check doesn't lose evidence contributed by a file
+     * outside this pass. Omit or pass an empty array on a full build.
+     */
+    extraInvokedPropertyNames?: string[],
   ): unknown[];
   buildImportEdges?(
     files: unknown[],

--- a/tests/integration/issue-2087-incremental-invoked-property-persistence.test.ts
+++ b/tests/integration/issue-2087-incremental-invoked-property-persistence.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Regression test for #2087: the #1895 object-literal-property value-ref
+ * liveness check (`collectInvokedPropertyNames`) only sees property/method
+ * names invoked via member-call syntax across the files actually being
+ * processed. On a full build that's the whole codebase, so it's exact. On
+ * `codegraph watch`'s single-file rebuild (`rebuildFile`/`buildCallEdges` in
+ * `domain/graph/builder/incremental.ts`), it was scoped to only the file
+ * being rebuilt — a consumer's `table.resolve(...)` call living in an
+ * untouched file was invisible, so a same-named object-literal property in
+ * the rebuilt producer file could be misclassified as dead.
+ *
+ * The fix persists per-file invoked-property-name evidence into a durable
+ * `invoked_property_names` table (both engines) whenever a file is parsed —
+ * full build, scoped incremental `codegraph build`, or a `codegraph watch`
+ * rebuild — so a later watch cycle that only touches the *producer* can
+ * still see evidence contributed by an untouched *consumer*.
+ *
+ * Fixture (mirrors #1895's):
+ *   factory.js  — declares `isRead` and wires it under `resolve` in an
+ *                 object-literal dispatch table.
+ *   consumer.js — the ONLY call site: `table.resolve(1)`.
+ *
+ * Parametrized on the initial full build's engine to exercise both
+ * population paths: the JS pipeline (`persistInvokedPropertyNames` in
+ * build-edges.ts) and the native orchestrator
+ * (`import_edges::persist_invoked_property_names` in Rust). The watch-mode
+ * `rebuildFile` call itself is always JS — `codegraph watch` has no native
+ * single-file rebuild path.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { getNodeId as getNodeIdQuery, initSchema, openDb } from '../../src/db/index.js';
+import { rebuildFile } from '../../src/domain/graph/builder/incremental.js';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+import type { EngineMode } from '../../src/types.js';
+
+const FILES: Record<string, string> = {
+  'factory.js': `
+function isRead(x) { return x + 1; }
+
+export function makeTable() {
+  return {
+    resolve: isRead,
+  };
+}
+`,
+  'consumer.js': `
+import { makeTable } from './factory.js';
+
+export function run() {
+  const table = makeTable();
+  return table.resolve(1);
+}
+`,
+};
+
+function writeFixture(dir: string) {
+  for (const [rel, content] of Object.entries(FILES)) {
+    const abs = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, content);
+  }
+}
+
+function readCallEdges(dbPath: string) {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return db
+      .prepare(
+        `SELECT n1.name AS src, n1.file AS src_file, n2.name AS tgt, n2.file AS tgt_file
+         FROM edges e
+         JOIN nodes n1 ON e.source_id = n1.id
+         JOIN nodes n2 ON e.target_id = n2.id
+         WHERE e.kind = 'calls'
+         ORDER BY n1.name, n2.name`,
+      )
+      .all() as Array<{ src: string; src_file: string; tgt: string; tgt_file: string }>;
+  } finally {
+    db.close();
+  }
+}
+
+function readInvokedPropertyNames(dbPath: string) {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return db
+      .prepare('SELECT file, name FROM invoked_property_names ORDER BY file, name')
+      .all() as Array<{ file: string; name: string }>;
+  } finally {
+    db.close();
+  }
+}
+
+function makeStmts(db: ReturnType<typeof openDb>) {
+  return {
+    insertNode: db.prepare(
+      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
+    ),
+    getNodeId: {
+      get: (name: string, kind: string, file: string, line: number) => {
+        const id = getNodeIdQuery(db, name, kind, file, line);
+        return id != null ? { id } : undefined;
+      },
+    },
+    insertEdge: db.prepare(
+      'INSERT INTO edges (source_id, target_id, kind, confidence, dynamic) VALUES (?, ?, ?, ?, ?)',
+    ),
+    countNodes: db.prepare('SELECT COUNT(*) as c FROM nodes WHERE file = ?'),
+    countEdges: db.prepare(
+      'SELECT COUNT(*) as c FROM edges WHERE source_id IN (SELECT id FROM nodes WHERE file = ?)',
+    ),
+    findNodeInFile: db.prepare(
+      "SELECT id, kind, file FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant') AND file = ?",
+    ),
+    findNodeByName: db.prepare(
+      "SELECT id, file, kind FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
+    ),
+    listSymbols: db.prepare("SELECT name, kind, line FROM nodes WHERE file = ? AND kind != 'file'"),
+    upsertFileHash: db.prepare(
+      'INSERT OR REPLACE INTO file_hashes (file, hash, mtime, size) VALUES (?, ?, ?, ?)',
+    ),
+    deleteFileHash: db.prepare('DELETE FROM file_hashes WHERE file = ?'),
+  };
+}
+
+const ENGINES: EngineMode[] = ['wasm', 'native'];
+
+describe.each(ENGINES)(
+  'codegraph watch keeps object-literal value-ref evidence on producer-only rebuild (#2087) — initial build: %s',
+  (engine) => {
+    let watchDir: string;
+    let dbPath: string;
+
+    beforeAll(async () => {
+      watchDir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2087-${engine}-`));
+      writeFixture(watchDir);
+
+      // Initial full build — populates `invoked_property_names` for both
+      // files via either the JS pipeline or the native orchestrator,
+      // depending on `engine`, and confirms the value-ref edge exists.
+      await buildGraph(watchDir, { incremental: false, skipRegistry: true, engine });
+      dbPath = path.join(watchDir, '.codegraph', 'graph.db');
+
+      const namesAfterFullBuild = readInvokedPropertyNames(dbPath);
+      expect(namesAfterFullBuild).toEqual([{ file: 'consumer.js', name: 'resolve' }]);
+
+      const edgesAfterFullBuild = readCallEdges(dbPath);
+      expect(edgesAfterFullBuild.find((e) => e.tgt === 'isRead')).toBeDefined();
+
+      // Touch ONLY factory.js — the consumer (the only `.resolve(...)` call
+      // site) is untouched, matching the issue's exact reproduction: an
+      // incremental rebuild triggered solely on the producer file.
+      const factoryFile = path.join(watchDir, 'factory.js');
+      fs.appendFileSync(factoryFile, '\n// touch\n');
+
+      // Run the watch-mode single-file rebuild path directly.
+      const db = openDb(dbPath);
+      initSchema(db);
+      await rebuildFile(db, watchDir, factoryFile, makeStmts(db), { engine }, null);
+      db.close();
+    }, 60_000);
+
+    afterAll(() => {
+      try {
+        if (watchDir) fs.rmSync(watchDir, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+    });
+
+    it('the isRead value-ref calls edge survives the producer-only watch rebuild', () => {
+      const edges = readCallEdges(dbPath);
+      const edge = edges.find((e) => e.tgt === 'isRead');
+      expect(
+        edge,
+        `Expected a value-ref calls edge to isRead, confirmed via consumer.js's\n` +
+          `persisted invoked-property-name evidence\nActual call edges:\n${JSON.stringify(edges, null, 2)}`,
+      ).toBeDefined();
+    });
+
+    it("consumer.js's invoked-property-name evidence survives the producer-only rebuild unchanged", () => {
+      // consumer.js was never touched, so its own persisted row must still
+      // be exactly what the initial full build wrote.
+      expect(readInvokedPropertyNames(dbPath)).toContainEqual({
+        file: 'consumer.js',
+        name: 'resolve',
+      });
+    });
+  },
+);
+
+/**
+ * `codegraph build`'s own scoped-incremental pipeline (buildGraph with
+ * incremental: true — distinct from `codegraph watch`'s rebuildFile path
+ * exercised above) has the identical gap: `buildCallEdgesPhase`
+ * (stages/build-edges.ts) narrows `ctx.fileSymbols` to just the changed
+ * file(s) + reverse-deps on a non-full build, so a purely in-memory
+ * `collectInvokedPropertyNames` computation loses the same cross-file
+ * evidence. Fixed by reading back `invoked_property_names` (persisted by
+ * `persistInvokedPropertyNames`) for both the JS-fallback sub-path
+ * (`buildCallEdgesJS`) and the native-fast-path sub-path
+ * (`buildCallEdgesNative`, threaded through `build_call_edges`'s new
+ * `extraInvokedPropertyNames` parameter). At least 6 filler files are added
+ * so the native-engine variant exceeds `smallFilesThreshold` (5) and
+ * exercises `buildCallEdgesNative` specifically, not just the JS fallback.
+ */
+const FILLER_COUNT = 6;
+
+function writeScopedFixture(dir: string) {
+  writeFixture(dir);
+  for (let i = 0; i < FILLER_COUNT; i++) {
+    fs.writeFileSync(
+      path.join(dir, `filler${i}.js`),
+      `export function filler${i}() { return ${i}; }\n`,
+    );
+  }
+}
+
+describe.each(ENGINES)(
+  'codegraph build scoped-incremental rebuild keeps object-literal value-ref evidence (#2087) — engine: %s',
+  (engine) => {
+    let buildDir: string;
+    let scopedDbPath: string;
+
+    beforeAll(async () => {
+      buildDir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2087-build-${engine}-`));
+      writeScopedFixture(buildDir);
+      scopedDbPath = path.join(buildDir, '.codegraph', 'graph.db');
+
+      // Initial build establishes file_hashes so the second build below is a
+      // genuinely scoped incremental rebuild, not another full one.
+      await buildGraph(buildDir, { incremental: true, skipRegistry: true, engine });
+      expect(readCallEdges(scopedDbPath).find((e) => e.tgt === 'isRead')).toBeDefined();
+
+      // Touch ONLY factory.js — consumer.js (the only `.resolve(...)` call
+      // site) is untouched, so this incremental rebuild's own ctx.fileSymbols
+      // never includes it.
+      fs.appendFileSync(path.join(buildDir, 'factory.js'), '\n// touch\n');
+      await buildGraph(buildDir, { incremental: true, skipRegistry: true, engine });
+    }, 60_000);
+
+    afterAll(() => {
+      try {
+        if (buildDir) fs.rmSync(buildDir, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+    });
+
+    it('the isRead value-ref calls edge survives the scoped incremental rebuild', () => {
+      const edges = readCallEdges(scopedDbPath);
+      const edge = edges.find((e) => e.tgt === 'isRead');
+      expect(
+        edge,
+        `Expected a value-ref calls edge to isRead after a producer-only scoped\n` +
+          `incremental rebuild\nActual call edges:\n${JSON.stringify(edges, null, 2)}`,
+      ).toBeDefined();
+    });
+  },
+);


### PR DESCRIPTION
## Summary

Closes #2087

Deferred from #2034's review: the #1895 object-literal-property value-ref liveness check (`collectInvokedPropertyNames`) only sees property/method names invoked via member-call syntax across the files actually being processed. A full build sees the whole codebase, so it's exact. On investigation this turned out to affect **three** narrower-scoped code paths, not just the one named in the issue:

1. `codegraph watch`'s single-file rebuild (`rebuildFile`/`buildCallEdges` in `incremental.ts`) — the case the issue names.
2. `codegraph build`'s own scoped-incremental pipeline, JS-fallback sub-path (`buildCallEdgesJS` in `build-edges.ts`).
3. `codegraph build`'s own scoped-incremental pipeline, native-fast-path sub-path (`buildCallEdgesNative` → `native.buildCallEdges` → Rust `build_call_edges`) — reachable once more than `smallFilesThreshold` (5) files are touched in one incremental rebuild.

In all three, a consumer's `table.resolve(...)` call living in an untouched file was invisible to the file(s) actually being reprocessed, so a same-named object-literal property in the touched file could be misclassified as dead.

## Changes

- New `invoked_property_names(file, name)` table (migration v29, both engines' schema).
- **Write side** — populated whenever a file is parsed, on both engines:
  - `persistInvokedPropertyNames` (`build-edges.ts`) — full build or scoped incremental, JS/WASM pipeline.
  - `import_edges::persist_invoked_property_names` (Rust) — the standalone native orchestrator, called from `pipeline.rs` right before `file_entries` is consumed by `build_call_edges`.
  - `persistInvokedPropertyNamesForFile` (`incremental.ts`) — `codegraph watch`'s single-file rebuild, for both the primary file and each reverse-dep (both go through the same shared `buildCallEdges` function).
  - Cleaned up on file removal/full reset via the existing `purgeFileData`/`clear_all_graph_data` choke points on both engines.
- **Read side** — each of the three narrower-scoped call sites now unions its own in-memory evidence with the persisted table's whole-graph view before doing the liveness check:
  - `buildCallEdgesJS` queries the table directly.
  - `buildCallEdgesNative` queries the table and passes the result through a new optional `extraInvokedPropertyNames` parameter on `native.buildCallEdges` → Rust's `build_call_edges`, which unions it into `EdgeContext.invoked_property_names` (now owned `HashSet<String>` instead of borrowed, since the extra evidence comes from outside `files`' lifetime).
  - `collectGraphWideInvokedPropertyNames` (`incremental.ts`) does the same for the watch-mode path.
  - The standalone native orchestrator (`pipeline.rs`) reads the table back (already including this pass's own fresh writes) and passes it the same way.

## Test plan

- [x] `cargo test -p codegraph-core --lib` — 819 passed
- [x] `npx vitest run tests/integration/issue-2087-incremental-invoked-property-persistence.test.ts` — new test, 6 passed (both engines × watch-mode rebuild + scoped `codegraph build` incremental rebuild, the latter padded with filler files so the native-engine variant exercises `buildCallEdgesNative` specifically, not just the JS fallback)
- [x] `npm test` — full suite, 4551 passed
- [x] `npx tsc --noEmit` clean
- [x] `cargo build -p codegraph-core --lib` clean
- [x] Manual repro of all three narrow-scope paths before/after the fix (producer-only rebuild via `codegraph watch` and via `codegraph build` incremental for both engines)
- [x] `codegraph diff-impact --staged -T` reviewed — 0 unexpected callers affected