### PR TITLE
chore: sync Cargo.lock codegraph-core version to 3.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "codegraph-core"
-version = "3.15.0"
+version = "3.16.0"
 dependencies = [
  "globset",
  "ignore",


### PR DESCRIPTION
## Summary

Closes #2201

`crates/codegraph-core/Cargo.toml` already declared `3.16.0`, but the committed `Cargo.lock` still recorded `codegraph-core` at `3.15.0` — a release-tooling step evidently bumped `Cargo.toml` without regenerating the lockfile. This surfaced as an unrelated one-line `Cargo.lock` diff on the first Rust build in any fresh clone/worktree (observed repeatedly across this batch's other PRs).

## Fix

Regenerated via a real `cargo build` so the lockfile matches `Cargo.toml`.

## Test plan

- [x] `cargo build --manifest-path crates/codegraph-core/Cargo.toml --release`: produces exactly the expected one-line diff.
- [x] `cargo test --lib`: 823 passed.
- [x] `cargo fmt --check`: clean.