### PR TITLE
fix(hooks): scope update-graph.sh rebuilds to the edited file's own project

### DIFF
--- a/.claude/hooks/update-graph.sh
+++ b/.claude/hooks/update-graph.sh
@@ -24,7 +24,13 @@ if [ -z "$FILE_PATH" ]; then
   exit 0
 fi
 
-PROJECT_DIR=$(git rev-parse --show-toplevel 2>/dev/null) || PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+# Derive PROJECT_DIR from the EDITED FILE's own git toplevel, not the
+# session's cwd (issue #2134). A session can be cwd'ed into worktree A while
+# an Edit/Write touches a file entirely outside it (a different repo, or a
+# scratch path with no repo at all) — resolving from cwd would rebuild A's
+# graph in response to a change that has nothing to do with it. If the file
+# isn't inside any git repo, there is no project to rebuild.
+PROJECT_DIR=$(git -C "$(dirname "$FILE_PATH")" rev-parse --show-toplevel 2>/dev/null) || exit 0
 
 # Only rebuild for source files codegraph tracks.
 # Skip docs, configs, test fixtures, and non-code files.
@@ -99,17 +105,21 @@ fi
 # not be installed yet either. Both used to fail identically silent
 # (stderr -> /dev/null, exit code swallowed by `|| true`), giving a
 # contributor no signal that graph auto-rebuild isn't active (issue #2074).
+# Prefer the project's own local build over a global `codegraph` on PATH
+# (issue #2134): a global binary can be a different, potentially older,
+# version than the one actually checked out here, and building with it
+# silently downgrades this project's build_meta / parsing results. Only
+# fall back to the global binary when the project has no local build at all.
 BUILD_OK=0
 BUILD_ERR=""
-if command -v codegraph &>/dev/null; then
+CLI_ENTRY="$PROJECT_DIR/dist/cli.js"
+if [ -f "$CLI_ENTRY" ]; then
+  BUILD_ERR=$(node "$CLI_ENTRY" build "$PROJECT_DIR" -d "$DB_PATH" $BUILD_FLAGS 2>&1 1>/dev/null) && BUILD_OK=1 || true
+elif command -v codegraph &>/dev/null; then
   BUILD_ERR=$(codegraph build "$PROJECT_DIR" -d "$DB_PATH" $BUILD_FLAGS 2>&1 1>/dev/null) && BUILD_OK=1 || true
 else
-  CLI_ENTRY="${CLAUDE_PROJECT_DIR:-$PROJECT_DIR}/dist/cli.js"
-  if [ ! -f "$CLI_ENTRY" ]; then
-    echo "[codegraph] $CLI_ENTRY not found — run 'npm install' (or 'npm run build') to enable graph auto-rebuild" >&2
-    exit 0
-  fi
-  BUILD_ERR=$(node "$CLI_ENTRY" build "$PROJECT_DIR" -d "$DB_PATH" $BUILD_FLAGS 2>&1 1>/dev/null) && BUILD_OK=1 || true
+  echo "[codegraph] $CLI_ENTRY not found and no global 'codegraph' on PATH — run 'npm install' (or 'npm run build') to enable graph auto-rebuild" >&2
+  exit 0
 fi
 
 if [ "$BUILD_OK" -eq 0 ]; then

