### PR TITLE
fix(incremental): persist per-file return-type evidence across builds

### DIFF
--- a/crates/codegraph-core/src/db/connection.rs
+++ b/crates/codegraph-core/src/db/connection.rs
@@ -502,6 +502,32 @@ const MIGRATIONS: &[Migration] = &[
       CREATE INDEX IF NOT EXISTS idx_invoked_property_names_name ON invoked_property_names(name);
     "#,
     },
+    Migration {
+        // #2138: durable, per-file record of every function/method's
+        // inferred return type — needed so cross-file return-type
+        // propagation (propagate_return_types_across_files /
+        // propagateReturnTypesAcrossFiles) can resolve
+        // `const x = importedFactory(); x.method()`-shaped dispatch to a
+        // file this build never re-parsed. Without this, an incremental
+        // build that re-parses a barrel-adjacent file wipes that file's
+        // outgoing calls/receiver edges and re-derives them from an
+        // in-memory return-type index scoped only to this build's file set,
+        // so a factory/getter defined in an untouched file silently drops
+        // out of dispatch resolution until a full --no-incremental rebuild.
+        // Populated once per full or incremental build (both engines).
+        // Mirrors src/db/migrations.ts v30.
+        version: 30,
+        up: r#"
+      CREATE TABLE IF NOT EXISTS return_types (
+        file TEXT NOT NULL,
+        fn_name TEXT NOT NULL,
+        type_name TEXT NOT NULL,
+        confidence REAL NOT NULL,
+        PRIMARY KEY (file, fn_name)
+      );
+      CREATE INDEX IF NOT EXISTS idx_return_types_file ON return_types(file);
+    "#,
+    },
 ];
 
 // ── napi types ──────────────────────────────────────────────────────────

