### PR TITLE
fix(ci): add non-blocking reminder for non-closing issue references in PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,4 +26,6 @@ N/A
 
 ## Related issues
 
-<!-- Link related issues: Fixes #123, Closes #456 -->
+<!-- Use a closing keyword if this PR fully resolves the issue: Closes #123, Fixes #456.
+     "Refs #123" / "Related #123" will NOT auto-close the issue on merge — only use those
+     for a non-closing reference. -->

--- a/.github/workflows/closing-keyword-check.yml
+++ b/.github/workflows/closing-keyword-check.yml
@@ -52,7 +52,12 @@ jobs:
               repo: context.repo.repo,
               issue_number: prNumber,
             });
-            const existing = comments.find((c) => c.body.includes(marker));
+            // Restrict to the workflow's own bot-authored comments — matching on the
+            // marker text alone would let a PR participant plant it in their own
+            // comment and have a later edit/reopen event overwrite or delete it.
+            const existing = comments.find(
+              (c) => c.body.includes(marker) && c.user.login === 'github-actions[bot]'
+            );
 
             if (flagged.size === 0) {
               if (existing) {

--- a/.github/workflows/closing-keyword-check.yml
+++ b/.github/workflows/closing-keyword-check.yml
@@ -1,0 +1,90 @@
+# Reminds PR authors when a description references an issue with a non-closing
+# phrase ("Refs #N", "Related #N", bare "(#N)") but no closing keyword for that
+# same number — the pattern behind issue #2181, where merged PRs silently left
+# already-fixed issues open because "Refs #N" looks like a valid reference but
+# does not trigger GitHub's auto-close. Informational only: a non-closing
+# reference is often intentional (partial fix, related work), so this never
+# fails the build — it only makes the gap visible for a human to confirm.
+#
+# Uses pull_request_target (not pull_request) so the check also works on PRs
+# from forks, which get a read-only GITHUB_TOKEN under pull_request. This is
+# safe without the workflow_run split codegraph-impact-comment.yml uses,
+# because this job never checks out or executes the PR's head content — it
+# only reads the trusted event payload's `pull_request.body` field.
+name: Closing Keyword Check
+on:
+  pull_request_target:
+    types: [opened, edited, reopened]
+    branches: [main]
+
+permissions:
+  pull-requests: write
+
+concurrency:
+  group: closing-keyword-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for non-closing issue references
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+
+            const closingKeywords = /\b(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s+#(\d+)/gi;
+            const closedIssues = new Set();
+            for (let m; (m = closingKeywords.exec(body)); ) closedIssues.add(m[1]);
+
+            const refPattern = /\b(?:refs?|related(?:\s+to)?|see)\s+#(\d+)|\(#(\d+)\)/gi;
+            const flagged = new Set();
+            for (let m; (m = refPattern.exec(body)); ) {
+              const num = m[1] || m[2];
+              if (!closedIssues.has(num)) flagged.add(num);
+            }
+
+            const marker = '<!-- closing-keyword-check -->';
+            const prNumber = context.payload.pull_request.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const existing = comments.find((c) => c.body.includes(marker));
+
+            if (flagged.size === 0) {
+              if (existing) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                });
+              }
+              return;
+            }
+
+            const issueList = [...flagged].map((n) => `#${n}`).join(', ');
+            const commentBody =
+              `${marker}\n` +
+              `**Heads up:** this PR references ${issueList} without a closing keyword ` +
+              '(`Closes #N` / `Fixes #N`). If this PR fully resolves ' +
+              `${issueList}, update the description so the issue auto-closes on merge — ` +
+              'otherwise disregard this comment.';
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: commentBody,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: commentBody,
+              });
+            }


### PR DESCRIPTION
## Summary

Closes #2181

Three issues (#1763, #1867, #1888) were already fully fixed and merged to `main` but stayed open because the merging PR used "Refs #N" instead of a closing keyword — which looks like a valid reference but does not trigger GitHub's auto-close on merge. Nothing previously caught this.

## Fix

A hard-failing CI gate isn't the right shape here: a non-closing reference (`Refs #N`, `Related #N`, a partial fix) is often intentional, and text alone can't distinguish that from a genuine mistake. Instead:

- New `.github/workflows/closing-keyword-check.yml`: scans the PR body for issue references using a non-closing phrase (`Refs #N`, `Related #N`, `related to #N`, `see #N`, or a bare `(#N)`) that have no closing keyword (`closes`/`fixes`/`resolves` + variants) for that same issue number, and posts (or clears, on later edits) a single informational PR comment. It never fails the build — it only makes the gap visible for a human to confirm.
- Uses `pull_request_target` rather than `pull_request`: the check only reads the trusted event payload's `body` field — no checkout, no code execution — so this is safe without the `workflow_run` split `codegraph-impact-comment.yml` uses for its riskier (code-executing) case, and it also works correctly on fork PRs, which get a read-only token under plain `pull_request`.
- Clarified the existing "Related issues" hint in `.github/PULL_REQUEST_TEMPLATE.md` to spell out that `Refs`/`Related` won't auto-close the issue — addressing the PR-template-reminder option directly, as defense in depth alongside the automated check.

## Test plan

- [x] Verified the regex/dedup logic locally against 8 cases (closes-only, refs-only, refs+closes for the same number, "related to", bare parens, lowercase "fixes", mixed multi-issue body, no references at all) — all produce the expected flagged set.
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — valid YAML.
- [x] `actionlint .github/workflows/closing-keyword-check.yml` — zero findings.