--- a/tests/unit/hook-update-graph-project-scope.test.ts
+++ b/tests/unit/hook-update-graph-project-scope.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Regression guard for issue #2134: .claude/hooks/update-graph.sh had two
+ * compounding bugs.
+ *
+ * 1. `PROJECT_DIR` was derived from `git rev-parse --show-toplevel` run in
+ *    the *session's cwd*, not from the edited file's own location. Editing
+ *    a file entirely outside the current project (a different repo, or a
+ *    path with no repo at all) still rebuilt whatever repo the session
+ *    happened to be cd'ed into.
+ * 2. The build binary was resolved via `command -v codegraph` (any global
+ *    binary on PATH) before ever checking for the project's own local
+ *    `dist/cli.js` build — a stale/mismatched global binary could silently
+ *    rebuild the graph with different parsing logic than the checked-out
+ *    version.
+ *
+ * The fix derives `PROJECT_DIR` from `dirname "$FILE_PATH"`'s own git
+ * toplevel (exiting early if the file isn't inside any git repo at all),
+ * and prefers the project-local `dist/cli.js` over a global `codegraph`,
+ * falling back to the global binary only when no local build exists.
+ */
+import { execFileSync, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const HOOK_PATH = path.join(REPO_ROOT, '.claude', 'hooks', 'update-graph.sh');
+
+function initRepo(dir: string): void {
+  fs.mkdirSync(dir, { recursive: true });
+  execFileSync('git', ['init', '-q'], { cwd: dir });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+  execFileSync('git', ['config', 'user.name', 'Test'], { cwd: dir });
+  fs.mkdirSync(path.join(dir, '.codegraph'), { recursive: true });
+  fs.writeFileSync(path.join(dir, '.codegraph', 'graph.db'), '');
+}
+
+/** A fake dist/cli.js that records it was invoked (with which project dir) and exits 0. */
+function installFakeCli(repo: string, sentinel: string): void {
+  fs.mkdirSync(path.join(repo, 'dist'), { recursive: true });
+  fs.writeFileSync(
+    path.join(repo, 'dist', 'cli.js'),
+    `require('fs').writeFileSync(${JSON.stringify(sentinel)}, process.argv.slice(2).join(' '));\n`,
+  );
+}
+
+function buildRestrictedPath(binDir: string, extra: string[] = []): string {
+  for (const bin of ['node', 'git', 'bash']) {
+    const link = path.join(binDir, bin);
+    if (!fs.existsSync(link)) {
+      const real = execFileSync('which', [bin]).toString().trim();
+      fs.symlinkSync(real, link);
+    }
+  }
+  return [binDir, ...extra, '/usr/bin', '/bin'].join(':');
+}
+
+function runHook(
+  filePath: string,
+  cwd: string,
+  pathValue: string,
+): { stderr: string; status: number | null } {
+  const toolInput = JSON.stringify({ tool_input: { file_path: filePath } });
+  const result = spawnSync('bash', [HOOK_PATH], {
+    cwd,
+    input: toolInput,
+    env: { PATH: pathValue },
+    encoding: 'utf8',
+  });
+  return { stderr: result.stderr ?? '', status: result.status };
+}
+
+describe.skipIf(process.platform === 'win32')(
+  "update-graph.sh scopes rebuilds to the edited file's own project (#2134)",
+  () => {
+    let tmpRoot: string;
+    let binDir: string;
+
+    beforeEach(() => {
+      tmpRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'update-graph-scope-')));
+      binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'update-graph-scope-bin-'));
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+      fs.rmSync(binDir, { recursive: true, force: true });
+    });
+
+    it('does not rebuild the session-cwd project when the edited file is outside any git repo', () => {
+      const sessionRepo = path.join(tmpRoot, 'session-repo');
+      initRepo(sessionRepo);
+      const sentinel = path.join(tmpRoot, 'session-repo-was-built');
+      installFakeCli(sessionRepo, sentinel);
+
+      // File lives entirely outside any git repo.
+      const outsideDir = path.join(tmpRoot, 'no-repo-scratch');
+      fs.mkdirSync(outsideDir, { recursive: true });
+      const targetFile = path.join(outsideDir, 'scratch.ts');
+      fs.writeFileSync(targetFile, '// scratch\n');
+
+      const { status } = runHook(targetFile, sessionRepo, buildRestrictedPath(binDir));
+
+      expect(status).toBe(0);
+      expect(fs.existsSync(sentinel)).toBe(false);
+    });
+
+    it("rebuilds the edited file's own project, not the session-cwd project, when they differ", () => {
+      const sessionRepo = path.join(tmpRoot, 'session-repo');
+      initRepo(sessionRepo);
+      const sessionSentinel = path.join(tmpRoot, 'session-repo-was-built');
+      installFakeCli(sessionRepo, sessionSentinel);
+
+      const otherRepo = path.join(tmpRoot, 'other-repo');
+      initRepo(otherRepo);
+      const otherSentinel = path.join(tmpRoot, 'other-repo-was-built');
+      installFakeCli(otherRepo, otherSentinel);
+
+      const targetFile = path.join(otherRepo, 'src', 'thing.ts');
+      fs.mkdirSync(path.dirname(targetFile), { recursive: true });
+      fs.writeFileSync(targetFile, '// content\n');
+
+      const { status } = runHook(targetFile, sessionRepo, buildRestrictedPath(binDir));
+
+      expect(status).toBe(0);
+      expect(fs.existsSync(otherSentinel)).toBe(true);
+      expect(fs.existsSync(sessionSentinel)).toBe(false);
+    });
+
+    it('prefers the project-local dist/cli.js over a global codegraph on PATH', () => {
+      const repo = path.join(tmpRoot, 'repo-with-local-build');
+      initRepo(repo);
+      const localSentinel = path.join(tmpRoot, 'local-cli-was-called');
+      installFakeCli(repo, localSentinel);
+
+      // A fake global `codegraph` that would prove the bug if it ran.
+      const globalSentinel = path.join(tmpRoot, 'global-codegraph-was-called');
+      const globalBinDir = fs.mkdtempSync(path.join(os.tmpdir(), 'update-graph-scope-globalbin-'));
+      fs.writeFileSync(
+        path.join(globalBinDir, 'codegraph'),
+        `#!/usr/bin/env bash\ntouch ${JSON.stringify(globalSentinel)}\nexit 0\n`,
+      );
+      fs.chmodSync(path.join(globalBinDir, 'codegraph'), 0o755);
+
+      const targetFile = path.join(repo, 'src', 'thing.ts');
+      fs.mkdirSync(path.dirname(targetFile), { recursive: true });
+      fs.writeFileSync(targetFile, '// content\n');
+
+      const { status } = runHook(targetFile, repo, buildRestrictedPath(binDir, [globalBinDir]));
+
+      expect(status).toBe(0);
+      expect(fs.existsSync(localSentinel)).toBe(true);
+      expect(fs.existsSync(globalSentinel)).toBe(false);
+
+      fs.rmSync(globalBinDir, { recursive: true, force: true });
+    });
+  },
+);


