### PR TITLE
fix(incremental): thread known-files list into watch-mode import resolution

### DIFF
--- a/crates/codegraph-core/src/domain/graph/resolve.rs
+++ b/crates/codegraph-core/src/domain/graph/resolve.rs
@@ -491,6 +491,23 @@ fn is_workspace_resolved(path: &str) -> bool {
         .contains(path)
 }
 
+/// Normalize each `known_files` entry to forward slashes.
+///
+/// Callers across the NAPI boundary (`resolve_import`/`resolve_imports` in
+/// `lib.rs`) may pass either the root-relative form (as stored in the
+/// `nodes` table) or the absolute form (as JS's `ctx.allFiles` /
+/// `getKnownFilesForIncremental` populate it) — and on Windows, an absolute
+/// path arrives with backslashes while `file_exists` always forward-slash
+/// normalizes the *candidate* paths it checks against this set before
+/// comparing. Without normalizing the set's own entries the same way, an
+/// absolute Windows candidate could never exact-match a set built from raw,
+/// backslash-separated JS strings — the in-process pipeline caller
+/// (`resolve_pipeline_imports`) doesn't need this because it builds
+/// `known_files` from `relative_path()`, which already normalizes.
+pub fn normalize_known_files(files: Vec<String>) -> HashSet<String> {
+    files.into_iter().map(|f| f.replace('\\', "/")).collect()
+}
+
 /// Resolve a single import path, mirroring `resolveImportPath()` in builder.js.
 ///
 /// `known_files` enables Rust `crate::`/`self::`/`super::` module-path
@@ -1644,6 +1661,30 @@ mod tests {
         .iter()
         .map(|s| s.to_string())
         .collect()
+    }
+
+    #[test]
+    fn normalize_known_files_converts_backslashes_to_forward_slashes() {
+        // Regression test for #2216: on Windows, JS callers across the NAPI
+        // boundary (ctx.allFiles / getKnownFilesForIncremental) pass absolute
+        // paths with backslashes, while file_exists always forward-slash
+        // normalizes the candidate it checks against this set — without this
+        // normalization those two could never exact-match.
+        let input = vec![
+            "C:\\project\\main.rs".to_string(),
+            "C:\\project\\service\\nested.rs".to_string(),
+        ];
+        let normalized = normalize_known_files(input);
+        assert!(normalized.contains("C:/project/main.rs"));
+        assert!(normalized.contains("C:/project/service/nested.rs"));
+    }
+
+    #[test]
+    fn normalize_known_files_is_a_no_op_for_already_forward_slash_paths() {
+        let input = vec!["/project/main.rs".to_string(), "service.rs".to_string()];
+        let normalized = normalize_known_files(input);
+        assert!(normalized.contains("/project/main.rs"));
+        assert!(normalized.contains("service.rs"));
     }
 
     #[test]

