### PR TITLE
fix(skills): dogfood skill hardcodes wrong GitHub repo slug

### DIFF
--- a/.claude/skills/dogfood/SKILL.md
+++ b/.claude/skills/dogfood/SKILL.md
@@ -45,7 +45,7 @@ Your goal is to install the published package, exercise every feature, compare e
 
    > **Tip:** To find the latest dev version, run:
    > ```bash
-   > gh release list --repo optave/codegraph --json tagName --jq '.[] | select(.tagName | startswith("dev-v")) | .tagName' | head -1 | sed 's/^dev-v//'
+   > gh release list --repo optave/ops-codegraph-tool --json tagName --jq '.[] | select(.tagName | startswith("dev-v")) | .tagName' | head -1 | sed 's/^dev-v//'
    > ```
 
 3. Verify the install: `npx codegraph --version` should print `$ARGUMENTS`.
@@ -292,7 +292,7 @@ For each bug found during testing:
 ### 7a. Check for duplicates
 
 ```bash
-gh issue list --repo optave/codegraph --state open --search "<bug title keywords>"
+gh issue list --repo optave/ops-codegraph-tool --state open --search "<bug title keywords>"
 ```
 
 If a matching issue already exists, skip creating a new one. Add a comment with your findings if you have new information.
@@ -302,7 +302,7 @@ If a matching issue already exists, skip creating a new one. Add a comment with 
 For each **new** bug, create a GitHub issue:
 
 ```bash
-gh issue create --repo optave/codegraph \
+gh issue create --repo optave/ops-codegraph-tool \
   --title "bug: <concise title>" \
   --label "bug,dogfood" \
   --body "$(cat <<'ISSUE_EOF'


### PR DESCRIPTION
## Summary

Closes #2184

Three `gh --repo` flags in `.claude/skills/dogfood/SKILL.md` pointed at `optave/codegraph` instead of the actual repo, `optave/ops-codegraph-tool`: `gh release list` (finding the latest dev version, line 48), `gh issue list` (duplicate-bug check, Phase 7a), and `gh issue create` (filing a new bug, Phase 7b).

## Fix

Hardcoded the correct literal slug at each site rather than detecting it dynamically via `gh repo view` (the approach used for `/resolve` and `/sweep`, #1966): unlike those skills, `/dogfood`'s own Phase 0 explicitly creates and `cd`s into a separate temp npm project to install and test the published package, so by the time Phase 7 runs, the working directory is very unlikely to be a checkout of this repo at all — `gh repo view` there would fail or resolve to the wrong repo entirely. This also matches the file's own existing pattern — the release tarball URLs a few lines above line 48 already hardcode the correct slug literally.

Every other `optave/codegraph` occurrence in this file is the npm package name (`@optave/codegraph`, `@optave/codegraph-<platform>-<arch>`), which is correct and untouched.

## Test plan

- [x] Confirmed no remaining `--repo optave/codegraph` occurrences; every other `optave/codegraph` mention is a legitimate npm package name.
- [x] `.claude/skills/create-skill/scripts/lint-skill.sh` against this file: identical findings before and after (1 pre-existing error, 12 pre-existing warnings, none related to this change).