### PR TITLE
fix(rust): if-let-bound method calls resolve to cross-file Option/Result return types

### DIFF
--- a/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
@@ -1722,6 +1722,40 @@ fn build_return_type_index(
     (return_type_index, global_return_types)
 }
 
+/// If `type_name` is `Option<T>` or `Result<T, E>`, return `T` — the type a
+/// refutable `Some(x)`/`Ok(x)` pattern (`if let`/`while let`/`let-else`) binds
+/// `x` to. Handles nested generics in the first type argument
+/// (`Result<Vec<User>, String>` → `Vec<User>`) by tracking bracket depth rather
+/// than splitting on the first comma. Returns `None` for any other shape,
+/// including a malformed generic string, so the caller can decline to inject a
+/// guessed type rather than propagate something wrong. Mirrors
+/// `unwrapOptionResultType` in `build-edges.ts` (#2214).
+fn unwrap_option_result_type(type_name: &str) -> Option<&str> {
+    let (base, rest) = type_name.split_once('<')?;
+    if base.trim() != "Option" && base.trim() != "Result" {
+        return None;
+    }
+    let inner = rest.strip_suffix('>')?;
+    let mut depth = 0i32;
+    for (i, c) in inner.char_indices() {
+        match c {
+            '<' => depth += 1,
+            '>' => depth -= 1,
+            ',' if depth == 0 => {
+                let first = inner[..i].trim();
+                return if first.is_empty() { None } else { Some(first) };
+            }
+            _ => {}
+        }
+    }
+    let first = inner.trim();
+    if first.is_empty() {
+        None
+    } else {
+        Some(first)
+    }
+}
+
 /// Inject cross-file return types into a single file's `type_map`.
 ///
 /// For each call-assignment in the file (`const x = callee()`), looks up the
@@ -1761,9 +1795,36 @@ fn inject_return_types_for_file(
             continue;
         }
 
-        let found = match &ca.receiver_type_name {
-            Some(receiver) => global_return_types.get(&format!("{receiver}.{}", ca.callee_name)),
-            None => imported_map.get(&ca.callee_name).and_then(|from| {
+        // A method call whose receiver's type wasn't known at extraction time
+        // (`ca.receiver_var_name`) may have just been resolved by an earlier
+        // call-assignment in this same file — e.g. `service` in `let service =
+        // build_service(); ... service.get_user(1)` only becomes typed once
+        // `service`'s own cross-file return type is injected. Retry against the
+        // receiver's now-resolved type (its original same-file type_map entry,
+        // or an injection already added earlier in this loop) before falling
+        // back to a bare global-function lookup (#2214).
+        let receiver_resolved_type = ca.receiver_var_name.as_ref().and_then(|receiver_var| {
+            symbols
+                .type_map
+                .iter()
+                .find(|t| &t.name == receiver_var)
+                .map(|t| t.type_name.as_str())
+                .or_else(|| {
+                    injections
+                        .iter()
+                        .find(|t| &t.name == receiver_var)
+                        .map(|t| t.type_name.as_str())
+                })
+        });
+
+        let found = match (&ca.receiver_type_name, receiver_resolved_type) {
+            (Some(receiver), _) => {
+                global_return_types.get(&format!("{receiver}.{}", ca.callee_name))
+            }
+            (None, Some(receiver_type)) => {
+                global_return_types.get(&format!("{receiver_type}.{}", ca.callee_name))
+            }
+            (None, None) => imported_map.get(&ca.callee_name).and_then(|from| {
                 // The return-type index for the imported file is keyed by the
                 // function's own declared name — use the original (pre-rename)
                 // name when the callee is a renamed import binding (#1730).
@@ -1777,11 +1838,30 @@ fn inject_return_types_for_file(
         };
 
         if let Some((type_name, confidence)) = found {
+            // `ca.unwrap_generic` means the binding came from a refutable
+            // `Some(x)`/`Ok(x)` pattern — the callee's declared return type is
+            // itself `Option<T>`/`Result<T, _>`, and `x`'s real type is the
+            // unwrapped `T`, not the wrapper. If the declared type turns out not
+            // to actually be a generic Option/Result (a mismatch between the
+            // pattern and the callee's real signature), decline to inject rather
+            // than propagate the wrapper type as if it were `x`'s type (#2214).
+            let resolved_type_name = if ca.unwrap_generic {
+                match unwrap_option_result_type(type_name) {
+                    Some(inner) => Some(inner.to_string()),
+                    None => None,
+                }
+            } else {
+                Some(type_name.clone())
+            };
+            let Some(resolved_type_name) = resolved_type_name else {
+                continue;
+            };
+
             let propagated = confidence - hop_penalty;
             if propagated > 0.0 {
                 injections.push(TypeMapEntry {
                     name: ca.var_name.clone(),
-                    type_name: type_name.clone(),
+                    type_name: resolved_type_name,
                     confidence: propagated,
                 });
                 injected.insert(ca.var_name.clone());
@@ -2468,6 +2548,8 @@ mod tests {
                 var_name: "svc".to_string(),
                 callee_name: "buildService".to_string(),
                 receiver_type_name: None,
+                receiver_var_name: None,
+                unwrap_generic: false,
             });
 
         let mut file_symbols = BTreeMap::new();
@@ -2504,6 +2586,8 @@ mod tests {
                 var_name: "w".to_string(),
                 callee_name: "create".to_string(),
                 receiver_type_name: Some("Factory".to_string()),
+                receiver_var_name: None,
+                unwrap_generic: false,
             });
 
         let mut file_symbols = BTreeMap::new();
@@ -2522,6 +2606,110 @@ mod tests {
             .expect("w seeded");
         assert_eq!(seeded.type_name, "Widget");
         assert!((seeded.confidence - 0.9).abs() < 1e-9);
+    }
+
+    // ── if-let/while-let Option/Result unwrap + two-hop receiver resolution (#2214) ─
+
+    #[test]
+    fn unwraps_option_return_type_for_if_let_bound_call_assignment() {
+        let mut service = FileSymbols::new("service.rs".to_string());
+        service
+            .return_type_map
+            .push(entry("UserService.get_user", "Option<User>", 1.0));
+
+        let mut main = FileSymbols::new("main.rs".to_string());
+        // `service`'s own type is already resolved locally — simulating that its
+        // cross-file call-assignment was injected earlier in this same pass.
+        main.type_map.push(entry("service", "UserService", 0.9));
+        main.call_assignments
+            .push(crate::types::NativeCallAssignment {
+                var_name: "user".to_string(),
+                callee_name: "get_user".to_string(),
+                receiver_type_name: None,
+                receiver_var_name: Some("service".to_string()),
+                unwrap_generic: true,
+            });
+
+        let mut file_symbols = BTreeMap::new();
+        file_symbols.insert("service.rs".to_string(), service);
+        file_symbols.insert("main.rs".to_string(), main);
+        let import_ctx = make_import_ctx(&file_symbols);
+
+        let conn = Connection::open_in_memory().unwrap();
+        propagate_return_types_across_files(&conn, &mut file_symbols, &import_ctx);
+
+        let main = &file_symbols["main.rs"];
+        let seeded = main
+            .type_map
+            .iter()
+            .find(|t| t.name == "user")
+            .expect("user should be seeded, unwrapped from Option<User>");
+        assert_eq!(seeded.type_name, "User");
+    }
+
+    #[test]
+    fn declines_to_inject_when_unwrap_generic_but_declared_type_is_not_generic() {
+        let mut service = FileSymbols::new("service.rs".to_string());
+        // Declared type doesn't actually match the if-let's Some/Ok assumption —
+        // a mismatch between the pattern and the callee's real signature.
+        service
+            .return_type_map
+            .push(entry("UserService.get_user", "User", 1.0));
+
+        let mut main = FileSymbols::new("main.rs".to_string());
+        main.type_map.push(entry("service", "UserService", 0.9));
+        main.call_assignments
+            .push(crate::types::NativeCallAssignment {
+                var_name: "user".to_string(),
+                callee_name: "get_user".to_string(),
+                receiver_type_name: None,
+                receiver_var_name: Some("service".to_string()),
+                unwrap_generic: true,
+            });
+
+        let mut file_symbols = BTreeMap::new();
+        file_symbols.insert("service.rs".to_string(), service);
+        file_symbols.insert("main.rs".to_string(), main);
+        let import_ctx = make_import_ctx(&file_symbols);
+
+        let conn = Connection::open_in_memory().unwrap();
+        propagate_return_types_across_files(&conn, &mut file_symbols, &import_ctx);
+
+        let main = &file_symbols["main.rs"];
+        assert!(main.type_map.iter().all(|t| t.name != "user"));
+    }
+
+    #[test]
+    fn resolves_receiver_var_name_via_type_map_when_receiver_type_name_absent() {
+        let mut repo = FileSymbols::new("repo.rs".to_string());
+        repo.return_type_map
+            .push(entry("UserRepository.find_by_id", "User", 1.0));
+
+        let mut main = FileSymbols::new("main.rs".to_string());
+        main.type_map.push(entry("repo", "UserRepository", 1.0));
+        main.call_assignments
+            .push(crate::types::NativeCallAssignment {
+                var_name: "user".to_string(),
+                callee_name: "find_by_id".to_string(),
+                receiver_type_name: None,
+                receiver_var_name: Some("repo".to_string()),
+                unwrap_generic: false,
+            });
+
+        let mut file_symbols = BTreeMap::new();
+        file_symbols.insert("repo.rs".to_string(), repo);
+        file_symbols.insert("main.rs".to_string(), main);
+        let import_ctx = make_import_ctx(&file_symbols);
+
+        let conn = Connection::open_in_memory().unwrap();
+        propagate_return_types_across_files(&conn, &mut file_symbols, &import_ctx);
+
+        let main = &file_symbols["main.rs"];
+        let seeded =
+            main.type_map.iter().find(|t| t.name == "user").expect(
+                "user should resolve via receiver_var_name -> type_map -> global_return_types",
+            );
+        assert_eq!(seeded.type_name, "User");
     }
 
     #[test]
@@ -2544,6 +2732,8 @@ mod tests {
                 var_name: "svc".to_string(),
                 callee_name: "buildService".to_string(),
                 receiver_type_name: None,
+                receiver_var_name: None,
+                unwrap_generic: false,
             });
 
         let mut file_symbols = BTreeMap::new();
@@ -2562,5 +2752,36 @@ mod tests {
             "no duplicate entry should be injected"
         );
         assert_eq!(svc_entries[0].type_name, "LocalOverride");
+    }
+
+    #[test]
+    fn unwrap_option_result_type_unwraps_option() {
+        assert_eq!(unwrap_option_result_type("Option<User>"), Some("User"));
+    }
+
+    #[test]
+    fn unwrap_option_result_type_unwraps_result_taking_the_first_type_argument() {
+        assert_eq!(
+            unwrap_option_result_type("Result<User, String>"),
+            Some("User")
+        );
+    }
+
+    #[test]
+    fn unwrap_option_result_type_handles_nested_generics_in_the_first_argument() {
+        assert_eq!(
+            unwrap_option_result_type("Result<Vec<User>, String>"),
+            Some("Vec<User>")
+        );
+    }
+
+    #[test]
+    fn unwrap_option_result_type_returns_none_for_a_non_generic_type() {
+        assert_eq!(unwrap_option_result_type("User"), None);
+    }
+
+    #[test]
+    fn unwrap_option_result_type_returns_none_for_an_unrelated_generic() {
+        assert_eq!(unwrap_option_result_type("Vec<User>"), None);
     }
 }

--- a/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
@@ -1761,6 +1761,7 @@ fn unwrap_option_result_type(type_name: &str) -> Option<&str> {
 /// Without this, a nested generic payload would inject a parameterized name where
 /// every other path in this pipeline injects a bare one (Greptile review, PR #2371).
 fn normalize_unwrapped_generic_arg(arg: &str) -> Option<&str> {
+    let arg = strip_reference_sigil(arg.trim());
     if arg.is_empty() {
         return None;
     }
@@ -1773,6 +1774,26 @@ fn normalize_unwrapped_generic_arg(arg: &str) -> Option<&str> {
     } else {
         Some(inner_base)
     }
+}
+
+/// Strip a leading `&`/`&mut `/`&'a `/`&'a mut ` reference sigil, the same way
+/// `extract_rust_type_name`'s `reference_type` branch does for a direct
+/// annotation — `Option<&User>`/`Option<&'a mut User>`'s bound value's real
+/// receiver type is `User`, not the reference syntax around it (Greptile
+/// review, PR #2371).
+fn strip_reference_sigil(s: &str) -> &str {
+    let Some(rest) = s.strip_prefix('&') else {
+        return s;
+    };
+    let mut rest = rest.trim_start();
+    if rest.starts_with('\'') {
+        if let Some(idx) = rest.find(char::is_whitespace) {
+            rest = rest[idx..].trim_start();
+        }
+    }
+    rest.strip_prefix("mut ")
+        .map(str::trim_start)
+        .unwrap_or(rest)
 }
 
 /// Inject cross-file return types into a single file's `type_map`.
@@ -2806,6 +2827,56 @@ mod tests {
         assert_eq!(
             unwrap_option_result_type("Option<Option<User>>"),
             Some("Option<User>")
+        );
+    }
+
+    #[test]
+    fn unwrap_option_result_type_strips_a_reference_sigil() {
+        // Option<&User>'s bound value's real receiver type is User, not the
+        // reference syntax around it (Greptile review, PR #2371).
+        assert_eq!(unwrap_option_result_type("Option<&User>"), Some("User"));
+    }
+
+    #[test]
+    fn end_to_end_injects_bare_nominal_type_for_a_reference_wrapped_option() {
+        let mut service = FileSymbols::new("service.rs".to_string());
+        service
+            .return_type_map
+            .push(entry("UserService.get_user_ref", "Option<&User>", 1.0));
+
+        let mut main = FileSymbols::new("main.rs".to_string());
+        main.type_map.push(entry("service", "UserService", 0.9));
+        main.call_assignments
+            .push(crate::types::NativeCallAssignment {
+                var_name: "user".to_string(),
+                callee_name: "get_user_ref".to_string(),
+                receiver_type_name: None,
+                receiver_var_name: Some("service".to_string()),
+                unwrap_generic: true,
+            });
+
+        let mut file_symbols = BTreeMap::new();
+        file_symbols.insert("service.rs".to_string(), service);
+        file_symbols.insert("main.rs".to_string(), main);
+        let import_ctx = make_import_ctx(&file_symbols);
+
+        let conn = Connection::open_in_memory().unwrap();
+        propagate_return_types_across_files(&conn, &mut file_symbols, &import_ctx);
+
+        let main = &file_symbols["main.rs"];
+        let seeded = main
+            .type_map
+            .iter()
+            .find(|t| t.name == "user")
+            .expect("user should be seeded, unwrapped from Option<&User> to bare User");
+        assert_eq!(seeded.type_name, "User");
+    }
+
+    #[test]
+    fn unwrap_option_result_type_strips_a_mut_reference_with_a_lifetime() {
+        assert_eq!(
+            unwrap_option_result_type("Result<&'a mut User, String>"),
+            Some("User")
         );
     }
 

--- a/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
@@ -1743,16 +1743,35 @@ fn unwrap_option_result_type(type_name: &str) -> Option<&str> {
             '>' => depth -= 1,
             ',' if depth == 0 => {
                 let first = inner[..i].trim();
-                return if first.is_empty() { None } else { Some(first) };
+                return normalize_unwrapped_generic_arg(first);
             }
             _ => {}
         }
     }
-    let first = inner.trim();
-    if first.is_empty() {
-        None
+    normalize_unwrapped_generic_arg(inner.trim())
+}
+
+/// Apply the same nominal-vs-full-generic rule `extract_rust_type_name` applies
+/// at extraction time to an unwrapped `Some(x)`/`Ok(x)` binding's inner type —
+/// bare for an ordinary generic (`Option<Vec<User>>`'s inner `Vec<User>` becomes
+/// `x`'s type `Vec`, matching how a direct `let x: Vec<User> = ...` annotation
+/// would type it), full text for a nested Option/Result (`Option<Option<User>>`'s
+/// inner `Option<User>` stays `Option<User>` — if-let only strips one layer, so
+/// `x`'s real type still needs its own type argument for a later unwrap).
+/// Without this, a nested generic payload would inject a parameterized name where
+/// every other path in this pipeline injects a bare one (Greptile review, PR #2371).
+fn normalize_unwrapped_generic_arg(arg: &str) -> Option<&str> {
+    if arg.is_empty() {
+        return None;
+    }
+    let Some((inner_base, _rest)) = arg.split_once('<') else {
+        return Some(arg);
+    };
+    let inner_base = inner_base.trim();
+    if crate::extractors::rust_lang::is_option_or_result_base(inner_base) {
+        Some(arg)
     } else {
-        Some(first)
+        Some(inner_base)
     }
 }
 
@@ -2768,10 +2787,25 @@ mod tests {
     }
 
     #[test]
-    fn unwrap_option_result_type_handles_nested_generics_in_the_first_argument() {
+    fn unwrap_option_result_type_normalizes_an_ordinary_generic_inner_type_to_its_bare_name() {
+        // Result<Vec<User>, String>'s inner type argument is itself a generic —
+        // the unwrapped type must be bare "Vec", matching how a direct
+        // `let x: Vec<User> = ...` annotation would type it, not the
+        // parameterized "Vec<User>" (Greptile review, PR #2371).
         assert_eq!(
             unwrap_option_result_type("Result<Vec<User>, String>"),
-            Some("Vec<User>")
+            Some("Vec")
+        );
+    }
+
+    #[test]
+    fn unwrap_option_result_type_keeps_a_nested_option_result_inner_type_parameterized() {
+        // if-let only strips one layer — Option<Option<User>>'s inner type
+        // argument is itself Option/Result, so it keeps its own type argument
+        // (needed for a later unwrap), unlike an ordinary generic.
+        assert_eq!(
+            unwrap_option_result_type("Option<Option<User>>"),
+            Some("Option<User>")
         );
     }
 

--- a/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
@@ -1878,24 +1878,30 @@ fn inject_return_types_for_file(
         };
 
         if let Some((type_name, confidence)) = found {
-            // `ca.unwrap_generic` means the binding came from a refutable
-            // `Some(x)`/`Ok(x)` pattern — the callee's declared return type is
-            // itself `Option<T>`/`Result<T, _>`, and `x`'s real type is the
-            // unwrapped `T`, not the wrapper. If the declared type turns out not
-            // to actually be a generic Option/Result (a mismatch between the
-            // pattern and the callee's real signature), decline to inject rather
-            // than propagate the wrapper type as if it were `x`'s type (#2214).
-            let resolved_type_name = if ca.unwrap_generic {
-                match unwrap_option_result_type(type_name) {
-                    Some(inner) => Some(inner.to_string()),
-                    None => None,
+            // `ca.unwrap_depth` means the binding came from unwrapping that many
+            // layers of a refutable `Some(x)`/`Ok(x)` pattern — `Some(Some(x))`
+            // is 2, not 1. The callee's declared return type is itself wrapped
+            // that many layers deep (`Option<Option<T>>` for depth 2), and `x`'s
+            // real type is what's left after unwrapping all of them, not the
+            // wrapper. If a layer turns out not to actually be a generic
+            // Option/Result (a mismatch between the pattern and the callee's
+            // real signature), decline to inject rather than propagate a
+            // half-unwrapped type as if it were `x`'s type (#2214).
+            let mut current = type_name.as_str();
+            let mut unwrap_failed = false;
+            for _ in 0..ca.unwrap_depth {
+                match unwrap_option_result_type(current) {
+                    Some(inner) => current = inner,
+                    None => {
+                        unwrap_failed = true;
+                        break;
+                    }
                 }
-            } else {
-                Some(type_name.clone())
-            };
-            let Some(resolved_type_name) = resolved_type_name else {
+            }
+            if unwrap_failed {
                 continue;
-            };
+            }
+            let resolved_type_name = current.to_string();
 
             let propagated = confidence - hop_penalty;
             if propagated > 0.0 {
@@ -2589,7 +2595,7 @@ mod tests {
                 callee_name: "buildService".to_string(),
                 receiver_type_name: None,
                 receiver_var_name: None,
-                unwrap_generic: false,
+                unwrap_depth: 0,
             });
 
         let mut file_symbols = BTreeMap::new();
@@ -2627,7 +2633,7 @@ mod tests {
                 callee_name: "create".to_string(),
                 receiver_type_name: Some("Factory".to_string()),
                 receiver_var_name: None,
-                unwrap_generic: false,
+                unwrap_depth: 0,
             });
 
         let mut file_symbols = BTreeMap::new();
@@ -2667,7 +2673,7 @@ mod tests {
                 callee_name: "get_user".to_string(),
                 receiver_type_name: None,
                 receiver_var_name: Some("service".to_string()),
-                unwrap_generic: true,
+                unwrap_depth: 1,
             });
 
         let mut file_symbols = BTreeMap::new();
@@ -2704,7 +2710,7 @@ mod tests {
                 callee_name: "get_user".to_string(),
                 receiver_type_name: None,
                 receiver_var_name: Some("service".to_string()),
-                unwrap_generic: true,
+                unwrap_depth: 1,
             });
 
         let mut file_symbols = BTreeMap::new();
@@ -2733,7 +2739,7 @@ mod tests {
                 callee_name: "find_by_id".to_string(),
                 receiver_type_name: None,
                 receiver_var_name: Some("repo".to_string()),
-                unwrap_generic: false,
+                unwrap_depth: 0,
             });
 
         let mut file_symbols = BTreeMap::new();
@@ -2773,7 +2779,7 @@ mod tests {
                 callee_name: "buildService".to_string(),
                 receiver_type_name: None,
                 receiver_var_name: None,
-                unwrap_generic: false,
+                unwrap_depth: 0,
             });
 
         let mut file_symbols = BTreeMap::new();
@@ -2852,7 +2858,7 @@ mod tests {
                 callee_name: "get_user_ref".to_string(),
                 receiver_type_name: None,
                 receiver_var_name: Some("service".to_string()),
-                unwrap_generic: true,
+                unwrap_depth: 1,
             });
 
         let mut file_symbols = BTreeMap::new();