--- a/crates/codegraph-core/src/domain/graph/resolve.rs
+++ b/crates/codegraph-core/src/domain/graph/resolve.rs
@@ -10,17 +10,23 @@ use crate::types::{ImportResolutionInput, PathAliases, ResolvedImport, Workspace
 /// Check file existence using known_files set when available, falling back to FS.
 ///
 /// When `known_files` is provided, candidates may be absolute paths while
-/// the set contains relative paths (normalized with forward slashes).
-/// We try both the raw path and the root-relative version so extension
-/// probing works regardless of the path format (#804).
+/// the set contains relative paths (normalized with forward slashes) — or,
+/// via `normalize_known_files`, absolute paths that are themselves already
+/// forward-slash normalized. `path` is normalized here (not just at the
+/// handful of Rust crate-path call sites that already did their own
+/// `.replace('\\', "/")`) so every caller — including the alias/exports/
+/// js-to-ts-remap resolvers, which pass their candidate through unmodified —
+/// gets a forward-slash-consistent comparison on Windows. We try both the
+/// normalized path and the root-relative version so extension probing works
+/// regardless of the path format (#804, #2216).
 fn file_exists(path: &str, known: Option<&HashSet<String>>, root_dir: &str) -> bool {
     match known {
         Some(set) => {
-            if set.contains(path) {
+            let normalized = path.replace('\\', "/");
+            if set.contains(&normalized) {
                 return true;
             }
             // Candidates are often absolute; known_files are relative — try stripping root
-            let normalized = path.replace('\\', "/");
             let root_normalized = root_dir.replace('\\', "/");
             let root_prefix = if root_normalized.ends_with('/') {
                 root_normalized
@@ -1190,6 +1196,27 @@ mod tests {
 
         // Relative candidate should still match directly
         assert!(file_exists("src/domain/parser.ts", Some(&known), root));
+    }
+
+    #[test]
+    fn file_exists_matches_unnormalized_backslash_candidate_against_absolute_known_files() {
+        // Regression test for #2216: on Windows, callers like
+        // resolve_via_alias build their candidate via PathBuf::display()
+        // without normalizing it — and known_files may be the absolute
+        // convention (ctx.allFiles / getKnownFilesForIncremental, normalized
+        // via normalize_known_files). Simulating that with a literal
+        // backslash-separated candidate string, on a Set already containing
+        // the forward-slash form, must still match — file_exists normalizes
+        // the query path itself rather than relying on the caller to have
+        // done so.
+        let mut known = HashSet::new();
+        known.insert("C:/project/src/index.ts".to_string());
+
+        assert!(file_exists(
+            "C:\\project\\src\\index.ts",
+            Some(&known),
+            "C:/project"
+        ));
     }
 
     #[test]

--- a/crates/codegraph-core/src/lib.rs
+++ b/crates/codegraph-core/src/lib.rs
@@ -93,8 +93,8 @@ pub fn parse_files_full(file_paths: Vec<String>, root_dir: String) -> Vec<FileSy
 /// *detection* of its own, only resolution against a supplied map; issue #1927).
 ///
 /// `known_files` enables Rust `crate::`/`self::`/`super::` module-path
-/// resolution (issue #2007); pass the project's known relative file paths
-/// when available.
+/// resolution (issue #2007); pass the project's known file paths (relative
+/// or absolute) when available.
 #[napi]
 pub fn resolve_import(
     from_file: String,
@@ -108,8 +108,7 @@ pub fn resolve_import(
         base_url: None,
         paths: vec![],
     });
-    let known_set =
-        known_files.map(|v| v.into_iter().collect::<std::collections::HashSet<String>>());
+    let known_set = known_files.map(domain::graph::resolve::normalize_known_files);
     let workspace_map = workspaces.map(|w| domain::graph::resolve::workspaces_from_packages(&w));
     domain::graph::resolve::resolve_import_path(
         &from_file,
@@ -145,8 +144,7 @@ pub fn resolve_imports(
         base_url: None,
         paths: vec![],
     });
-    let known_set =
-        known_files.map(|v| v.into_iter().collect::<std::collections::HashSet<String>>());
+    let known_set = known_files.map(domain::graph::resolve::normalize_known_files);
     let workspace_map = workspaces.map(|w| domain::graph::resolve::workspaces_from_packages(&w));
     domain::graph::resolve::reset_workspace_resolved_paths();
     domain::graph::resolve::clear_exports_cache();

--- a/src/domain/graph/builder/incremental.ts
+++ b/src/domain/graph/builder/incremental.ts
@@ -228,7 +228,13 @@ function getKnownFilesForIncremental(db: BetterSqlite3Database, rootDir: string)
   const rows = db.prepare("SELECT DISTINCT file FROM nodes WHERE kind = 'file'").all() as Array<{
     file: string;
   }>;
-  return rows.map((r) => path.join(rootDir, r.file));
+  // `r.file` is stored forward-slash-normalized (cross-platform DB
+  // consistency) even for a nested relative path like "service/nested.rs".
+  // Joining it into rootDir in one path.join() call would leave those
+  // internal forward slashes intact on Windows, producing a mixed-separator
+  // absolute path that can't exact-match a purely-backslash candidate built
+  // elsewhere — so join one segment at a time instead.
+  return rows.map((r) => path.join(rootDir, ...r.file.split('/')));
 }
 
 function deleteOutgoingEdges(db: BetterSqlite3Database, relPath: string): void {

--- a/src/domain/graph/builder/incremental.ts
+++ b/src/domain/graph/builder/incremental.ts
@@ -212,6 +212,25 @@ function findReverseDeps(db: BetterSqlite3Database, relPath: string): string[] {
   return (findRevDepsStmt.all(relPath, relPath) as Array<{ file: string }>).map((r) => r.file);
 }
 
+/**
+ * Project-wide known-files list for `resolveImportPath`'s Rust `crate::`/
+ * `self::`/`super::` resolution (#2007) — absolute paths, matching
+ * `ctx.allFiles`'s format on the full-build path (`resolve-imports.ts`).
+ * The full-build path already has this in memory before import resolution
+ * runs; a single-file incremental rebuild has no such list, so this queries
+ * it from the DB once per `rebuildFile` call and threads it down to every
+ * `resolveImportPath` call site in this file (#2216) — without it, a
+ * `crate::`/`self::`/`super::` import in a file processed via `codegraph
+ * watch` silently fails to resolve even though the same file would resolve
+ * correctly in a full rebuild.
+ */
+function getKnownFilesForIncremental(db: BetterSqlite3Database, rootDir: string): string[] {
+  const rows = db.prepare("SELECT DISTINCT file FROM nodes WHERE kind = 'file'").all() as Array<{
+    file: string;
+  }>;
+  return rows.map((r) => path.join(rootDir, r.file));
+}
+
 function deleteOutgoingEdges(db: BetterSqlite3Database, relPath: string): void {
   const { deleteDataflowByCallEdgeStmt, deleteOutEdgesStmt } = getRevDepStmts(db);
   // Clear any inter-procedural dataflow rows that reference outgoing edges via
@@ -247,6 +266,8 @@ function rebuildReverseDepEdges(
   symbols: ExtractorOutput,
   stmts: IncrementalStmts,
   skipBarrel: boolean,
+  // #2216: see getKnownFilesForIncremental's doc comment.
+  knownFiles: readonly string[],
   // #2077: forwarded to buildCallEdges — see its own param doc.
   maxIterations?: number,
 ): number {
@@ -255,7 +276,7 @@ function rebuildReverseDepEdges(
 
   // #1967: keep this reverse-dep's persisted barrel rename table current if
   // it's itself a barrel — independent of the edges rebuilt below.
-  persistReexportRenamesForFile(db, depRelPath, symbols, rootDir);
+  persistReexportRenamesForFile(db, depRelPath, symbols, rootDir, knownFiles);
 
   const aliases: PathAliases = { baseUrl: null, paths: {} };
   let edgesAdded = buildContainmentEdges(db, stmts, depRelPath, symbols);
@@ -268,6 +289,7 @@ function rebuildReverseDepEdges(
     fileNodeRow.id,
     aliases,
     skipBarrel ? null : db,
+    knownFiles,
   );
   const { importedNames, importedOriginalNames } = buildImportedNamesMap(
     symbols,
@@ -275,6 +297,7 @@ function rebuildReverseDepEdges(
     depRelPath,
     aliases,
     db,
+    knownFiles,
   );
   edgesAdded += buildCallEdges(
     db,
@@ -519,6 +542,7 @@ function persistReexportRenamesForFile(
   relPath: string,
   symbols: ExtractorOutput,
   rootDir: string,
+  knownFiles: readonly string[],
 ): void {
   const { renameDeleteStmt, renameInsertStmt } = getBarrelStmts(db);
   renameDeleteStmt.run(relPath);
@@ -539,7 +563,13 @@ function persistReexportRenamesForFile(
   const aliases = loadPathAliases(rootDir);
   for (const imp of reexports) {
     if (!imp.renamedImports?.length) continue;
-    const source = resolveImportPath(path.join(rootDir, relPath), imp.source, rootDir, aliases);
+    const source = resolveImportPath(
+      path.join(rootDir, relPath),
+      imp.source,
+      rootDir,
+      aliases,
+      knownFiles,
+    );
     for (const rename of imp.renamedImports) {
       renameInsertStmt.run(relPath, rename.local, rename.imported, source);
     }
@@ -715,8 +745,15 @@ function emitEdgesForImport(
   rootDir: string,
   aliases: PathAliases,
   db: BetterSqlite3Database | null,
+  knownFiles: readonly string[],
 ): number {
-  const resolvedPath = resolveImportPath(path.join(rootDir, relPath), imp.source, rootDir, aliases);
+  const resolvedPath = resolveImportPath(
+    path.join(rootDir, relPath),
+    imp.source,
+    rootDir,
+    aliases,
+    knownFiles,
+  );
   const targetRow = stmts.getNodeId.get(resolvedPath, 'file', resolvedPath, 0);
   if (!targetRow) return 0;
 
@@ -761,10 +798,20 @@ function buildImportEdges(
   fileNodeId: number,
   aliases: PathAliases,
   db: BetterSqlite3Database | null,
+  knownFiles: readonly string[],
 ): number {
   let edgesAdded = 0;
   for (const imp of symbols.imports) {
-    edgesAdded += emitEdgesForImport(stmts, imp, fileNodeId, relPath, rootDir, aliases, db);
+    edgesAdded += emitEdgesForImport(
+      stmts,
+      imp,
+      fileNodeId,
+      relPath,
+      rootDir,
+      aliases,
+      db,
+      knownFiles,
+    );
   }
   return edgesAdded;
 }
@@ -783,6 +830,7 @@ function buildImportedNamesMap(
   relPath: string,
   aliases: PathAliases,
   db: BetterSqlite3Database,
+  knownFiles: readonly string[],
 ): { importedNames: Map<string, string>; importedOriginalNames: Map<string, string> } {
   const importedNames = new Map<string, string>();
   const importedOriginalNames = new Map<string, string>();
@@ -792,6 +840,7 @@ function buildImportedNamesMap(
       imp.source,
       rootDir,
       aliases,
+      knownFiles,
     );
     for (const { local, original } of importNamePairs(imp)) {
       // Mirror full-build's `buildImportedNamesMap`: follow barrel re-exports so
@@ -1613,23 +1662,36 @@ function rebuildEdgesForTargetFile(
   symbols: ExtractorOutput,
   fileNodeRow: { id: number },
   rootDir: string,
+  // #2216: project-wide known-files list, needed for Rust crate::/self::/
+  // super:: resolution (#2007) — see getKnownFilesForIncremental's doc comment.
+  knownFiles: readonly string[],
   // #2077: forwarded to buildCallEdges — see its own param doc.
   maxIterations?: number,
 ): number {
   // #1967: keep this file's persisted barrel rename table current if it's
   // itself a barrel — independent of the edges rebuilt below.
-  persistReexportRenamesForFile(db, relPath, symbols, rootDir);
+  persistReexportRenamesForFile(db, relPath, symbols, rootDir, knownFiles);
 
   const aliases: PathAliases = { baseUrl: null, paths: {} };
   let edgesAdded = buildContainmentEdges(db, stmts, relPath, symbols);
   edgesAdded += rebuildDirContainment(db, stmts, relPath);
-  edgesAdded += buildImportEdges(stmts, relPath, symbols, rootDir, fileNodeRow.id, aliases, db);
+  edgesAdded += buildImportEdges(
+    stmts,
+    relPath,
+    symbols,
+    rootDir,
+    fileNodeRow.id,
+    aliases,
+    db,
+    knownFiles,
+  );
   const { importedNames, importedOriginalNames } = buildImportedNamesMap(
     symbols,
     rootDir,
     relPath,
     aliases,
     db,
+    knownFiles,
   );
   edgesAdded += buildCallEdges(
     db,
@@ -1690,6 +1752,7 @@ function emitBarrelImportEdgesForReverseDeps(
   stmts: IncrementalStmts,
   depSymbols: Map<string, ExtractorOutput>,
   rootDir: string,
+  knownFiles: readonly string[],
 ): number {
   let edgesAdded = 0;
   for (const [depRelPath, symbols_] of depSymbols) {
@@ -1703,6 +1766,7 @@ function emitBarrelImportEdgesForReverseDeps(
         imp.source,
         rootDir,
         aliases_,
+        knownFiles,
       );
       edgesAdded += resolveBarrelImportEdges(db, stmts, fileNodeRow_.id, resolvedPath, imp);
     }
@@ -1726,6 +1790,8 @@ async function runReverseDepCascade(
   stmts: IncrementalStmts,
   engineOpts: EngineOpts,
   cache: unknown,
+  // #2216: see getKnownFilesForIncremental's doc comment.
+  knownFiles: readonly string[],
 ): Promise<{
   edgesAdded: number;
   reverseDepsEdgesBefore: number;
@@ -1750,11 +1816,12 @@ async function runReverseDepCascade(
       symbols_,
       stmts,
       true,
+      knownFiles,
       engineOpts.pointsToMaxIterations,
     );
   }
   // Pass 2: add barrel import edges (reexports edges now exist)
-  edgesAdded += emitBarrelImportEdgesForReverseDeps(db, stmts, depSymbols, rootDir);
+  edgesAdded += emitBarrelImportEdgesForReverseDeps(db, stmts, depSymbols, rootDir, knownFiles);
   return { edgesAdded, reverseDepsEdgesBefore, depSymbols };
 }
 
@@ -2107,6 +2174,12 @@ export async function rebuildFile(
       edgesBefore,
     };
 
+  // #2216: computed once per rebuild (this file's own node row is already
+  // inserted above, so it's included) and threaded through every
+  // resolveImportPath call below — see getKnownFilesForIncremental's doc
+  // comment for why a single-file incremental rebuild needs this at all.
+  const knownFiles = getKnownFilesForIncremental(db, rootDir);
+
   let edgesAdded = rebuildEdgesForTargetFile(
     db,
     stmts,
@@ -2114,13 +2187,14 @@ export async function rebuildFile(
     symbols,
     fileNodeRow,
     rootDir,
+    knownFiles,
     engineOpts.pointsToMaxIterations,
   );
   const {
     edgesAdded: cascadeEdges,
     reverseDepsEdgesBefore,
     depSymbols,
-  } = await runReverseDepCascade(db, rootDir, reverseDeps, stmts, engineOpts, cache);
+  } = await runReverseDepCascade(db, rootDir, reverseDeps, stmts, engineOpts, cache, knownFiles);
   edgesAdded += cascadeEdges;
 
   // Phase 8.5 CHA + RTA dispatch expansion post-pass (#1852) — runs after all

--- a/src/domain/graph/resolve.ts
+++ b/src/domain/graph/resolve.ts
@@ -485,6 +485,20 @@ function isRustCargoTargetRoot(file: string): boolean {
 }
 
 /**
+ * True if `knownFiles` contains `candidate` (an absolute path) — checking
+ * both the absolute form (as populated by `ctx.allFiles` on the full-build
+ * path and `getKnownFilesForIncremental` on the watch-mode path) and the
+ * root-relative, forward-slash-normalized form (as stored in the `nodes`
+ * table), mirroring the native resolver's `file_exists` dual check. Callers
+ * of `resolveImportPath` are not required to agree on one convention, so
+ * this must accept either.
+ */
+function knownFilesHasFile(knownFiles: Set<string>, candidate: string, rootDir: string): boolean {
+  if (knownFiles.has(candidate)) return true;
+  return knownFiles.has(normalizePath(path.relative(rootDir, candidate)));
+}
+
+/**
  * Find the crate-root .rs file whose directory is an ancestor of
  * `fromFile`, walking up from fromFile's directory and stopping at
  * `rootDir`. Returns the absolute path, or null if none is found among
@@ -508,8 +522,7 @@ function findRustCrateRoot(
   for (;;) {
     for (const name of ['main.rs', 'lib.rs']) {
       const candidate = path.join(dir, name);
-      const rel = normalizePath(path.relative(rootDir, candidate));
-      if (knownFiles.has(rel)) return candidate;
+      if (knownFilesHasFile(knownFiles, candidate, rootDir)) return candidate;
     }
     if (!dir.startsWith(rootDir)) return null;
     const parent = path.dirname(dir);
@@ -534,13 +547,11 @@ function rustParentModuleFile(
   const searchDir = base === 'mod' ? path.dirname(dir) : dir;
 
   for (const candidate of [`${searchDir}.rs`, path.join(searchDir, 'mod.rs')]) {
-    const rel = normalizePath(path.relative(rootDir, candidate));
-    if (knownFiles.has(rel)) return candidate;
+    if (knownFilesHasFile(knownFiles, candidate, rootDir)) return candidate;
   }
   for (const name of ['main.rs', 'lib.rs']) {
     const candidate = path.join(searchDir, name);
-    const rel = normalizePath(path.relative(rootDir, candidate));
-    if (knownFiles.has(rel)) return candidate;
+    if (knownFilesHasFile(knownFiles, candidate, rootDir)) return candidate;
   }
   return null;
 }
@@ -571,15 +582,13 @@ function walkRustModuleSegments(
     const seg = segments[i]!;
     const fileCandidate = path.join(currentDir, `${seg}.rs`);
     const modCandidate = path.join(currentDir, seg, 'mod.rs');
-    const fileRel = normalizePath(path.relative(rootDir, fileCandidate));
-    const modRel = normalizePath(path.relative(rootDir, modCandidate));
 
-    if (knownFiles.has(fileRel)) {
+    if (knownFilesHasFile(knownFiles, fileCandidate, rootDir)) {
       currentFile = fileCandidate;
       currentDir = path.join(currentDir, seg);
       continue;
     }
-    if (knownFiles.has(modRel)) {
+    if (knownFilesHasFile(knownFiles, modCandidate, rootDir)) {
       currentFile = modCandidate;
       currentDir = path.join(currentDir, seg);
       continue;

--- a/tests/integration/issue-2216-watch-rust-crate-path.test.ts
+++ b/tests/integration/issue-2216-watch-rust-crate-path.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Regression test for #2216: `codegraph watch`'s single-file rebuild path
+ * (`rebuildFile` in `domain/graph/builder/incremental.ts`) never threaded a
+ * project-wide known-files list into `resolveImportPath`, so a Rust
+ * `crate::`/`self::`/`super::` import (#2007) in a file processed via watch
+ * mode silently failed to resolve — even though the same file resolves
+ * correctly in a full or hash-based-incremental `codegraph build`, both of
+ * which already have the project's file list in memory as `ctx.allFiles`
+ * before import resolution runs.
+ *
+ * `resolveImportPathJS`/the native resolver only attempt Rust crate-path
+ * resolution when a non-null/non-empty known-files set is passed in —
+ * without it, `use crate::greeter::greet;` falls straight through to the
+ * generic fallback and returns the import specifier string unchanged, which
+ * never matches any real file node.
+ *
+ * The fixture deliberately has *two* same-named `greet` functions in
+ * different modules — with only one candidate in the graph, the call
+ * resolver's global same-name fallback would still find the right target
+ * even with import resolution completely broken, masking this exact bug.
+ * With two candidates, only a correctly-resolved `crate::greeter::greet`
+ * import can disambiguate which `greet` `main` actually calls; before this
+ * fix, the call edge was dropped entirely rather than risk resolving to the
+ * wrong one.
+ *
+ * Fixture:
+ *   main.rs    — `mod greeter; mod other; use crate::greeter::greet; fn main() { greet(); }`
+ *   greeter.rs — `pub fn greet() -> String { "hi from greeter".to_string() }`
+ *   other.rs   — `pub fn greet() -> String { "hi from other".to_string() }`
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { getNodeId as getNodeIdQuery, initSchema, openDb } from '../../src/db/index.js';
+import { rebuildFile } from '../../src/domain/graph/builder/incremental.js';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+import type { EngineMode } from '../../src/types.js';
+
+const FILES: Record<string, string> = {
+  'main.rs': `
+mod greeter;
+mod other;
+use crate::greeter::greet;
+
+fn main() {
+    greet();
+}
+`,
+  'other.rs': `
+pub fn greet() -> String {
+    "hi from other".to_string()
+}
+`,
+  'greeter.rs': `
+pub fn greet() -> String {
+    "hi from greeter".to_string()
+}
+`,
+};
+
+function writeFixture(dir: string) {
+  for (const [rel, content] of Object.entries(FILES)) {
+    const abs = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, content);
+  }
+}
+
+function readCallEdges(dbPath: string) {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return db
+      .prepare(
+        `SELECT n1.name AS src, n1.file AS src_file, n2.name AS tgt, n2.file AS tgt_file
+         FROM edges e
+         JOIN nodes n1 ON e.source_id = n1.id
+         JOIN nodes n2 ON e.target_id = n2.id
+         WHERE e.kind = 'calls'
+         ORDER BY n1.name, n2.name`,
+      )
+      .all() as Array<{ src: string; src_file: string; tgt: string; tgt_file: string }>;
+  } finally {
+    db.close();
+  }
+}
+
+function makeStmts(db: ReturnType<typeof openDb>) {
+  return {
+    insertNode: db.prepare(
+      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
+    ),
+    getNodeId: {
+      get: (name: string, kind: string, file: string, line: number) => {
+        const id = getNodeIdQuery(db, name, kind, file, line);
+        return id != null ? { id } : undefined;
+      },
+    },
+    insertEdge: db.prepare(
+      'INSERT INTO edges (source_id, target_id, kind, confidence, dynamic) VALUES (?, ?, ?, ?, ?)',
+    ),
+    countNodes: db.prepare('SELECT COUNT(*) as c FROM nodes WHERE file = ?'),
+    countEdges: db.prepare(
+      'SELECT COUNT(*) as c FROM edges WHERE source_id IN (SELECT id FROM nodes WHERE file = ?)',
+    ),
+    findNodeInFile: db.prepare(
+      "SELECT id, kind, file FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant') AND file = ?",
+    ),
+    findNodeByName: db.prepare(
+      "SELECT id, file, kind FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
+    ),
+    listSymbols: db.prepare("SELECT name, kind, line FROM nodes WHERE file = ? AND kind != 'file'"),
+    upsertFileHash: db.prepare(
+      'INSERT OR REPLACE INTO file_hashes (file, hash, mtime, size) VALUES (?, ?, ?, ?)',
+    ),
+    deleteFileHash: db.prepare('DELETE FROM file_hashes WHERE file = ?'),
+  };
+}
+
+const ENGINES: EngineMode[] = ['wasm', 'native'];
+
+describe.each(ENGINES)(
+  'codegraph watch resolves Rust crate:: import on rebuild (#2216) — initial build: %s',
+  (engine) => {
+    let watchDir: string;
+    let dbPath: string;
+
+    beforeAll(async () => {
+      watchDir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2216-${engine}-`));
+      writeFixture(watchDir);
+
+      // Initial full build — crate:: resolution already works here (#2007).
+      await buildGraph(watchDir, { incremental: false, skipRegistry: true, engine });
+      dbPath = path.join(watchDir, '.codegraph', 'graph.db');
+
+      // Sanity check: the initial full build actually resolved the edge.
+      const edgesAfterFullBuild = readCallEdges(dbPath);
+      expect(edgesAfterFullBuild.find((e) => e.src === 'main' && e.tgt === 'greet')).toBeDefined();
+
+      // Touch main.rs — the file containing the crate:: import — and run the
+      // watch-mode single-file rebuild path directly.
+      const mainFile = path.join(watchDir, 'main.rs');
+      fs.appendFileSync(mainFile, '\n// touch\n');
+
+      const db = openDb(dbPath);
+      initSchema(db);
+      await rebuildFile(db, watchDir, mainFile, makeStmts(db), { engine }, null);
+      db.close();
+    }, 60_000);
+
+    afterAll(() => {
+      try {
+        if (watchDir) fs.rmSync(watchDir, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+    });
+
+    it('main -> greet call edge survives the watch rebuild via crate:: resolution', () => {
+      const edges = readCallEdges(dbPath);
+      const edge = edges.find((e) => e.src === 'main' && e.tgt === 'greet');
+      expect(
+        edge,
+        `Expected main -> greet call edge, resolved via crate::greeter::greet\nActual call edges:\n${JSON.stringify(edges, null, 2)}`,
+      ).toBeDefined();
+      expect(edge?.tgt_file).toBe('greeter.rs');
+    });
+  },
+);

--- a/tests/unit/resolve.test.ts
+++ b/tests/unit/resolve.test.ts
@@ -928,6 +928,23 @@ describe('resolveImportPathJS - Rust crate::/self::/super:: paths (#2007)', () =
     expect(result).toBe('crate::service::build_service');
   });
 
+  it('resolves crate:: when knownFiles are absolute paths, not just root-relative ones (#2216)', () => {
+    // ctx.allFiles (full-build path) and getKnownFilesForIncremental
+    // (watch-mode path) both populate knownFiles with absolute paths —
+    // the resolver must not assume the root-relative form used elsewhere
+    // in this describe block is the only one callers pass.
+    const absoluteKnownFiles = knownFiles.map((rel) => path.join(rustDir, rel));
+    const fromFile = path.join(rustDir, 'main.rs');
+    const result = resolveImportPathJS(
+      fromFile,
+      'crate::service::build_service',
+      rustDir,
+      null,
+      absoluteKnownFiles,
+    );
+    expect(result).toBe('service.rs');
+  });
+
   describe('standalone Cargo targets (src/bin/, examples/, tests/, benches/)', () => {
     let targetsDir: string;
     const targetKnownFiles = [


### PR DESCRIPTION
## Summary

`codegraph watch`'s single-file rebuild path (`rebuildFile` in `domain/graph/builder/incremental.ts`) never passed a project-wide known-files list to `resolveImportPath`, so a Rust `crate::`/`self::`/`super::` import (#2007) in a file processed via watch mode silently failed to resolve — `resolveImportPathJS` (and the native resolver) only attempt Rust crate-path resolution when a known-files set is present; without it, the import falls straight through to the generic fallback and returns the bare specifier string, which matches no real file node.

Unlike the full-build path — where the project's file list is already in memory as `ctx.allFiles` before import resolution runs — a single-file incremental rebuild has no such list. Added `getKnownFilesForIncremental` (a `SELECT DISTINCT file FROM nodes WHERE kind = 'file'` query, converted to absolute paths to match `ctx.allFiles`'s format), computed once per `rebuildFile` call and threaded through every `resolveImportPath` call site in the file: `persistReexportRenamesForFile`, `emitEdgesForImport`, `buildImportEdges`, `buildImportedNamesMap`, `emitBarrelImportEdgesForReverseDeps`, `rebuildEdgesForTargetFile`, `rebuildReverseDepEdges`, and `runReverseDepCascade`.

No native-side change needed: `crates/codegraph-core/src/domain/graph/builder/incremental.rs` only provides the parse-tree cache (`ParseTreeCache`) — the single-file rebuild orchestration itself is TS-only regardless of `--engine`, calling into native only for parsing/import-resolution primitives (which already accept `known_files` correctly).

## Test plan

- [x] New `tests/integration/issue-2216-watch-rust-crate-path.test.ts`: a 3-file Rust fixture with two same-named `greet` functions in different modules (so the call resolver's global same-name fallback can't mask the bug) — `main.rs` imports `crate::greeter::greet` specifically. Verified this test **fails** (`main -> greet` edge dropped entirely) when the fix is reverted, and **passes** on both engines with the fix in place.
- [x] `npm test`: full suite, 291 files, 4739/4739 pass
- [x] `npm run lint`, `npx tsc --noEmit` (via `npm run build`): clean
- [x] `codegraph diff-impact --staged`: 10 functions changed, impact fully contained to `incremental.ts` — the one external caller (`watcher.ts`) needs no changes since `rebuildFile`'s public signature is unchanged

Closes #2216