--- a/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
@@ -725,6 +725,12 @@ pub fn run_pipeline(
     import_edges::persist_reexport_renames(conn, &import_ctx.reexport_map)
         .map_err(|e| format!("reexport rename persistence failed: {e}"))?;
 
+    // #2138: persist this pass's own return-type evidence before it's read
+    // back below — gives a later incremental build a durable, whole-graph
+    // view of files it doesn't itself re-parse.
+    import_edges::persist_return_types(conn, &file_symbols)
+        .map_err(|e| format!("return type persistence failed: {e}"))?;
+
     // Build import edges. A write failure here (transaction-start, a
     // malformed chunk, or commit) propagates via `?` instead of being
     // discarded — the old `run_pipeline` had no way to know edges were
@@ -737,7 +743,7 @@ pub fn run_pipeline(
     // Phase 8.2: cross-file return-type propagation — seed each file's
     // type_map with the return types of imported functions before call-edge
     // building, mirroring propagateReturnTypesAcrossFiles in build-edges.ts.
-    propagate_return_types_across_files(&mut file_symbols, &import_ctx);
+    propagate_return_types_across_files(conn, &mut file_symbols, &import_ctx);
 
     // Build call edges using existing Rust edge_builder (internal path)
     // For now, call edges are built via the existing napi-exported function's
@@ -1602,12 +1608,13 @@ fn collect_imported_names_for_file(
 /// so method calls and receiver edges on that variable resolve. Must run
 /// before `build_and_insert_call_edges`.
 fn propagate_return_types_across_files(
+    conn: &Connection,
     file_symbols: &mut BTreeMap<String, FileSymbols>,
     import_ctx: &ImportEdgeContext,
 ) {
     use crate::domain::graph::builder::stages::build_edges::PROPAGATION_HOP_PENALTY;
 
-    let (return_type_index, global_return_types) = build_return_type_index(file_symbols);
+    let (return_type_index, global_return_types) = build_return_type_index(conn, file_symbols);
     if return_type_index.is_empty() {
         return;
     }
@@ -1633,7 +1640,17 @@ fn propagate_return_types_across_files(
 /// - `return_type_index`: `rel_path → (fn_name → (type_name, confidence))`
 /// - `global_return_types`: flat map for qualified `Type.method` lookups; higher
 ///   confidence wins, tie-break is deterministic (paths visited in sorted order).
+///
+/// #2138: unions in DB-persisted return types (`return_types`, written by
+/// `persist_return_types`) for files not present in `file_symbols` — i.e.
+/// files this build pass didn't itself re-parse. On a scoped incremental
+/// build a barrel-adjacent file can get its outgoing edges wiped and
+/// re-derived from this index alone; without the DB union, dispatch to a
+/// factory/getter defined in an untouched file (e.g. `getWasmWorkerPool()`)
+/// silently drops out. Files with fresh in-memory data are never overridden
+/// by (potentially stale) persisted rows.
 fn build_return_type_index(
+    conn: &Connection,
     file_symbols: &BTreeMap<String, FileSymbols>,
 ) -> (
     HashMap<String, HashMap<String, (String, f64)>>,
@@ -1647,6 +1664,31 @@ fn build_return_type_index(
         let per_file = return_type_index.entry(rel_path.clone()).or_default();
         for e in &symbols.return_type_map {
             per_file.insert(e.name.clone(), (e.type_name.clone(), e.confidence));
+        }
+    }
+
+    let fresh_files: HashSet<String> = return_type_index.keys().cloned().collect();
+    if let Ok(mut stmt) =
+        conn.prepare("SELECT file, fn_name, type_name, confidence FROM return_types")
+    {
+        if let Ok(rows) = stmt.query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, f64>(3)?,
+            ))
+        }) {
+            for row in rows.flatten() {
+                let (file, fn_name, type_name, confidence) = row;
+                if fresh_files.contains(&file) {
+                    continue;
+                }
+                return_type_index
+                    .entry(file)
+                    .or_default()
+                    .insert(fn_name, (type_name, confidence));
+            }
         }
     }
 
@@ -2421,7 +2463,8 @@ mod tests {
         file_symbols.insert("driver.js".to_string(), driver);
         let import_ctx = make_import_ctx(&file_symbols);
 
-        propagate_return_types_across_files(&mut file_symbols, &import_ctx);
+        let conn = Connection::open_in_memory().unwrap();
+        propagate_return_types_across_files(&conn, &mut file_symbols, &import_ctx);
 
         let driver = &file_symbols["driver.js"];
         let seeded = driver
@@ -2456,7 +2499,8 @@ mod tests {
         file_symbols.insert("driver.js".to_string(), driver);
         let import_ctx = make_import_ctx(&file_symbols);
 
-        propagate_return_types_across_files(&mut file_symbols, &import_ctx);
+        let conn = Connection::open_in_memory().unwrap();
+        propagate_return_types_across_files(&conn, &mut file_symbols, &import_ctx);
 
         let driver = &file_symbols["driver.js"];
         let seeded = driver
@@ -2495,7 +2539,8 @@ mod tests {
         file_symbols.insert("driver.js".to_string(), driver);
         let import_ctx = make_import_ctx(&file_symbols);
 
-        propagate_return_types_across_files(&mut file_symbols, &import_ctx);
+        let conn = Connection::open_in_memory().unwrap();
+        propagate_return_types_across_files(&conn, &mut file_symbols, &import_ctx);
 
         let driver = &file_symbols["driver.js"];
         let svc_entries: Vec<_> = driver.type_map.iter().filter(|t| t.name == "svc").collect();

--- a/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
@@ -1614,6 +1614,15 @@ fn propagate_return_types_across_files(
 ) {
     use crate::domain::graph::builder::stages::build_edges::PROPAGATION_HOP_PENALTY;
 
+    // #2138: skip entirely — including the return_types DB read added below
+    // — when nothing in this build needs cross-file resolution. A no-op or
+    // small incremental rebuild with no call-assignments anywhere must not
+    // pay for a whole-table SELECT it has no use for (this guard is what
+    // keeps that read off the no-op rebuild's hot path).
+    if !file_symbols.values().any(|s| !s.call_assignments.is_empty()) {
+        return;
+    }
+
     let (return_type_index, global_return_types) = build_return_type_index(conn, file_symbols);
     if return_type_index.is_empty() {
         return;

--- a/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
@@ -1619,7 +1619,10 @@ fn propagate_return_types_across_files(
     // small incremental rebuild with no call-assignments anywhere must not
     // pay for a whole-table SELECT it has no use for (this guard is what
     // keeps that read off the no-op rebuild's hot path).
-    if !file_symbols.values().any(|s| !s.call_assignments.is_empty()) {
+    if !file_symbols
+        .values()
+        .any(|s| !s.call_assignments.is_empty())
+    {
         return;
     }
 

--- a/crates/codegraph-core/src/domain/graph/builder/stages/detect_changes.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/detect_changes.rs
@@ -1123,6 +1123,10 @@ pub fn purge_changed_files(
         // never leaves stale rows behind for the incremental #1895 liveness
         // check to read later.
         ("DELETE FROM invoked_property_names WHERE file = ?1", false),
+        // #2138: per-file return-type evidence — cleared so a deleted (or
+        // changed) file never leaves stale rows behind for cross-file
+        // return-type propagation to read on a later incremental build.
+        ("DELETE FROM return_types WHERE file = ?1", false),
         // Core tables (errors logged)
         ("DELETE FROM edges WHERE source_id IN (SELECT id FROM nodes WHERE file = ?1) OR target_id IN (SELECT id FROM nodes WHERE file = ?1)", true),
         ("DELETE FROM nodes WHERE file = ?1", true),
@@ -1169,6 +1173,7 @@ pub fn clear_all_graph_data(conn: &Connection, has_embeddings: bool) {
          DELETE FROM cfg_edges; DELETE FROM cfg_blocks; DELETE FROM node_metrics; \
          DELETE FROM edges; DELETE FROM function_complexity; DELETE FROM dataflow; \
          DELETE FROM ast_nodes; DELETE FROM reexport_renames; DELETE FROM invoked_property_names; \
+         DELETE FROM return_types; \
          DELETE FROM nodes; DELETE FROM file_hashes;",
     );
     if has_embeddings {

--- a/crates/codegraph-core/src/domain/graph/builder/stages/import_edges.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/import_edges.rs
@@ -333,6 +333,53 @@ pub fn persist_invoked_property_names(
     Ok(())
 }
 
+/// Persist per-file return-type evidence (#2138) into `return_types` — gives
+/// a later incremental build's `propagate_return_types_across_files` a
+/// durable, whole-graph view of files it doesn't itself re-parse this pass.
+/// Mirrors `persistReturnTypes` in `build-edges.ts`. See that function's doc
+/// comment (and `propagate_return_types_across_files`'s) for the
+/// dispatch-edge loss this closes.
+///
+/// Deletes and re-inserts per file so a file whose return types changed (or
+/// were removed entirely) never leaves stale rows behind for it.
+pub fn persist_return_types(
+    conn: &Connection,
+    file_symbols: &BTreeMap<String, FileSymbols>,
+) -> Result<(), String> {
+    if file_symbols.is_empty() {
+        return Ok(());
+    }
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|e| format!("persist_return_types: failed to start transaction: {e}"))?;
+    {
+        let mut delete_stmt = tx
+            .prepare("DELETE FROM return_types WHERE file = ?1")
+            .map_err(|e| e.to_string())?;
+        let mut insert_stmt = tx
+            .prepare(
+                "INSERT OR IGNORE INTO return_types (file, fn_name, type_name, confidence) VALUES (?1, ?2, ?3, ?4)",
+            )
+            .map_err(|e| e.to_string())?;
+        for (rel_path, symbols) in file_symbols {
+            delete_stmt.execute([rel_path]).map_err(|e| e.to_string())?;
+            for entry in &symbols.return_type_map {
+                insert_stmt
+                    .execute(rusqlite::params![
+                        rel_path,
+                        entry.name,
+                        entry.type_name,
+                        entry.confidence
+                    ])
+                    .map_err(|e| e.to_string())?;
+            }
+        }
+    }
+    tx.commit()
+        .map_err(|e| format!("persist_return_types: commit failed: {e}"))?;
+    Ok(())
+}
+
 /// Detect which of `candidate_paths` are barrel-only (reexport count >=
 /// definition count).
 ///

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -544,6 +544,38 @@ export const MIGRATIONS: Migration[] = [
       CREATE INDEX IF NOT EXISTS idx_invoked_property_names_name ON invoked_property_names(name);
     `,
   },
+  {
+    // #2138: durable, per-file record of every function/method's inferred
+    // return type — needed so cross-file return-type propagation
+    // (propagateReturnTypesAcrossFiles / propagate_return_types_across_files)
+    // can resolve `const x = importedFactory(); x.method()`-shaped dispatch
+    // to a file this build never re-parsed.
+    //
+    // Without this, an incremental build that re-parses a barrel-adjacent
+    // file (Stage 6b) wipes that file's outgoing calls/receiver edges and
+    // re-derives them from an in-memory return-type index built only from
+    // *this build's* file set — so a factory/getter defined in an untouched
+    // file (e.g. `getWasmWorkerPool()` in wasm-worker-pool.ts) silently
+    // drops out, and the edges it fed are lost until a full
+    // `--no-incremental` rebuild. Persisting this table once per full or
+    // incremental build (both engines — the native orchestrator mirrors this
+    // via import_edges::persist_return_types in Rust) gives every build a
+    // durable, whole-graph view for files it didn't itself parse.
+    //
+    // Deletes and re-inserts per file so a file whose return types changed
+    // (or were removed) never leaves stale rows behind for it.
+    version: 30,
+    up: `
+      CREATE TABLE IF NOT EXISTS return_types (
+        file TEXT NOT NULL,
+        fn_name TEXT NOT NULL,
+        type_name TEXT NOT NULL,
+        confidence REAL NOT NULL,
+        PRIMARY KEY (file, fn_name)
+      );
+      CREATE INDEX IF NOT EXISTS idx_return_types_file ON return_types(file);
+    `,
+  },
 ];
 
 interface PragmaColumnInfo {

--- a/src/db/repository/build-stmts.ts
+++ b/src/db/repository/build-stmts.ts
@@ -24,6 +24,10 @@ interface PurgeStmts {
    *  in — cleared so a deleted (or no-longer-matching) file never leaves
    *  stale rows behind for the incremental #1895 liveness check to read. */
   invokedPropertyNames: SqliteStatement | null;
+  /** #2138: per-file return-type evidence — cleared so a deleted (or
+   *  changed) file never leaves stale rows behind for cross-file
+   *  return-type propagation to read on a later incremental build. */
+  returnTypes: SqliteStatement | null;
 }
 
 interface PurgeOpts {
@@ -92,6 +96,7 @@ function preparePurgeStmts(db: BetterSqlite3Database): PurgeStmts {
     fileHashes: tryPrepare('DELETE FROM file_hashes WHERE file = ?'),
     reexportRenames: tryPrepare('DELETE FROM reexport_renames WHERE barrel_file = ?'),
     invokedPropertyNames: tryPrepare('DELETE FROM invoked_property_names WHERE file = ?'),
+    returnTypes: tryPrepare('DELETE FROM return_types WHERE file = ?'),
   };
 }
 
@@ -126,6 +131,7 @@ function runPurge(stmts: PurgeStmts, file: string, opts: PurgeOpts = {}): void {
   stmts.astNodes?.run(file);
   stmts.reexportRenames?.run(file);
   stmts.invokedPropertyNames?.run(file);
+  stmts.returnTypes?.run(file);
 
   // Core tables
   stmts.edges.run({ f: file });

--- a/src/domain/graph/builder/incremental.ts
+++ b/src/domain/graph/builder/incremental.ts
@@ -454,6 +454,53 @@ function persistInvokedPropertyNamesForFile(
   }
 }
 
+// Lazily-cached prepared statements for the #2138 return-type registry.
+let _returnTypesDb: BetterSqlite3Database | null = null;
+let _returnTypesDeleteStmt: SqliteStatement | null = null;
+let _returnTypesInsertStmt: SqliteStatement | null = null;
+
+function getReturnTypeStmts(db: BetterSqlite3Database): {
+  deleteStmt: SqliteStatement;
+  insertStmt: SqliteStatement;
+} {
+  if (_returnTypesDb !== db) {
+    _returnTypesDb = db;
+    _returnTypesDeleteStmt = db.prepare('DELETE FROM return_types WHERE file = ?');
+    _returnTypesInsertStmt = db.prepare(
+      'INSERT OR IGNORE INTO return_types (file, fn_name, type_name, confidence) VALUES (?, ?, ?, ?)',
+    );
+  }
+  return { deleteStmt: _returnTypesDeleteStmt!, insertStmt: _returnTypesInsertStmt! };
+}
+
+/**
+ * Persist this file's return-type evidence (#2138) into `return_types` —
+ * the durable counterpart of `persistReturnTypes` in `build-edges.ts`
+ * (full-build path), needed here because `codegraph watch`'s single-file
+ * rebuild never goes through that stage but DOES purge this file's existing
+ * `return_types` row via `purgeFileData` before this function runs. Without
+ * this write-back, a file's return-type evidence would be permanently
+ * erased the first time it's touched via `codegraph watch` — worse than
+ * never having the row at all, since a later scoped `codegraph build`
+ * incremental rebuild that depends on it (issue #2138's own fix) would then
+ * find nothing where a stale-but-present row previously existed.
+ *
+ * Always deletes this file's existing rows first (even when it now defines
+ * no functions with an inferable return type) so a file that lost its only
+ * such function never leaves a stale row behind.
+ */
+function persistReturnTypesForFile(
+  db: BetterSqlite3Database,
+  relPath: string,
+  symbols: ExtractorOutput,
+): void {
+  const { deleteStmt, insertStmt } = getReturnTypeStmts(db);
+  deleteStmt.run(relPath);
+  for (const [fnName, entry] of symbols.returnTypeMap ?? []) {
+    insertStmt.run(relPath, fnName, entry.type, entry.confidence);
+  }
+}
+
 /**
  * Persist this file's barrel re-export rename pairs (`export { X as Y } from
  * …`) into `reexport_renames` (#1967) — the durable counterpart of
@@ -1440,6 +1487,11 @@ function buildCallEdges(
   // for future rebuilds of OTHER files, regardless of what this rebuild
   // itself needed it for.
   persistInvokedPropertyNamesForFile(db, relPath, ownInvokedPropertyNames);
+  // #2138: same rationale — purgeFileData (called before this function runs)
+  // already deleted this file's return_types row; restore it so a later
+  // scoped `codegraph build` incremental rebuild can still resolve dispatch
+  // through this file's factories/getters.
+  persistReturnTypesForFile(db, relPath, symbols);
   return edgesAdded;
 }
 

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -540,6 +540,15 @@ function buildImportEdgesNative(
  * the callee's return type in the source file's returnTypeMap and inject it.
  *
  * Called once before call-edge building so both the native and JS paths benefit.
+ *
+ * #2138: on a scoped incremental build, `fileSymbols` only contains the files
+ * this pass actually re-parsed — a barrel-adjacent file dragged into the
+ * changed set gets its outgoing edges wiped and re-derived from this
+ * in-memory index alone, silently losing dispatch to a factory/getter
+ * defined in an untouched file. Unioning in `return_types` (persisted once
+ * per build, see persistReturnTypes) closes that gap for files this pass
+ * didn't itself parse — in-memory entries always win since they reflect
+ * this revision.
  */
 function propagateReturnTypesAcrossFiles(
   fileSymbols: Map<string, ExtractorOutput>,
@@ -550,6 +559,18 @@ function propagateReturnTypesAcrossFiles(
   const returnTypeIndex = new Map<string, Map<string, TypeMapEntry>>();
   for (const [relPath, symbols] of fileSymbols) {
     if (symbols.returnTypeMap?.size) returnTypeIndex.set(relPath, symbols.returnTypeMap);
+  }
+  const freshFiles = new Set(returnTypeIndex.keys());
+  for (const row of ctx.db
+    .prepare('SELECT file, fn_name, type_name, confidence FROM return_types')
+    .all() as Array<{ file: string; fn_name: string; type_name: string; confidence: number }>) {
+    if (freshFiles.has(row.file)) continue; // fresh in-memory data wins
+    let perFile = returnTypeIndex.get(row.file);
+    if (!perFile) {
+      perFile = new Map();
+      returnTypeIndex.set(row.file, perFile);
+    }
+    perFile.set(row.fn_name, { type: row.type_name, confidence: row.confidence });
   }
   if (returnTypeIndex.size === 0) return;
 
@@ -982,6 +1003,33 @@ function persistInvokedPropertyNames(ctx: PipelineContext): void {
       const names = collectInvokedPropertyNames([symbols.calls]);
       for (const name of names) {
         insertStmt.run(relPath, name);
+      }
+    }
+  });
+  tx();
+}
+
+/**
+ * Persist per-file return-type evidence (#2138) into `return_types` — gives
+ * a later incremental build's propagateReturnTypesAcrossFiles() a durable,
+ * whole-graph view of files it doesn't itself re-parse. See that function's
+ * doc comment for the false-negative this closes.
+ *
+ * Deletes and re-inserts per file so a file whose return types changed (or
+ * were removed entirely) never leaves stale rows behind for it.
+ */
+function persistReturnTypes(ctx: PipelineContext): void {
+  const { db, fileSymbols } = ctx;
+  const deleteStmt = db.prepare('DELETE FROM return_types WHERE file = ?');
+  const insertStmt = db.prepare(
+    'INSERT OR IGNORE INTO return_types (file, fn_name, type_name, confidence) VALUES (?, ?, ?, ?)',
+  );
+
+  const tx = db.transaction(() => {
+    for (const [relPath, symbols] of fileSymbols) {
+      deleteStmt.run(relPath);
+      for (const [fnName, entry] of symbols.returnTypeMap ?? []) {
+        insertStmt.run(relPath, fnName, entry.type, entry.confidence);
       }
     }
   });
@@ -2511,6 +2559,8 @@ function buildCallEdgesPhase(
   // #2087: persist once per pass regardless of which sub-path below resolves
   // this build's edges — see persistInvokedPropertyNames doc comment.
   persistInvokedPropertyNames(ctx);
+  // #2138: same rationale, for cross-file return-type propagation.
+  persistReturnTypes(ctx);
 
   // Skip native call-edge path for small incremental builds: napi-rs
   // marshaling overhead for allNodes exceeds Rust computation savings.
@@ -2636,9 +2686,11 @@ export async function buildEdges(ctx: PipelineContext): Promise<void> {
   const native = ctx.engineName === 'native' ? loadNative() : null;
 
   // Phase 8.2: Augment typeMaps with cross-file return-type propagation before
-  // the transaction opens. This is pure in-memory mutation (no DB I/O) and must
-  // run outside the transaction to avoid leaving ctx.fileSymbols in a partial
-  // state if the transaction rolls back unexpectedly.
+  // the transaction opens. This only reads return_types (#2138) — the write
+  // happens later in persistReturnTypes, inside buildCallEdgesPhase — so it's
+  // still safe to run outside the transaction, avoiding leaving
+  // ctx.fileSymbols in a partial state if the transaction rolls back
+  // unexpectedly.
   propagateReturnTypesAcrossFiles(ctx.fileSymbols, ctx, ctx.rootDir);
   // Phase 8.5: Build CHA context after propagation so typeMap confidence values
   // (used for RTA seeding) reflect any cross-file propagated types.

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -555,6 +555,19 @@ function propagateReturnTypesAcrossFiles(
   ctx: PipelineContext,
   rootDir: string,
 ): void {
+  // #2138: skip entirely — including the return_types DB read below — when
+  // nothing in this build needs cross-file resolution. A no-op or small
+  // incremental rebuild with no call-assignments anywhere must not pay for
+  // a whole-table SELECT it has no use for.
+  let anyCallAssignments = false;
+  for (const symbols of fileSymbols.values()) {
+    if (symbols.callAssignments?.length) {
+      anyCallAssignments = true;
+      break;
+    }
+  }
+  if (!anyCallAssignments) return;
+
   // Index: filePath → per-file return-type map
   const returnTypeIndex = new Map<string, Map<string, TypeMapEntry>>();
   for (const [relPath, symbols] of fileSymbols) {

--- a/src/domain/graph/builder/stages/detect-changes.ts
+++ b/src/domain/graph/builder/stages/detect-changes.ts
@@ -633,7 +633,7 @@ function handleFullBuild(ctx: PipelineContext): void {
   const hasEmbeddings = detectHasEmbeddings(db, ctx.nativeDb);
   ctx.hasEmbeddings = hasEmbeddings;
   const deletions =
-    'PRAGMA foreign_keys = OFF; DELETE FROM cfg_edges; DELETE FROM cfg_blocks; DELETE FROM node_metrics; DELETE FROM edges; DELETE FROM function_complexity; DELETE FROM dataflow; DELETE FROM ast_nodes; DELETE FROM reexport_renames; DELETE FROM invoked_property_names; DELETE FROM nodes; DELETE FROM file_hashes; PRAGMA foreign_keys = ON;';
+    'PRAGMA foreign_keys = OFF; DELETE FROM cfg_edges; DELETE FROM cfg_blocks; DELETE FROM node_metrics; DELETE FROM edges; DELETE FROM function_complexity; DELETE FROM dataflow; DELETE FROM ast_nodes; DELETE FROM reexport_renames; DELETE FROM invoked_property_names; DELETE FROM return_types; DELETE FROM nodes; DELETE FROM file_hashes; PRAGMA foreign_keys = ON;';
   db.exec(
     hasEmbeddings
       ? `${deletions.replace('PRAGMA foreign_keys = ON;', '')} DELETE FROM embeddings; PRAGMA foreign_keys = ON;`

--- a/tests/integration/issue-2138-incremental-return-type-persistence.test.ts
+++ b/tests/integration/issue-2138-incremental-return-type-persistence.test.ts
@@ -46,6 +46,8 @@ import os from 'node:os';
 import path from 'node:path';
 import Database from 'better-sqlite3';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { getNodeId as getNodeIdQuery, initSchema, openDb } from '../../src/db/index.js';
+import { rebuildFile } from '../../src/domain/graph/builder/incremental.js';
 import { buildGraph } from '../../src/domain/graph/builder.js';
 import type { EngineMode } from '../../src/types.js';
 
@@ -117,6 +119,49 @@ function readEdges(dbPath: string, kind: 'calls' | 'receiver') {
   }
 }
 
+function readReturnTypes(dbPath: string) {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return db
+      .prepare('SELECT file, fn_name, type_name FROM return_types ORDER BY file, fn_name')
+      .all() as Array<{ file: string; fn_name: string; type_name: string }>;
+  } finally {
+    db.close();
+  }
+}
+
+function makeStmts(db: ReturnType<typeof openDb>) {
+  return {
+    insertNode: db.prepare(
+      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
+    ),
+    getNodeId: {
+      get: (name: string, kind: string, file: string, line: number) => {
+        const id = getNodeIdQuery(db, name, kind, file, line);
+        return id != null ? { id } : undefined;
+      },
+    },
+    insertEdge: db.prepare(
+      'INSERT INTO edges (source_id, target_id, kind, confidence, dynamic) VALUES (?, ?, ?, ?, ?)',
+    ),
+    countNodes: db.prepare('SELECT COUNT(*) as c FROM nodes WHERE file = ?'),
+    countEdges: db.prepare(
+      'SELECT COUNT(*) as c FROM edges WHERE source_id IN (SELECT id FROM nodes WHERE file = ?)',
+    ),
+    findNodeInFile: db.prepare(
+      "SELECT id, kind, file FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant') AND file = ?",
+    ),
+    findNodeByName: db.prepare(
+      "SELECT id, file, kind FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
+    ),
+    listSymbols: db.prepare("SELECT name, kind, line FROM nodes WHERE file = ? AND kind != 'file'"),
+    upsertFileHash: db.prepare(
+      'INSERT OR REPLACE INTO file_hashes (file, hash, mtime, size) VALUES (?, ?, ?, ?)',
+    ),
+    deleteFileHash: db.prepare('DELETE FROM file_hashes WHERE file = ?'),
+  };
+}
+
 const ENGINES: EngineMode[] = ['wasm', 'native'];
 
 describe.each(ENGINES)(
@@ -169,3 +214,70 @@ describe.each(ENGINES)(
     });
   },
 );
+
+/**
+ * Regression guard for a gap found in review: `codegraph watch`'s
+ * single-file rebuild (`rebuildFile`/`buildCallEdges` in incremental.ts)
+ * purges a rebuilt file's `return_types` row via `purgeFileData` (issue
+ * #2138's own purge-statement addition) but, before this fix, never wrote
+ * it back — permanently erasing that file's return-type evidence the first
+ * time it was touched via watch mode. A later scoped `codegraph build`
+ * incremental rebuild (this issue's actual fix) would then find no
+ * evidence at all for that file, worse than the pre-fix state where the
+ * table didn't exist. `persistReturnTypesForFile` closes this by
+ * restoring the row immediately after the purge, every time.
+ */
+describe('codegraph watch restores return_types after purging it (#2138 review)', () => {
+  let watchDir: string;
+  let dbPath: string;
+
+  beforeAll(async () => {
+    watchDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-2138-watch-'));
+    writeFixture(watchDir);
+    dbPath = path.join(watchDir, '.codegraph', 'graph.db');
+
+    await buildGraph(watchDir, { incremental: false, skipRegistry: true, engine: 'wasm' });
+    expect(readReturnTypes(dbPath)).toContainEqual({
+      file: 'producer.js',
+      fn_name: 'getPool',
+      type_name: 'Pool',
+    });
+
+    // Rebuild producer.js itself via codegraph watch's single-file path —
+    // this purges (and, with the fix, restores) its own return_types row.
+    const producerFile = path.join(watchDir, 'producer.js');
+    fs.appendFileSync(producerFile, '\n// touch\n');
+    const db = openDb(dbPath);
+    initSchema(db);
+    await rebuildFile(db, watchDir, producerFile, makeStmts(db), { engine: 'wasm' }, null);
+    db.close();
+  }, 60_000);
+
+  afterAll(() => {
+    try {
+      if (watchDir) fs.rmSync(watchDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it("producer.js's return_types row survives its own watch-mode rebuild", () => {
+    expect(readReturnTypes(dbPath)).toContainEqual({
+      file: 'producer.js',
+      fn_name: 'getPool',
+      type_name: 'Pool',
+    });
+  });
+
+  it('a later scoped incremental build can still resolve dispatch through producer.js', async () => {
+    // Touch ONLY trigger.js, exactly like the main describe block above —
+    // proves the watch-rebuilt row is not just present but actually usable
+    // by the main build pipeline's cross-file propagation.
+    fs.appendFileSync(path.join(watchDir, 'trigger.js'), '\n// touch\n');
+    await buildGraph(watchDir, { incremental: true, skipRegistry: true, engine: 'wasm' });
+
+    const edges = readEdges(dbPath, 'calls');
+    expect(edges.find((e) => e.tgt === 'Pool.doWork')).toBeDefined();
+    expect(readEdges(dbPath, 'receiver').find((e) => e.tgt === 'Pool')).toBeDefined();
+  });
+});

--- a/tests/integration/issue-2138-incremental-return-type-persistence.test.ts
+++ b/tests/integration/issue-2138-incremental-return-type-persistence.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Regression test for #2138: an incremental `codegraph build` triggered by
+ * editing a file with NO relationship to a getter/class dispatch pair
+ * permanently lost the `calls`/`receiver` edges for that dispatch.
+ *
+ * Root cause (see issue for the full trace): Stage 6b's barrel-candidate
+ * re-parse re-parses any file the changed file imports from, if that file
+ * has its own re-export (making it "barrel-like" in the DB's eyes) —
+ * regardless of whether the changed file's edit has anything to do with
+ * that file's own logic. Re-parsing wipes the barrel-like file's outgoing
+ * `calls`/`receiver` edges and re-derives them from an in-memory
+ * cross-file return-type index scoped only to *this build's* file set. A
+ * factory/getter defined in a file that wasn't re-parsed this build (like
+ * `producer.js`'s `getPool()` below) silently drops out of that index, so
+ * the dispatch edges it fed are lost — and stay lost, since reverting the
+ * triggering edit re-triggers the same re-parse/re-derive cycle.
+ *
+ * The fix persists per-file return-type evidence into a durable
+ * `return_types` table (both engines) whenever a file is parsed, so a later
+ * build's cross-file return-type propagation has a whole-graph view of
+ * files it doesn't itself re-parse.
+ *
+ * Fixture:
+ *   producer.js       — defines `Pool` (class, `doWork()` method) and the
+ *                        factory `getPool()` returning a `Pool` instance.
+ *                        Never touched after the initial build.
+ *   reexport-target.js — trivial file `caller.js` re-exports from, so
+ *                        caller.js has its own outgoing `reexports` edge
+ *                        and is classified barrel-like.
+ *   caller.js         — imports `getPool` from producer.js and calls
+ *                        `getPool().doWork()`; also re-exports from
+ *                        reexport-target.js. This is the file whose
+ *                        `calls`/`receiver` edges get wiped and re-derived.
+ *   trigger.js        — imports something from caller.js (making caller.js
+ *                        a Stage-6b barrel-reparse candidate) but is
+ *                        otherwise unrelated to producer.js/Pool. This is
+ *                        the file actually edited between builds.
+ *
+ * Parametrized on engine to exercise both population paths: the JS
+ * pipeline (`persistReturnTypes` in build-edges.ts) and the native
+ * orchestrator (`import_edges::persist_return_types` in Rust).
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+import type { EngineMode } from '../../src/types.js';
+
+const FILES: Record<string, string> = {
+  'producer.js': `
+export class Pool {
+  doWork() { return 1; }
+}
+
+export function getPool() {
+  return new Pool();
+}
+`,
+  'reexport-target.js': `
+export const reexported = 1;
+`,
+  // Two own definitions (run, extra) vs. one reexport — deliberately kept
+  // above parity so caller.js is classified "hybrid" (barrel-like enough to
+  // be pulled into Stage 6b's reparse via its own reexports edge, but NOT
+  // "barrel-only") and its own calls/receiver edges are still emitted. At
+  // reexports == ownDefs parity, the barrel-only heuristic (reexports >=
+  // ownDefs) misclassifies it and strips its outgoing edges entirely,
+  // independent of this issue's fix — a real edge case, but not this one.
+  'caller.js': `
+export { reexported } from './reexport-target.js';
+import { getPool } from './producer.js';
+
+export function run() {
+  const pool = getPool();
+  return pool.doWork();
+}
+
+export function extra() {
+  return 2;
+}
+`,
+  'trigger.js': `
+import { run } from './caller.js';
+
+export function callRun() {
+  return run();
+}
+`,
+};
+
+function writeFixture(dir: string) {
+  for (const [rel, content] of Object.entries(FILES)) {
+    const abs = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, content);
+  }
+}
+
+function readEdges(dbPath: string, kind: 'calls' | 'receiver') {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return db
+      .prepare(
+        `SELECT n1.name AS src, n1.file AS src_file, n2.name AS tgt, n2.file AS tgt_file
+         FROM edges e
+         JOIN nodes n1 ON e.source_id = n1.id
+         JOIN nodes n2 ON e.target_id = n2.id
+         WHERE e.kind = ?
+         ORDER BY n1.name, n2.name`,
+      )
+      .all(kind) as Array<{ src: string; src_file: string; tgt: string; tgt_file: string }>;
+  } finally {
+    db.close();
+  }
+}
+
+const ENGINES: EngineMode[] = ['wasm', 'native'];
+
+describe.each(ENGINES)(
+  'codegraph build scoped-incremental rebuild keeps cross-file dispatch to an untouched factory (#2138) — engine: %s',
+  (engine) => {
+    let buildDir: string;
+    let dbPath: string;
+
+    beforeAll(async () => {
+      buildDir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2138-${engine}-`));
+      writeFixture(buildDir);
+      dbPath = path.join(buildDir, '.codegraph', 'graph.db');
+
+      // Initial build establishes file_hashes so the second build below is a
+      // genuinely scoped incremental rebuild, not another full one.
+      await buildGraph(buildDir, { incremental: true, skipRegistry: true, engine });
+      expect(readEdges(dbPath, 'calls').find((e) => e.tgt === 'Pool.doWork')).toBeDefined();
+      expect(readEdges(dbPath, 'receiver').find((e) => e.tgt === 'Pool')).toBeDefined();
+
+      // Touch ONLY trigger.js — completely unrelated to producer.js/Pool.
+      // caller.js and producer.js are both untouched.
+      fs.appendFileSync(path.join(buildDir, 'trigger.js'), '\n// touch\n');
+      await buildGraph(buildDir, { incremental: true, skipRegistry: true, engine });
+    }, 60_000);
+
+    afterAll(() => {
+      try {
+        if (buildDir) fs.rmSync(buildDir, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+    });
+
+    it('the calls -> Pool.doWork edge survives the unrelated-file incremental rebuild', () => {
+      const edges = readEdges(dbPath, 'calls');
+      const edge = edges.find((e) => e.tgt === 'Pool.doWork');
+      expect(
+        edge,
+        `Expected a calls edge to doWork after touching only trigger.js\nActual calls edges:\n${JSON.stringify(edges, null, 2)}`,
+      ).toBeDefined();
+    });
+
+    it('the receiver -> Pool edge survives the unrelated-file incremental rebuild', () => {
+      const edges = readEdges(dbPath, 'receiver');
+      const edge = edges.find((e) => e.tgt === 'Pool');
+      expect(
+        edge,
+        `Expected a receiver edge to Pool after touching only trigger.js\nActual receiver edges:\n${JSON.stringify(edges, null, 2)}`,
+      ).toBeDefined();
+    });
+  },
+);


### PR DESCRIPTION
## Summary

Closes #2138

An incremental `codegraph build` triggered by editing a file with NO relationship to a getter/class dispatch pair permanently lost the `calls`/`receiver` edges for that dispatch (10 edges in the original report, e.g. `parser.ts`'s calls to `WasmWorkerPool.parse` via `getWasmWorkerPool()`).

## Root cause

Stage 6b's barrel-candidate re-parse re-parses any file the changed file imports from, if that file has its own re-export (making it "barrel-like" in the DB's eyes) — regardless of whether the changed file's edit has anything to do with that file's own logic. Re-parsing wipes the barrel-like file's outgoing `calls`/`receiver` edges and re-derives them from an in-memory cross-file return-type index scoped only to *this build's* file set. A factory/getter defined in a file that wasn't re-parsed this build (like `wasm-worker-pool.ts`'s `getWasmWorkerPool()`) silently drops out of that index, so the dispatch edges it fed are lost — and stay lost, since reverting the triggering edit re-triggers the same re-parse/re-derive cycle without ever seeing the untouched file's return type again.

Reproducible on both engines (verified with a dedicated fixture): the WASM/JS pipeline's `resolve-imports.ts`/`build-edges.ts` and the native orchestrator's `pipeline.rs` both re-parse barrel candidates and re-derive return types from a build-scoped index only.

## Fix

Persists per-file return-type evidence into a durable `return_types` table (schema v30, both engines) whenever a file is parsed — mirroring the `invoked_property_names` pattern already established for #2087:

- `src/db/migrations.ts` / `crates/codegraph-core/src/db/connection.rs`: new `return_types(file, fn_name, type_name, confidence)` table, migration v30.
- `src/db/repository/build-stmts.ts` / `crates/codegraph-core/.../detect_changes.rs`: per-file purge and full-reset entries, mirroring `invoked_property_names`.
- `persistReturnTypes` (`build-edges.ts`) / `import_edges::persist_return_types` (Rust): writes each build's own `returnTypeMap`/`return_type_map` entries.
- `propagateReturnTypesAcrossFiles` (`build-edges.ts`) / `build_return_type_index` (`pipeline.rs`): now union in DB-persisted entries for files not present in the current build's file set — in-memory data always wins for files this pass actually re-parsed, so a stale persisted row can never override fresh data.

## Test plan

- [x] New `tests/integration/issue-2138-incremental-return-type-persistence.test.ts` (parametrized on both engines): full build establishes `getPool() -> Pool.doWork()` dispatch edges, then touching an unrelated file that merely imports from the barrel-like caller confirms the edges survive the incremental rebuild.
- [x] Manually verified against the exact bug shape end-to-end (fixture with a getter/class pair in an untouched file + a barrel-adjacent caller + an unrelated trigger file) before and after the fix, both engines.
- [x] Full `cargo test --lib` passes (820 tests).
- [x] Full `npm test` passes (4602 tests, 286 files).
- [x] `npx tsc --noEmit` and `npm run lint` clean.

Filed #2339 separately for an unrelated edge case discovered while building the regression fixture: the barrel-only classification heuristic (`reexports >= ownDefs`) misclassifies a hybrid file as barrel-only at exact parity, stripping its own edges independent of this fix.