### PR TITLE
fix(bench): only set CODEGRAPH_ENGINE for actual engine-comparison forks

### DIFF
--- a/scripts/lib/fork-engine.ts
+++ b/scripts/lib/fork-engine.ts
@@ -24,7 +24,10 @@
 import { fork } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
-const WORKER_ENV_KEY = '__BENCH_ENGINE__';
+// Exported so tests can verify forkWorker() only sets CODEGRAPH_ENGINE for
+// this exact envKey (the engine-comparison fork), not for other callers'
+// own envKey (e.g. embedding-benchmark.ts's model-name workers, issue #2140).
+export const WORKER_ENV_KEY = '__BENCH_ENGINE__';
 const TARGETS_ENV_KEY = '__BENCH_TARGETS__';
 
 /**
@@ -75,8 +78,17 @@ export function forkWorker(scriptPath, envKey, workerName, argv = [], timeoutMs 
 
 		console.error(`\n[fork] Spawning ${workerName} worker (pid isolation)...`);
 
+		// CODEGRAPH_ENGINE only makes sense when workerName IS an engine choice
+		// ('wasm'/'native') — true for forkEngines' own two calls below (envKey
+		// === WORKER_ENV_KEY), but not for embedding-benchmark.ts's model-name
+		// workers (envKey === its own MODEL_WORKER_KEY), which would otherwise
+		// set CODEGRAPH_ENGINE to a model name like "minilm" and trip the
+		// invalid-engine-value warning on every embed call inside that worker.
+		const env = { ...process.env, [envKey]: workerName };
+		if (envKey === WORKER_ENV_KEY) env.CODEGRAPH_ENGINE = workerName;
+
 		const child = fork(scriptPath, argv, {
-			env: { ...process.env, [envKey]: workerName, CODEGRAPH_ENGINE: workerName },
+			env,
 			stdio: ['ignore', 'pipe', 'inherit', 'ipc'],
 		});
 

--- a/tests/unit/fork-engine-codegraph-engine-env.test.ts
+++ b/tests/unit/fork-engine-codegraph-engine-env.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Regression test for issue #2140: `forkWorker()` unconditionally set
+ * `CODEGRAPH_ENGINE` to whatever `workerName` it was given. That's correct
+ * for `forkEngines()`'s own two calls (`workerName` is `'wasm'`/`'native'`,
+ * a valid engine value), but `embedding-benchmark.ts` reuses `forkWorker()`
+ * directly with `workerName` set to a *model* name (`'minilm'`,
+ * `'jina-small'`, ...) — an invalid `CODEGRAPH_ENGINE` value that tripped a
+ * "not a valid engine value" warning on every embed call inside that
+ * worker.
+ *
+ * The fix: only set `CODEGRAPH_ENGINE` when the caller's `envKey` is the
+ * same `WORKER_ENV_KEY` `forkEngines()` itself uses — true for an actual
+ * engine-comparison fork, never true for `embedding-benchmark.ts`'s own
+ * distinct model-worker env key.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { forkWorker, WORKER_ENV_KEY } from '../../scripts/lib/fork-engine.js';
+
+const CHILD_SCRIPT = `
+process.stdout.write(JSON.stringify({ codegraphEngine: process.env.CODEGRAPH_ENGINE ?? null }));
+process.exit(0);
+`;
+
+describe('forkWorker CODEGRAPH_ENGINE gating (#2140)', () => {
+  let scriptPath: string;
+
+  it('sets CODEGRAPH_ENGINE when envKey is the real engine-comparison key', async () => {
+    scriptPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'cg-2140-')), 'child.mjs');
+    fs.writeFileSync(scriptPath, CHILD_SCRIPT);
+
+    const result = await forkWorker(scriptPath, WORKER_ENV_KEY, 'wasm', []);
+    expect(result).toEqual({ codegraphEngine: 'wasm' });
+  });
+
+  it('does not set CODEGRAPH_ENGINE for a different envKey (e.g. a model-name worker)', async () => {
+    scriptPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'cg-2140-')), 'child.mjs');
+    fs.writeFileSync(scriptPath, CHILD_SCRIPT);
+
+    const result = await forkWorker(scriptPath, '__BENCH_MODEL__', 'minilm', []);
+    expect(result).toEqual({ codegraphEngine: null });
+  });
+});

--- a/tests/unit/fork-engine-codegraph-engine-env.test.ts
+++ b/tests/unit/fork-engine-codegraph-engine-env.test.ts
@@ -40,6 +40,11 @@ describe('forkWorker CODEGRAPH_ENGINE gating (#2140)', () => {
     fs.writeFileSync(scriptPath, CHILD_SCRIPT);
 
     const result = await forkWorker(scriptPath, '__BENCH_MODEL__', 'minilm', []);
-    expect(result).toEqual({ codegraphEngine: null });
+    // Compares against whatever this test process's own CODEGRAPH_ENGINE
+    // happens to be (undefined normally, but forkWorker() still inherits
+    // the parent env otherwise) rather than hardcoding null — a shell/CI
+    // environment with CODEGRAPH_ENGINE ambiently set would otherwise fail
+    // this assertion despite the worker name correctly not being applied.
+    expect(result).toEqual({ codegraphEngine: process.env.CODEGRAPH_ENGINE ?? null });
   });
 });


### PR DESCRIPTION
## Summary

Closes #2140

`forkWorker()` (`scripts/lib/fork-engine.ts`) unconditionally set `CODEGRAPH_ENGINE` to whatever `workerName` it was given. That's correct for `forkEngines()`'s own two calls (`workerName` is `'wasm'`/`'native'`, a valid engine value), but `embedding-benchmark.ts` reuses `forkWorker()` directly with `workerName` set to a *model* name (`'minilm'`, `'jina-small'`, ...) — an invalid `CODEGRAPH_ENGINE` value that tripped a `"not a valid engine value"` warning on every embed call inside that worker. Purely cosmetic noise (it already fell back to `"auto"` correctly), but a real fix rather than living with it.

## Fix

`forkWorker()` now only sets `CODEGRAPH_ENGINE` when the caller's `envKey` is the same `WORKER_ENV_KEY` `forkEngines()` itself uses internally — true for an actual engine-comparison fork, never true for a caller using its own distinct env key (like `embedding-benchmark.ts`'s `MODEL_WORKER_KEY`). No call-site changes needed anywhere, including `embedding-benchmark.ts` itself.

## Test plan

- [x] New `tests/unit/fork-engine-codegraph-engine-env.test.ts`: forks a tiny throwaway child script and confirms `CODEGRAPH_ENGINE` is set when `envKey` is the real `WORKER_ENV_KEY`, and unset for a different envKey.
- [x] Full `npm test` suite passes (4606 tests, 287 files).
- [x] `npx tsc --noEmit` and `npm run lint` clean.