### PR TITLE
docs(hooks): resync guard-git.sh example with the live hook

### DIFF
--- a/.claude/hooks/mask-quoted-text.mjs
+++ b/.claude/hooks/mask-quoted-text.mjs
@@ -154,6 +154,18 @@ function maskQuotedStrings(input) {
     const ch = input[i];
     if (quote) {
       if (quoteExecTriggered) {
+        // Mirror the escaped-quote handling below: an escaped `\"` inside an
+        // exec-triggered double-quoted payload is NOT the closing quote —
+        // treating it as one (Greptile review) would end the exemption
+        // early and let the real remainder of the payload (which can
+        // contain a real dangerous command, e.g.
+        // `bash -c "echo \"x\" && git clean -fd"`) fall through to normal
+        // masking, hiding it.
+        if (ch === '\\' && quote === '"' && i + 1 < input.length) {
+          out += ch + input[i + 1];
+          i++;
+          continue;
+        }
         out += ch;
         if (ch === quote) quote = null;
         continue;

--- a/docs/examples/claude-code-hooks/README.md
+++ b/docs/examples/claude-code-hooks/README.md
@@ -46,7 +46,7 @@ If an instruction matters, make it a blocking hook. If it's in CLAUDE.md but not
 
 | Hook | Trigger | What it does |
 |------|---------|-------------|
-| `guard-git.sh` | PreToolUse on Bash | Blocks `git add .`, `git reset`, `git restore`, `git clean`, `git stash`; validates commits only include files the session actually edited |
+| `guard-git.sh` (+ `mask-quoted-text.mjs`, `check-git-clean-force.mjs`) | PreToolUse on Bash | Blocks `git add .`, `git reset`, `git restore`, a force-deleting `git clean` (dry-run is allowed), `git stash`; blocks AI attribution in commit messages; validates branch names and that commits only include files the session actually edited |
 | `track-edits.sh` | PostToolUse on Edit/Write | Logs every file edited to `.claude/session-edits.log` — required by guard-git.sh and pre-commit.sh |
 | `track-moves.sh` | PostToolUse on Bash | Logs files affected by `mv`/`git mv`/`cp` to the edit log |
 
@@ -78,7 +78,9 @@ All session-local state files (`session-edits.log`) use `git rev-parse --show-to
 - **With pre-commit checks:** Add `pre-commit.sh` + `pre-commit-checks.js` + `lint-staged.sh`
 - **Multi-agent / worktrees:** Add `guard-git.sh` + `track-edits.sh` + `track-moves.sh`
 
-**Branch name validation:** The `guard-git.sh` in this repo's `.claude/hooks/` validates branch names against conventional prefixes (`feat/`, `fix/`, etc.). The example version omits this — add your own validation if needed.
+**Branch name validation:** `guard-git.sh` validates branch names against conventional prefixes (`feat/`, `fix/`, etc.) on `git push` and `gh pr create`. Adjust the `PATTERN` in `validate_branch_name` if your project uses different conventions.
+
+**Kept in sync automatically:** `guard-git.sh` and its two companion scripts (`mask-quoted-text.mjs`, `check-git-clean-force.mjs`) here are exact copies of this repo's own `.claude/hooks/` — a test (`tests/unit/hook-guard-git-clean.test.ts`) fails CI if they ever diverge, so this example always reflects the live hook's actual behavior instead of drifting into a stale, partial snapshot (#2105).
 
 ## Incremental build freshness
 

--- a/docs/examples/claude-code-hooks/check-git-clean-force.mjs
+++ b/docs/examples/claude-code-hooks/check-git-clean-force.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+// check-git-clean-force.mjs — reads the (masked, -C-normalized) NCOMMAND
+// from stdin and prints `BLOCK` if it contains a `git clean` invocation that
+// would actually delete (carries -f/--force and lacks -n/--dry-run),
+// otherwise prints nothing. Used by guard-git.sh (#2099).
+//
+// Splits into logical command segments on every real shell command
+// separator (&&, &, ||, ;, |, newline) — not just `&&` — so a flag on one
+// command can never be misread as belonging to an unrelated `git clean` on
+// a different segment (Greptile review: `git clean -fd; ls -n` and
+// `git clean -fd & ls -n` must still block, since the `-n` belongs to the
+// other command, not the clean invocation).
+//
+// Within a segment, flags are matched against whole whitespace-separated
+// tokens (not a substring/boundary regex against the raw segment text), so
+// bundled short options are recognized correctly: `-ndf` and `-fnd` both
+// carry both `-n` and `-f`, matching git's own bundled short-flag parsing.
+// Tokens at or after a bare `--` are pathspecs, not options (git's own
+// convention) — `git clean -f -- -n` must still block, since the trailing
+// `-n` names a literal path, not a dry-run flag (Greptile review).
+
+const SEGMENT_SEPARATOR = /&&|&|\|\||[;|\n]/;
+const CLEAN_INVOCATION = /(^|\s)git\s+clean(\s|$)/;
+const FORCE_TOKEN = /^(--force|-[a-zA-Z]*f[a-zA-Z]*)$/;
+const DRY_RUN_TOKEN = /^(--dry-run|-[a-zA-Z]*n[a-zA-Z]*)$/;
+
+let input = '';
+process.stdin.on('data', (chunk) => {
+  input += chunk;
+});
+process.stdin.on('end', () => {
+  const segments = input.split(SEGMENT_SEPARATOR);
+  for (const segment of segments) {
+    if (!CLEAN_INVOCATION.test(segment)) continue;
+    const allTokens = segment.trim().split(/\s+/);
+    const pathspecBoundary = allTokens.indexOf('--');
+    const optionTokens = pathspecBoundary === -1 ? allTokens : allTokens.slice(0, pathspecBoundary);
+    const hasForce = optionTokens.some((t) => FORCE_TOKEN.test(t));
+    const hasDryRun = optionTokens.some((t) => DRY_RUN_TOKEN.test(t));
+    if (hasForce && !hasDryRun) {
+      process.stdout.write('BLOCK');
+      return;
+    }
+  }
+});

--- a/docs/examples/claude-code-hooks/guard-git.sh
+++ b/docs/examples/claude-code-hooks/guard-git.sh
@@ -21,10 +21,54 @@ if [ -z "$COMMAND" ]; then
   exit 0
 fi
 
-# Act on git commands (may appear after cd "..." &&)
-if ! echo "$COMMAND" | grep -qE '(^|\s|&&\s*)git\s+'; then
+# Act on git and gh commands (may appear after cd "..." &&, inside a quoted
+# nested-shell invocation like `bash -c "git clean -fd"`, or inside a command
+# substitution like `"message $(git clean -fd)"` — #2099 Greptile review).
+# This is only a cheap fast-path skip, so it's deliberately permissive
+# (["'`(] as extra allowed prefix boundaries alongside start/whitespace/&&)
+# rather than exact: a false "yes" here just means the rest of the script
+# runs its checks anyway, while a false "no" would exit before ever reaching
+# them.
+if ! echo "$COMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*|["'"'"'`(])(git|gh)[[:space:]]+'; then
   exit 0
 fi
+
+# Mask the *contents* of quoted strings (single or double) before any of the
+# "does this command invoke a dangerous verb" checks below run (#2099). Every
+# such check is a plain substring/regex scan over the command text, with no
+# awareness of shell quoting — so text that merely APPEARS inside a quoted
+# argument (e.g. `gh issue create --body "...git clean -fd..."`) matched the
+# same pattern as a real invocation and got blocked. See mask-quoted-text.mjs
+# for the masking rules. Extraction logic below (detect_work_dir, MSG_FILE,
+# the AI-attribution scan) deliberately keeps reading the raw, unmasked
+# $COMMAND — masking only feeds the verb-detection checks that use $NCOMMAND.
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+MASKED_COMMAND=$(echo "$COMMAND" | node "$HOOK_DIR/mask-quoted-text.mjs" 2>/dev/null) || true
+if [ -z "$MASKED_COMMAND" ]; then
+  MASKED_COMMAND="$COMMAND"
+fi
+
+# Normalize: strip `git -C "<path>"` / `git -C <path>` so downstream subcommand
+# patterns (git[[:space:]]+push, git[[:space:]]+commit, …) match regardless of whether `-C` is
+# present. detect_work_dir still inspects the raw $COMMAND to find the target.
+# The unquoted pattern requires a non-quote first char so it does not mis-match
+# the opening `"` of a quoted path (which would leave a trailing `path"` in
+# NCOMMAND). The pattern re-anchors on `git`, so multi-`-C` chains (e.g.
+# `git -C /a -C /b push`) need a second pass to collapse the residual `-C`.
+NCOMMAND=$(echo "$MASKED_COMMAND" | sed -E 's/(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+-C[[:space:]]+"[^"]+"/\1git/g; s/(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+-C[[:space:]]+[^"[:space:]][^[:space:]]*/\1git/g')
+NCOMMAND=$(echo "$NCOMMAND" | sed -E 's/(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+-C[[:space:]]+"[^"]+"/\1git/g; s/(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+-C[[:space:]]+[^"[:space:]][^[:space:]]*/\1git/g')
+
+# Strip any remaining literal quote/substitution-delimiter characters from
+# NCOMMAND (#2099 Greptile review): an exec-triggered quote
+# (`bash -c "git clean -fd"`) or a command substitution
+# (`"message $(git clean -fd)"`, which executes even inside an otherwise
+# masked double-quoted string) is left unmasked by mask-quoted-text.mjs, but
+# its delimiters survive — e.g. `"git` or `$(git` — sitting directly adjacent
+# to the verb, defeating every `(^|[[:space:]])`-anchored check below.
+# NCOMMAND is used exclusively for verb detection (never for value
+# extraction — detect_work_dir/MSG_FILE read the raw $COMMAND instead), so
+# these characters carry no meaning here once masking has already run.
+NCOMMAND=$(echo "$NCOMMAND" | sed -E "s/[\"'\`()]/ /g")
 
 deny() {
   local reason="$1"
@@ -41,72 +85,216 @@ deny() {
 }
 
 # --- Block dangerous commands ---
-# Patterns use (^|\s|&&\s*) to catch commands chained after cd/other commands
 
 # git add . / git add -A / git add --all (broad staging)
-if echo "$COMMAND" | grep -qE '(^|\s|&&\s*)git\s+add\s+(\.\s*$|-A|--all)'; then
+if echo "$NCOMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+add[[:space:]]+(\.[[:space:]]*$|-A|--all)'; then
   deny "BLOCKED: 'git add .' / 'git add -A' stages ALL changes including other sessions' work. Stage specific files instead: git add <file1> <file2>"
 fi
 
 # git reset (unstaging / hard reset)
-if echo "$COMMAND" | grep -qE '(^|\s|&&\s*)git\s+reset'; then
+if echo "$NCOMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+reset'; then
   deny "BLOCKED: 'git reset' can unstage or destroy other sessions' work. To unstage your own files, use: git restore --staged <file>"
 fi
 
 # git checkout -- <file> (reverting files)
-if echo "$COMMAND" | grep -qE '(^|\s|&&\s*)git\s+checkout\s+--'; then
+if echo "$NCOMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+checkout[[:space:]]+--'; then
   deny "BLOCKED: 'git checkout -- <file>' reverts working tree changes and may destroy other sessions' edits. If you need to discard your own changes, be explicit about which files."
 fi
 
 # git restore (reverting) — EXCEPT git restore --staged (safe unstaging)
-if echo "$COMMAND" | grep -qE '(^|\s|&&\s*)git\s+restore'; then
-  if ! echo "$COMMAND" | grep -qE '(^|\s|&&\s*)git\s+restore\s+--staged'; then
+if echo "$NCOMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+restore'; then
+  if ! echo "$NCOMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+restore[[:space:]]+--staged'; then
     deny "BLOCKED: 'git restore <file>' reverts working tree changes and may destroy other sessions' edits. To unstage files safely, use: git restore --staged <file>"
   fi
 fi
 
-# git clean (delete untracked files)
-if echo "$COMMAND" | grep -qE '(^|\s|&&\s*)git\s+clean'; then
-  deny "BLOCKED: 'git clean' deletes untracked files that may belong to other sessions."
+# git clean (delete untracked files) — #2099: `-n`/`--dry-run` is a pure
+# listing operation (git itself treats --dry-run as always overriding -f, so
+# it never deletes regardless of what else is on the line) and is exactly the
+# discovery mechanism /housekeep's Phase 2 recommends; only block an
+# invocation that would actually delete (carries -f/--force, and no
+# -n/--dry-run). A bare `git clean` with neither flag already refuses to run
+# without config changes this hook has no visibility into, so it's left
+# unblocked rather than flagging something git itself won't execute.
+# Delegates to check-git-clean-force.mjs (not an inline awk/grep pair) so the
+# per-segment split and bundled-short-flag matching (`-ndf`, `-fnd`, …) are
+# correct — an earlier version here split only on `&&`, so a flag on an
+# unrelated `;`/`|`/newline-separated command could suppress the block, and
+# missed bundled `-n` (Greptile review on #2099's own PR).
+if echo "$NCOMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+clean'; then
+  if [ "$(echo "$NCOMMAND" | node "$HOOK_DIR/check-git-clean-force.mjs" 2>/dev/null)" = "BLOCK" ]; then
+    deny "BLOCKED: 'git clean -f'/'--force' deletes untracked files that may belong to other sessions. Preview first with 'git clean -n'/'--dry-run'."
+  fi
 fi
 
 # git stash (hides all changes)
-if echo "$COMMAND" | grep -qE '(^|\s|&&\s*)git\s+stash'; then
+if echo "$NCOMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+stash'; then
   deny "BLOCKED: 'git stash' hides all working tree changes including other sessions' work. In worktree mode, commit your changes directly instead."
+fi
+
+# --- Working directory detection ---
+
+# Resolve the working directory a git command targets:
+# - `git -C "<dir>" ...`   → the -C target (takes precedence — explicit git-level override)
+# - `cd "<dir>" && git ...` → the cd target
+# Falls back to empty string (caller uses cwd).
+#
+# Optional arg: target subcommand hint (e.g. `push`, `commit`). When given,
+# narrows the search to the `&&`-separated segment whose git invocation runs
+# that subcommand, so chained commands like
+#   `git -C /a push && git -C /b commit -m ...`
+# resolve each caller to its own worktree instead of always picking the last
+# `git` token. Within the chosen segment the LAST `-C` wins (git's `-C` is
+# cumulative, so the final `-C` is the effective CWD) — this closes the
+# multi-`-C` bypass (`git -C /ok -C /bad push` resolves to `/bad`).
+detect_work_dir() {
+  local target_subcmd="${1:-}"
+  local work_dir=""
+  local search_str="$COMMAND"
+
+  if [ -n "$target_subcmd" ]; then
+    local segment
+    segment=$(echo "$COMMAND" | awk -v tgt="$target_subcmd" 'BEGIN{RS="&&"}{
+      if ($0 ~ "git[[:space:]]+([^|;&]*[[:space:]])?" tgt "([[:space:]]|$)") { print; exit }
+    }')
+    if [ -n "$segment" ]; then
+      search_str="$segment"
+    fi
+  fi
+
+  # `git -C` is the explicit git-level override and wins over any ambient cd prefix,
+  # so check it first (e.g. `cd /tmp && git -C /worktree push` targets /worktree).
+  # Greedy `.*-C` anchors on the LAST `-C` in the chosen segment.
+  # Two separate sed invocations (quoted path first, then unquoted fallback) instead
+  # of a single `;t;s` chain — BSD sed parses chained s/// after `t` as a label.
+  if echo "$search_str" | grep -qE 'git[[:space:]]+([^&|;]*[[:space:]])?-C[[:space:]]+'; then
+    work_dir=$(echo "$search_str" | sed -nE 's/.*-C[[:space:]]+"([^"]+)".*/\1/p')
+    if [ -z "$work_dir" ]; then
+      work_dir=$(echo "$search_str" | sed -nE 's/.*-C[[:space:]]+([^[:space:]]+).*/\1/p')
+    fi
+  fi
+  if [ -z "$work_dir" ] && echo "$COMMAND" | grep -qE '^[[:space:]]*cd[[:space:]]+'; then
+    work_dir=$(echo "$COMMAND" | sed -nE 's/^[[:space:]]*cd[[:space:]]+"?([^"&]+)"?[[:space:]]*&&.*/\1/p')
+  fi
+  # Trim trailing whitespace
+  work_dir="${work_dir%"${work_dir##*[![:space:]]}"}"
+  echo "$work_dir"
+}
+
+# --- Branch name validation helper ---
+
+validate_branch_name() {
+  local subcmd="${1:-}"
+  local work_dir
+  work_dir=$(detect_work_dir "$subcmd")
+
+  local BRANCH=""
+  if [ -n "$work_dir" ] && [ -d "$work_dir" ]; then
+    BRANCH=$(git -C "$work_dir" rev-parse --abbrev-ref HEAD 2>/dev/null) || true
+  fi
+  if [ -z "$BRANCH" ]; then
+    BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || true
+  fi
+
+  if [ -n "$BRANCH" ] && [ "$BRANCH" != "main" ] && [ "$BRANCH" != "HEAD" ]; then
+    local PATTERN="^(feat|fix|docs|refactor|test|chore|ci|perf|build|release|dependabot|revert)/"
+    if [[ ! "$BRANCH" =~ $PATTERN ]]; then
+      deny "BLOCKED: Branch '$BRANCH' does not match required pattern. Branch names must start with: feat/, fix/, docs/, refactor/, test/, chore/, ci/, perf/, build/, release/, revert/"
+    fi
+  fi
+}
+
+# --- Branch name validation on push ---
+
+if echo "$NCOMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+push'; then
+  validate_branch_name push
+fi
+
+# --- Branch name validation on gh pr create ---
+
+if echo "$NCOMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*)gh[[:space:]]+pr[[:space:]]+create'; then
+  # `gh pr create` does not use `git -C`; detect_work_dir falls through to the
+  # `cd` path or cwd. No subcommand hint to pass.
+  validate_branch_name
+fi
+
+# --- Block AI attribution in commit messages ---
+
+if echo "$NCOMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+commit'; then
+  if echo "$COMMAND" | grep -qiE 'co-authored-by:.*claude|co-authored-by:.*anthropic|generated with claude|generated with \[claude|built with claude|claude\.ai'; then
+    deny "BLOCKED: Remove AI attribution lines (Co-Authored-By with Claude/Anthropic, 'Generated with Claude', 'Built with Claude', claude.ai URLs) from the commit message."
+  fi
+  # Extract -F <file> or --file=<file> or --file <file> (all equivalent git commit forms)
+  MSG_FILE=$(echo "$COMMAND" | grep -oE '\-F[[:space:]]+[^[:space:]]+' | awk '{print $2}' || true)
+  if [ -z "$MSG_FILE" ]; then
+    MSG_FILE=$(echo "$COMMAND" | grep -oE '\-\-file=[^[:space:]]+' | sed 's/--file=//' || true)
+  fi
+  if [ -z "$MSG_FILE" ]; then
+    MSG_FILE=$(echo "$COMMAND" | grep -oE '\-\-file[[:space:]]+[^[:space:]]+' | awk '{print $2}' || true)
+  fi
+  if [ -n "$MSG_FILE" ] && [ -f "$MSG_FILE" ]; then
+    if grep -qiE 'co-authored-by:.*claude|co-authored-by:.*anthropic|generated with claude|generated with \[claude|built with claude|claude\.ai' "$MSG_FILE"; then
+      deny "BLOCKED: Remove AI attribution lines from the commit message file '$MSG_FILE'."
+    fi
+  fi
 fi
 
 # --- Commit validation against edit log ---
 
-if echo "$COMMAND" | grep -qE '(^|\s|&&\s*)git\s+commit'; then
-  # Use git worktree root so each worktree session has its own edit log
-  PROJECT_DIR=$(git rev-parse --show-toplevel 2>/dev/null) || PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
-  LOG_FILE="$PROJECT_DIR/.claude/session-edits.log"
-
-  # If no edit log exists, allow (backward compat for sessions without tracking)
-  if [ ! -f "$LOG_FILE" ] || [ ! -s "$LOG_FILE" ]; then
-    exit 0
+if echo "$NCOMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+commit'; then
+  # Resolve the target worktree so the edit log and staged-file listing come
+  # from the same repo the commit targets (e.g. `git -C <pr-worktree> commit`).
+  WORK_DIR=$(detect_work_dir commit)
+  MERGE_IN_PROGRESS=false
+  if [ -n "$WORK_DIR" ] && [ -d "$WORK_DIR" ]; then
+    PROJECT_DIR=$(git -C "$WORK_DIR" rev-parse --show-toplevel 2>/dev/null) || PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+    STAGED_FILES=$(git -C "$WORK_DIR" diff --cached --name-only 2>/dev/null) || true
+    git -C "$WORK_DIR" rev-parse --verify -q MERGE_HEAD >/dev/null 2>&1 && MERGE_IN_PROGRESS=true
+  else
+    PROJECT_DIR=$(git rev-parse --show-toplevel 2>/dev/null) || PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+    STAGED_FILES=$(git diff --cached --name-only 2>/dev/null) || true
+    git rev-parse --verify -q MERGE_HEAD >/dev/null 2>&1 && MERGE_IN_PROGRESS=true
   fi
 
-  # Get unique edited files from log
-  EDITED_FILES=$(awk '{print $2}' "$LOG_FILE" | sort -u)
+  # A merge in progress (MERGE_HEAD present) stages every auto-merged file from
+  # the incoming branch alongside any manually resolved conflicts — not just
+  # files this session edited via tools. git also structurally refuses a
+  # partial-pathspec `git commit <files>` while MERGE_HEAD exists ("cannot do
+  # a partial commit during a merge"), so the edit-log check's own suggested
+  # workaround is impossible here. Skip only the edit-log validation for merge
+  # commits — scoped to this `if`, not an early `exit 0`, so any commit-time
+  # check added below in the future still runs for merge commits too.
+  #
+  # `rev-parse --verify` (not a bare file-existence test) requires MERGE_HEAD
+  # to resolve to a real object in this repo's object database, so a stray or
+  # hand-crafted file at that path can't be used to fake a merge and bypass
+  # the check below.
+  if [ "$MERGE_IN_PROGRESS" = false ]; then
+    LOG_FILE="$PROJECT_DIR/.claude/session-edits.log"
 
-  # Get staged files
-  STAGED_FILES=$(git diff --cached --name-only 2>/dev/null) || true
-
-  if [ -z "$STAGED_FILES" ]; then
-    exit 0
-  fi
-
-  # Find staged files that weren't edited in this session
-  UNEXPECTED=""
-  while IFS= read -r staged_file; do
-    if ! echo "$EDITED_FILES" | grep -qxF "$staged_file"; then
-      UNEXPECTED="${UNEXPECTED:+$UNEXPECTED, }$staged_file"
+    # If no edit log exists, allow (backward compat for sessions without tracking)
+    if [ ! -f "$LOG_FILE" ] || [ ! -s "$LOG_FILE" ]; then
+      exit 0
     fi
-  done <<< "$STAGED_FILES"
 
-  if [ -n "$UNEXPECTED" ]; then
-    deny "BLOCKED: These staged files were NOT edited in this session: $UNEXPECTED. They may belong to another session. Commit only your files: git commit <your-files> -m \"msg\""
+    # Get unique edited files from log
+    EDITED_FILES=$(awk '{print $2}' "$LOG_FILE" | sort -u)
+
+    if [ -z "$STAGED_FILES" ]; then
+      exit 0
+    fi
+
+    # Find staged files that weren't edited in this session
+    UNEXPECTED=""
+    while IFS= read -r staged_file; do
+      if ! echo "$EDITED_FILES" | grep -qxF "$staged_file"; then
+        UNEXPECTED="${UNEXPECTED:+$UNEXPECTED, }$staged_file"
+      fi
+    done <<< "$STAGED_FILES"
+
+    if [ -n "$UNEXPECTED" ]; then
+      deny "BLOCKED: These staged files were NOT edited in this session: $UNEXPECTED. They may belong to another session. Commit only your files: git commit <your-files> -m \"msg\""
+    fi
   fi
 fi
 

--- a/docs/examples/claude-code-hooks/mask-quoted-text.mjs
+++ b/docs/examples/claude-code-hooks/mask-quoted-text.mjs
@@ -154,6 +154,18 @@ function maskQuotedStrings(input) {
     const ch = input[i];
     if (quote) {
       if (quoteExecTriggered) {
+        // Mirror the escaped-quote handling below: an escaped `\"` inside an
+        // exec-triggered double-quoted payload is NOT the closing quote —
+        // treating it as one (Greptile review) would end the exemption
+        // early and let the real remainder of the payload (which can
+        // contain a real dangerous command, e.g.
+        // `bash -c "echo \"x\" && git clean -fd"`) fall through to normal
+        // masking, hiding it.
+        if (ch === '\\' && quote === '"' && i + 1 < input.length) {
+          out += ch + input[i + 1];
+          i++;
+          continue;
+        }
         out += ch;
         if (ch === quote) quote = null;
         continue;

--- a/docs/examples/claude-code-hooks/mask-quoted-text.mjs
+++ b/docs/examples/claude-code-hooks/mask-quoted-text.mjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+// mask-quoted-text.mjs — reads a shell command line from stdin and writes it
+// back with the *contents* of every quoted string (single or double) and
+// every heredoc body replaced by `#`/masked placeholders, preserving quote
+// delimiters and overall length/line structure.
+//
+// Used by guard-git.sh (#2099) so its "does this command invoke a dangerous
+// verb" checks scan text that can never accidentally match inside data that
+// isn't a real command invocation — e.g.
+// `gh issue create --body "...git clean -fd..."` previously tripped the
+// same regex as a real `git clean` invocation, since those checks are plain
+// substring/regex scans with no awareness of shell quoting. Heredoc bodies
+// (`git commit -m "$(cat <<'EOF' ... EOF)"`, the form this repo's own
+// CLAUDE.md mandates for commit messages) are the same class of problem:
+// the message text is data, not commands, but sits outside any single-line
+// quote pair.
+//
+// EXEC_TRIGGER_TOKENS (Greptile review): a quote or heredoc immediately
+// following `-c`/`--command`/`-e`/`--eval`/`eval` is not inert data — shells
+// and interpreters (`bash -c "..."`, `sh -c '...'`, `node -e "..."`,
+// `eval "..."`) execute that string as real code. Masking it would hide a
+// genuine `git clean -fd` payload from every verb-detection check below.
+// Such quotes/heredocs are left completely unmasked instead.
+//
+// COMMAND SUBSTITUTION (Greptile review): `$(...)` and `` `...` `` execute
+// their contents even inside an ORDINARY double-quoted string that is
+// otherwise inert data (`git commit -m "message $(git clean -fd)"` really
+// does run `git clean -fd` when bash expands it) — single quotes are the
+// only quoting that suppresses this. The same applies inside a heredoc body
+// whose delimiter is UNQUOTED (`<<EOF`, as opposed to `<<'EOF'`/`<<"EOF"`,
+// which suppress all expansion, matching the form CLAUDE.md mandates for
+// commit messages). Such spans are left unmasked (with correctly nested
+// paren/backtick matching) regardless of exec-trigger context, since they
+// execute unconditionally.
+//
+// This is a heuristic, not a full shell-grammar parser: `\"` inside a
+// double-quoted string is treated as an escaped quote (consumed as two
+// masked characters, not a string terminator); single-quoted strings in real
+// shells never support backslash escapes at all, so none are attempted here;
+// nested `$(...)`/backtick detection does not itself account for quotes
+// *inside* the substitution. Proportionate to a PreToolUse guard, matching
+// the tolerance for edge cases already accepted by guard-git.sh's other
+// regex-based checks.
+
+const HEREDOC_START = /<<-?~?\s*(['"]?)([A-Za-z_][A-Za-z0-9_]*)\1?/;
+const EXEC_TRIGGER_TOKENS = new Set(['-c', '--command', '-e', '--eval', 'eval']);
+
+/** The whitespace-delimited token immediately before `pos` in `str`, or ''. */
+function precedingToken(str, pos) {
+  let end = pos;
+  while (end > 0 && /\s/.test(str[end - 1])) end--;
+  let start = end;
+  while (start > 0 && !/\s/.test(str[start - 1])) start--;
+  return str.slice(start, end);
+}
+
+/**
+ * If `text[i]` starts a `$(...)` (balanced nested parens) or `` `...` ``
+ * command-substitution span, returns `{ span, nextIndex }` — the full
+ * verbatim span text and the index of the character right after it.
+ * Returns `null` when `i` doesn't start such a span.
+ */
+function scanCommandSubstitution(text, i) {
+  if (text[i] === '$' && text[i + 1] === '(') {
+    let depth = 1;
+    let j = i + 2;
+    let span = '$(';
+    for (; j < text.length && depth > 0; j++) {
+      span += text[j];
+      if (text[j] === '(') depth++;
+      else if (text[j] === ')') depth--;
+    }
+    return { span, nextIndex: j };
+  }
+  if (text[i] === '`') {
+    let j = i + 1;
+    let span = '`';
+    for (; j < text.length; j++) {
+      span += text[j];
+      if (text[j] === '`') {
+        j++;
+        break;
+      }
+    }
+    return { span, nextIndex: j };
+  }
+  return null;
+}
+
+/**
+ * Mask every character in `text` to `#` (preserving newlines), except for
+ * `$(...)`/`` `...` `` spans (see `scanCommandSubstitution`), which are
+ * copied verbatim — those execute unconditionally in real bash wherever
+ * expansion is active at all, regardless of surrounding masking context.
+ */
+function maskExceptCommandSubstitution(text) {
+  let out = '';
+  for (let i = 0; i < text.length; i++) {
+    const sub = scanCommandSubstitution(text, i);
+    if (sub) {
+      out += sub.span;
+      i = sub.nextIndex - 1;
+      continue;
+    }
+    out += text[i] === '\n' ? '\n' : '#';
+  }
+  return out;
+}
+
+function maskHeredocBodies(text) {
+  const lines = text.split('\n');
+  const out = [];
+  let delimiter = null;
+  let execTriggered = false;
+  let delimiterQuoted = false;
+  for (const line of lines) {
+    if (delimiter !== null) {
+      if (line.trim() === delimiter) {
+        delimiter = null;
+        out.push(line);
+      } else if (execTriggered) {
+        out.push(line);
+      } else if (delimiterQuoted) {
+        out.push('#'.repeat(line.length));
+      } else {
+        // Unquoted heredoc delimiter (`<<EOF`) — the shell still expands
+        // $(...)/backticks inside the body, so those spans must stay visible.
+        out.push(maskExceptCommandSubstitution(line));
+      }
+      continue;
+    }
+    out.push(line);
+    const match = line.match(HEREDOC_START);
+    if (match) {
+      delimiter = match[2];
+      delimiterQuoted = match[1] === "'" || match[1] === '"';
+      // Coarse, line-level check: does this heredoc's own start line carry
+      // an exec-trigger token anywhere on it (e.g. `bash -c "$(cat <<'EOF'`)?
+      // A false "yes" here only means a heredoc that didn't need the
+      // exemption stays unmasked — a missed mask, not a hidden invocation —
+      // which is the safe direction to err in.
+      const tokens = line.trim().split(/\s+/);
+      execTriggered = tokens.some((t) => EXEC_TRIGGER_TOKENS.has(t));
+    }
+  }
+  return out.join('\n');
+}
+
+function maskQuotedStrings(input) {
+  let out = '';
+  let quote = null;
+  let quoteExecTriggered = false;
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i];
+    if (quote) {
+      if (quoteExecTriggered) {
+        out += ch;
+        if (ch === quote) quote = null;
+        continue;
+      }
+      // Command substitution executes even inside an otherwise-inert
+      // double-quoted string (single quotes suppress it entirely, so this
+      // only applies when quote === '"').
+      if (quote === '"') {
+        const sub = scanCommandSubstitution(input, i);
+        if (sub) {
+          out += sub.span;
+          i = sub.nextIndex - 1;
+          continue;
+        }
+      }
+      if (ch === '\\' && quote === '"' && i + 1 < input.length) {
+        out += '##';
+        i++;
+        continue;
+      }
+      if (ch === quote) {
+        out += ch;
+        quote = null;
+        continue;
+      }
+      out += ch === '\n' ? '\n' : '#';
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      quoteExecTriggered = EXEC_TRIGGER_TOKENS.has(precedingToken(input, i));
+      out += ch;
+      continue;
+    }
+    out += ch;
+  }
+  return out;
+}
+
+let input = '';
+process.stdin.on('data', (chunk) => {
+  input += chunk;
+});
+process.stdin.on('end', () => {
+  process.stdout.write(maskQuotedStrings(maskHeredocBodies(input)));
+});

--- a/tests/unit/hook-guard-git-clean.test.ts
+++ b/tests/unit/hook-guard-git-clean.test.ts
@@ -19,6 +19,7 @@
  * always overriding `-f`).
  */
 import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
@@ -230,5 +231,23 @@ describe('guard-git.sh mask-quoted-text.mjs', () => {
     const input = ["cat <<'EOF'", 'masked body', 'EOF', 'git clean -fd'].join('\n');
     const output = mask(input);
     expect(output.split('\n').at(-1)).toBe('git clean -fd');
+  });
+});
+
+describe('guard-git.sh docs example stays in sync (#2105)', () => {
+  // docs/examples/claude-code-hooks/guard-git.sh is meant to be a working
+  // copy of the live hook for users setting up their own repo — it had
+  // drifted far enough out of sync (missing worktree detection, branch
+  // validation, AI-attribution blocking, and more) that it no longer
+  // reflected the real hook's behavior at all. Kept as an exact copy and
+  // enforced here instead of documented-and-hoped-for, since a prose note
+  // alone already failed to prevent the original drift.
+  const HOOKS = ['guard-git.sh', 'mask-quoted-text.mjs', 'check-git-clean-force.mjs'];
+  const DOCS_DIR = path.join(REPO_ROOT, 'docs', 'examples', 'claude-code-hooks');
+
+  it.each(HOOKS)('%s is byte-identical to its docs/examples copy', (name) => {
+    const live = fs.readFileSync(path.join(REPO_ROOT, '.claude', 'hooks', name), 'utf8');
+    const docs = fs.readFileSync(path.join(DOCS_DIR, name), 'utf8');
+    expect(docs).toBe(live);
   });
 });

--- a/tests/unit/hook-guard-git-clean.test.ts
+++ b/tests/unit/hook-guard-git-clean.test.ts
@@ -147,6 +147,14 @@ describe('guard-git.sh does not false-positive on quoted text (#2099)', () => {
     expect(isDenied('bash -c "echo hello"')).toBe(false);
   });
 
+  it('still blocks a dangerous command after an escaped quote inside an executable -c payload (Greptile review)', () => {
+    // An escaped \" inside `bash -c "..."` is not the closing quote — ending
+    // the exec-trigger exemption there would let the real remainder of the
+    // payload (a genuine git clean -fd here) fall through to normal
+    // masking and get hidden.
+    expect(isDenied('bash -c "echo \\"x\\" && git clean -fd"')).toBe(true);
+  });
+
   it('still blocks a command substitution inside an ordinary double-quoted argument (Greptile review)', () => {
     // $(...) and `...` execute even inside an otherwise-inert double-quoted
     // string — real bash actually runs `git clean -fd` here when expanding


### PR DESCRIPTION
## Summary

Closes #2105

`docs/examples/claude-code-hooks/guard-git.sh` had drifted far from `.claude/hooks/guard-git.sh` — missing worktree detection (`detect_work_dir`), branch-name validation, AI-attribution blocking in commit messages, the `MERGE_HEAD` skip from PR #2100, and now the entire quote-masking/dry-run-aware clean-guard rework from #2099. It no longer reflected the real hook's behavior at all.

## Changes

- Copies the current `.claude/hooks/guard-git.sh` and its two companion scripts (`mask-quoted-text.mjs`, `check-git-clean-force.mjs`) verbatim into the docs example.
- Adds a byte-identity test (`tests/unit/hook-guard-git-clean.test.ts`, "docs example stays in sync" block) so CI fails if these ever diverge again — a prose README note already failed to prevent the original drift once, so this needed to be enforced rather than just documented.
- Updates the README's hook description and removes the now-stale "the example version omits branch validation" note (the example now includes it, since it's an exact copy).

Filed #2330 for the same class of drift found on `pre-commit.sh`, `post-git-ops.sh`, `enrich-context.sh`, and `update-graph.sh` while checking the rest of the example hooks — out of scope for this fix, which is specifically about `guard-git.sh` per the issue.

## Test plan

- [x] `npx vitest run tests/unit/hook-guard-git-clean.test.ts` — 32 passed (including 3 new sync-check tests)
- [x] `npm test` — full suite, 4583 passed
- [x] `diff .claude/hooks/guard-git.sh docs/examples/claude-code-hooks/guard-git.sh` — no output (identical)