### PR TITLE
fix(ast-analysis): keep function scope active through Dart's sibling body

### DIFF
--- a/crates/codegraph-core/src/ast_analysis/complexity.rs
+++ b/crates/codegraph-core/src/ast_analysis/complexity.rs
@@ -787,6 +787,15 @@ pub static GROOVY_RULES: LangRules = LangRules {
 };
 
 /// Look up complexity rules by language ID (matches `COMPLEXITY_RULES` keys in JS).
+///
+/// No "dart" arm yet (tracked by #1923's tier-2 rollout). When one is added:
+/// tree-sitter-dart puts a function's body in a SIBLING node, not a child of
+/// function_signature/method_signature (#2182 — see
+/// `src/ast-analysis/rules/b2.ts`'s `dataflowDart` for the TS-side fix and
+/// `crate::shared::ast_nodes::find_body_sibling_node` for the ready-to-use
+/// Rust helper). `LangRules` will need a `body_sibling_types` field and
+/// `walk()` below will need to call the helper additively, mirroring
+/// `src/ast-analysis/visitor.ts`'s `bodySiblingTypes` handling.
 pub fn lang_rules(lang_id: &str) -> Option<&'static LangRules> {
     match lang_id {
         "javascript" | "typescript" | "tsx" => Some(&JS_TS_RULES),

--- a/crates/codegraph-core/src/ast_analysis/dataflow.rs
+++ b/crates/codegraph-core/src/ast_analysis/dataflow.rs
@@ -506,6 +506,17 @@ static RUBY_DATAFLOW: DataflowRules = DataflowRules {
 };
 
 /// Get dataflow rules for a language ID string.
+///
+/// No "dart" arm — unlike the languages above, Dart dataflow only exists on
+/// the TS/WASM side today (`src/ast-analysis/rules/b2.ts`'s `dataflowDart`,
+/// fixed for the function_signature/function_body sibling-body split by
+/// #2182). Porting it here needs a `body_sibling_types`-aware `visit()`
+/// (see `crate::shared::ast_nodes::find_body_sibling_node`), and note tree-
+/// sitter-dart's Rust grammar differs structurally from the WASM one used
+/// by TS: function_signature/function_body are children of an intermediate
+/// `function_declaration` wrapper (not direct children of the top-level
+/// node), and function_signature DOES expose a `parameters` field here
+/// (TS's WASM grammar has no such field — confirmed while fixing #2182).
 fn get_dataflow_rules(lang_id: &str) -> Option<&'static DataflowRules> {
     match lang_id {
         "javascript" | "typescript" | "tsx" => Some(&JS_TS_DATAFLOW),

--- a/crates/codegraph-core/src/shared/ast_nodes.rs
+++ b/crates/codegraph-core/src/shared/ast_nodes.rs
@@ -1,0 +1,99 @@
+use tree_sitter::Node;
+
+/// Find a node's next sibling whose kind is in `body_types`, skipping over
+/// intervening `comment` nodes. Mirrors `src/shared/ast-nodes.ts`'s
+/// `findBodySiblingNode` — needed for grammars (e.g. tree-sitter-dart's
+/// function_signature/function_body split, #2082/#2182) where a function's
+/// body lives as a SIBLING of its signature/declaration node rather than as
+/// a child of it — every consumer that walks only a matched node's own
+/// subtree would otherwise silently see zero body content.
+///
+/// Returns `None` if no sibling exists, or if the next non-comment
+/// sibling's kind isn't in `body_types` (e.g. tree-sitter-dart's bare `;`
+/// for an abstract method signature with no body at all).
+pub fn find_body_sibling_node<'a>(node: &Node<'a>, body_types: &[&str]) -> Option<Node<'a>> {
+    let parent = node.parent()?;
+    for i in 0..parent.child_count() {
+        let child = parent.child(i)?;
+        if child.id() != node.id() {
+            continue;
+        }
+        let mut j = i + 1;
+        let mut next = parent.child(j);
+        while let Some(n) = next {
+            if n.kind() != "comment" {
+                break;
+            }
+            j += 1;
+            next = parent.child(j);
+        }
+        return next.filter(|n| body_types.contains(&n.kind()));
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tree_sitter::Parser;
+
+    fn parse_dart(code: &str) -> tree_sitter::Tree {
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_dart::LANGUAGE.into())
+            .unwrap();
+        parser.parse(code, None).unwrap()
+    }
+
+    #[test]
+    fn finds_the_sibling_body_of_a_top_level_function_signature() {
+        // (source_file (function_declaration signature: (function_signature ...)
+        //   body: (function_body ...))) — function_signature and function_body
+        // are both direct children of function_declaration, i.e. siblings of
+        // each other, not parent/child.
+        let tree = parse_dart("int add(int a, int b) {\n  return a + b;\n}\n");
+        let decl = tree.root_node().child(0).unwrap();
+        assert_eq!(decl.kind(), "function_declaration");
+        let sig = decl.child_by_field_name("signature").unwrap();
+        assert_eq!(sig.kind(), "function_signature");
+
+        let body = find_body_sibling_node(&sig, &["function_body"]);
+        assert!(body.is_some(), "expected to find a function_body sibling");
+        assert_eq!(body.unwrap().kind(), "function_body");
+    }
+
+    #[test]
+    fn returns_none_for_a_bodyless_abstract_signature() {
+        // An abstract method's function_signature has NO next sibling at
+        // all (its parent, `declaration`, has only the signature as a
+        // child) — must not panic or false-positive.
+        let tree = parse_dart("abstract class Foo {\n  int bar();\n}\n");
+        let class_body = tree
+            .root_node()
+            .child(0)
+            .unwrap()
+            .child_by_field_name("body")
+            .unwrap();
+        // Walk down: class_body -> class_member -> declaration -> function_signature
+        let class_member = class_body.named_child(0).unwrap();
+        assert_eq!(class_member.kind(), "class_member");
+        let declaration = class_member.named_child(0).unwrap();
+        assert_eq!(declaration.kind(), "declaration");
+        let sig = declaration.named_child(0).unwrap();
+        assert_eq!(sig.kind(), "function_signature");
+
+        assert!(find_body_sibling_node(&sig, &["function_body"]).is_none());
+    }
+
+    #[test]
+    fn skips_an_intervening_comment_node_between_signature_and_body() {
+        let tree = parse_dart("int add(int a, int b) // trailing comment\n{\n  return a + b;\n}\n");
+        let decl = tree.root_node().child(0).unwrap();
+        assert_eq!(decl.kind(), "function_declaration");
+        let sig = decl.child_by_field_name("signature").unwrap();
+        assert_eq!(sig.kind(), "function_signature");
+
+        let body = find_body_sibling_node(&sig, &["function_body"]);
+        assert_eq!(body.map(|n| n.kind()), Some("function_body"));
+    }
+}

