### PR TITLE
fix(exports): consumer discriminator misclassifies top-level calls

### DIFF
--- a/src/domain/analysis/exports.ts
+++ b/src/domain/analysis/exports.ts
@@ -20,7 +20,7 @@ const _consumersStmtCache: StmtCache<{
   name: string;
   file: string;
   line: number;
-  sourceKind: string;
+  edgeKind: string;
 }> = new WeakMap();
 const _reexportsFromStmtCache: StmtCache<{ file: string }> = new WeakMap();
 const _reexportsToStmtCache: StmtCache<{ file: string }> = new WeakMap();
@@ -184,7 +184,7 @@ function exportsFileImpl(
   const consumersStmt = cachedStmt(
     _consumersStmtCache,
     db,
-    `SELECT n.name, n.file, n.line, n.kind AS sourceKind FROM edges e JOIN nodes n ON e.source_id = n.id
+    `SELECT n.name, n.file, n.line, e.kind AS edgeKind FROM edges e JOIN nodes n ON e.source_id = n.id
          WHERE e.target_id = ? AND e.kind IN ('calls', 'imports-type')`,
   );
   const reexportsFromStmt = cachedStmt(
@@ -232,7 +232,7 @@ function exportsFileImpl(
         name: string;
         file: string;
         line: number;
-        sourceKind: string;
+        edgeKind: string;
       }>;
       if (noTests) consumers = consumers.filter((c) => !isTestFile(c.file));
 
@@ -244,17 +244,24 @@ function exportsFileImpl(
         role: s.role || null,
         signature: fileLines ? extractSignature(fileLines, s.line, displayOpts) : null,
         summary: fileLines ? extractSummary(fileLines, s.line, displayOpts) : null,
-        // `consumerKind` discriminates a real caller/constructor symbol
-        // (source is a function/method/class node with a genuine call-site
-        // line) from a whole-file reference such as `import type { X }`
-        // (source is the importing file node itself — see the comment on
-        // `consumersStmt` above). Renderers must not treat `name`/`line` on
-        // a `'file'` entry as a caller symbol/call-site (#1830).
+        // `consumerKind` discriminates a real caller/constructor symbol (a
+        // genuine `calls` edge, with a real call-site line) from a
+        // whole-file reference such as `import type { X }` (an
+        // `imports-type` edge, always sourced from the importing file node
+        // itself — see emitNamedSymbolEdges). Keyed off the *edge* kind,
+        // not the source node's kind: findCaller falls back to the file
+        // node as a call's source for a genuine top-level call with no
+        // enclosing function/binding (e.g. a bare statement at module
+        // scope), so a `calls` edge can legitimately have a file-kind
+        // source too — using source kind alone would misclassify that real
+        // call as a type-only import (Greptile, #1973/#2189). Renderers
+        // must not treat `name`/`line` on a `'file'` entry as a caller
+        // symbol/call-site (#1830).
         consumers: consumers.map((c) => ({
           name: c.name,
           file: c.file,
           line: c.line,
-          consumerKind: c.sourceKind === 'file' ? ('file' as const) : ('symbol' as const),
+          consumerKind: c.edgeKind === 'imports-type' ? ('file' as const) : ('symbol' as const),
         })),
         consumerCount: consumers.length,
       };

--- a/tests/integration/exports.test.ts
+++ b/tests/integration/exports.test.ts
@@ -275,10 +275,16 @@ describe('exportsData — import type consumer crediting (#1724)', () => {
     const configIface = insertNode(db, 'Config', 'interface', 'types.ts', 1);
     // Interface exported from types.ts, genuinely never referenced anywhere.
     const unusedIface = insertNode(db, 'Unused', 'interface', 'types.ts', 10);
+    // Exported function called from a bare top-level statement in
+    // consumer.ts with no enclosing function/binding — findCaller falls
+    // back to the *file* node as the call's source in that case, so this
+    // is a genuine 'calls' edge sourced from a file-kind node (#2189).
+    const topLevelTarget = insertNode(db, 'topLevelTarget', 'function', 'types.ts', 20);
 
     const markExported = db.prepare('UPDATE nodes SET exported = 1 WHERE id = ?');
     markExported.run(configIface);
     markExported.run(unusedIface);
+    markExported.run(topLevelTarget);
 
     // consumer.ts does `import type { Config } from './types'`. The builder
     // emits the symbol-level edge with the importing *file* as source (see
@@ -286,6 +292,9 @@ describe('exportsData — import type consumer crediting (#1724)', () => {
     // and incremental.ts) since the import statement — not a specific
     // function — is what references the type.
     insertEdge(db, fConsumer, configIface, 'imports-type');
+    // consumer.ts calls topLevelTarget() from a bare top-level statement —
+    // a real 'calls' edge sourced from the file node itself (#2189).
+    insertEdge(db, fConsumer, topLevelTarget, 'calls');
 
     db.close();
   });
@@ -315,6 +324,20 @@ describe('exportsData — import type consumer crediting (#1724)', () => {
     // importing file), unlike a real caller whose name is a function/method.
     expect(config.consumers[0].name).toBe('consumer.ts');
     expect(config.consumers[0].line).toBe(0);
+  });
+
+  // Regression coverage for #2189: a genuine top-level `calls` edge sourced
+  // from a file node (findCaller's fallback for a bare top-level statement
+  // with no enclosing function/binding) must NOT be misclassified as a
+  // type-only import just because its source happens to be file-kind —
+  // the discriminator must key off the *edge* kind, not the source node's
+  // kind, which the two rows in this fixture happen to share.
+  test('a real top-level call sourced from a file node is discriminated as symbol-level, not file-level (#2189)', () => {
+    const data = exportsData('types.ts', dbPath2);
+    const target = data.results.find((r) => r.name === 'topLevelTarget');
+    expect(target).toBeDefined();
+    expect(target.consumers.length).toBe(1);
+    expect(target.consumers[0].consumerKind).toBe('symbol');
   });
 
   test('interface consumed only via `import type` is excluded from --unused', () => {


### PR DESCRIPTION
## Summary

Closes #2189

`exports.ts`'s `consumersStmt` keyed `consumerKind` off the SOURCE NODE's kind (`n.kind === 'file'`), not the edge's own kind. `findCaller` (`domain/graph/builder/call-resolver.ts`) falls back to the file node as a call's source when there's no enclosing function/method or variable binding — a bare top-level statement — which produces a genuine `calls` edge sourced from a file-kind node, structurally identical from the source-node's-kind point of view to an `imports-type` edge (always file-sourced by construction). A real top-level call to an exported function was misclassified `consumerKind: 'file'` and rendered as a type-only import, hiding a genuine caller.

## Fix

Applies the identical fix already validated for the same discriminator in `src/features/check.ts`'s `checkNoDeletedExportsInUse` (via `src/db/repository/edges.ts`'s `findExternalConsumers`, #1973): select `e.kind AS edgeKind` instead of the source node's kind, and discriminate on `edgeKind === 'imports-type'`.

## Test plan

- [x] Added a regression test reproducing the exact scenario (an exported function called from a bare top-level statement, sourced from the importing file's own node) — verified it fails against the old source-kind logic (`consumerKind: 'file'` instead of `'symbol'`) and passes against the fix.
- [x] Full `tests/integration/exports.test.ts`: 24 passed.
- [x] `npx tsc --noEmit`, `npm run lint`: clean.
- [x] Full `npm test`: 289 files, 4631 passed.