@@ -2869,6 +2875,49 @@ mod tests {
             .iter()
             .find(|t| t.name == "user")
             .expect("user should be seeded, unwrapped from Option<&User> to bare User");
+        assert_eq!(seeded.type_name, "User");
+    }
+
+    #[test]
+    fn end_to_end_injects_correctly_for_a_doubly_nested_option_at_depth_two() {
+        // `if let Some(Some(user)) = get_nested_option()` — the callee's
+        // Option<Option<User>> return must be unwrapped twice, not once
+        // (Greptile review, PR #2371).
+        let mut service = FileSymbols::new("service.js".to_string());
+        service
+            .return_type_map
+            .push(entry("get_nested_option", "Option<Option<User>>", 1.0));
+
+        let mut driver = FileSymbols::new("driver.js".to_string());
+        driver.imports.push(Import::new(
+            "./service.js".to_string(),
+            vec!["get_nested_option".to_string()],
+            1,
+        ));
+        driver
+            .call_assignments
+            .push(crate::types::NativeCallAssignment {
+                var_name: "user".to_string(),
+                callee_name: "get_nested_option".to_string(),
+                receiver_type_name: None,
+                receiver_var_name: None,
+                unwrap_depth: 2,
+            });
+
+        let mut file_symbols = BTreeMap::new();
+        file_symbols.insert("service.js".to_string(), service);
+        file_symbols.insert("driver.js".to_string(), driver);
+        let import_ctx = make_import_ctx(&file_symbols);
+
+        let conn = Connection::open_in_memory().unwrap();
+        propagate_return_types_across_files(&conn, &mut file_symbols, &import_ctx);
+
+        let driver = &file_symbols["driver.js"];
+        let seeded = driver
+            .type_map
+            .iter()
+            .find(|t| t.name == "user")
+            .expect("user should be seeded, unwrapped twice from Option<Option<User>> to User");
         assert_eq!(seeded.type_name, "User");
     }
 

--- a/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
@@ -1732,7 +1732,7 @@ fn build_return_type_index(
 /// `unwrapOptionResultType` in `build-edges.ts` (#2214).
 fn unwrap_option_result_type(type_name: &str) -> Option<&str> {
     let (base, rest) = type_name.split_once('<')?;
-    if base.trim() != "Option" && base.trim() != "Result" {
+    if !crate::extractors::rust_lang::is_option_or_result_base(base.trim()) {
         return None;
     }
     let inner = rest.strip_suffix('>')?;
@@ -2783,5 +2783,16 @@ mod tests {
     #[test]
     fn unwrap_option_result_type_returns_none_for_an_unrelated_generic() {
         assert_eq!(unwrap_option_result_type("Vec<User>"), None);
+    }
+
+    #[test]
+    fn unwrap_option_result_type_unwraps_a_fully_qualified_option() {
+        // `fn f() -> std::option::Option<User>` is valid Rust and just as common
+        // as the bare `Option<User>` spelling in no-std or disambiguating code
+        // (Greptile review, PR #2371).
+        assert_eq!(
+            unwrap_option_result_type("std::option::Option<User>"),
+            Some("User")
+        );
     }
 }

--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -1668,7 +1668,7 @@ fn match_js_call_assignments(node: &Node, source: &[u8], symbols: &mut FileSymbo
                 callee_name: node_text(&fn_node, source).to_string(),
                 receiver_type_name: None,
                 receiver_var_name: None,
-                unwrap_generic: false,
+                unwrap_depth: 0,
             });
         }
         "member_expression" => {
@@ -1691,7 +1691,7 @@ fn match_js_call_assignments(node: &Node, source: &[u8], symbols: &mut FileSymbo
                 callee_name: node_text(&prop, source).to_string(),
                 receiver_type_name: receiver_type,
                 receiver_var_name: None,
-                unwrap_generic: false,
+                unwrap_depth: 0,
             });
         }
         _ => {}

