### PR TITLE
fix(ci): pin GitHub Actions to commit SHAs instead of mutable version tags

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -38,21 +38,21 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           ref: main
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download benchmark history artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: benchmark-files
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download benchmark JSON results
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: benchmark-results-json
           run-id: ${{ github.event.workflow_run.id }}
@@ -132,13 +132,13 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           ref: main
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-node@v7.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
           cache: "npm"
@@ -207,7 +207,7 @@ jobs:
       - name: Cache HuggingFace models
         if: steps.existing.outputs.skip != 'true'
         id: hf-cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.cache/huggingface
           # Key on the benchmark script (which owns the model list), not on
@@ -244,7 +244,7 @@ jobs:
 
       - name: Upload embedding result
         if: steps.existing.outputs.skip != 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: embedding-benchmark-result
           path: embedding-benchmark-result.json

--- a/.github/workflows/build-native-matrix.yml
+++ b/.github/workflows/build-native-matrix.yml
@@ -59,15 +59,15 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           targets: ${{ matrix.target }}
 
@@ -86,7 +86,7 @@ jobs:
           "$HOME/.cargo/bin/rustc" --version
 
       - name: Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           workspaces: crates/codegraph-core
 
@@ -133,7 +133,7 @@ jobs:
         run: napi build --release --target ${{ matrix.target }}
 
       - name: Upload native binary
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: native-${{ matrix.artifact_key }}
           path: crates/codegraph-core/*.node

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Lint
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
 
@@ -54,7 +54,7 @@ jobs:
     outputs:
       native_changed: ${{ steps.check.outputs.native_changed }}
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -118,18 +118,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: Native host build (${{ matrix.os }})
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           workspaces: crates/codegraph-core
 
@@ -150,7 +150,7 @@ jobs:
         run: cargo test --release
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: native-host-${{ matrix.os }}
           path: crates/codegraph-core/*.node
@@ -175,10 +175,10 @@ jobs:
     name: Test Node ${{ matrix.node-version }} (${{ matrix.os }})
 
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -201,7 +201,7 @@ jobs:
 
       - name: Download PR-built native addon
         if: needs.native-host-build.result == 'success'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: native-host-${{ matrix.os }}
           path: crates/codegraph-core
@@ -218,10 +218,10 @@ jobs:
     runs-on: ubuntu-latest
     name: TypeScript type check
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
 
@@ -249,7 +249,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Security audit
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Audit production dependencies
         # --package-lock-only reads the lock file directly — no npm install needed.
@@ -267,10 +267,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Verify dynamic imports
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
 
@@ -283,10 +283,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Grammar version parity
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
 
@@ -308,10 +308,10 @@ jobs:
     name: Engine parity (${{ matrix.os }})
 
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
 
@@ -334,7 +334,7 @@ jobs:
 
       - name: Download PR-built native addon
         if: needs.native-host-build.result == 'success'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: native-host-${{ matrix.os }}
           path: crates/codegraph-core
@@ -400,15 +400,15 @@ jobs:
     name: Rust compile check
 
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           components: rustfmt
 
       - name: Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           workspaces: crates/codegraph-core
 
@@ -459,29 +459,29 @@ jobs:
       CODEGRAPH_FAST_SKIP_DIAG: "1"
 
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v7.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
           cache: "npm"
 
       - name: Setup Python (for resolution benchmark + tracer validation)
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
 
       - name: Setup Go (for resolution benchmark + tracer validation)
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: "stable"
           cache: false
 
       - name: Download PR-built native addon
         if: needs.native-host-build.result == 'success'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: native-host-ubuntu-latest
           path: crates/codegraph-core/
@@ -581,7 +581,7 @@ jobs:
       # without re-running the full benchmark suite locally.
       - name: Upload benchmark JSON results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: benchmark-results-json
           path: |

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.6.1
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,7 +22,7 @@ jobs:
     outputs:
       trivial: ${{ steps.check.outputs.trivial }}
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -103,7 +103,7 @@ jobs:
           exit 1
 
       - name: Checkout repository
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
 
@@ -265,7 +265,7 @@ jobs:
           exit 1
 
       - name: Checkout repository
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
 

--- a/.github/workflows/codegraph-impact-comment.yml
+++ b/.github/workflows/codegraph-impact-comment.yml
@@ -12,7 +12,7 @@ on:
 
 permissions:
   pull-requests: write
-  # Required by actions/download-artifact@v4 when downloading from another
+  # Required by actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4 when downloading from another
   # workflow run (cross-run artifact API calls require actions: read).
   actions: read
 
@@ -28,13 +28,13 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Download impact artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: codegraph-impact
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Comment on PR
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/codegraph-impact.yml
+++ b/.github/workflows/codegraph-impact.yml
@@ -12,10 +12,10 @@ jobs:
   impact:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v7.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
       - name: Install dependencies
@@ -32,7 +32,7 @@ jobs:
               exit 1
             fi
           done
-      - uses: actions/cache@v6
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: .codegraph/
           key: codegraph-${{ hashFiles('src/**', 'package.json') }}
@@ -44,7 +44,7 @@ jobs:
       - name: Save PR number
         run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
       - name: Upload impact artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: codegraph-impact
           path: |

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -12,11 +12,11 @@ jobs:
     name: Validate commits
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v7.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
 

--- a/.github/workflows/embedding-regression.yml
+++ b/.github/workflows/embedding-regression.yml
@@ -21,10 +21,10 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
 
@@ -33,7 +33,7 @@ jobs:
         run: npm install
 
       - name: Cache HuggingFace models
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.cache/huggingface
           key: hf-models-minilm-v1

--- a/.github/workflows/perf-canary.yml
+++ b/.github/workflows/perf-canary.yml
@@ -42,18 +42,18 @@ jobs:
       CODEGRAPH_FAST_SKIP_DIAG: "1"
 
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@v7.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: "npm"
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           workspaces: crates/codegraph-core
 
@@ -107,7 +107,7 @@ jobs:
 
       - name: Upload canary result
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: incremental-canary-result
           path: incremental-canary-result.json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
       # Only the scheduled path below actually reads repo history (git rev-list);
       # release/workflow_dispatch exit immediately with should_run=true and never
       # touch the checkout, so skip the full-depth clone for those triggers.
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: github.event_name == 'schedule'
         with:
           fetch-depth: 0
@@ -87,8 +87,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7.0.1
-      - uses: actions/setup-node@v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
 
@@ -97,10 +97,10 @@ jobs:
       # Without this, npm install pulls the last-published binary, which lags
       # behind PR changes that touch both the TS and Rust extractors.
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           workspaces: crates/codegraph-core
 
@@ -130,7 +130,7 @@ jobs:
       version: ${{ steps.compute.outputs.version }}
       npm_tag: ${{ steps.compute.outputs.npm_tag }}
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -211,28 +211,28 @@ jobs:
       CODEGRAPH_FAST_SKIP_DIAG: "1"
 
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v7.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
           cache: "npm"
 
       - name: Setup Python (for resolution benchmark + tracer validation)
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
 
       - name: Setup Go (for resolution benchmark + tracer validation)
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: "stable"
           cache: false
 
       - name: Download native artifact (linux-x64)
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: native-linux-x64
           path: crates/codegraph-core/
@@ -340,7 +340,7 @@ jobs:
         run: npm run test:regression-guard
 
       - name: Upload benchmark history files
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: benchmark-files
           path: |
@@ -354,7 +354,7 @@ jobs:
       # gate in the Benchmark workflow). Separated from the history-files
       # artifact because consumers read different shapes.
       - name: Upload benchmark JSON results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: benchmark-results-json
           path: |
@@ -373,9 +373,9 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@v7.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
 
@@ -399,7 +399,7 @@ jobs:
         run: npm pkg delete scripts.prepublishOnly
 
       - name: Download native artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: ${{ runner.temp }}/artifacts/
 
@@ -548,7 +548,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           ref: main
@@ -556,7 +556,7 @@ jobs:
 
       # Node 24 required: ships with npm v11 which supports OIDC trusted publishing.
       # Node 22 ships with npm v10 which lacks the OIDC handshake protocol needed by the npm registry.
-      - uses: actions/setup-node@v7.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"
 
@@ -581,7 +581,7 @@ jobs:
         run: npm pkg delete scripts.prepublishOnly
 
       - name: Download native artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: ${{ runner.temp }}/artifacts/
 

--- a/.github/workflows/shield-license-compliance.yml
+++ b/.github/workflows/shield-license-compliance.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7.0.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
           cache: "npm"
@@ -152,7 +152,7 @@ jobs:
           fi
 
       - name: Upload license reports
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: license-compliance-reports
           path: license-reports/


### PR DESCRIPTION
## Summary

Closes #2170

Every `uses:` line across the 12 remaining workflows referenced a mutable major/minor version tag (`actions/checkout@v7.0.1`, `actions/setup-node@v7.0.0`, `dtolnay/rust-toolchain@stable`, `Swatinem/rust-cache@v2`, `actions/cache@v6`, `actions/upload-artifact@v4`/`v7`, `actions/download-artifact@v4`/`v8`, `actions/setup-python@v7`, `actions/setup-go@v7`, `actions/github-script@v9`, `contributor-assistant/github-action@v2.6.1`). If any of these tags is ever repointed (upstream compromise or accidental force-push), the next CI run executes unreviewed code with whatever permissions that job holds. `update-recall-floors.yml` already followed the safe pattern; everything else didn't.

## Fix

Resolved the exact commit SHA each tag currently points to (via `gh api repos/<owner>/<repo>/git/refs/...`, dereferencing annotated tag objects where needed) and pinned every `uses:` line to `<sha> # <tag>`, matching `update-recall-floors.yml`'s existing style. `anthropics/claude-code-action` in `claude.yml` was already SHA-pinned. `.github/dependabot.yml` already has a `github-actions` ecosystem entry on a weekly schedule, so these pins will get automatic bump PRs going forward — no new Dependabot config needed.

Local (`./.github/workflows/...`) and reusable-workflow (`workflow_call`) references are untouched — same-repo refs move with the branch, so pinning them would just be noise.

## Test plan

- [x] `python3 -c "import yaml; ..."` — all 14 workflow files parse as valid YAML.
- [x] `actionlint .github/workflows/*.yml` — byte-identical warning output (249 lines) before and after this change on every file; introduces zero new findings, fixes zero unrelated ones (all pre-existing warnings are shellcheck notes on `run:` scripts, out of scope here).
- [x] Verified two of the resolved SHAs (`actions/checkout@v7.0.1`, `actions/setup-node@v7.0.0`) exactly match the SHAs already committed in `update-recall-floors.yml`.