--- a/crates/codegraph-core/src/shared/mod.rs
+++ b/crates/codegraph-core/src/shared/mod.rs
@@ -1,1 +1,2 @@
+pub mod ast_nodes;
 pub mod constants;

--- a/src/ast-analysis/rules/b2.ts
+++ b/src/ast-analysis/rules/b2.ts
@@ -481,21 +481,82 @@ export const halsteadScala: HalsteadRules = {
 // ─── Dart ─────────────────────────────────────────────────────────────────────
 //
 // Dart uses `function_signature` for top-level functions and `method_signature`
-// for class methods (both confirmed in extractor). The extractor uses
-// `childForFieldName('name')` for the function name on both node types.
+// for class methods. Per tree-sitter-dart's node-types.json:
+//   - function_signature declares ONE named field, `name`; its parameter
+//     list (`formal_parameter_list`) is an unnamed positional child.
+//   - method_signature declares NO named fields at all — a method's actual
+//     `function_signature` (or getter_signature/setter_signature/
+//     constructor_signature) is nested one level inside it, alongside the
+//     SIBLING `function_body` that belongs to method_signature itself
+//     (#2182). So a method's name/params come from the nested signature
+//     node, while its body's scope is attributed to the outer
+//     method_signature node — extractDartFunctionName/getDartParamListNode
+//     below resolve each accordingly, mirroring the same walk the extractor
+//     (src/extractors/dart.ts's extractDartFunctionName) already does for
+//     symbol-table name resolution.
 // Dart call: `selector` node with `argument_part` — the extractor uses this.
 // There is no standard `call_expression` node type in tree-sitter-dart.
 // We use `function_signature` as the primary function node type.
-// Parameters: `childForFieldName('parameters')` on function_signature (confirmed in extractor).
+
+/** Child node types that carry a method's own `name`/parameter-list fields. */
+const DART_NESTED_SIGNATURE_TYPES = new Set([
+  'function_signature',
+  'getter_signature',
+  'setter_signature',
+  'constructor_signature',
+]);
+
+/**
+ * function_signature has a direct `name` field; method_signature has none —
+ * its name lives on the nested signature child described above.
+ */
+function extractDartFunctionName(node: TreeSitterNode): string | null {
+  const direct = node.childForFieldName('name');
+  if (direct) return direct.text;
+  for (const child of node.namedChildren) {
+    if (DART_NESTED_SIGNATURE_TYPES.has(child.type)) {
+      const nested = child.childForFieldName('name');
+      if (nested) return nested.text;
+    }
+  }
+  return null;
+}
+
+/**
+ * function_signature exposes NO named field for its parameter list
+ * (confirmed via node-types.json: `name` is its only declared field) —
+ * `formal_parameter_list` is an unnamed positional child, so
+ * `paramListField` (a field-name lookup) can never find it.
+ *
+ * Deliberately does NOT descend into a nested signature child for
+ * method_signature: the nested function_signature/getter_signature/etc. is
+ * ITSELF a separate entry in functionNodes, so the walker already visits
+ * it as its own boundary and independently finds its own direct
+ * formal_parameter_list. Falling back into it here would attribute the
+ * same params to method_signature's scope too, double-counting them.
+ */
+function getDartParamListNode(funcNode: TreeSitterNode): TreeSitterNode | null {
+  for (const child of funcNode.namedChildren) {
+    if (child.type === 'formal_parameter_list') return child;
+  }
+  return null;
+}
 
 function extractDartParamName(node: TreeSitterNode): string[] | null {
-  // Dart: parameter types include 'formal_parameter', 'named_formal_parameter',
-  // 'optional_formal_parameter', and bare 'identifier'
-  if (
-    node.type === 'formal_parameter' ||
-    node.type === 'optional_formal_parameter' ||
-    node.type === 'named_formal_parameter'
-  ) {
+  // `[int x, int y]` (optional-positional) / `{int x, int y}` (named) param
+  // groups wrap MULTIPLE formal_parameter children in one
+  // optional_formal_parameters node (node-types.json — confirmed there is
+  // no singular optional_formal_parameter/named_formal_parameter type in
+  // this grammar). Recurse to collect every name inside the group.
+  if (node.type === 'optional_formal_parameters') {
+    const names: string[] = [];
+    for (const child of node.namedChildren) {
+      const childNames = extractDartParamName(child);
+      if (childNames) names.push(...childNames);
+    }
+    return names.length > 0 ? names : null;
+  }
+  if (node.type === 'formal_parameter') {
     const nameNode = node.childForFieldName('name');
     if (nameNode) return [nameNode.text];
     // Fallback: last identifier child is usually the name
@@ -511,14 +572,27 @@ function extractDartParamName(node: TreeSitterNode): string[] | null {
 
 export const dataflowDart: DataflowRulesConfig = makeDataflowRules({
   functionNodes: new Set(['function_signature', 'method_signature']),
+  // tree-sitter-dart puts a function's body in a SIBLING node, not a child
+  // of function_signature/method_signature (#2182) — without this, every
+  // return/assignment/call/mutation inside the body is invisible to the
+  // dataflow walker since it never descends into the sibling while this
+  // function's scope is active.
+  bodySiblingTypes: new Set(['function_body']),
   nameField: 'name',
+  // method_signature has no name field of its own (see extractDartFunctionName's
+  // doc comment) — without this, every return/assignment/call/mutation
+  // inside a Dart METHOD's body was silently dropped, since handleReturn
+  // et al. gate on `scope.funcName` being truthy.
+  nameExtractor: extractDartFunctionName,
 
-  paramListField: 'parameters',
-  paramWrapperTypes: new Set([
-    'formal_parameter',
-    'optional_formal_parameter',
-    'named_formal_parameter',
-  ]),
+  // function_signature/method_signature expose no named field for their
+  // parameter list (only `name` is a declared field per node-types.json) —
+  // paramListField (a field-name lookup) can never find formal_parameter_list,
+  // which is an unnamed positional child. This was ALSO silently broken,
+  // not just the body-sibling issue: every Dart parameter extraction
+  // returned nothing, contrary to this repo's #2182 report assuming
+  // parameter extraction "happened to work."
+  getParamListNode: getDartParamListNode,
   extractParamName: extractDartParamName,
 
   returnNode: 'return_statement',

--- a/src/ast-analysis/shared.ts
+++ b/src/ast-analysis/shared.ts
@@ -77,6 +77,7 @@ export function makeCfgRules(overrides: Partial<CfgRulesConfig>): CfgRulesConfig
 export const DATAFLOW_DEFAULTS: DataflowRulesConfig = {
   // Scope entry
   functionNodes: new Set(), // REQUIRED: non-empty
+  bodySiblingTypes: null, // set for grammars where the body is a sibling of functionNodes, not a child (#2182)
 
   // Function name extraction
   nameField: 'name',

--- a/src/ast-analysis/visitor.ts
+++ b/src/ast-analysis/visitor.ts
@@ -12,6 +12,7 @@
  */
 
 import { debug } from '../infrastructure/logger.js';
+import { findBodySiblingNode } from '../shared/ast-nodes.js';
 import type {
   ScopeEntry,
   TreeSitterNode,
@@ -27,6 +28,17 @@ function mergeFunctionNodeTypes(visitors: Visitor[], base: Set<string>): Set<str
   for (const v of visitors) {
     if (v.functionNodeTypes) {
       for (const t of v.functionNodeTypes) merged.add(t);
+    }
+  }
+  return merged;
+}
+
+/** Merge each visitor's custom bodySiblingTypes into the master set. */
+function mergeBodySiblingTypes(visitors: Visitor[], base: Set<string>): Set<string> {
+  const merged = new Set(base);
+  for (const v of visitors) {
+    if (v.bodySiblingTypes) {
+      for (const t of v.bodySiblingTypes) merged.add(t);
     }
   }
   return merged;
@@ -155,22 +167,37 @@ function collectResults(visitors: Visitor[]): WalkResults {
 interface WalkState {
   visitors: Visitor[];
   allFuncTypes: Set<string>;
+  bodySiblingTypes: Set<string>;
   nestingNodeTypes: Set<string>;
   getFunctionName: (node: TreeSitterNode) => string | null;
   context: VisitorContext;
   scopeStack: ScopeEntry[];
   skipDepths: Map<number, number>;
+  /**
+   * IDs (TreeSitterNode.id, not object references — tree-sitter node
+   * wrapper objects aren't stable across separate .child()/.parent calls
+   * for the same underlying AST position, confirmed by the existing
+   * .id-based sibling comparison in src/extractors/dart.ts) of body-sibling
+   * nodes already walked as part of their function's scope (see the
+   * isFuncBoundary branch in walkNode). The node's own parent will still
+   * reach this same node later in its normal child iteration — without
+   * this guard it would be walked (and its enterNode/enterFunction effects
+   * double-dispatched) a second time, outside the function's scope.
+   */
+  consumedSiblingIds: Set<number>;
 }
 
 /** Build walk state from options: resolve function types, init visitors, create shared context. */
 function buildWalkState(visitors: Visitor[], langId: string, options: WalkOptions): WalkState {
   const {
     functionNodeTypes = new Set<string>(),
+    bodySiblingTypes = new Set<string>(),
     nestingNodeTypes = new Set<string>(),
     getFunctionName = () => null,
   } = options;
 
   const allFuncTypes = mergeFunctionNodeTypes(visitors, functionNodeTypes);
+  const allBodySiblingTypes = mergeBodySiblingTypes(visitors, bodySiblingTypes);
   initVisitors(visitors, langId);
 
   const scopeStack: ScopeEntry[] = [];
@@ -184,17 +211,20 @@ function buildWalkState(visitors: Visitor[], langId: string, options: WalkOption
   return {
     visitors,
     allFuncTypes,
+    bodySiblingTypes: allBodySiblingTypes,
     nestingNodeTypes,
     getFunctionName,
     context,
     scopeStack,
     skipDepths: new Map<number, number>(),
+    consumedSiblingIds: new Set<number>(),
   };
 }
 
 /** Single DFS step: dispatch enter/exit hooks and recurse into children. */
 function walkNode(state: WalkState, node: TreeSitterNode | null, depth: number): void {
   if (!node) return;
+  if (state.consumedSiblingIds.has(node.id)) return;
   if (depth > MAX_WALK_DEPTH) {
     debug(`walkWithVisitors: AST depth limit (${MAX_WALK_DEPTH}) hit — subtree truncated`);
     return;
@@ -203,11 +233,13 @@ function walkNode(state: WalkState, node: TreeSitterNode | null, depth: number):
   const {
     visitors,
     allFuncTypes,
+    bodySiblingTypes,
     nestingNodeTypes,
     getFunctionName,
     context,
     scopeStack,
     skipDepths,
+    consumedSiblingIds,
   } = state;
   const type = node.type;
   const isFuncBoundary = allFuncTypes.has(type);
@@ -235,6 +267,24 @@ function walkNode(state: WalkState, node: TreeSitterNode | null, depth: number):
   clearSkipFlags(skipDepths, visitors.length, depth);
 
   if (isFuncBoundary) {
+    // Some grammars (e.g. tree-sitter-dart's function_signature/method_signature)
+    // put the function's actual body in a SIBLING node instead of nesting it —
+    // the children loop above never reaches it. Walk it now, while this
+    // function's scope is still on scopeStack, before firing exitFunction.
+    if (bodySiblingTypes.size > 0) {
+      const bodySibling = findBodySiblingNode(node, bodySiblingTypes);
+      // Walk BEFORE marking consumed: walkNode's own early-return guard
+      // checks consumedSiblingIds unconditionally, so marking it first
+      // would make this very call a no-op. The mark only needs to be in
+      // place before the sibling's actual PARENT later reaches it
+      // naturally (via a fresh, non-identical Node wrapper for the same
+      // AST position — hence comparing by .id, not by reference).
+      if (bodySibling && !consumedSiblingIds.has(bodySibling.id)) {
+        walkNode(state, bodySibling, depth + 1);
+        consumedSiblingIds.add(bodySibling.id);
+      }
+    }
+
     dispatchExitFunction(visitors, skipDepths, node, funcName, context, depth);
     scopeStack.pop();
     context.currentFunction =
@@ -250,6 +300,8 @@ function walkNode(state: WalkState, node: TreeSitterNode | null, depth: number):
  * @param {string} langId     - language identifier
  * @param {object} [options]
  * @param {Set}    [options.functionNodeTypes] - set of node types that are function boundaries
+ * @param {Set}    [options.bodySiblingTypes]  - set of node types that are a function's body but
+ *                                               live as a sibling of the boundary node, not a child (#2182)
  * @param {Set}    [options.nestingNodeTypes]  - set of node types that increase nesting depth
  * @param {function} [options.getFunctionName] - (funcNode) => string|null
  * @returns {object} Map of visitor.name → finish() result

--- a/src/ast-analysis/visitors/complexity-visitor.ts
+++ b/src/ast-analysis/visitors/complexity-visitor.ts
@@ -269,6 +269,7 @@ export function createComplexityVisitor(
   return {
     name: 'complexity',
     functionNodeTypes: cRules.functionNodes,
+    bodySiblingTypes: cRules.bodySiblingTypes ?? undefined,
 
     enterFunction(
       funcNode: TreeSitterNode,

--- a/src/ast-analysis/visitors/dataflow-visitor.ts
+++ b/src/ast-analysis/visitors/dataflow-visitor.ts
@@ -542,6 +542,7 @@ export function createDataflowVisitor(rules: AnyRules): Visitor {
   return {
     name: 'dataflow',
     functionNodeTypes: rules.functionNodes,
+    bodySiblingTypes: rules.bodySiblingTypes ?? undefined,
 
     enterFunction(
       funcNode: TreeSitterNode,

--- a/src/features/complexity.ts
+++ b/src/features/complexity.ts
@@ -14,6 +14,7 @@ import { walkWithVisitors } from '../ast-analysis/visitor.js';
 import { createComplexityVisitor } from '../ast-analysis/visitors/complexity-visitor.js';
 import { getFunctionNodeId } from '../db/index.js';
 import { debug, info } from '../infrastructure/logger.js';
+import { findBodySiblingNode } from '../shared/ast-nodes.js';
 import type {
   BetterSqlite3Database,
   ComplexityRules,
@@ -112,6 +113,14 @@ export function computeHalsteadMetrics(
   }
 
   walk(functionNode);
+
+  // Some grammars (e.g. tree-sitter-dart) put the function's body in a
+  // sibling node rather than nesting it inside functionNode (#2182) — walk
+  // it too, additively, so its operators/operands aren't silently missed.
+  if (rules.bodySiblingTypes) {
+    const bodySibling = findBodySiblingNode(functionNode, rules.bodySiblingTypes);
+    if (bodySibling) walk(bodySibling);
+  }
 
   return summarizeHalsteadCounts(operators, operands);
 }
@@ -328,6 +337,16 @@ export function computeFunctionComplexity(
   }
 
   walk(functionNode, 0, true);
+
+  // Some grammars (e.g. tree-sitter-dart) put the function's body in a
+  // sibling node rather than nesting it inside functionNode (#2182) — walk
+  // it too, additively (isTopFunction=false, so a nested function inside
+  // the body is still treated as nested rather than as this function's own
+  // top-level scope again).
+  if (rules.bodySiblingTypes) {
+    const bodySibling = findBodySiblingNode(functionNode, rules.bodySiblingTypes);
+    if (bodySibling) walk(bodySibling, 0, false);
+  }
 
   return { cognitive: acc.cognitive, cyclomatic: acc.cyclomatic, maxNesting: acc.maxNesting };
 }

--- a/src/shared/ast-nodes.ts
+++ b/src/shared/ast-nodes.ts
@@ -1,0 +1,33 @@
+import type { TreeSitterNode } from '../types.js';
+
+/**
+ * Find a node's next sibling whose type is in `bodyTypes`, skipping over
+ * intervening `comment` nodes. Needed for grammars (e.g. tree-sitter-dart's
+ * function_signature/function_body split, #2082/#2182) where a function's
+ * body lives as a SIBLING of its signature/declaration node rather than as
+ * a child of it — every consumer that walks only a matched node's own
+ * subtree would otherwise silently see zero body content.
+ *
+ * Returns null if no sibling exists, or if the next non-comment sibling's
+ * type isn't in `bodyTypes` (e.g. tree-sitter-dart's bare `;` for an
+ * abstract method signature with no body at all).
+ */
+export function findBodySiblingNode(
+  node: TreeSitterNode,
+  bodyTypes: Set<string>,
+): TreeSitterNode | null {
+  const parent = node.parent;
+  if (!parent) return null;
+  for (let i = 0; i < parent.childCount; i++) {
+    if (parent.child(i)?.id === node.id) {
+      let j = i + 1;
+      let next = parent.child(j);
+      while (next && next.type === 'comment') {
+        j++;
+        next = parent.child(j);
+      }
+      return next && bodyTypes.has(next.type) ? next : null;
+    }
+  }
+  return null;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1042,11 +1042,21 @@ export interface Visitor {
   exitFunction?(funcNode: TreeSitterNode, funcName: string | null, context: VisitorContext): void;
   finish?(): unknown;
   functionNodeTypes?: Set<string>;
+  /**
+   * Node types whose content is a function's body but lives as a SIBLING of
+   * the function boundary node rather than nested inside it (e.g. tree-sitter
+   * Dart's function_signature/function_body split, #2182). When set, the
+   * walker keeps the function's scope active through this sibling before
+   * firing exitFunction, instead of only ever seeing the boundary node's own
+   * children.
+   */
+  bodySiblingTypes?: Set<string>;
 }
 
 /** Options for walkWithVisitors. */
 export interface WalkOptions {
   functionNodeTypes?: Set<string>;
+  bodySiblingTypes?: Set<string>;
   nestingNodeTypes?: Set<string>;
   getFunctionName?: (node: TreeSitterNode) => string | null;
 }
@@ -1105,6 +1115,13 @@ export interface ComplexityRules {
   optionalChainType: string | null;
   nestingNodes: Set<string>;
   functionNodes: Set<string>;
+  /**
+   * Node types whose content is a function's body but is a SIBLING of the
+   * matched functionNodes node rather than nested inside it (e.g. Dart's
+   * function_signature/function_body split, #2182). Optional — omitted for
+   * every language where the body nests normally.
+   */
+  bodySiblingTypes?: Set<string> | null;
   ifNodeType: string | null;
   elseNodeType: string | null;
   elifNodeType: string | null;
@@ -1118,6 +1135,8 @@ export interface HalsteadRules {
   operandLeafTypes: Set<string>;
   compoundOperators: Set<string>;
   skipTypes: Set<string>;
+  /** See ComplexityRules.bodySiblingTypes — same split-signature/body case (#2182). */
+  bodySiblingTypes?: Set<string> | null;
 }
 
 /** CFG rules for a language (merged result of CFG_DEFAULTS + overrides). */
@@ -1156,6 +1175,8 @@ export interface CfgRulesConfig {
 /** Dataflow rules for a language (merged result of DATAFLOW_DEFAULTS + overrides). */
 export interface DataflowRulesConfig {
   functionNodes: Set<string>;
+  /** See ComplexityRules.bodySiblingTypes — same split-signature/body case (#2182). */
+  bodySiblingTypes?: Set<string> | null;
   nameField: string;
   /** Override for languages with nested function name structures (e.g. C/C++). */
   nameExtractor: ((node: TreeSitterNode) => string | null) | null;

--- a/tests/parsers/dataflow-dart.test.ts
+++ b/tests/parsers/dataflow-dart.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Unit tests for extractDataflow() against parsed Dart ASTs.
+ *
+ * tree-sitter-dart puts a function's body in a SIBLING node
+ * (function_body) rather than nesting it inside function_signature/
+ * method_signature (#2182) — these tests exercise the body-sibling walk
+ * mechanism (src/ast-analysis/visitor.ts) directly through dataflowDart,
+ * for both top-level functions and class methods (method_signature has no
+ * name field of its own; its name/params come from a nested
+ * function_signature, while its body is its own sibling — see b2.ts's
+ * extractDartFunctionName/getDartParamListNode doc comments).
+ */
+import { beforeAll, describe, expect, it } from 'vitest';
+import { createParsers, getParser } from '../../src/domain/parser.js';
+import { extractDataflow } from '../../src/features/dataflow.js';
+
+describe('extractDataflow — Dart', () => {
+  let parsers: any;
+
+  beforeAll(async () => {
+    parsers = await createParsers();
+  });
+
+  function parseAndExtract(code: string) {
+    const parser = getParser(parsers, 'test.dart');
+    if (!parser) return null;
+    const tree = parser.parse(code);
+    return extractDataflow(tree, 'test.dart', [], 'dart');
+  }
+
+  describe('parameters', () => {
+    it('extracts parameters from a top-level function', () => {
+      const data = parseAndExtract(
+        'int add(int a, int b) {\n  var sum = a + b;\n  return sum;\n}\n',
+      );
+      expect(data!.parameters).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ funcName: 'add', paramName: 'a', paramIndex: 0 }),
+          expect.objectContaining({ funcName: 'add', paramName: 'b', paramIndex: 1 }),
+        ]),
+      );
+    });
+
+    it('extracts parameters from a class method exactly once (no double-count via the nested signature)', () => {
+      const data = parseAndExtract(
+        'class Calculator {\n  int add(int a, int b) {\n    return a + b;\n  }\n}\n',
+      );
+      const addParams = (data!.parameters as any[]).filter((p) => p.funcName === 'add');
+      expect(addParams).toHaveLength(2);
+      expect(addParams).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ paramName: 'a', paramIndex: 0 }),
+          expect.objectContaining({ paramName: 'b', paramIndex: 1 }),
+        ]),
+      );
+    });
+
+    it('extracts optional and named parameter groups', () => {
+      const data = parseAndExtract(
+        'int greet(String name, {int times = 1, bool loud = false}) {\n  return times;\n}\n',
+      );
+      expect(data!.parameters).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ funcName: 'greet', paramName: 'name' }),
+          expect.objectContaining({ funcName: 'greet', paramName: 'times' }),
+          expect.objectContaining({ funcName: 'greet', paramName: 'loud' }),
+        ]),
+      );
+    });
+  });
+
+  describe('returns', () => {
+    it('captures a return expression from a top-level function body (sibling of function_signature)', () => {
+      const data = parseAndExtract(
+        'int multiply(int x, int y) {\n  var result = x * y;\n  return result;\n}\n',
+      );
+      expect(data!.returns).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            funcName: 'multiply',
+            referencedNames: expect.arrayContaining(['result']),
+          }),
+        ]),
+      );
+    });
+
+    it('captures a return expression from a class method body (sibling of method_signature)', () => {
+      const data = parseAndExtract(
+        'class Calculator {\n  int add(int a, int b) {\n    var sum = a + b;\n    return sum;\n  }\n}\n',
+      );
+      expect(data!.returns).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            funcName: 'add',
+            referencedNames: expect.arrayContaining(['sum']),
+          }),
+        ]),
+      );
+    });
+
+    it('captures returns from two sibling functions independently (no scope bleed across body-sibling walks)', () => {
+      const data = parseAndExtract(
+        'int helper(int z) {\n  return z;\n}\nint caller(int a) {\n  return a;\n}\n',
+      );
+      expect(data!.returns).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ funcName: 'helper', referencedNames: ['z'] }),
+          expect.objectContaining({ funcName: 'caller', referencedNames: ['a'] }),
+        ]),
+      );
+    });
+  });
+});

