### PR TITLE
fix(skills): resolve's repo-detection fallback regex retains .git suffix

### DIFF
--- a/.claude/skills/resolve/SKILL.md
+++ b/.claude/skills/resolve/SKILL.md
@@ -60,7 +60,7 @@ fi
 # Detect repo slug dynamically so the skill works in any fork or renamed org
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null \
   || git remote get-url origin 2>/dev/null \
-     | sed -nE 's#^(git@github\.com:|https://github\.com/)([^/]+/[^/]+)/?$#\2#p' \
+     | sed -nE 's#^(git@github\.com:|https://github\.com/|ssh://git@github\.com/)([^/]+/[^/]+)/?$#\2#p' \
      | sed -E 's/\.git$//')
 if [ -z "$REPO" ]; then
   echo "ERROR: could not detect GitHub repo slug — ensure 'gh' is authenticated or 'origin' points to GitHub"
@@ -81,7 +81,7 @@ Persist PR metadata for use in later phases (shell variables don't survive acros
 PR_NUMBER=$(echo "${ARGUMENTS:-}" | tr -d '[:space:]#')
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null \
   || git remote get-url origin 2>/dev/null \
-     | sed -nE 's#^(git@github\.com:|https://github\.com/)([^/]+/[^/]+)/?$#\2#p' \
+     | sed -nE 's#^(git@github\.com:|https://github\.com/|ssh://git@github\.com/)([^/]+/[^/]+)/?$#\2#p' \
      | sed -E 's/\.git$//')
 mkdir -p .codegraph/resolve
 # Trap ensures .codegraph/resolve/ is always cleaned up on non-zero exit, even after a crash.

--- a/.claude/skills/resolve/SKILL.md
+++ b/.claude/skills/resolve/SKILL.md
@@ -59,7 +59,9 @@ fi
 
 # Detect repo slug dynamically so the skill works in any fork or renamed org
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null \
-  || git remote get-url origin | sed -E 's|.*github\.com[:/](.+)(\.git)?$|\1|')
+  || git remote get-url origin 2>/dev/null \
+     | sed -nE 's#^(git@github\.com:|https://github\.com/)([^/]+/[^/]+)/?$#\2#p' \
+     | sed -E 's/\.git$//')
 if [ -z "$REPO" ]; then
   echo "ERROR: could not detect GitHub repo slug — ensure 'gh' is authenticated or 'origin' points to GitHub"
   exit 1
@@ -78,7 +80,9 @@ Persist PR metadata for use in later phases (shell variables don't survive acros
 ```bash
 PR_NUMBER=$(echo "${ARGUMENTS:-}" | tr -d '[:space:]#')
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null \
-  || git remote get-url origin | sed -E 's|.*github\.com[:/](.+)(\.git)?$|\1|')
+  || git remote get-url origin 2>/dev/null \
+     | sed -nE 's#^(git@github\.com:|https://github\.com/)([^/]+/[^/]+)/?$#\2#p' \
+     | sed -E 's/\.git$//')
 mkdir -p .codegraph/resolve
 # Trap ensures .codegraph/resolve/ is always cleaned up on non-zero exit, even after a crash.
 # This prevents stale state from corrupting a future re-run (Phase 1 reads head-branch / base-branch


### PR DESCRIPTION
## Summary

Closes #2186

Greptile caught the identical flaw in PR #2185 while reviewing the same fallback pattern being added to `/sweep`. `/resolve` had it in two places (`gh repo view`'s fallback, only exercised when `gh` isn't authenticated):

```bash
REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null \
  || git remote get-url origin | sed -E 's|.*github\.com[:/](.+)(\.git)?$|\1|')
```

1. The greedy `(.+)` capture swallows `.git` before the optional `(\.git)?` group ever gets a chance to match it, so a standard `https://github.com/owner/repo.git` or `git@github.com:owner/repo.git` remote resolves to `owner/repo.git` instead of `owner/repo` — every subsequent `gh --repo` call in the skill then targets an invalid slug.
2. When `origin` isn't a `github.com` URL at all, plain `sed 's|pattern|replacement|'` leaves a non-matching line unchanged, so the raw (wrong) URL becomes `$REPO` — non-empty, so the existing `-z` guard doesn't catch it, and the skill proceeds with a garbage repo identifier instead of failing loudly.

## Fix

Mirrors the exact fix already applied to `/sweep` in PR #2185: a two-pass `sed` (non-greedy quantifiers aren't POSIX ERE — `+?` errors on BSD sed's `-E` and isn't GNU-portable either). The first pass only prints when the URL is a genuine `github.com` remote (so a non-GitHub `origin` correctly produces empty output, caught by the `-z` guard); the second unconditionally strips a trailing `.git`, sidestepping the greedy-capture problem entirely.

## Test plan

- [x] Verified the new regex against `https://github.com/owner/repo.git`, `git@github.com:owner/repo.git`, `https://github.com/owner/repo` (no suffix), and a non-GitHub remote (`https://gitlab.com/owner/repo.git`) — all four resolve correctly (`owner/repo`, `owner/repo`, `owner/repo`, empty respectively).
- [x] `.claude/skills/create-skill/scripts/lint-skill.sh` against this file: same pre-existing errors, plus the same `2>/dev/null`-without-comment warning already present (and unaddressed) on the identical construct in `/sweep`'s already-merged version — no new issue class introduced.