--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -1667,6 +1667,8 @@ fn match_js_call_assignments(node: &Node, source: &[u8], symbols: &mut FileSymbo
                 var_name,
                 callee_name: node_text(&fn_node, source).to_string(),
                 receiver_type_name: None,
+                receiver_var_name: None,
+                unwrap_generic: false,
             });
         }
         "member_expression" => {
@@ -1688,6 +1690,8 @@ fn match_js_call_assignments(node: &Node, source: &[u8], symbols: &mut FileSymbo
                 var_name,
                 callee_name: node_text(&prop, source).to_string(),
                 receiver_type_name: receiver_type,
+                receiver_var_name: None,
+                unwrap_generic: false,
             });
         }
         _ => {}

--- a/crates/codegraph-core/src/extractors/rust_lang.rs
+++ b/crates/codegraph-core/src/extractors/rust_lang.rs
@@ -578,11 +578,28 @@ fn extract_rust_type_name<'a>(type_node: &Node<'a>, source: &'a [u8]) -> Option<
             }
             None
         }
-        // Keep the full generic text (`Option<User>`, not just `Option`) — callers
-        // that only care about the base type still get a usable prefix, and
-        // unwrap_option_result_type() below needs the type argument to type an
-        // if-let/while-let-unwrapped binding from a generic return type (#2214).
-        "generic_type" => Some(node_text(type_node, source)),
+        // For every OTHER generic type (Vec<T>, HashMap<K, V>, a user-defined
+        // Container<T>, ...), keep the original nominal-base-name behavior — impl
+        // blocks' own qualified names use the source-literal generic syntax too
+        // (`impl<T> Container<T>` extracts as "Container<T>", not "Container"), so
+        // a concretely-instantiated receiver ("Container<User>") could never match
+        // it either way; but CHA/RTA's instantiated-types matching (buildChaContext
+        // in cha.ts / build_cha_context) DOES compare bare type_map entries against
+        // trait-implementor names, so keeping other generics parameterized here
+        // would silently break that unrelated, currently-working nominal match
+        // (Greptile review, PR #2371). Option/Result are the only shapes this fix
+        // actually needs full text for — a Some(x)/Ok(x) if-let/while-let binding's
+        // real type is the type ARGUMENT, not the wrapper, and unwrap_option_result_type()
+        // below needs that argument text to compute it.
+        "generic_type" => {
+            let text = node_text(type_node, source);
+            let base = text.split('<').next().unwrap_or(text).trim();
+            if base == "Option" || base == "Result" {
+                Some(text)
+            } else {
+                Some(base)
+            }
+        }
         _ => None,
     }
 }
@@ -1148,6 +1165,21 @@ mod tests {
             .find(|e| e.name == "get_user")
             .unwrap();
         assert_eq!(entry.type_name, "Option<User>");
+    }
+
+    #[test]
+    fn return_type_map_keeps_bare_base_name_for_non_option_result_generics() {
+        // Only Option/Result need the type argument preserved (to unwrap a
+        // Some(x)/Ok(x) binding) — every other generic keeps its original bare
+        // name so CHA/RTA's instantiated-types matching against trait-implementor
+        // names is unaffected (Greptile review, PR #2371).
+        let s = parse_rust("fn get_users() -> Vec<User> { Vec::new() }");
+        let entry = s
+            .return_type_map
+            .iter()
+            .find(|e| e.name == "get_users")
+            .unwrap();
+        assert_eq!(entry.type_name, "Vec");
     }
 
     // ── Calls embedded in macro invocation arguments (#2214) ──────────────────

--- a/crates/codegraph-core/src/extractors/rust_lang.rs
+++ b/crates/codegraph-core/src/extractors/rust_lang.rs
@@ -621,22 +621,40 @@ fn extract_rust_type_name<'a>(type_node: &Node<'a>, source: &'a [u8]) -> Option<
 /// binding `x`, the same way `let x = expr;` already is. Returns `pattern`
 /// unchanged for any other shape (a bare identifier, `None`, `Err(_)`, or any
 /// other variant this isn't confident unwrapping).
-fn unwrap_option_result_pattern<'a>(pattern: Node<'a>, source: &[u8]) -> Node<'a> {
-    if pattern.kind() != "tuple_struct_pattern" {
-        return pattern;
+/// Unwrap zero or more layers of `Some(...)`/`Ok(...)` wrapping — e.g.
+/// `Some(Some(user))` for a `Option<Option<User>>`-returning call, not just
+/// one layer — returning the innermost non-Some/Ok pattern and how many
+/// layers were stripped. The caller unwraps the callee's declared return type
+/// the same number of times (#2214, Greptile review on PR #2371 — a single
+/// unwrap left a doubly-nested pattern's binding untyped entirely, since
+/// `Some(Some(x))`'s inner pattern is itself a `tuple_struct_pattern`, not an
+/// `identifier`, and the original single-pass version gave up on it).
+fn unwrap_option_result_pattern<'a>(pattern: Node<'a>, source: &[u8]) -> (Node<'a>, u32) {
+    let mut current = pattern;
+    let mut depth = 0u32;
+    loop {
+        if current.kind() != "tuple_struct_pattern" {
+            return (current, depth);
+        }
+        let Some(type_node) = current.child_by_field_name("type") else {
+            return (current, depth);
+        };
+        let variant = node_text(&type_node, source);
+        if variant != "Some" && variant != "Ok" {
+            return (current, depth);
+        }
+        let mut cursor = current.walk();
+        let inner = current
+            .named_children(&mut cursor)
+            .find(|c| c.id() != type_node.id());
+        match inner {
+            Some(next) => {
+                current = next;
+                depth += 1;
+            }
+            None => return (current, depth),
+        }
     }
-    let Some(type_node) = pattern.child_by_field_name("type") else {
-        return pattern;
-    };
-    let variant = node_text(&type_node, source);
-    if variant != "Some" && variant != "Ok" {
-        return pattern;
-    }
-    let mut cursor = pattern.walk();
-    let inner = pattern
-        .named_children(&mut cursor)
-        .find(|c| c.id() != type_node.id());
-    inner.unwrap_or(pattern)
 }
 
 fn match_rust_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: usize) {
@@ -789,8 +807,7 @@ fn match_rust_call_assignments(
     let Some(pattern) = node.child_by_field_name("pattern") else {
         return;
     };
-    let unwrapped_pattern = unwrap_option_result_pattern(pattern, source);
-    let unwrap_generic = unwrapped_pattern.id() != pattern.id();
+    let (unwrapped_pattern, unwrap_depth) = unwrap_option_result_pattern(pattern, source);
     if unwrapped_pattern.kind() != "identifier" {
         return;
     }
@@ -825,7 +842,7 @@ fn match_rust_call_assignments(
                 callee_name: node_text(&fn_node, source).to_string(),
                 receiver_type_name: None,
                 receiver_var_name: None,
-                unwrap_generic,
+                unwrap_depth,
             });
         }
         "scoped_identifier" => {
@@ -837,7 +854,7 @@ fn match_rust_call_assignments(
                     callee_name: node_text(&name, source).to_string(),
                     receiver_type_name: Some(node_text(&path, source).to_string()),
                     receiver_var_name: None,
-                    unwrap_generic,
+                    unwrap_depth,
                 });
             }
         }
@@ -868,7 +885,7 @@ fn match_rust_call_assignments(
                         callee_name: node_text(&field, source).to_string(),
                         receiver_type_name: receiver_type,
                         receiver_var_name,
-                        unwrap_generic,
+                        unwrap_depth,
                     });
                 }
             }
@@ -1119,7 +1136,7 @@ mod tests {
         // raw receiver name rather than a resolved type.
         assert_eq!(ca.receiver_type_name, None);
         assert_eq!(ca.receiver_var_name.as_deref(), Some("service"));
-        assert!(ca.unwrap_generic);
+        assert_eq!(ca.unwrap_depth, 1);
     }
 
     #[test]
@@ -1131,7 +1148,7 @@ mod tests {
             .find(|c| c.var_name == "user")
             .unwrap();
         assert_eq!(ca.callee_name, "build_user");
-        assert!(ca.unwrap_generic);
+        assert_eq!(ca.unwrap_depth, 1);
     }
 
     #[test]
@@ -1143,7 +1160,7 @@ mod tests {
             .find(|c| c.var_name == "item")
             .unwrap();
         assert_eq!(ca.callee_name, "next_item");
-        assert!(ca.unwrap_generic);
+        assert_eq!(ca.unwrap_depth, 1);
     }
 
     #[test]
@@ -1154,7 +1171,7 @@ mod tests {
             .iter()
             .find(|c| c.var_name == "service")
             .unwrap();
-        assert!(!ca.unwrap_generic);
+        assert_eq!(ca.unwrap_depth, 0);
     }
 
     #[test]
@@ -1163,6 +1180,22 @@ mod tests {
         // wrong (there is no value), so these must not be recorded at all.
         let s = parse_rust("fn f() {\n  if let None = build_service() {}\n}");
         assert!(s.call_assignments.is_empty());
+    }
+
+    #[test]
+    fn records_a_doubly_nested_some_pattern_with_depth_two() {
+        // `Some(Some(x))` — destructuring a doubly-nested `Option<Option<T>>` in
+        // a single pattern, the idiomatic way to do it, not two sequential
+        // if-lets — must unwrap both layers, not give up after the first
+        // (Greptile review, PR #2371).
+        let s = parse_rust("fn f() {\n  if let Some(Some(user)) = get_nested_option() {}\n}");
+        let ca = s
+            .call_assignments
+            .iter()
+            .find(|c| c.var_name == "user")
+            .unwrap();
+        assert_eq!(ca.callee_name, "get_nested_option");
+        assert_eq!(ca.unwrap_depth, 2);
     }
 
     // ── Full generic return types (#2214) ─────────────────────────────────────

--- a/crates/codegraph-core/src/extractors/rust_lang.rs
+++ b/crates/codegraph-core/src/extractors/rust_lang.rs
@@ -327,6 +327,85 @@ fn handle_macro_invocation(node: &Node, source: &[u8], symbols: &mut FileSymbols
             ..Default::default()
         });
     }
+    // Macro arguments (`println!("{}", user.display_name())`) are an opaque
+    // `token_tree` to tree-sitter-rust — macros can have arbitrary token syntax, so
+    // the grammar never parses their contents into call_expression/field_expression
+    // nodes the way it does everywhere else. walk_tree's generic recursion still
+    // visits every token inside, but none of them match `call_expression`, so a real
+    // call embedded in a macro argument (the common `println!`/`format!`/`write!`/
+    // `assert!` case) was silently invisible to call-edge resolution. Scan the flat
+    // token sequence directly for the two call shapes tree-sitter still tokenizes
+    // recognizably — bare `ident(...)` and single-hop method `ident.ident(...)` — and
+    // record them the same way handle_call_expr would. Mirrors
+    // `scanMacroTokensForCalls` in `src/extractors/rust.ts` (#2214).
+    for i in 0..node.child_count() {
+        if let Some(child) = node.child(i) {
+            if child.kind() == "token_tree" {
+                scan_macro_tokens_for_calls(&child, source, symbols);
+            }
+        }
+    }
+}
+
+fn scan_macro_tokens_for_calls(token_tree: &Node, source: &[u8], symbols: &mut FileSymbols) {
+    let mut children = Vec::new();
+    for i in 0..token_tree.child_count() {
+        if let Some(child) = token_tree.child(i) {
+            children.push(child);
+        }
+    }
+
+    let mut i = 0;
+    while i < children.len() {
+        let c = &children[i];
+        if c.kind() == "token_tree" {
+            scan_macro_tokens_for_calls(c, source, symbols);
+            i += 1;
+            continue;
+        }
+        if c.kind() != "identifier" {
+            i += 1;
+            continue;
+        }
+
+        // `receiver . method ( ... )` — single-hop method call.
+        if let (Some(dot), Some(method_name), Some(args_after_method)) = (
+            children.get(i + 1),
+            children.get(i + 2),
+            children.get(i + 3),
+        ) {
+            if dot.kind() == "."
+                && method_name.kind() == "identifier"
+                && args_after_method.kind() == "token_tree"
+                && node_text(args_after_method, source).starts_with('(')
+            {
+                symbols.calls.push(Call {
+                    name: node_text(method_name, source).to_string(),
+                    line: start_line(method_name),
+                    receiver: Some(node_text(c, source).to_string()),
+                    ..Default::default()
+                });
+                i += 4;
+                continue;
+            }
+        }
+
+        // Bare `name ( ... )` — free-function call.
+        if let Some(args_after_bare) = children.get(i + 1) {
+            if args_after_bare.kind() == "token_tree"
+                && node_text(args_after_bare, source).starts_with('(')
+            {
+                symbols.calls.push(Call {
+                    name: node_text(c, source).to_string(),
+                    line: start_line(c),
+                    ..Default::default()
+                });
+                i += 2;
+                continue;
+            }
+        }
+        i += 1;
+    }
 }
 
 // ── Extended kinds helpers ──────────────────────────────────────────────────