--- a/tests/unit/visitor.test.ts
+++ b/tests/unit/visitor.test.ts
@@ -17,6 +17,22 @@ async function ensureParser() {
   };
 }
 
+// Dart's grammar puts a function's body in a SIBLING node
+// (function_signature + function_body under the same parent), not a child
+// (#2182) — used below to test the bodySiblingTypes walker mechanism
+// against a real grammar that actually needs it.
+let parseDart: any;
+
+async function ensureDartParser() {
+  if (parseDart) return;
+  const { createParsers, getParser } = await import('../../src/domain/parser.js');
+  const parsers = await createParsers();
+  parseDart = (code) => {
+    const p = getParser(parsers, 'test.dart');
+    return p.parse(code);
+  };
+}
+
 const { walkWithVisitors } = await import('../../src/ast-analysis/visitor.js');
 
 describe('walkWithVisitors', () => {
@@ -233,5 +249,97 @@ describe('walkWithVisitors', () => {
 
     const results = walkWithVisitors(tree.rootNode, [visitor], 'javascript');
     expect(results.noFinish).toBeUndefined();
+  });
+});
+
+describe('bodySiblingTypes (#2182)', () => {
+  it('walks a function boundary node whose body is a sibling, not a child, before firing exitFunction', async () => {
+    await ensureDartParser();
+    const tree = parseDart('int add(int a, int b) {\n  return a + b;\n}\n');
+    const order: string[] = [];
+    const visitor = {
+      name: 'order',
+      functionNodeTypes: new Set(['function_signature']),
+      bodySiblingTypes: new Set(['function_body']),
+      enterFunction() {
+        order.push('enterFunction');
+      },
+      enterNode(node) {
+        order.push(`enter:${node.type}`);
+      },
+      exitFunction() {
+        order.push('exitFunction');
+      },
+    };
+
+    walkWithVisitors(tree.rootNode, [visitor], 'dart', {
+      functionNodeTypes: new Set(['function_signature']),
+      getFunctionName: (n) => n.childForFieldName('name')?.text ?? null,
+    });
+
+    const exitIdx = order.indexOf('exitFunction');
+    const bodyIdx = order.indexOf('enter:function_body');
+    const returnIdx = order.indexOf('enter:return_statement');
+    expect(exitIdx).toBeGreaterThan(-1);
+    expect(bodyIdx).toBeGreaterThan(-1);
+    expect(returnIdx).toBeGreaterThan(-1);
+    // The sibling body — and everything inside it — must be walked before
+    // exitFunction pops the function's scope, or scope-dependent visitors
+    // (e.g. dataflow's return/assignment tracking) silently see nothing.
+    expect(bodyIdx).toBeLessThan(exitIdx);
+    expect(returnIdx).toBeLessThan(exitIdx);
+  });
+
+  it('does not walk the sibling body twice (once injected, once via the parent’s own natural iteration)', async () => {
+    await ensureDartParser();
+    const tree = parseDart('int add(int a, int b) {\n  return a + b;\n}\n');
+    let functionBodyEnterCount = 0;
+    const visitor = {
+      name: 'count',
+      functionNodeTypes: new Set(['function_signature']),
+      bodySiblingTypes: new Set(['function_body']),
+      enterNode(node) {
+        if (node.type === 'function_body') functionBodyEnterCount++;
+      },
+    };
+
+    walkWithVisitors(tree.rootNode, [visitor], 'dart', {
+      functionNodeTypes: new Set(['function_signature']),
+    });
+
+    expect(functionBodyEnterCount).toBe(1);
+  });
+
+  it('keeps each function’s body-sibling walk in its own scope frame across two sibling functions', async () => {
+    await ensureDartParser();
+    const tree = parseDart(
+      'int helper(int z) {\n  return z;\n}\nint caller(int a) {\n  return a;\n}\n',
+    );
+    const returnsByFunc: Record<string, string[]> = {};
+    const visitor = {
+      name: 'scoped-returns',
+      functionNodeTypes: new Set(['function_signature']),
+      bodySiblingTypes: new Set(['function_body']),
+      enterFunction(_node, funcName) {
+        if (funcName) returnsByFunc[funcName] = [];
+      },
+      enterNode(node, context) {
+        if (node.type === 'return_statement') {
+          const active = context.currentFunction;
+          const name = active?.childForFieldName?.('name')?.text;
+          if (name) returnsByFunc[name].push(node.text);
+        }
+      },
+    };
+
+    walkWithVisitors(tree.rootNode, [visitor], 'dart', {
+      functionNodeTypes: new Set(['function_signature']),
+      getFunctionName: (n) => n.childForFieldName('name')?.text ?? null,
+    });
+
+    expect(returnsByFunc.helper).toHaveLength(1);
+    expect(returnsByFunc.caller).toHaveLength(1);
+    expect(returnsByFunc.helper[0]).toContain('return z');
+    expect(returnsByFunc.caller[0]).toContain('return a');
   });
 });


