### PR TITLE
docs: readme Node version badge says >=22.6, package.json requires >=22.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://www.npmjs.com/package/@optave/codegraph"><img src="https://img.shields.io/npm/v/@optave/codegraph?style=flat-square&logo=npm&logoColor=white&label=npm" alt="npm version" /></a>
   <a href="https://github.com/optave/ops-codegraph-tool/blob/main/LICENSE"><img src="https://img.shields.io/github/license/optave/ops-codegraph-tool?style=flat-square&logo=opensourceinitiative&logoColor=white" alt="Apache-2.0 License" /></a>
   <a href="https://github.com/optave/ops-codegraph-tool/actions"><img src="https://img.shields.io/github/actions/workflow/status/optave/ops-codegraph-tool/codegraph-impact.yml?style=flat-square&logo=githubactions&logoColor=white&label=CI" alt="CI" /></a>
-  <img src="https://img.shields.io/badge/node-%3E%3D22.6-339933?style=flat-square&logo=node.js&logoColor=white" alt="Node >= 22.6" />
+  <img src="https://img.shields.io/badge/node-%3E%3D22.12.0-339933?style=flat-square&logo=node.js&logoColor=white" alt="Node >= 22.12.0" />
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

Closes #2190

Same staleness #1976/#1831 already found and fixed in CLAUDE.md/CONTRIBUTING.md — this time in the README badge instead. `generated/*.md` files also mention 22.6 but are auto-generated historical snapshots, not in scope.

## Test plan

- [x] Verified `package.json`'s `engines.node` is `>=22.12.0`.
- [x] Confirmed no other actively-maintained (non-`generated/`) doc still references `22.6`.