### PR DESCRIPTION
## Summary

Closes #2134

`.claude/hooks/update-graph.sh` had two compounding bugs found during v3.16.0 dogfooding:

1. `PROJECT_DIR` was derived from `git rev-parse --show-toplevel` run in the session's cwd, not from the edited file's own location. Writing/editing a file entirely outside the current project — a different repo, or a scratch path with no repo at all — still triggered a rebuild of whatever repo the session happened to be cd'ed into.
2. The build binary was resolved via `command -v codegraph` (any global binary on PATH) before ever checking the project's own local `dist/cli.js` build. A stale/mismatched global binary could silently rebuild the graph with older parsing logic, downgrading `build_meta.codegraph_version` and changing node/edge counts with no visible signal.

## Fix

- `PROJECT_DIR` is now derived from `git -C "$(dirname "$FILE_PATH")" rev-parse --show-toplevel` — the edited file's own git toplevel. If the file isn't inside any git repo, the hook exits immediately (nothing to rebuild).
- The build now prefers the project-local `dist/cli.js` whenever it exists, falling back to a global `codegraph` on PATH only when no local build is present.

## Test plan

- [x] New regression tests (`tests/unit/hook-update-graph-project-scope.test.ts`): editing a file outside any git repo doesn't rebuild the session-cwd project; editing a file in a different repo than the session's cwd rebuilds that file's own project, not the session's; a project-local `dist/cli.js` is preferred over a global `codegraph` on PATH even when both are present.
- [x] Existing hook regression suites (`hook-update-graph-diagnostics`, `hook-fallback-build-path`, `hook-extensions`) still pass unchanged.
- [x] Full `npm test` suite passes (1654 tests).
- [x] `npm run lint` clean.

Filed #2336 separately for the pre-existing (unrelated) drift between this hook and its `docs/examples/claude-code-hooks/` copy.