### PR DESCRIPTION
## Summary

Closes #2182

tree-sitter-dart's `function_signature`/`method_signature` never contain their own body — it's a SIBLING node (`function_body`) under the same parent, not a child. Every walker that recurses only into a matched function node's own children (`src/ast-analysis/visitor.ts`'s shared DFS walker, plus the standalone `computeFunctionComplexity`/`computeHalsteadMetrics` in `src/features/complexity.ts`) exits/pops the function's scope before ever reaching the body, so complexity/Halstead would silently compute the trivial base case, and `dataflowDart`'s return/assignment/call/mutation tracking (`b2.ts`) never saw a single statement.

## Fix

Added a generic `bodySiblingTypes` mechanism (`ComplexityRules`/`HalsteadRules`/`DataflowRulesConfig`, `Visitor`/`WalkOptions`) so a language's rules can declare that a function boundary's body lives in a sibling node. `visitor.ts`'s walker now finds and walks that sibling — with the function's scope frame still active — before firing `exitFunction`/popping, instead of only ever seeing the boundary node's own subtree. Wired `dataflowDart` to it now, since it's the only live Dart consumer; `COMPLEXITY_RULES`/`HALSTEAD_RULES` don't have a Dart entry yet (#1923's tier-2 rollout), but the mechanism is ready for when they do.