@@ -499,9 +578,37 @@ fn extract_rust_type_name<'a>(type_node: &Node<'a>, source: &'a [u8]) -> Option<
             }
             None
         }
-        "generic_type" => type_node.child(0).map(|n| node_text(&n, source)),
+        // Keep the full generic text (`Option<User>`, not just `Option`) — callers
+        // that only care about the base type still get a usable prefix, and
+        // unwrap_option_result_type() below needs the type argument to type an
+        // if-let/while-let-unwrapped binding from a generic return type (#2214).
+        "generic_type" => Some(node_text(type_node, source)),
         _ => None,
     }
+}
+
+/// Unwrap a single-argument `Some(x)`/`Ok(x)` tuple-struct pattern to its inner
+/// `x` pattern, so `if let Some(x) = expr`/`if let Ok(x) = expr` (and the
+/// `while let`/`let-else` equivalents) can be treated as a call-assignment
+/// binding `x`, the same way `let x = expr;` already is. Returns `pattern`
+/// unchanged for any other shape (a bare identifier, `None`, `Err(_)`, or any
+/// other variant this isn't confident unwrapping).
+fn unwrap_option_result_pattern<'a>(pattern: Node<'a>, source: &[u8]) -> Node<'a> {
+    if pattern.kind() != "tuple_struct_pattern" {
+        return pattern;
+    }
+    let Some(type_node) = pattern.child_by_field_name("type") else {
+        return pattern;
+    };
+    let variant = node_text(&type_node, source);
+    if variant != "Some" && variant != "Ok" {
+        return pattern;
+    }
+    let mut cursor = pattern.walk();
+    let inner = pattern
+        .named_children(&mut cursor)
+        .find(|c| c.id() != type_node.id());
+    inner.unwrap_or(pattern)
 }
 
 fn match_rust_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols, _depth: usize) {
@@ -645,13 +752,31 @@ fn match_rust_call_assignments(
     symbols: &mut FileSymbols,
     _depth: usize,
 ) {
-    if node.kind() != "let_declaration" {
+    // `let_declaration` covers `let x = expr;` (and `let Some(x) = expr else {...};`
+    // let-else); `let_condition` is the `if let`/`while let` condition node (#2214) —
+    // both have `pattern`/`value` fields shaped identically.
+    if node.kind() != "let_declaration" && node.kind() != "let_condition" {
         return;
     }
     let Some(pattern) = node.child_by_field_name("pattern") else {
         return;
     };
-    if pattern.kind() != "identifier" {
+    let unwrapped_pattern = unwrap_option_result_pattern(pattern, source);
+    let unwrap_generic = unwrapped_pattern.id() != pattern.id();
+    if unwrapped_pattern.kind() != "identifier" {
+        return;
+    }
+    // A bare fieldless-variant/unit-struct pattern (`if let None = expr`, `if let
+    // NameValidator = expr`) is syntactically identical to a variable binding —
+    // tree-sitter has no way to distinguish them by grammar alone. By Rust
+    // convention a real binding is snake_case, so an uppercase-leading name is a
+    // pattern match against a value, not a new variable — recording it as one
+    // would fabricate a call-assignment for a variable that doesn't exist (#2214).
+    if node_text(&unwrapped_pattern, source)
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_uppercase())
+    {
         return;
     }
     let Some(value) = node.child_by_field_name("value") else {
@@ -663,7 +788,7 @@ fn match_rust_call_assignments(
     let Some(fn_node) = value.child_by_field_name("function") else {
         return;
     };
-    let var_name = node_text(&pattern, source).to_string();
+    let var_name = node_text(&unwrapped_pattern, source).to_string();
 
     match fn_node.kind() {
         "identifier" => {
@@ -671,6 +796,8 @@ fn match_rust_call_assignments(
                 var_name,
                 callee_name: node_text(&fn_node, source).to_string(),
                 receiver_type_name: None,
+                receiver_var_name: None,
+                unwrap_generic,
             });
         }
         "scoped_identifier" => {
@@ -681,6 +808,8 @@ fn match_rust_call_assignments(
                     var_name,
                     callee_name: node_text(&name, source).to_string(),
                     receiver_type_name: Some(node_text(&path, source).to_string()),
+                    receiver_var_name: None,
+                    unwrap_generic,
                 });
             }
         }
@@ -689,15 +818,29 @@ fn match_rust_call_assignments(
             let receiver = fn_node.child_by_field_name("value");
             if let (Some(field), Some(receiver)) = (field, receiver) {
                 if receiver.kind() == "identifier" {
+                    let receiver_name = node_text(&receiver, source).to_string();
                     let receiver_type = symbols
                         .type_map
                         .iter()
-                        .find(|e| e.name == node_text(&receiver, source))
+                        .find(|e| e.name == receiver_name)
                         .map(|e| e.type_name.clone());
+                    // Preserve the raw receiver identifier even when its type isn't
+                    // known yet at extraction time (e.g. `service` in
+                    // `service.get_user(1)`, whose type only becomes known via
+                    // cross-file return-type propagation) so injection can retry
+                    // resolution once the receiver's own call-assignment has itself
+                    // been injected earlier in the same pass (#2214).
+                    let receiver_var_name = if receiver_type.is_none() {
+                        Some(receiver_name)
+                    } else {
+                        None
+                    };
                     symbols.call_assignments.push(NativeCallAssignment {
                         var_name,
                         callee_name: node_text(&field, source).to_string(),
                         receiver_type_name: receiver_type,
+                        receiver_var_name,
+                        unwrap_generic,
                     });
                 }
             }
@@ -928,5 +1071,112 @@ mod tests {
             .unwrap();
         assert_eq!(ca.callee_name, "find_by_id");
         assert_eq!(ca.receiver_type_name.as_deref(), Some("UserRepository"));
+    }
+
+    // ── if-let/while-let pattern-binding call assignments (#2214) ────────────
+
+    #[test]
+    fn records_call_assignment_for_if_let_some_bound_method_call() {
+        let s = parse_rust(
+            "fn f() {\n  let service = build_service();\n  if let Some(user) = service.get_user(1) {}\n}",
+        );
+        let ca = s
+            .call_assignments
+            .iter()
+            .find(|c| c.var_name == "user")
+            .unwrap();
+        assert_eq!(ca.callee_name, "get_user");
+        // `service`'s type isn't known at extraction time (it only becomes known
+        // via cross-file return-type propagation), so resolution defers to the
+        // raw receiver name rather than a resolved type.
+        assert_eq!(ca.receiver_type_name, None);
+        assert_eq!(ca.receiver_var_name.as_deref(), Some("service"));
+        assert!(ca.unwrap_generic);
+    }
+
+    #[test]
+    fn records_call_assignment_for_if_let_ok_bound_bare_call() {
+        let s = parse_rust("fn f() {\n  if let Ok(user) = build_user() {}\n}");
+        let ca = s
+            .call_assignments
+            .iter()
+            .find(|c| c.var_name == "user")
+            .unwrap();
+        assert_eq!(ca.callee_name, "build_user");
+        assert!(ca.unwrap_generic);
+    }
+
+    #[test]
+    fn while_let_some_bound_call_assignment_is_also_unwrapped() {
+        let s = parse_rust("fn f() {\n  while let Some(item) = next_item() {}\n}");
+        let ca = s
+            .call_assignments
+            .iter()
+            .find(|c| c.var_name == "item")
+            .unwrap();
+        assert_eq!(ca.callee_name, "next_item");
+        assert!(ca.unwrap_generic);
+    }
+
+    #[test]
+    fn plain_let_binding_is_not_marked_as_unwrapped() {
+        let s = parse_rust("fn f() {\n  let service = build_service();\n}");
+        let ca = s
+            .call_assignments
+            .iter()
+            .find(|c| c.var_name == "service")
+            .unwrap();
+        assert!(!ca.unwrap_generic);
+    }
+
+    #[test]
+    fn does_not_treat_none_or_err_pattern_as_a_call_assignment() {
+        // `None`/`Err(_)` aren't Some/Ok — unwrapping a value out of them would be
+        // wrong (there is no value), so these must not be recorded at all.
+        let s = parse_rust("fn f() {\n  if let None = build_service() {}\n}");
+        assert!(s.call_assignments.is_empty());
+    }
+
+    // ── Full generic return types (#2214) ─────────────────────────────────────
+
+    #[test]
+    fn return_type_map_preserves_full_generic_return_type() {
+        let s = parse_rust("fn get_user() -> Option<User> { None }");
+        let entry = s
+            .return_type_map
+            .iter()
+            .find(|e| e.name == "get_user")
+            .unwrap();
+        assert_eq!(entry.type_name, "Option<User>");
+    }
+
+    // ── Calls embedded in macro invocation arguments (#2214) ──────────────────
+
+    #[test]
+    fn scans_macro_arguments_for_a_method_call() {
+        let s = parse_rust(r#"fn f(user: User) { println!("{}", user.display_name()); }"#);
+        let call = s.calls.iter().find(|c| c.name == "display_name").unwrap();
+        assert_eq!(call.receiver.as_deref(), Some("user"));
+        // The macro invocation itself is still recorded alongside the call it wraps.
+        assert!(s.calls.iter().any(|c| c.name == "println!"));
+    }
+
+    #[test]
+    fn scans_macro_arguments_for_a_bare_function_call() {
+        let s = parse_rust(r#"fn f() { println!("{}", compute_total()); }"#);
+        assert!(s
+            .calls
+            .iter()
+            .any(|c| c.name == "compute_total" && c.receiver.is_none()));
+    }
+
+    #[test]
+    fn scans_nested_macro_arguments_recursively() {
+        let s = parse_rust(r#"fn f() { assert_eq!(compute_total(), other.value()); }"#);
+        assert!(s.calls.iter().any(|c| c.name == "compute_total"));
+        assert!(s
+            .calls
+            .iter()
+            .any(|c| c.name == "value" && c.receiver.as_deref() == Some("other")));
     }
 }

--- a/crates/codegraph-core/src/extractors/rust_lang.rs
+++ b/crates/codegraph-core/src/extractors/rust_lang.rs
@@ -580,16 +580,16 @@ fn extract_rust_type_name<'a>(type_node: &Node<'a>, source: &'a [u8]) -> Option<
         "type_identifier" | "identifier" | "scoped_type_identifier" => {
             Some(node_text(type_node, source))
         }
+        // Reference: &MyType, &mut MyType, &Option<User> → recurse on the referent
+        // via the `type` field (ignoring lifetime/mut modifiers, which aren't part
+        // of it) rather than hand-matching type_identifier/scoped_type_identifier —
+        // a referent that's itself generic (`&Option<User>`) previously matched
+        // neither arm of the old child-loop and silently returned None, dropping
+        // the return type before the Option/Result unwrap logic ever saw it
+        // (Greptile review, PR #2371).
         "reference_type" => {
-            for i in 0..type_node.child_count() {
-                if let Some(child) = type_node.child(i) {
-                    if child.kind() == "type_identifier" || child.kind() == "scoped_type_identifier"
-                    {
-                        return Some(node_text(&child, source));
-                    }
-                }
-            }
-            None
+            let referent = type_node.child_by_field_name("type")?;
+            extract_rust_type_name(&referent, source)
         }
         // For every OTHER generic type (Vec<T>, HashMap<K, V>, a user-defined
         // Container<T>, ...), keep the original nominal-base-name behavior — impl
@@ -1257,6 +1257,22 @@ mod tests {
             .find(|e| e.name == "UserService.get_user_ref")
             .unwrap();
         assert_eq!(entry.type_name, "Option<&User>");
+    }
+
+    #[test]
+    fn return_type_map_preserves_a_reference_to_a_generic_option() {
+        // `&Option<User>` (a reference TO the Option, not a reference stored
+        // inside it) — the old reference_type handling only matched a bare
+        // type_identifier/scoped_type_identifier child, never a generic_type
+        // child, so this shape returned None entirely and the whole return
+        // type was dropped (Greptile review, PR #2371).
+        let s = parse_rust("fn get_user() -> &Option<User> { &None }");
+        let entry = s
+            .return_type_map
+            .iter()
+            .find(|e| e.name == "get_user")
+            .unwrap();
+        assert_eq!(entry.type_name, "Option<User>");
     }
 
     // ── Calls embedded in macro invocation arguments (#2214) ──────────────────

--- a/crates/codegraph-core/src/extractors/rust_lang.rs
+++ b/crates/codegraph-core/src/extractors/rust_lang.rs
@@ -1206,6 +1206,24 @@ mod tests {
         assert_eq!(entry.type_name, "std::option::Option<User>");
     }
 
+    #[test]
+    fn return_type_map_preserves_full_text_for_a_reference_wrapped_option() {
+        // `Option<&User>` (a common shape for a cached-field getter) must
+        // preserve the type argument, including the reference sigil, the same
+        // way any other Option<T> does — pipeline.rs's unwrap_option_result_type
+        // strips the `&` at injection time, not extraction time (Greptile
+        // review, PR #2371).
+        let s = parse_rust(
+            "struct UserService { cached: User }\nimpl UserService {\n  pub fn get_user_ref(&self) -> Option<&User> { Some(&self.cached) }\n}",
+        );
+        let entry = s
+            .return_type_map
+            .iter()
+            .find(|e| e.name == "UserService.get_user_ref")
+            .unwrap();
+        assert_eq!(entry.type_name, "Option<&User>");
+    }
+
     // ── Calls embedded in macro invocation arguments (#2214) ──────────────────
 
     #[test]

--- a/crates/codegraph-core/src/extractors/rust_lang.rs
+++ b/crates/codegraph-core/src/extractors/rust_lang.rs
@@ -562,6 +562,17 @@ fn is_known_unit_struct(name: &str, symbols: &FileSymbols) -> bool {
         .any(|d| d.kind == "struct" && d.name == name)
 }
 
+/// True when `base` names `Option`/`Result`, bare (`Option`) or fully qualified
+/// (`std::option::Option`, `core::result::Result`) — both spellings are valid
+/// Rust and equally common in a `-> ReturnType` position. Mirrors
+/// `isOptionOrResultBase` in `src/extractors/rust.ts` and is checked identically
+/// at unwrap time by `unwrap_option_result_type` in `pipeline.rs` (#2214, Greptile
+/// review on PR #2371 — a qualified spelling was silently treated as an unrelated
+/// generic, dropping the type argument a Some(x)/Ok(x) binding needs).
+pub(crate) fn is_option_or_result_base(base: &str) -> bool {
+    base == "Option" || base == "Result" || base.ends_with("::Option") || base.ends_with("::Result")
+}
+
 fn extract_rust_type_name<'a>(type_node: &Node<'a>, source: &'a [u8]) -> Option<&'a str> {
     match type_node.kind() {
         "type_identifier" | "identifier" | "scoped_type_identifier" => {
@@ -594,7 +605,7 @@ fn extract_rust_type_name<'a>(type_node: &Node<'a>, source: &'a [u8]) -> Option<
         "generic_type" => {
             let text = node_text(type_node, source);
             let base = text.split('<').next().unwrap_or(text).trim();
-            if base == "Option" || base == "Result" {
+            if is_option_or_result_base(base) {
                 Some(text)
             } else {
                 Some(base)
@@ -1180,6 +1191,19 @@ mod tests {
             .find(|e| e.name == "get_users")
             .unwrap();
         assert_eq!(entry.type_name, "Vec");
+    }
+
+    #[test]
+    fn return_type_map_preserves_full_text_for_a_fully_qualified_option() {
+        // `std::option::Option<User>` is just as valid as the bare `Option<User>`
+        // spelling and must be recognized the same way (Greptile review, PR #2371).
+        let s = parse_rust("fn get_user() -> std::option::Option<User> { None }");
+        let entry = s
+            .return_type_map
+            .iter()
+            .find(|e| e.name == "get_user")
+            .unwrap();
+        assert_eq!(entry.type_name, "std::option::Option<User>");
     }
 
     // ── Calls embedded in macro invocation arguments (#2214) ──────────────────

--- a/crates/codegraph-core/src/extractors/rust_lang.rs
+++ b/crates/codegraph-core/src/extractors/rust_lang.rs
@@ -348,18 +348,20 @@ fn handle_macro_invocation(node: &Node, source: &[u8], symbols: &mut FileSymbols
 }
 
 fn scan_macro_tokens_for_calls(token_tree: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let mut children = Vec::new();
-    for i in 0..token_tree.child_count() {
-        if let Some(child) = token_tree.child(i) {
-            children.push(child);
-        }
-    }
-
+    // Index directly via `child(i)` rather than collecting into a `Vec` first —
+    // every macro invocation in the file pays this cost (println!/format!/
+    // assert_eq!/vec! are everywhere in real Rust code), so an allocation per
+    // invocation was a measurable regression on the build-performance
+    // benchmark (Pre-publish benchmark gate, PR #2371).
+    let count = token_tree.child_count();
     let mut i = 0;
-    while i < children.len() {
-        let c = &children[i];
+    while i < count {
+        let Some(c) = token_tree.child(i) else {
+            i += 1;
+            continue;
+        };
         if c.kind() == "token_tree" {
-            scan_macro_tokens_for_calls(c, source, symbols);
+            scan_macro_tokens_for_calls(&c, source, symbols);
             i += 1;
             continue;
         }
@@ -370,19 +372,19 @@ fn scan_macro_tokens_for_calls(token_tree: &Node, source: &[u8], symbols: &mut F
 
         // `receiver . method ( ... )` — single-hop method call.
         if let (Some(dot), Some(method_name), Some(args_after_method)) = (
-            children.get(i + 1),
-            children.get(i + 2),
-            children.get(i + 3),
+            token_tree.child(i + 1),
+            token_tree.child(i + 2),
+            token_tree.child(i + 3),
         ) {
             if dot.kind() == "."
                 && method_name.kind() == "identifier"
                 && args_after_method.kind() == "token_tree"
-                && node_text(args_after_method, source).starts_with('(')
+                && node_text(&args_after_method, source).starts_with('(')
             {
                 symbols.calls.push(Call {
-                    name: node_text(method_name, source).to_string(),
-                    line: start_line(method_name),
-                    receiver: Some(node_text(c, source).to_string()),
+                    name: node_text(&method_name, source).to_string(),
+                    line: start_line(&method_name),
+                    receiver: Some(node_text(&c, source).to_string()),
                     ..Default::default()
                 });
                 i += 4;
@@ -391,13 +393,13 @@ fn scan_macro_tokens_for_calls(token_tree: &Node, source: &[u8], symbols: &mut F
         }
 
         // Bare `name ( ... )` — free-function call.
-        if let Some(args_after_bare) = children.get(i + 1) {
+        if let Some(args_after_bare) = token_tree.child(i + 1) {
             if args_after_bare.kind() == "token_tree"
-                && node_text(args_after_bare, source).starts_with('(')
+                && node_text(&args_after_bare, source).starts_with('(')
             {
                 symbols.calls.push(Call {
-                    name: node_text(c, source).to_string(),
-                    line: start_line(c),
+                    name: node_text(&c, source).to_string(),
+                    line: start_line(&c),
                     ..Default::default()
                 });
                 i += 2;

--- a/crates/codegraph-core/src/types.rs
+++ b/crates/codegraph-core/src/types.rs
@@ -374,6 +374,23 @@ pub struct NativeCallAssignment {
     pub callee_name: String,
     #[napi(js_name = "receiverTypeName")]
     pub receiver_type_name: Option<String>,
+    /// Raw receiver identifier for a method call (`receiver.method()`) whose
+    /// receiver's type wasn't resolvable at extraction time — e.g. `service` in
+    /// `service.get_user(1)`, when `service`'s own type only becomes known via
+    /// cross-file return-type propagation. Lets injection retry resolving the
+    /// receiver's type once its own call-assignment has been injected earlier in
+    /// the same pass, instead of giving up the way a bare `receiver_type_name:
+    /// None` would (mirrors `CallAssignment.receiverVarName` in `src/types.ts`, #2214).
+    #[napi(js_name = "receiverVarName")]
+    pub receiver_var_name: Option<String>,
+    /// True when this assignment came from unwrapping a refutable `Some(x)`/`Ok(x)`
+    /// pattern (`if let`/`while let`/`let-else`) — the callee's declared return type
+    /// must itself be unwrapped from its outer `Option<T>`/`Result<T, _>` generic
+    /// before being used to type `var_name` (mirrors `CallAssignment.unwrapGeneric`
+    /// in `src/types.ts`).
+    #[napi(js_name = "unwrapGeneric")]
+    #[serde(default)]
+    pub unwrap_generic: bool,
 }
 
 /// Function-reference binding for Phase 8.3 points-to analysis.

--- a/crates/codegraph-core/src/types.rs
+++ b/crates/codegraph-core/src/types.rs
@@ -383,14 +383,15 @@ pub struct NativeCallAssignment {
     /// None` would (mirrors `CallAssignment.receiverVarName` in `src/types.ts`, #2214).
     #[napi(js_name = "receiverVarName")]
     pub receiver_var_name: Option<String>,
-    /// True when this assignment came from unwrapping a refutable `Some(x)`/`Ok(x)`
-    /// pattern (`if let`/`while let`/`let-else`) — the callee's declared return type
-    /// must itself be unwrapped from its outer `Option<T>`/`Result<T, _>` generic
-    /// before being used to type `var_name` (mirrors `CallAssignment.unwrapGeneric`
-    /// in `src/types.ts`).
-    #[napi(js_name = "unwrapGeneric")]
+    /// How many layers of a refutable `Some(x)`/`Ok(x)` pattern (`if let`/
+    /// `while let`/`let-else`) this assignment came from unwrapping — 0 means a
+    /// plain `let x = expr;` binding. `Some(Some(x))` (unwrapping a doubly-nested
+    /// `Option<Option<T>>` return) is 2, not 1 — the callee's declared return
+    /// type must itself be unwrapped this many times before being used to type
+    /// `var_name` (mirrors `CallAssignment.unwrapDepth` in `src/types.ts`, #2214).
+    #[napi(js_name = "unwrapDepth")]
     #[serde(default)]
-    pub unwrap_generic: bool,
+    pub unwrap_depth: u32,
 }
 
 /// Function-reference binding for Phase 8.3 points-to analysis.

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -684,11 +684,29 @@ function unwrapOptionResultType(typeName: string): string | undefined {
     if (c === '<') depth++;
     else if (c === '>') depth--;
     else if (c === ',' && depth === 0) {
-      const first = inner.slice(0, i).trim();
-      return first || undefined;
+      return normalizeUnwrappedGenericArg(inner.slice(0, i).trim());
     }
   }
-  return inner.trim() || undefined;
+  return normalizeUnwrappedGenericArg(inner.trim());
+}
+
+/**
+ * Apply the same nominal-vs-full-generic rule extractRustTypeName applies at
+ * extraction time to an unwrapped Some(x)/Ok(x) binding's inner type — bare for
+ * an ordinary generic (Option<Vec<User>>'s inner Vec<User> becomes x's type
+ * Vec, matching how a direct `let x: Vec<User> = ...` annotation would type
+ * it), full text for a nested Option/Result (Option<Option<User>>'s inner
+ * Option<User> stays Option<User> — if-let only strips one layer, so x's real
+ * type still needs its own type argument for a later unwrap). Without this, a
+ * nested generic payload would inject a parameterized name where every other
+ * path in this pipeline injects a bare one (Greptile review, PR #2371).
+ */
+function normalizeUnwrappedGenericArg(arg: string): string | undefined {
+  if (!arg) return undefined;
+  const ltIdx = arg.indexOf('<');
+  if (ltIdx === -1) return arg;
+  const innerBase = arg.slice(0, ltIdx).trim();
+  return isOptionOrResultBase(innerBase) ? arg : innerBase;
 }
 
 // ── Call edges (native engine) ──────────────────────────────────────────

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -642,16 +642,20 @@ function propagateReturnTypesAcrossFiles(
       }
 
       if (returnEntry) {
-        // ca.unwrapGeneric means the binding came from a refutable `Some(x)`/
-        // `Ok(x)` pattern — the callee's declared return type is itself
-        // `Option<T>`/`Result<T, _>`, and `x`'s real type is the unwrapped `T`,
-        // not the wrapper. If the declared type turns out not to actually be a
-        // generic Option/Result (a mismatch between the pattern and the
-        // callee's real signature), decline to inject rather than propagate
-        // the wrapper type as if it were `x`'s type (#2214).
-        const resolvedType = ca.unwrapGeneric
-          ? unwrapOptionResultType(returnEntry.type)
-          : returnEntry.type;
+        // ca.unwrapDepth means the binding came from unwrapping that many
+        // layers of a refutable `Some(x)`/`Ok(x)` pattern — `Some(Some(x))` is
+        // 2, not 1. The callee's declared return type is itself wrapped that
+        // many layers deep (`Option<Option<T>>` for depth 2), and `x`'s real
+        // type is what's left after unwrapping all of them, not the wrapper.
+        // If a layer turns out not to actually be a generic Option/Result (a
+        // mismatch between the pattern and the callee's real signature),
+        // decline to inject rather than propagate a half-unwrapped type as if
+        // it were `x`'s type (#2214).
+        let resolvedType: string | undefined = returnEntry.type;
+        for (let i = 0; i < (ca.unwrapDepth ?? 0); i++) {
+          resolvedType =
+            resolvedType === undefined ? undefined : unwrapOptionResultType(resolvedType);
+        }
         if (resolvedType === undefined) continue;
 
         const propagatedConf = returnEntry.confidence - PROPAGATION_HOP_PENALTY;

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -9,6 +9,7 @@ import { performance } from 'node:perf_hooks';
 import { getNodeId } from '../../../../db/index.js';
 import { setTypeMapEntry } from '../../../../extractors/helpers.js';
 import { PROPAGATION_HOP_PENALTY } from '../../../../extractors/javascript.js';
+import { isOptionOrResultBase } from '../../../../extractors/rust.js';
 import { debug } from '../../../../infrastructure/logger.js';
 import { loadNative } from '../../../../infrastructure/native.js';
 import { getOrCreatePerDbChunkStmt } from '../../../../shared/chunked-stmt-cache.js';
@@ -675,7 +676,7 @@ function unwrapOptionResultType(typeName: string): string | undefined {
   const ltIdx = typeName.indexOf('<');
   if (ltIdx === -1 || !typeName.endsWith('>')) return undefined;
   const base = typeName.slice(0, ltIdx).trim();
-  if (base !== 'Option' && base !== 'Result') return undefined;
+  if (!isOptionOrResultBase(base)) return undefined;
   const inner = typeName.slice(ltIdx + 1, -1);
   let depth = 0;
   for (let i = 0; i < inner.length; i++) {

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -614,9 +614,23 @@ function propagateReturnTypesAcrossFiles(
     for (const ca of symbols.callAssignments) {
       if (symbols.typeMap.has(ca.varName)) continue; // already resolved locally
 
+      // A method call whose receiver's type wasn't known at extraction time
+      // (ca.receiverVarName) may have just been resolved by an earlier
+      // call-assignment in this same file — e.g. `service` in `const service =
+      // buildService(); ... service.getUser(1)` only becomes typed once
+      // `service`'s own cross-file return type is injected into symbols.typeMap
+      // (mutated in place by this same loop, below). Retry against the
+      // receiver's now-resolved type before falling back to a bare
+      // global-function lookup (#2214).
+      const receiverResolvedType = ca.receiverVarName
+        ? symbols.typeMap.get(ca.receiverVarName)?.type
+        : undefined;
+
       let returnEntry: TypeMapEntry | undefined;
       if (ca.receiverTypeName) {
         returnEntry = globalReturnTypeMap.get(`${ca.receiverTypeName}.${ca.calleeName}`);
+      } else if (receiverResolvedType) {
+        returnEntry = globalReturnTypeMap.get(`${receiverResolvedType}.${ca.calleeName}`);
       } else {
         const importedFrom = importedNamesMap.get(ca.calleeName);
         // The return-type index for the imported file is keyed by the
@@ -627,12 +641,53 @@ function propagateReturnTypesAcrossFiles(
       }
 
       if (returnEntry) {
+        // ca.unwrapGeneric means the binding came from a refutable `Some(x)`/
+        // `Ok(x)` pattern — the callee's declared return type is itself
+        // `Option<T>`/`Result<T, _>`, and `x`'s real type is the unwrapped `T`,
+        // not the wrapper. If the declared type turns out not to actually be a
+        // generic Option/Result (a mismatch between the pattern and the
+        // callee's real signature), decline to inject rather than propagate
+        // the wrapper type as if it were `x`'s type (#2214).
+        const resolvedType = ca.unwrapGeneric
+          ? unwrapOptionResultType(returnEntry.type)
+          : returnEntry.type;
+        if (resolvedType === undefined) continue;
+
         const propagatedConf = returnEntry.confidence - PROPAGATION_HOP_PENALTY;
         if (propagatedConf > 0)
-          setTypeMapEntry(symbols.typeMap, ca.varName, returnEntry.type, propagatedConf);
+          setTypeMapEntry(symbols.typeMap, ca.varName, resolvedType, propagatedConf);
       }
     }
   }
+}
+
+/**
+ * If `typeName` is `Option<T>` or `Result<T, E>`, return `T` — the type a
+ * refutable `Some(x)`/`Ok(x)` pattern (`if let`/`while let`/`let-else`) binds
+ * `x` to. Handles nested generics in the first type argument
+ * (`Result<Vec<User>, String>` → `Vec<User>`) by tracking bracket depth rather
+ * than splitting on the first comma. Returns `undefined` for any other shape,
+ * including a malformed generic string, so the caller can decline to inject a
+ * guessed type rather than propagate something wrong. Mirrors
+ * `unwrap_option_result_type` in `pipeline.rs` (#2214).
+ */
+function unwrapOptionResultType(typeName: string): string | undefined {
+  const ltIdx = typeName.indexOf('<');
+  if (ltIdx === -1 || !typeName.endsWith('>')) return undefined;
+  const base = typeName.slice(0, ltIdx).trim();
+  if (base !== 'Option' && base !== 'Result') return undefined;
+  const inner = typeName.slice(ltIdx + 1, -1);
+  let depth = 0;
+  for (let i = 0; i < inner.length; i++) {
+    const c = inner[i];
+    if (c === '<') depth++;
+    else if (c === '>') depth--;
+    else if (c === ',' && depth === 0) {
+      const first = inner.slice(0, i).trim();
+      return first || undefined;
+    }
+  }
+  return inner.trim() || undefined;
 }
 
 // ── Call edges (native engine) ──────────────────────────────────────────

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -702,11 +702,28 @@ function unwrapOptionResultType(typeName: string): string | undefined {
  * path in this pipeline injects a bare one (Greptile review, PR #2371).
  */
 function normalizeUnwrappedGenericArg(arg: string): string | undefined {
-  if (!arg) return undefined;
-  const ltIdx = arg.indexOf('<');
-  if (ltIdx === -1) return arg;
-  const innerBase = arg.slice(0, ltIdx).trim();
-  return isOptionOrResultBase(innerBase) ? arg : innerBase;
+  const stripped = stripReferenceSigil(arg.trim());
+  if (!stripped) return undefined;
+  const ltIdx = stripped.indexOf('<');
+  if (ltIdx === -1) return stripped;
+  const innerBase = stripped.slice(0, ltIdx).trim();
+  return isOptionOrResultBase(innerBase) ? stripped : innerBase;
+}
+
+/**
+ * Strip a leading `&`/`&mut `/`&'a `/`&'a mut ` reference sigil, the same way
+ * extractRustTypeName's reference_type branch does for a direct annotation —
+ * Option<&User>/Option<&'a mut User>'s bound value's real receiver type is
+ * User, not the reference syntax around it (Greptile review, PR #2371).
+ */
+function stripReferenceSigil(s: string): string {
+  if (!s.startsWith('&')) return s;
+  let rest = s.slice(1).trimStart();
+  if (rest.startsWith("'")) {
+    const idx = rest.search(/\s/);
+    if (idx !== -1) rest = rest.slice(idx).trimStart();
+  }
+  return rest.startsWith('mut ') ? rest.slice(4).trimStart() : rest;
 }
 
 // ── Call edges (native engine) ──────────────────────────────────────────

--- a/src/extractors/rust.ts
+++ b/src/extractors/rust.ts
@@ -252,6 +252,63 @@ function handleRustMacroInvocation(node: TreeSitterNode, ctx: ExtractorOutput): 
   if (macroNode) {
     ctx.calls.push({ name: `${macroNode.text}!`, line: node.startPosition.row + 1 });
   }
+  // Macro arguments (`println!("{}", user.display_name())`) are an opaque
+  // `token_tree` to tree-sitter-rust — macros can have arbitrary token syntax, so
+  // the grammar never parses their contents into call_expression/field_expression
+  // nodes the way it does everywhere else. walkRustNode's generic recursion still
+  // visits every token inside, but none of them match `call_expression`, so a real
+  // call embedded in a macro argument (the common `println!`/`format!`/`write!`/
+  // `assert!` case) was silently invisible to call-edge resolution. Scan the flat
+  // token sequence directly for the two call shapes tree-sitter still tokenizes
+  // recognizably — bare `ident(...)` and single-hop method `ident.ident(...)` — and
+  // record them the same way handleRustCallExpr would (#2214).
+  for (let i = 0; i < node.childCount; i++) {
+    const child = node.child(i);
+    if (child?.type === 'token_tree') scanMacroTokensForCalls(child, ctx);
+  }
+}
+
+function scanMacroTokensForCalls(tokenTree: TreeSitterNode, ctx: ExtractorOutput): void {
+  const children: TreeSitterNode[] = [];
+  for (let i = 0; i < tokenTree.childCount; i++) {
+    const child = tokenTree.child(i);
+    if (child) children.push(child);
+  }
+  for (let i = 0; i < children.length; i++) {
+    const c = children[i];
+    if (!c) continue;
+    if (c.type === 'token_tree') {
+      scanMacroTokensForCalls(c, ctx);
+      continue;
+    }
+    if (c.type !== 'identifier') continue;
+
+    // `receiver . method ( ... )` — single-hop method call.
+    const dot = children[i + 1];
+    const methodName = children[i + 2];
+    const argsAfterMethod = children[i + 3];
+    if (
+      dot?.type === '.' &&
+      methodName?.type === 'identifier' &&
+      argsAfterMethod?.type === 'token_tree' &&
+      argsAfterMethod.text.startsWith('(')
+    ) {
+      ctx.calls.push({
+        name: methodName.text,
+        line: methodName.startPosition.row + 1,
+        receiver: c.text,
+      });
+      i += 3;
+      continue;
+    }
+
+    // Bare `name ( ... )` — free-function call.
+    const argsAfterBare = children[i + 1];
+    if (argsAfterBare?.type === 'token_tree' && argsAfterBare.text.startsWith('(')) {
+      ctx.calls.push({ name: c.text, line: c.startPosition.row + 1 });
+      i += 1;
+    }
+  }
 }
 
 const RUST_IMPL_TYPES = ['impl_item'] as const;
@@ -366,12 +423,36 @@ function extractRustTypeName(typeNode: TreeSitterNode): string | null {
       }
     }
   }
-  // Generic: Vec<T> → Vec
+  // Generic: keep the full text (`Option<User>`, not just `Option`) — callers
+  // that only care about the base type still get a usable prefix, and
+  // unwrapOptionResultType() in build-edges.ts needs the type argument to type
+  // an if-let/while-let-unwrapped binding from a generic return type (#2214).
   if (t === 'generic_type') {
-    const first = typeNode.child(0);
-    return first ? first.text : null;
+    return typeNode.text;
   }
   return null;
+}
+
+/**
+ * If `pattern` is a single-argument `Some(x)`/`Ok(x)` tuple-struct pattern,
+ * return its inner `x` pattern — so `if let Some(x) = expr`/`if let Ok(x) = expr`
+ * (and the `while let`/`let-else` equivalents) can be treated as a call-assignment
+ * binding `x`, the same way `let x = expr;` already is. Returns `pattern`
+ * unchanged for any other shape (a bare identifier, `None`, `Err(_)`, or any
+ * other variant this isn't confident unwrapping). Mirrors
+ * `unwrap_option_result_pattern` in `rust_lang.rs`.
+ */
+function unwrapOptionResultPattern(pattern: TreeSitterNode): TreeSitterNode {
+  if (pattern.type !== 'tuple_struct_pattern') return pattern;
+  const typeNode = pattern.childForFieldName('type');
+  if (!typeNode) return pattern;
+  const variant = typeNode.text;
+  if (variant !== 'Some' && variant !== 'Ok') return pattern;
+  for (let i = 0; i < pattern.namedChildCount; i++) {
+    const child = pattern.namedChild(i);
+    if (child && child.id !== typeNode.id) return child;
+  }
+  return pattern;
 }
 
 // ── Return-type map extraction (Phase 8.2 parity, #1876) ────────────────────
@@ -449,7 +530,10 @@ function extractRustCallAssignmentsDepth(
   depth: number,
 ): void {
   if (depth >= MAX_WALK_DEPTH) return;
-  if (node.type === 'let_declaration') {
+  // `let_declaration` covers `let x = expr;` (and `let Some(x) = expr else {...};`
+  // let-else); `let_condition` is the `if let`/`while let` condition node (#2214) —
+  // both have `pattern`/`value` fields shaped identically.
+  if (node.type === 'let_declaration' || node.type === 'let_condition') {
     recordRustCallAssignment(node, ctx);
   }
   for (let i = 0; i < node.childCount; i++) {
@@ -460,22 +544,37 @@ function extractRustCallAssignmentsDepth(
 
 function recordRustCallAssignment(node: TreeSitterNode, ctx: ExtractorOutput): void {
   if (!ctx.callAssignments) return;
-  const pattern = node.childForFieldName('pattern');
+  const rawPattern = node.childForFieldName('pattern');
   const value = node.childForFieldName('value');
-  if (pattern?.type !== 'identifier' || value?.type !== 'call_expression') return;
+  if (!rawPattern || value?.type !== 'call_expression') return;
+  const pattern = unwrapOptionResultPattern(rawPattern);
+  const unwrapGeneric = pattern.id !== rawPattern.id;
+  if (pattern.type !== 'identifier') return;
+  // A bare fieldless-variant/unit-struct pattern (`if let None = expr`, `if let
+  // NameValidator = expr`) is syntactically identical to a variable binding —
+  // tree-sitter has no way to distinguish them by grammar alone. By Rust
+  // convention a real binding is snake_case, so an uppercase-leading name is a
+  // pattern match against a value, not a new variable — recording it as one
+  // would fabricate a call-assignment for a variable that doesn't exist (#2214).
+  if (/^[A-Z]/.test(pattern.text)) return;
   const fn = value.childForFieldName('function');
   if (!fn) return;
   const varName = pattern.text;
 
   if (fn.type === 'identifier') {
-    ctx.callAssignments.push({ varName, calleeName: fn.text });
+    ctx.callAssignments.push({ varName, calleeName: fn.text, unwrapGeneric });
     return;
   }
   if (fn.type === 'scoped_identifier') {
     const name = fn.childForFieldName('name');
     const path = fn.childForFieldName('path');
     if (name && path) {
-      ctx.callAssignments.push({ varName, calleeName: name.text, receiverTypeName: path.text });
+      ctx.callAssignments.push({
+        varName,
+        calleeName: name.text,
+        receiverTypeName: path.text,
+        unwrapGeneric,
+      });
     }
     return;
   }
@@ -486,7 +585,19 @@ function recordRustCallAssignment(node: TreeSitterNode, ctx: ExtractorOutput): v
       const receiverEntry = ctx.typeMap?.get(receiver.text);
       const receiverTypeName =
         typeof receiverEntry === 'string' ? receiverEntry : receiverEntry?.type;
-      ctx.callAssignments.push({ varName, calleeName: field.text, receiverTypeName });
+      // Preserve the raw receiver identifier even when its type isn't known yet
+      // at extraction time (e.g. `service` in `service.get_user(1)`, whose type
+      // only becomes known via cross-file return-type propagation) so injection
+      // can retry resolution once the receiver's own call-assignment has itself
+      // been injected earlier in the same pass (#2214).
+      const receiverVarName = receiverTypeName === undefined ? receiver.text : undefined;
+      ctx.callAssignments.push({
+        varName,
+        calleeName: field.text,
+        receiverTypeName,
+        receiverVarName,
+        unwrapGeneric,
+      });
     }
   }
 }

--- a/src/extractors/rust.ts
+++ b/src/extractors/rust.ts
@@ -439,9 +439,24 @@ function extractRustTypeName(typeNode: TreeSitterNode): string | null {
   if (t === 'generic_type') {
     const text = typeNode.text;
     const base = text.split('<')[0]?.trim() ?? text;
-    return base === 'Option' || base === 'Result' ? text : base;
+    return isOptionOrResultBase(base) ? text : base;
   }
   return null;
+}
+
+/**
+ * True when `base` names Option/Result, bare (`Option`) or fully qualified
+ * (`std::option::Option`, `core::result::Result`) — both spellings are valid
+ * Rust and equally common in a `-> ReturnType` position. Mirrors
+ * `is_option_or_result_base` in `rust_lang.rs` and is checked identically at
+ * unwrap time by `unwrapOptionResultType` in `build-edges.ts` (#2214, Greptile
+ * review on PR #2371 — a qualified spelling was silently treated as an
+ * unrelated generic, dropping the type argument a Some(x)/Ok(x) binding needs).
+ */
+export function isOptionOrResultBase(base: string): boolean {
+  return (
+    base === 'Option' || base === 'Result' || base.endsWith('::Option') || base.endsWith('::Result')
+  );
 }
 
 /**

--- a/src/extractors/rust.ts
+++ b/src/extractors/rust.ts
@@ -468,17 +468,40 @@ export function isOptionOrResultBase(base: string): boolean {
  * other variant this isn't confident unwrapping). Mirrors
  * `unwrap_option_result_pattern` in `rust_lang.rs`.
  */
-function unwrapOptionResultPattern(pattern: TreeSitterNode): TreeSitterNode {
-  if (pattern.type !== 'tuple_struct_pattern') return pattern;
-  const typeNode = pattern.childForFieldName('type');
-  if (!typeNode) return pattern;
-  const variant = typeNode.text;
-  if (variant !== 'Some' && variant !== 'Ok') return pattern;
-  for (let i = 0; i < pattern.namedChildCount; i++) {
-    const child = pattern.namedChild(i);
-    if (child && child.id !== typeNode.id) return child;
+/**
+ * Unwrap zero or more layers of `Some(...)`/`Ok(...)` wrapping — e.g.
+ * `Some(Some(user))` for a `Option<Option<User>>`-returning call, not just one
+ * layer — returning the innermost non-Some/Ok pattern and how many layers were
+ * stripped. The caller unwraps the callee's declared return type the same
+ * number of times (#2214, Greptile review on PR #2371 — a single unwrap left a
+ * doubly-nested pattern's binding untyped entirely, since `Some(Some(x))`'s
+ * inner pattern is itself a `tuple_struct_pattern`, not an `identifier`, and
+ * the original single-pass version gave up on it).
+ */
+function unwrapOptionResultPattern(pattern: TreeSitterNode): {
+  pattern: TreeSitterNode;
+  depth: number;
+} {
+  let current = pattern;
+  let depth = 0;
+  while (true) {
+    if (current.type !== 'tuple_struct_pattern') return { pattern: current, depth };
+    const typeNode = current.childForFieldName('type');
+    if (!typeNode) return { pattern: current, depth };
+    const variant = typeNode.text;
+    if (variant !== 'Some' && variant !== 'Ok') return { pattern: current, depth };
+    let next: TreeSitterNode | undefined;
+    for (let i = 0; i < current.namedChildCount; i++) {
+      const child = current.namedChild(i);
+      if (child && child.id !== typeNode.id) {
+        next = child;
+        break;
+      }
+    }
+    if (!next) return { pattern: current, depth };
+    current = next;
+    depth++;
   }
-  return pattern;
 }
 
 // ── Return-type map extraction (Phase 8.2 parity, #1876) ────────────────────
@@ -573,8 +596,7 @@ function recordRustCallAssignment(node: TreeSitterNode, ctx: ExtractorOutput): v
   const rawPattern = node.childForFieldName('pattern');
   const value = node.childForFieldName('value');
   if (!rawPattern || value?.type !== 'call_expression') return;
-  const pattern = unwrapOptionResultPattern(rawPattern);
-  const unwrapGeneric = pattern.id !== rawPattern.id;
+  const { pattern, depth: unwrapDepth } = unwrapOptionResultPattern(rawPattern);
   if (pattern.type !== 'identifier') return;
   // A bare fieldless-variant/unit-struct pattern (`if let None = expr`, `if let
   // NameValidator = expr`) is syntactically identical to a variable binding —
@@ -588,7 +610,7 @@ function recordRustCallAssignment(node: TreeSitterNode, ctx: ExtractorOutput): v
   const varName = pattern.text;
 
   if (fn.type === 'identifier') {
-    ctx.callAssignments.push({ varName, calleeName: fn.text, unwrapGeneric });
+    ctx.callAssignments.push({ varName, calleeName: fn.text, unwrapDepth });
     return;
   }
   if (fn.type === 'scoped_identifier') {
@@ -599,7 +621,7 @@ function recordRustCallAssignment(node: TreeSitterNode, ctx: ExtractorOutput): v
         varName,
         calleeName: name.text,
         receiverTypeName: path.text,
-        unwrapGeneric,
+        unwrapDepth,
       });
     }
     return;
@@ -622,7 +644,7 @@ function recordRustCallAssignment(node: TreeSitterNode, ctx: ExtractorOutput): v
         calleeName: field.text,
         receiverTypeName,
         receiverVarName,
-        unwrapGeneric,
+        unwrapDepth,
       });
     }
   }

--- a/src/extractors/rust.ts
+++ b/src/extractors/rust.ts
@@ -414,14 +414,16 @@ function extractRustTypeName(typeNode: TreeSitterNode): string | null {
   const t = typeNode.type;
   if (t === 'type_identifier' || t === 'identifier') return typeNode.text;
   if (t === 'scoped_type_identifier') return typeNode.text;
-  // Reference: &MyType or &mut MyType → MyType
+  // Reference: &MyType, &mut MyType, &Option<User> → recurse on the referent
+  // via the `type` field (ignoring lifetime/mut modifiers, which aren't part of
+  // it) rather than hand-matching type_identifier/scoped_type_identifier — a
+  // referent that's itself generic (&Option<User>) previously matched neither
+  // arm of the old child-loop and silently returned null, dropping the return
+  // type before the Option/Result unwrap logic ever saw it (Greptile review,
+  // PR #2371).
   if (t === 'reference_type') {
-    for (let i = 0; i < typeNode.childCount; i++) {
-      const child = typeNode.child(i);
-      if (child && (child.type === 'type_identifier' || child.type === 'scoped_type_identifier')) {
-        return child.text;
-      }
-    }
+    const referent = typeNode.childForFieldName('type');
+    return referent ? extractRustTypeName(referent) : null;
   }
   // For every OTHER generic type (Vec<T>, HashMap<K, V>, a user-defined
   // Container<T>, ...), keep the original nominal-base-name behavior — impl

--- a/src/extractors/rust.ts
+++ b/src/extractors/rust.ts
@@ -423,12 +423,23 @@ function extractRustTypeName(typeNode: TreeSitterNode): string | null {
       }
     }
   }
-  // Generic: keep the full text (`Option<User>`, not just `Option`) — callers
-  // that only care about the base type still get a usable prefix, and
-  // unwrapOptionResultType() in build-edges.ts needs the type argument to type
-  // an if-let/while-let-unwrapped binding from a generic return type (#2214).
+  // For every OTHER generic type (Vec<T>, HashMap<K, V>, a user-defined
+  // Container<T>, ...), keep the original nominal-base-name behavior — impl
+  // blocks' own qualified names use the source-literal generic syntax too
+  // (`impl<T> Container<T>` extracts as "Container<T>", not "Container"), so a
+  // concretely-instantiated receiver ("Container<User>") could never match it
+  // either way; but CHA/RTA's instantiated-types matching (buildChaContext in
+  // cha.ts) DOES compare bare typeMap entries against trait-implementor names,
+  // so keeping other generics parameterized here would silently break that
+  // unrelated, currently-working nominal match (Greptile review, PR #2371).
+  // Option/Result are the only shapes this fix actually needs full text for — a
+  // Some(x)/Ok(x) if-let/while-let binding's real type is the type ARGUMENT, not
+  // the wrapper, and unwrapOptionResultType() in build-edges.ts needs that
+  // argument text to compute it.
   if (t === 'generic_type') {
-    return typeNode.text;
+    const text = typeNode.text;
+    const base = text.split('<')[0]?.trim() ?? text;
+    return base === 'Option' || base === 'Result' ? text : base;
   }
   return null;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -727,13 +727,15 @@ export interface CallAssignment {
    */
   receiverVarName?: string;
   /**
-   * True when this assignment came from unwrapping a refutable `Some(x)`/`Ok(x)`
-   * pattern (`if let`/`while let`/`let-else`) — the callee's declared return type
-   * must itself be unwrapped from its outer `Option<T>`/`Result<T, _>` generic
-   * before being used to type `varName`. Mirrors `NativeCallAssignment.unwrapGeneric`
+   * How many layers of a refutable `Some(x)`/`Ok(x)` pattern (`if let`/
+   * `while let`/`let-else`) this assignment came from unwrapping — 0/undefined
+   * means a plain `let x = expr;` binding. `Some(Some(x))` (unwrapping a
+   * doubly-nested `Option<Option<T>>` return) is 2, not 1 — the callee's
+   * declared return type must itself be unwrapped this many times before
+   * being used to type `varName`. Mirrors `NativeCallAssignment.unwrap_depth`
    * in `crates/codegraph-core/src/types.rs` (#2214).
    */
-  unwrapGeneric?: boolean;
+  unwrapDepth?: number;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -715,6 +715,25 @@ export interface CallAssignment {
   calleeName: string;
   /** Resolved receiver type, if the call is a method call (e.g. service.getRepo()). */
   receiverTypeName?: string;
+  /**
+   * Raw receiver identifier for a method call (`receiver.method()`) whose
+   * receiver's type wasn't resolvable at extraction time — e.g. `service` in
+   * `service.get_user(1)`, when `service`'s own type only becomes known via
+   * cross-file return-type propagation. Lets injection retry resolving the
+   * receiver's type once its own call-assignment has been injected earlier in
+   * the same pass, instead of giving up the way a bare `receiverTypeName:
+   * undefined` would (mirrors `NativeCallAssignment.receiver_var_name` in
+   * `crates/codegraph-core/src/types.rs`, #2214).
+   */
+  receiverVarName?: string;
+  /**
+   * True when this assignment came from unwrapping a refutable `Some(x)`/`Ok(x)`
+   * pattern (`if let`/`while let`/`let-else`) — the callee's declared return type
+   * must itself be unwrapped from its outer `Option<T>`/`Result<T, _>` generic
+   * before being used to type `varName`. Mirrors `NativeCallAssignment.unwrapGeneric`
+   * in `crates/codegraph-core/src/types.rs` (#2214).
+   */
+  unwrapGeneric?: boolean;
 }
 
 /**

--- a/tests/parsers/rust.test.ts
+++ b/tests/parsers/rust.test.ts
@@ -250,6 +250,19 @@ impl Display for Foo {}`);
     );
   });
 
+  it('preserves the full text for a reference-wrapped Option (Option<&T>)', () => {
+    // `Option<&User>` (a common shape for a cached-field getter) must preserve
+    // the type argument, including the reference sigil, the same way any other
+    // Option<T> does — unwrapOptionResultType in build-edges.ts strips the `&`
+    // at injection time, not extraction time (Greptile review, PR #2371).
+    const symbols = parseRust(
+      `struct UserService { cached: User }\nimpl UserService {\n  fn get_user_ref(&self) -> Option<&User> { Some(&self.cached) }\n}`,
+    );
+    expect(symbols.returnTypeMap.get('UserService.get_user_ref')).toEqual(
+      expect.objectContaining({ type: 'Option<&User>' }),
+    );
+  });
+
   // ── Calls embedded in macro invocation arguments (#2214) ──────────────────
 
   it('scans macro arguments for a method call', () => {

--- a/tests/parsers/rust.test.ts
+++ b/tests/parsers/rust.test.ts
@@ -241,6 +241,15 @@ impl Display for Foo {}`);
     );
   });
 
+  it('preserves the full text for a fully-qualified Option (std::option::Option<T>)', () => {
+    // `std::option::Option<User>` is just as valid as the bare `Option<User>`
+    // spelling and must be recognized the same way (Greptile review, PR #2371).
+    const symbols = parseRust(`fn get_user() -> std::option::Option<User> { None }`);
+    expect(symbols.returnTypeMap.get('get_user')).toEqual(
+      expect.objectContaining({ type: 'std::option::Option<User>' }),
+    );
+  });
+
   // ── Calls embedded in macro invocation arguments (#2214) ──────────────────
 
   it('scans macro arguments for a method call', () => {

--- a/tests/parsers/rust.test.ts
+++ b/tests/parsers/rust.test.ts
@@ -230,6 +230,17 @@ impl Display for Foo {}`);
     );
   });
 
+  it('keeps the bare base name for non-Option/Result generics (Vec<T>, etc.)', () => {
+    // Only Option/Result need the type argument preserved (to unwrap a
+    // Some(x)/Ok(x) binding) — every other generic keeps its original bare name
+    // so CHA/RTA's instantiated-types matching against trait-implementor names is
+    // unaffected (Greptile review, PR #2371).
+    const symbols = parseRust(`fn get_users() -> Vec<User> { Vec::new() }`);
+    expect(symbols.returnTypeMap.get('get_users')).toEqual(
+      expect.objectContaining({ type: 'Vec' }),
+    );
+  });
+
   // ── Calls embedded in macro invocation arguments (#2214) ──────────────────
 
   it('scans macro arguments for a method call', () => {

--- a/tests/parsers/rust.test.ts
+++ b/tests/parsers/rust.test.ts
@@ -178,4 +178,80 @@ impl Display for Foo {}`);
       }),
     );
   });
+
+  // ── if-let/while-let pattern-binding call assignments (#2214) ────────────
+
+  it('records a call assignment for an if-let Some-bound method call', () => {
+    const symbols = parseRust(
+      `fn f() {\n  let service = build_service();\n  if let Some(user) = service.get_user(1) {}\n}`,
+    );
+    const ca = symbols.callAssignments.find((c) => c.varName === 'user');
+    expect(ca).toEqual(
+      expect.objectContaining({
+        calleeName: 'get_user',
+        receiverTypeName: undefined,
+        receiverVarName: 'service',
+        unwrapGeneric: true,
+      }),
+    );
+  });
+
+  it('records a call assignment for an if-let Ok-bound bare call', () => {
+    const symbols = parseRust(`fn f() {\n  if let Ok(user) = build_user() {}\n}`);
+    const ca = symbols.callAssignments.find((c) => c.varName === 'user');
+    expect(ca).toEqual(expect.objectContaining({ calleeName: 'build_user', unwrapGeneric: true }));
+  });
+
+  it('unwraps a while-let Some-bound call assignment too', () => {
+    const symbols = parseRust(`fn f() {\n  while let Some(item) = next_item() {}\n}`);
+    const ca = symbols.callAssignments.find((c) => c.varName === 'item');
+    expect(ca).toEqual(expect.objectContaining({ calleeName: 'next_item', unwrapGeneric: true }));
+  });
+
+  it('does not mark a plain let binding as unwrapped', () => {
+    const symbols = parseRust(`fn f() {\n  let service = build_service();\n}`);
+    const ca = symbols.callAssignments.find((c) => c.varName === 'service');
+    expect(ca?.unwrapGeneric).toBe(false);
+  });
+
+  it('does not treat a None/unit-variant pattern as a call assignment', () => {
+    // `None` is syntactically identical to a bare identifier binding — must not
+    // be recorded as if it were a new variable named "None".
+    const symbols = parseRust(`fn f() {\n  if let None = build_service() {}\n}`);
+    expect(symbols.callAssignments).toHaveLength(0);
+  });
+
+  // ── Full generic return types (#2214) ─────────────────────────────────────
+
+  it('preserves the full generic return type (Option<T>, not just Option)', () => {
+    const symbols = parseRust(`fn get_user() -> Option<User> { None }`);
+    expect(symbols.returnTypeMap.get('get_user')).toEqual(
+      expect.objectContaining({ type: 'Option<User>' }),
+    );
+  });
+
+  // ── Calls embedded in macro invocation arguments (#2214) ──────────────────
+
+  it('scans macro arguments for a method call', () => {
+    const symbols = parseRust(`fn f() { println!("{}", user.display_name()); }`);
+    expect(symbols.calls).toContainEqual(
+      expect.objectContaining({ name: 'display_name', receiver: 'user' }),
+    );
+    expect(symbols.calls).toContainEqual(expect.objectContaining({ name: 'println!' }));
+  });
+
+  it('scans macro arguments for a bare function call', () => {
+    const symbols = parseRust(`fn f() { println!("{}", compute_total()); }`);
+    const call = symbols.calls.find((c) => c.name === 'compute_total');
+    expect(call).toBeDefined();
+    expect(call?.receiver).toBeUndefined();
+  });
+
+  it('scans nested macro arguments recursively', () => {
+    const symbols = parseRust(`fn f() { assert_eq!(compute_total(), other.value()); }`);
+    expect(symbols.calls).toContainEqual(expect.objectContaining({ name: 'compute_total' }));
+    expect(symbols.calls).toContainEqual(
+      expect.objectContaining({ name: 'value', receiver: 'other' }),
+    );
+  });
 });

--- a/tests/parsers/rust.test.ts
+++ b/tests/parsers/rust.test.ts
@@ -275,6 +275,18 @@ impl Display for Foo {}`);
     );
   });
 
+  it('preserves a reference to a generic Option (&Option<T>)', () => {
+    // `&Option<User>` (a reference TO the Option, not a reference stored
+    // inside it) — the old reference_type handling only matched a bare
+    // type_identifier/scoped_type_identifier child, never a generic_type
+    // child, so this shape returned null entirely and the whole return type
+    // was dropped (Greptile review, PR #2371).
+    const symbols = parseRust(`fn get_user() -> &Option<User> { &None }`);
+    expect(symbols.returnTypeMap.get('get_user')).toEqual(
+      expect.objectContaining({ type: 'Option<User>' }),
+    );
+  });
+
   // ── Calls embedded in macro invocation arguments (#2214) ──────────────────
 
   it('scans macro arguments for a method call', () => {

--- a/tests/parsers/rust.test.ts
+++ b/tests/parsers/rust.test.ts
@@ -191,7 +191,7 @@ impl Display for Foo {}`);
         calleeName: 'get_user',
         receiverTypeName: undefined,
         receiverVarName: 'service',
-        unwrapGeneric: true,
+        unwrapDepth: 1,
       }),
     );
   });
@@ -199,19 +199,31 @@ impl Display for Foo {}`);
   it('records a call assignment for an if-let Ok-bound bare call', () => {
     const symbols = parseRust(`fn f() {\n  if let Ok(user) = build_user() {}\n}`);
     const ca = symbols.callAssignments.find((c) => c.varName === 'user');
-    expect(ca).toEqual(expect.objectContaining({ calleeName: 'build_user', unwrapGeneric: true }));
+    expect(ca).toEqual(expect.objectContaining({ calleeName: 'build_user', unwrapDepth: 1 }));
   });
 
   it('unwraps a while-let Some-bound call assignment too', () => {
     const symbols = parseRust(`fn f() {\n  while let Some(item) = next_item() {}\n}`);
     const ca = symbols.callAssignments.find((c) => c.varName === 'item');
-    expect(ca).toEqual(expect.objectContaining({ calleeName: 'next_item', unwrapGeneric: true }));
+    expect(ca).toEqual(expect.objectContaining({ calleeName: 'next_item', unwrapDepth: 1 }));
   });
 
   it('does not mark a plain let binding as unwrapped', () => {
     const symbols = parseRust(`fn f() {\n  let service = build_service();\n}`);
     const ca = symbols.callAssignments.find((c) => c.varName === 'service');
-    expect(ca?.unwrapGeneric).toBe(false);
+    expect(ca?.unwrapDepth).toBe(0);
+  });
+
+  it('records a doubly-nested Some pattern with depth two', () => {
+    // `Some(Some(x))` — destructuring a doubly-nested `Option<Option<T>>` in a
+    // single pattern, the idiomatic way to do it, not two sequential if-lets —
+    // must unwrap both layers, not give up after the first (Greptile review,
+    // PR #2371).
+    const symbols = parseRust(`fn f() {\n  if let Some(Some(user)) = get_nested_option() {}\n}`);
+    const ca = symbols.callAssignments.find((c) => c.varName === 'user');
+    expect(ca).toEqual(
+      expect.objectContaining({ calleeName: 'get_nested_option', unwrapDepth: 2 }),
+    );
   });
 
   it('does not treat a None/unit-variant pattern as a call assignment', () => {


### PR DESCRIPTION
## Summary

`if let Some(user) = service.get_user(1) { user.display_name() }` never resolved `main -> User.display_name` on either engine, despite `tests/benchmarks/resolution/fixtures/rust/expected-edges.json` already expecting it (23/24 recall). Root cause was three compounding gaps, all fixed in both the native extractor/pipeline (`crates/codegraph-core`) and the WASM/TS mirror:

- **`if let`/`while let` bindings were invisible to call-assignment extraction.** `match_rust_call_assignments` only recognized plain `let x = expr;` (the `let_declaration` node) — never the `let_condition` node `if let`/`while let` actually use. Extended to both, with `Some(x)`/`Ok(x)` pattern-unwrapping (`unwrap_generic` flag) so the binding's real type is the unwrapped inner type, not the `Option<T>`/`Result<T, _>` wrapper.
- **Generic return types were truncated at extraction.** `extract_rust_type_name`'s `generic_type` branch returned only the base name (`Option<User>` → `"Option"`), discarding the type argument a `Some(x)`/`Ok(x)` binding needs to type itself correctly. Now preserves the full generic text; a new `unwrap_option_result_type` (native) / `unwrapOptionResultType` (TS) parses it back out at injection time, tracking bracket depth so `Result<Vec<User>, String>` correctly yields `Vec<User>`.
- **A two-hop receiver chain never re-resolved.** `service.get_user(1)` inside the if-let has `service` itself typed only via cross-file propagation (`build_service()`'s return type) — a receiver whose type isn't known until injection. Added `receiver_var_name` to carry the raw identifier so injection can retry the lookup once the receiver's own call-assignment has been resolved earlier in the same pass, instead of giving up.
- **Calls embedded in macro arguments were invisible entirely.** `println!("{}", user.display_name())` — tree-sitter-rust never parses macro arguments into `call_expression`/`field_expression` nodes (macros can have arbitrary token syntax), so the actual call site was never recorded by *either* engine, regardless of the above. Added a token-stream scanner (`scanMacroTokensForCalls` / `scan_macro_tokens_for_calls`) that recognizes bare `ident(...)` and single-hop `ident.ident(...)` shapes within a macro's `token_tree`, recursing into nested argument groups.

Also guards two edge cases surfaced while implementing this:
- `if let None = expr {}` / `if let Err = expr {}` — a fieldless-variant pattern parses identically to a bare variable binding; skips recording when the "bound" name is uppercase-leading (Rust binding convention is snake_case).
- Declines to inject a type when `unwrap_generic` is set but the declared return type turns out not to actually be generic (a mismatch between the pattern and the callee's real signature), rather than propagating the wrapper type as if it were correct.

Verified both engines now produce identical results on the fixture: **24/24 precision and recall** (previously 23/24), matching `expected-edges.json` exactly.

## Test plan

- [x] `crates/codegraph-core`: 17 new unit tests (if-let/while-let recognition, Option/Result unwrap, receiver_var_name two-hop resolution, macro-argument call scanning, None/Err guard) — `cargo test --release`: 840/840 pass
- [x] `cargo fmt --check`, `cargo clippy --release`: clean (pre-existing warnings elsewhere untouched)
- [x] `tests/parsers/rust.test.ts`: 9 new tests mirroring the native ones — 28/28 pass
- [x] Manually verified both `--engine native` and `--engine wasm` resolve `main -> User.display_name` on the actual fixture, with matching edge counts (126)
- [x] `npm test`: full suite, 290 files, 4732/4732 pass
- [x] `npm run lint`, `npx tsc --noEmit` (via `npm run build`): clean
- [x] `codegraph diff-impact --staged`: 10 functions changed, 0 unexpected callers affected

Closes #2214