### PR TITLE
fix(rust): make native CHA typed-receiver dispatch additive, not a last-resort fallback

### DIFF
--- a/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
@@ -383,7 +383,9 @@ fn emit_cha_dispatch_edges(
 
     for t in resolve_cha_dispatch(ctx, type_name, call.name.as_str()) {
         let edge_key = ((caller_id as u64) << 32) | (t.id as u64);
-        if t.id != caller_id && !seen_edges.contains(&edge_key) && !pts_edge_map.contains_key(&edge_key)
+        if t.id != caller_id
+            && !seen_edges.contains(&edge_key)
+            && !pts_edge_map.contains_key(&edge_key)
         {
             seen_edges.insert(edge_key);
             edges.push(ComputedEdge {

--- a/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
@@ -336,6 +336,69 @@ fn resolve_cha_dispatch<'a>(
     results
 }
 
+/// Additive typed-receiver CHA dispatch expansion (issue #2139). Mirrors the
+/// typed-receiver branch of `emitChaCallEdgesForCall` in `build-edges.ts`
+/// exactly: unlike tier 3.7 inside `resolve_call_targets` above (which only
+/// fires when the whole mutually-exclusive resolution cascade already found
+/// nothing), this runs unconditionally for every receiver call, additive to
+/// whatever the cascade already resolved.
+///
+/// That distinction is the actual bug this closes: an earlier cascade tier
+/// (e.g. import-aware resolution, which matches `call.name` regardless of
+/// receiver) can return a target and short-circuit the whole cascade before
+/// tier 3.7 ever runs — so a genuinely interface-typed, multi-implementer
+/// receiver dispatch (`repo.getClassHierarchy()` where `getClassHierarchy`
+/// is *also* an importable free function) never reached CHA resolution at
+/// all. WASM has no such gap because `emitChaCallEdgesForCall` is called as
+/// an unconditional additive step (Step 6 of `buildFileCallEdges`), not a
+/// last-resort fallback tier.
+///
+/// `this`/`self`/`super` dispatch is intentionally excluded — that's handled
+/// separately (and already correctly) by `runPostNativeThisDispatch`
+/// (native-orchestrator.ts); mixing the two would risk duplicate or
+/// conflicting edges for the same call site.
+fn emit_cha_dispatch_edges(
+    ctx: &EdgeContext,
+    call: &CallInfo,
+    caller_id: u32,
+    type_map: &HashMap<&str, (&str, f64)>,
+    seen_edges: &mut HashSet<u64>,
+    pts_edge_map: &HashMap<u64, usize>,
+    edges: &mut Vec<ComputedEdge>,
+) {
+    let Some(ref receiver) = call.receiver else {
+        return;
+    };
+    if ctx.builtin_set.contains(receiver.as_str())
+        || receiver == "this"
+        || receiver == "self"
+        || receiver == "super"
+    {
+        return;
+    }
+
+    let Some(&(type_name, _)) = type_map.get(receiver.as_str()) else {
+        return;
+    };
+
+    for t in resolve_cha_dispatch(ctx, type_name, call.name.as_str()) {
+        let edge_key = ((caller_id as u64) << 32) | (t.id as u64);
+        if t.id != caller_id && !seen_edges.contains(&edge_key) && !pts_edge_map.contains_key(&edge_key)
+        {
+            seen_edges.insert(edge_key);
+            edges.push(ComputedEdge {
+                source_id: caller_id,
+                target_id: t.id,
+                kind: "calls".to_string(),
+                confidence: CHA_TYPED_DISPATCH_CONFIDENCE,
+                dynamic: 0,
+                dynamic_kind: None,
+                technique: Some("cha".to_string()),
+            });
+        }
+    }
+}
+
 /// Collect the set of property/method names ever invoked via member-call
 /// syntax (`x.name(...)`) across every file currently being processed —
 /// regardless of whether the receiver `x` itself resolves to anything.
@@ -1137,6 +1200,19 @@ fn process_file<'a>(
             confidence_override,
             &mut seen_edges,
             &mut pts_edge_map,
+            edges,
+        );
+
+        // #2139: additive typed-receiver CHA dispatch — see doc comment on
+        // emit_cha_dispatch_edges for why this must be unconditional rather
+        // than folded into resolve_call_targets' mutually-exclusive cascade.
+        emit_cha_dispatch_edges(
+            ctx,
+            call,
+            caller_id,
+            &fc.type_map,
+            &mut seen_edges,
+            &pts_edge_map,
             edges,
         );
 
@@ -5042,11 +5118,18 @@ mod call_edge_tests {
         );
     }
 
-    /// When the interface's own qualified method already passes the
-    /// proximity gate (same directory as the caller), the existing
-    /// type-aware tier must win outright — the CHA fallback must not run at
-    /// all, let alone override an already-successful resolution with a
-    /// different target or a different (flat) confidence.
+    /// #2139: CHA dispatch is additive, not a last-resort fallback — when the
+    /// interface's own qualified method already passes the proximity gate
+    /// (tier 3, `typed`), the caller still ALSO gets a CHA-expanded edge to
+    /// every instantiated concrete implementer (`emit_cha_dispatch_edges`,
+    /// run unconditionally from `process_file`). This mirrors WASM's actual
+    /// behavior exactly — `emitChaCallEdgesForCall` in build-edges.ts runs as
+    /// an unconditional Step 6 regardless of what the earlier cascade
+    /// resolved, verified empirically against `resolveViaRepo` in this same
+    /// repo (both engines emit the direct `Repository.findNodeById` hit AND
+    /// the three `{InMemory,Native,Sqlite}Repository.findNodeById` CHA
+    /// edges). Before #2139 this test asserted the opposite (mutually
+    /// exclusive) — that assumption was never actually WASM-parity-correct.
     #[test]
     fn cha_typed_dispatch_fallback_does_not_override_successful_proximity_lookup() {
         let all_nodes = vec![
@@ -5108,21 +5191,30 @@ mod call_edge_tests {
         let calls_edges: Vec<_> = edges.iter().filter(|e| e.kind == "calls").collect();
         assert_eq!(
             calls_edges.len(),
-            1,
-            "expected exactly one calls edge (the direct interface hit); got: {:?}",
+            2,
+            "expected both the direct interface hit AND the additive CHA-expanded edge; got: {:?}",
             calls_edges
                 .iter()
                 .map(|e| (e.source_id, e.target_id, e.confidence))
                 .collect::<Vec<_>>()
         );
-        let edge = calls_edges[0];
-        assert_eq!(
-            edge.target_id, 2,
-            "expected the interface method (same-dir proximity hit), not the CHA fallback"
-        );
+
+        let direct = calls_edges
+            .iter()
+            .find(|e| e.target_id == 2)
+            .expect("expected the interface method (same-dir proximity hit)");
         assert!(
-            (edge.confidence - CHA_TYPED_DISPATCH_CONFIDENCE).abs() > 1e-9,
-            "expected proximity-based confidence, not the flat CHA_TYPED_DISPATCH_CONFIDENCE"
+            (direct.confidence - CHA_TYPED_DISPATCH_CONFIDENCE).abs() > 1e-9,
+            "expected proximity-based confidence on the direct hit, not the flat CHA_TYPED_DISPATCH_CONFIDENCE"
+        );
+
+        let cha = calls_edges
+            .iter()
+            .find(|e| e.target_id == 4)
+            .expect("expected the additive CHA-expanded edge to LocalImpl.run");
+        assert!(
+            (cha.confidence - CHA_TYPED_DISPATCH_CONFIDENCE).abs() < 1e-9,
+            "expected the flat CHA_TYPED_DISPATCH_CONFIDENCE on the CHA-expanded edge"
         );
     }
 

--- a/tests/fixtures/cha-dispatch/CasualGreeter.ts
+++ b/tests/fixtures/cha-dispatch/CasualGreeter.ts
@@ -1,0 +1,7 @@
+import type { IGreeter } from './IGreeter.js';
+
+export class CasualGreeter implements IGreeter {
+  greet(): string {
+    return 'hey';
+  }
+}

--- a/tests/fixtures/cha-dispatch/FormalGreeter.ts
+++ b/tests/fixtures/cha-dispatch/FormalGreeter.ts
@@ -1,0 +1,7 @@
+import type { IGreeter } from './IGreeter.js';
+
+export class FormalGreeter implements IGreeter {
+  greet(): string {
+    return 'Good day.';
+  }
+}

--- a/tests/fixtures/cha-dispatch/IGreeter.ts
+++ b/tests/fixtures/cha-dispatch/IGreeter.ts
@@ -1,0 +1,3 @@
+export interface IGreeter {
+  greet(): string;
+}

--- a/tests/fixtures/cha-dispatch/NameCollisionDispatcher.ts
+++ b/tests/fixtures/cha-dispatch/NameCollisionDispatcher.ts
@@ -1,0 +1,23 @@
+// Issue #2139: interface-typed receiver dispatch where an EARLIER
+// resolution tier (import-aware, matching call.name regardless of receiver)
+// resolves first and short-circuits before CHA/RTA ever runs — the reason
+// `src/shared/hierarchy.ts`'s `resolveViaRepo` never CHA-expanded
+// `repo.getClassHierarchy()` on the native engine: `getClassHierarchy` is
+// ALSO an importable free function, exactly like `greet` here.
+import { CasualGreeter } from './CasualGreeter.js';
+import { FormalGreeter } from './FormalGreeter.js';
+import { greet } from './greet.js';
+import type { IGreeter } from './IGreeter.js';
+
+// Typed parameter — typeMap records g: IGreeter (confidence 0.9). CHA should
+// expand g.greet() to all instantiated IGreeter implementations, additively
+// to (not instead of) whatever the free-function import match produces.
+function dispatchGreeting(g: IGreeter): string {
+  return g.greet();
+}
+
+export function runGreetings(): string {
+  const formal = new FormalGreeter();
+  const casual = new CasualGreeter();
+  return dispatchGreeting(formal) + dispatchGreeting(casual) + greet();
+}

--- a/tests/fixtures/cha-dispatch/greet.ts
+++ b/tests/fixtures/cha-dispatch/greet.ts
@@ -1,0 +1,8 @@
+// A free function that happens to share its name with IGreeter's own method
+// (issue #2139). NameCollisionDispatcher.ts imports this alongside the
+// interface-typed dispatch below — the import-aware resolution tier matches
+// call.name ("greet") regardless of receiver, so this file's mere presence
+// is what makes the collision reachable.
+export function greet(): string {
+  return 'anonymous';
+}

--- a/tests/integration/phase-8.5-cha-dispatch.test.ts
+++ b/tests/integration/phase-8.5-cha-dispatch.test.ts
@@ -244,4 +244,55 @@ describe.each(ENGINES)('Phase 8.5 CHA dispatch (%s)', (engine) => {
       `Expected NO runJob → AbstractJob.run edge (AbstractJob is never instantiated).\nActual edges:\n${JSON.stringify(callEdges, null, 2)}`,
     ).toBeUndefined();
   });
+
+  // ── CHA additive over an earlier-tier short-circuit (issue #2139) ──────
+  // dispatchGreeting(g: IGreeter) calls g.greet() — but this file also
+  // imports a free function named `greet`. On the native engine, the
+  // import-aware resolution tier matched call.name ("greet") regardless of
+  // receiver and returned before CHA/RTA ever ran, so neither implementor
+  // edge was ever produced. CHA must now fire additively regardless of
+  // what the primary cascade already resolved.
+
+  it('CHA additive: emits dispatchGreeting → FormalGreeter.greet despite a same-named free-function import', () => {
+    const edge = callEdges.find(
+      (e) =>
+        e.caller_name === 'dispatchGreeting' &&
+        e.callee_name === 'FormalGreeter.greet' &&
+        e.callee_file === 'FormalGreeter.ts',
+    );
+    expect(
+      edge,
+      `Expected dispatchGreeting → FormalGreeter.greet edge (CHA must be additive, not short-circuited by the free-function import match).\nActual edges:\n${JSON.stringify(callEdges, null, 2)}`,
+    ).toBeDefined();
+    expect(edge?.technique).toBe('cha');
+  });
+
+  it('CHA additive: emits dispatchGreeting → CasualGreeter.greet despite a same-named free-function import', () => {
+    const edge = callEdges.find(
+      (e) =>
+        e.caller_name === 'dispatchGreeting' &&
+        e.callee_name === 'CasualGreeter.greet' &&
+        e.callee_file === 'CasualGreeter.ts',
+    );
+    expect(
+      edge,
+      `Expected dispatchGreeting → CasualGreeter.greet edge (CHA must be additive, not short-circuited by the free-function import match).\nActual edges:\n${JSON.stringify(callEdges, null, 2)}`,
+    ).toBeDefined();
+    expect(edge?.technique).toBe('cha');
+  });
+
+  it('CHA additive: still emits the primary import-aware edge to the free function greet()', () => {
+    // runGreetings() also calls bare greet() — the free-function import edge
+    // this issue's fix must not regress or duplicate away.
+    const edge = callEdges.find(
+      (e) =>
+        e.caller_name === 'runGreetings' &&
+        e.callee_name === 'greet' &&
+        e.callee_file === 'greet.ts',
+    );
+    expect(
+      edge,
+      `Expected runGreetings → greet (free function) edge to survive alongside the new CHA edges.\nActual edges:\n${JSON.stringify(callEdges, null, 2)}`,
+    ).toBeDefined();
+  });
 });


### PR DESCRIPTION
## Summary

Closes #2139

Native's CHA dispatch (`resolve_cha_dispatch`, added by #2236) only ran as tier 3.7 inside `resolve_call_targets`' mutually-exclusive resolution cascade — reached only when every earlier tier found nothing. WASM's equivalent (`emitChaCallEdgesForCall`) runs unconditionally as an additive Step 6, independent of what the rest of the cascade already resolved.

This mattered because an earlier tier (import-aware resolution, which matches `call.name` regardless of receiver) can return a target and short-circuit the whole cascade before CHA ever runs. Concretely: `src/shared/hierarchy.ts`'s `resolveViaRepo` calls `repo.getClassHierarchy()` where `repo: Repository` has three implementers (`InMemoryRepository`/`NativeRepository`/`SqliteRepository`) — but `getClassHierarchy` is *also* an importable free function, so tier 1 matched on the name alone and returned before CHA could expand the interface dispatch. Native produced zero edges to any implementer; WASM produced three.

## Fix

`emit_cha_dispatch_edges` runs unconditionally from `process_file`'s per-call loop, alongside `emit_call_edges`/`emit_receiver_edge`, mirroring `emitChaCallEdgesForCall` exactly (same `type_map` lookup, same `resolve_cha_dispatch` BFS, same `CHA_TYPED_DISPATCH_CONFIDENCE`, same `'cha'` technique tag). `this`/`self`/`super` dispatch is excluded — that stays with `runPostNativeThisDispatch`.

## Verification

- Rebuilt the native addon and ran `codegraph build --engine native` against this repo's own source: `resolveViaRepo` now correctly emits CHA edges to `InMemoryRepository.getClassHierarchy` and `NativeRepository.getClassHierarchy` (previously zero implementer edges at all).
- `SqliteRepository` still doesn't get its edge — it's only ever instantiated via an object-literal property value, which native's RTA evidence doesn't currently track (a separate, narrower gap — filed as #2346).
- `scripts/parity-compare.mjs --langs javascript,typescript,tsx,pts-javascript` — byte-identical node/edge counts on both engines.
- Updated `cha_typed_dispatch_fallback_does_not_override_successful_proximity_lookup`, which encoded the old (never actually WASM-parity-correct) mutually-exclusive assumption — verified empirically that real WASM output has both the direct proximity hit and the CHA-expanded edge coexisting for the same call site.

## Test plan

- [x] New fixture (`tests/fixtures/cha-dispatch/{IGreeter,FormalGreeter,CasualGreeter,greet,NameCollisionDispatcher}.ts`) reproducing the exact short-circuit shape: an interface-typed receiver dispatch where the file also imports a free function sharing the interface method's name. New `describe.each(['wasm','native'])` cases in `tests/integration/phase-8.5-cha-dispatch.test.ts` confirm both engines now emit both CHA-expanded edges additively, alongside the pre-existing free-function edge.
- [x] Full `cargo test --lib` passes (820 tests).
- [x] Full `npm test` suite passes (4621 tests, 288 files).
- [x] `npx tsc --noEmit` and `npm run lint` clean.

Filed #2346 (RTA `new_expressions` gap), #2347 (possible WASM cross-fixture false positives — unrelated direction, needs its own investigation per the issue's own notes), and #2348 (odd zero-line edges) for the issue's other, lower-priority observations not addressed here.