A real bug surfaced while building this: the "don't re-walk an already-consumed sibling" guard used a `Set<TreeSitterNode>` keyed by object reference, but tree-sitter node wrapper objects aren't stable across separate `.child()`/`.parent()` calls for the same AST position (confirmed by the existing `.id`-based comparison already used in `extractors/dart.ts`) — so the guard silently never matched, and the sibling was walked twice. Caught by a dedicated regression test, not by output inspection (dataflow's own scope-name gating happened to mask the symptom for parameters/returns in the cases I checked by hand; an ungated visitor like the future complexity one would have silently doubled cyclomatic/cognitive counts for every Dart function's body). Fixed by tracking node `.id` instead of the node itself.

## Additional dataflowDart bugs found while verifying the fix end-to-end

The fix produced nothing observable until these were also corrected — all independent of the sibling-body issue itself, contrary to this repo's #2182 report assuming parameter extraction "happened to work":

- `paramListField: 'parameters'` can never match — neither `function_signature` nor `method_signature` has a named `parameters` field in this grammar (confirmed via `node-types.json`); `formal_parameter_list` is an unnamed positional child. Replaced with a `getParamListNode` override.
- `method_signature` has no `name` field of its own — a method's name lives on its nested `function_signature`/`getter_signature`/`setter_signature`/`constructor_signature` child. Without a matching `nameExtractor`, every return/assignment/call inside a Dart METHOD's body was silently dropped (`handleReturn` et al. gate on `scope.funcName` being truthy).
- `extractDartParamName` checked for `'optional_formal_parameter'`/`'named_formal_parameter'` node types that don't exist in this grammar — only the plural `optional_formal_parameters` (a group wrapper for `[..]`/`{..}` param lists) exists. Added recursive handling for it.

## Scope boundary

Filed rather than fixed inline (independent of the sibling-body architecture bug specifically):
- #2356 — arrow-body (`=>`) functions never record an implicit return
- #2357 — local variable declarations/assignments and calls still entirely unconfigured for Dart
- #2358 — `extractParams` gives every name from one grouped-param wrapper the same `paramIndex` (a cross-language generic-mechanism gap, not Dart-specific)
- #2359 — Rust engine has no Dart dataflow at all; needs a `body_sibling_types`-aware `DartDataflowRules` port, noting the Rust-native tree-sitter-dart grammar structurally differs from the WASM one (a `function_declaration` wrapper node, and a real `parameters` field that the WASM grammar lacks)

Added `crate::shared::ast_nodes::find_body_sibling_node` (Rust mirror of the new TS helper, unit-tested against the real Rust-native tree-sitter-dart grammar) plus doc comments at both engines' language-rules registries pointing future implementers at it, but did not touch `LangRules`/`DataflowRules`' ~19 existing per-language struct literals for a mechanism with zero current Rust consumers.

## Test plan

- [x] New `tests/unit/visitor.test.ts` suite: scope stays active through the sibling, the sibling is walked exactly once, and two sibling functions each get their own scope frame.
- [x] New `tests/parsers/dataflow-dart.test.ts`: parameters (top-level function, class method with no double-count, optional/named groups) and returns (top-level function, class method, two independent functions).
- [x] Manually verified `computeFunctionComplexity`/`computeAllMetrics` against a synthetic Dart complexity config with an if/else-if/else body: cyclomatic 3 both before and after wiring through `bodySiblingTypes` (no doubling).
- [x] Full `npm test`: 289 files, 4630 passed, 30 skipped, 2 todo.
- [x] `cargo test --lib`: 823 passed (3 new).
- [x] `npx tsc --noEmit`, `npm run lint`, `cargo fmt --check`: clean.
- [x] `scripts/parity-compare.mjs --langs javascript,typescript,tsx,dart`: node/edge counts identical between engines (the only parity dimension this change could affect — the shared walker fix is TS/WASM-only and gated entirely behind a `bodySiblingTypes` check that stays empty, hence a no-op, for every language but Dart).