### PR TITLE
fix(watch): watch-mode rebuild now populates full node schema

### DIFF
--- a/src/domain/graph/builder/incremental.ts
+++ b/src/domain/graph/builder/incremental.ts
@@ -85,6 +85,11 @@ export interface IncrementalStmts {
   upsertFileHash: { run: (...params: unknown[]) => unknown };
   /** Delete a `file_hashes` row for a file removed from disk. */
   deleteFileHash: { run: (...params: unknown[]) => unknown };
+  /**
+   * Mark a node `exported = 1`, keyed by `(name, kind, file, line)` —
+   * mirrors the full-build path's `markExportedSymbols` (issue #2220).
+   */
+  markExported: { run: (...params: unknown[]) => unknown };
 }
 
 interface RebuildResult {
@@ -102,18 +107,43 @@ interface RebuildResult {
 
 // ── Node insertion ──────────────────────────────────────────────────────
 
+/**
+ * Insert this file's node, its definitions and their children, and its
+ * exports — mirroring `insertDefinitionsAndExports`/`collectChildRowsAndFileEdges`
+ * in `stages/insert-nodes.ts` (the full-build path) so a symbol touched only
+ * by watch-mode rebuilds gets the same `qualified_name`/`scope`/`visibility`/
+ * `parent_id`/`content_hash`/`exported` columns a full or regular incremental
+ * `codegraph build` would have given it (issue #2220) — downstream queries
+ * that filter/join on those columns must not behave differently depending on
+ * which rebuild path last touched a symbol.
+ *
+ * `def.name` scoping mirrors insert-nodes.ts exactly: a dotted definition
+ * name (e.g. some extractors' `ClassName.methodName` convention) yields a
+ * `scope` of everything before the last dot; children get `parent_id` set to
+ * their def's real node id (looked up post-insert, not `lastInsertRowid`,
+ * since `INSERT OR IGNORE` leaves that unreliable for an already-existing
+ * row on a re-rebuild) and a `qualified_name` of `${def.name}.${child.name}`.
+ */
 function insertFileNodes(stmts: IncrementalStmts, relPath: string, symbols: ExtractorOutput): void {
-  stmts.insertNode.run(relPath, 'file', relPath, 0, null, null);
+  stmts.insertNode.run(relPath, 'file', relPath, 0, null, null, null, null, null, null, null);
   for (const def of symbols.definitions) {
+    const dotIdx = def.name.lastIndexOf('.');
+    const scope = dotIdx !== -1 ? def.name.slice(0, dotIdx) : null;
     stmts.insertNode.run(
       def.name,
       def.kind,
       relPath,
       def.line,
       def.endLine || null,
+      null,
+      def.name,
+      scope,
+      def.visibility ?? null,
+      def.contentHash ?? null,
       def.accessorKind ?? null,
     );
     if (def.children?.length) {
+      const defId = stmts.getNodeId.get(def.name, def.kind, relPath, def.line)?.id ?? null;
       for (const child of def.children) {
         stmts.insertNode.run(
           child.name,
@@ -121,13 +151,31 @@ function insertFileNodes(stmts: IncrementalStmts, relPath: string, symbols: Extr
           relPath,
           child.line,
           child.endLine || null,
+          defId,
+          `${def.name}.${child.name}`,
+          def.name,
+          child.visibility ?? null,
+          child.contentHash ?? null,
           null,
         );
       }
     }
   }
   for (const exp of symbols.exports) {
-    stmts.insertNode.run(exp.name, exp.kind, relPath, exp.line, null, null);
+    stmts.insertNode.run(
+      exp.name,
+      exp.kind,
+      relPath,
+      exp.line,
+      null,
+      null,
+      exp.name,
+      null,
+      null,
+      null,
+      null,
+    );
+    stmts.markExported.run(exp.name, exp.kind, relPath, exp.line);
   }
 }
 

--- a/src/domain/graph/watcher.ts
+++ b/src/domain/graph/watcher.ts
@@ -18,8 +18,17 @@ function shouldIgnorePath(filePath: string, ignoreSet: ReadonlySet<string>): boo
 /** Prepare all SQL statements needed by the watcher's incremental rebuild. */
 function prepareWatcherStatements(db: ReturnType<typeof openDb>): IncrementalStmts {
   return {
+    // Column set and order mirror the full-build path's getNodeStmt
+    // (src/domain/graph/builder/helpers.ts) — issue #2220: a symbol touched
+    // only by a watch-mode rebuild must get the same qualified_name/scope/
+    // visibility/parent_id/content_hash a full or regular incremental build
+    // would have given it.
     insertNode: db.prepare(
-      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
+      'INSERT OR IGNORE INTO nodes (name,kind,file,line,end_line,parent_id,qualified_name,scope,visibility,content_hash,accessor_kind) VALUES (?,?,?,?,?,?,?,?,?,?,?)',
+    ),
+    // Mirrors the full-build path's getExportStmt (issue #2220).
+    markExported: db.prepare(
+      'UPDATE nodes SET exported = 1 WHERE name = ? AND kind = ? AND file = ? AND line = ?',
     ),
     getNodeId: {
       get: (...params: unknown[]) => {

--- a/tests/helpers/incremental-stmts.ts
+++ b/tests/helpers/incremental-stmts.ts
@@ -1,0 +1,45 @@
+import { getNodeId as getNodeIdQuery, type openDb } from '../../src/db/index.js';
+import type { IncrementalStmts } from '../../src/domain/graph/builder/incremental.js';
+
+/**
+ * Build the `IncrementalStmts` bundle `rebuildFile` needs, matching
+ * production's `prepareWatcherStatements` (`src/domain/graph/watcher.ts`)
+ * exactly — shared by every watch-mode/incremental integration test instead
+ * of each duplicating (and risking drifting out of sync with) the same set
+ * of prepared statements.
+ */
+export function createIncrementalStmts(db: ReturnType<typeof openDb>): IncrementalStmts {
+  return {
+    insertNode: db.prepare(
+      'INSERT OR IGNORE INTO nodes (name,kind,file,line,end_line,parent_id,qualified_name,scope,visibility,content_hash,accessor_kind) VALUES (?,?,?,?,?,?,?,?,?,?,?)',
+    ),
+    markExported: db.prepare(
+      'UPDATE nodes SET exported = 1 WHERE name = ? AND kind = ? AND file = ? AND line = ?',
+    ),
+    getNodeId: {
+      get: (...params: unknown[]) => {
+        const [name, kind, file, line] = params as [string, string, string, number];
+        const id = getNodeIdQuery(db, name, kind, file, line);
+        return id != null ? { id } : undefined;
+      },
+    },
+    insertEdge: db.prepare(
+      'INSERT OR IGNORE INTO edges (source_id, target_id, kind, confidence, dynamic) VALUES (?, ?, ?, ?, ?)',
+    ),
+    countNodes: db.prepare('SELECT COUNT(*) as c FROM nodes WHERE file = ?'),
+    countEdges: db.prepare(
+      'SELECT COUNT(*) as c FROM edges WHERE source_id IN (SELECT id FROM nodes WHERE file = ?)',
+    ),
+    findNodeInFile: db.prepare(
+      "SELECT id, kind, file, line, accessor_kind AS accessorKind FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant') AND file = ?",
+    ),
+    findNodeByName: db.prepare(
+      "SELECT id, file, kind, line, accessor_kind AS accessorKind FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
+    ),
+    listSymbols: db.prepare("SELECT name, kind, line FROM nodes WHERE file = ? AND kind != 'file'"),
+    upsertFileHash: db.prepare(
+      'INSERT OR REPLACE INTO file_hashes (file, hash, mtime, size) VALUES (?, ?, ?, ?)',
+    ),
+    deleteFileHash: db.prepare('DELETE FROM file_hashes WHERE file = ?'),
+  };
+}

--- a/tests/integration/issue-1259-watch-call-resolution.test.ts
+++ b/tests/integration/issue-1259-watch-call-resolution.test.ts
@@ -23,9 +23,10 @@ import os from 'node:os';
 import path from 'node:path';
 import Database from 'better-sqlite3';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { getNodeId as getNodeIdQuery, initSchema, openDb } from '../../src/db/index.js';
+import { initSchema, openDb } from '../../src/db/index.js';
 import { rebuildFile } from '../../src/domain/graph/builder/incremental.js';
 import { buildGraph } from '../../src/domain/graph/builder.js';
+import { createIncrementalStmts } from '../helpers/incremental-stmts.js';
 
 // Files are laid out so that an unimported call to a same-named symbol in a
 // distant directory resolves at confidence 0.3 (different grandparent dir) —
@@ -72,40 +73,6 @@ function readEdges(dbPath: string) {
   }
 }
 
-/** Prepared statements the watcher normally supplies (mirrors watcher.ts). */
-function makeStmts(db: ReturnType<typeof openDb>) {
-  return {
-    insertNode: db.prepare(
-      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
-    ),
-    getNodeId: {
-      get: (name: string, kind: string, file: string, line: number) => {
-        const id = getNodeIdQuery(db, name, kind, file, line);
-        return id != null ? { id } : undefined;
-      },
-    },
-    insertEdge: db.prepare(
-      'INSERT INTO edges (source_id, target_id, kind, confidence, dynamic) VALUES (?, ?, ?, ?, ?)',
-    ),
-    countNodes: db.prepare('SELECT COUNT(*) as c FROM nodes WHERE file = ?'),
-    countEdges: db.prepare(
-      'SELECT COUNT(*) as c FROM edges WHERE source_id IN (SELECT id FROM nodes WHERE file = ?)',
-    ),
-    findNodeInFile: db.prepare(
-      "SELECT id, kind, file FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant') AND file = ?",
-    ),
-    findNodeByName: db.prepare(
-      // `kind` column included for resolveByMethodOrGlobal's method filter.
-      "SELECT id, file, kind FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
-    ),
-    listSymbols: db.prepare("SELECT name, kind, line FROM nodes WHERE file = ? AND kind != 'file'"),
-    upsertFileHash: db.prepare(
-      'INSERT OR REPLACE INTO file_hashes (file, hash, mtime, size) VALUES (?, ?, ?, ?)',
-    ),
-    deleteFileHash: db.prepare('DELETE FROM file_hashes WHERE file = ?'),
-  };
-}
-
 describe('Watch-mode call resolution parity (#1259)', () => {
   let fullEdges: ReturnType<typeof readEdges>;
   let watchEdges: ReturnType<typeof readEdges>;
@@ -131,7 +98,14 @@ describe('Watch-mode call resolution parity (#1259)', () => {
     // consumer.js, which is where the resolver divergence manifested).
     const db = openDb(path.join(watchDir, '.codegraph', 'graph.db'));
     initSchema(db);
-    await rebuildFile(db, watchDir, watchLeaf, makeStmts(db), { engine: 'auto' }, null);
+    await rebuildFile(
+      db,
+      watchDir,
+      watchLeaf,
+      createIncrementalStmts(db),
+      { engine: 'auto' },
+      null,
+    );
     db.close();
 
     // Same edit + clean full rebuild on the other copy for the parity oracle.

--- a/tests/integration/issue-1370-incremental-caller-name.test.ts
+++ b/tests/integration/issue-1370-incremental-caller-name.test.ts
@@ -22,9 +22,10 @@ import os from 'node:os';
 import path from 'node:path';
 import Database from 'better-sqlite3';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { getNodeId as getNodeIdQuery, initSchema, openDb } from '../../src/db/index.js';
+import { initSchema, openDb } from '../../src/db/index.js';
 import { rebuildFile } from '../../src/domain/graph/builder/incremental.js';
 import { buildGraph } from '../../src/domain/graph/builder.js';
+import { createIncrementalStmts } from '../helpers/incremental-stmts.js';
 
 const FILES: Record<string, string> = {
   'service.js': `
@@ -70,38 +71,6 @@ function readCallEdges(dbPath: string) {
   }
 }
 
-function makeStmts(db: ReturnType<typeof openDb>) {
-  return {
-    insertNode: db.prepare(
-      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
-    ),
-    getNodeId: {
-      get: (name: string, kind: string, file: string, line: number) => {
-        const id = getNodeIdQuery(db, name, kind, file, line);
-        return id != null ? { id } : undefined;
-      },
-    },
-    insertEdge: db.prepare(
-      'INSERT INTO edges (source_id, target_id, kind, confidence, dynamic) VALUES (?, ?, ?, ?, ?)',
-    ),
-    countNodes: db.prepare('SELECT COUNT(*) as c FROM nodes WHERE file = ?'),
-    countEdges: db.prepare(
-      'SELECT COUNT(*) as c FROM edges WHERE source_id IN (SELECT id FROM nodes WHERE file = ?)',
-    ),
-    findNodeInFile: db.prepare(
-      "SELECT id, kind, file FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant') AND file = ?",
-    ),
-    findNodeByName: db.prepare(
-      "SELECT id, file, kind FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
-    ),
-    listSymbols: db.prepare("SELECT name, kind, line FROM nodes WHERE file = ? AND kind != 'file'"),
-    upsertFileHash: db.prepare(
-      'INSERT OR REPLACE INTO file_hashes (file, hash, mtime, size) VALUES (?, ?, ?, ?)',
-    ),
-    deleteFileHash: db.prepare('DELETE FROM file_hashes WHERE file = ?'),
-  };
-}
-
 describe('Incremental rebuildFile passes callerName to resolver (#1370)', () => {
   let fullEdges: ReturnType<typeof readCallEdges>;
   let watchEdges: ReturnType<typeof readCallEdges>;
@@ -124,7 +93,14 @@ describe('Incremental rebuildFile passes callerName to resolver (#1370)', () => 
     // Run the incremental watch path — this is where callerName was missing.
     const db = openDb(path.join(watchDir, '.codegraph', 'graph.db'));
     initSchema(db);
-    await rebuildFile(db, watchDir, watchFile, makeStmts(db), { engine: 'wasm' }, null);
+    await rebuildFile(
+      db,
+      watchDir,
+      watchFile,
+      createIncrementalStmts(db),
+      { engine: 'wasm' },
+      null,
+    );
     db.close();
 
     // Apply the same touch to the full-build copy and rebuild from scratch.

--- a/tests/integration/issue-1731-hash-edge-coupling.test.ts
+++ b/tests/integration/issue-1731-hash-edge-coupling.test.ts
@@ -32,10 +32,11 @@ import os from 'node:os';
 import path from 'node:path';
 import Database from 'better-sqlite3';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { getNodeId as getNodeIdQuery, initSchema, openDb } from '../../src/db/index.js';
+import { initSchema, openDb } from '../../src/db/index.js';
 import { fileHash } from '../../src/domain/graph/builder/helpers.js';
 import { rebuildFile } from '../../src/domain/graph/builder/incremental.js';
 import { buildGraph } from '../../src/domain/graph/builder.js';
+import { createIncrementalStmts } from '../helpers/incremental-stmts.js';
 
 // ── Fault injection for suite 1 ──────────────────────────────────────────
 // A `vi.hoisted` object is used (rather than a plain module-scope `let`) so
@@ -160,38 +161,6 @@ describe('Issue #1731: file_hashes/edges coupling survives a mid-build failure',
 
 // ── Suite 2: watch-mode rebuildFile ───────────────────────────────────────
 
-function makeStmts(db: ReturnType<typeof openDb>) {
-  return {
-    insertNode: db.prepare(
-      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
-    ),
-    getNodeId: {
-      get: (name: string, kind: string, file: string, line: number) => {
-        const id = getNodeIdQuery(db, name, kind, file, line);
-        return id != null ? { id } : undefined;
-      },
-    },
-    insertEdge: db.prepare(
-      'INSERT INTO edges (source_id, target_id, kind, confidence, dynamic) VALUES (?, ?, ?, ?, ?)',
-    ),
-    countNodes: db.prepare('SELECT COUNT(*) as c FROM nodes WHERE file = ?'),
-    countEdges: db.prepare(
-      'SELECT COUNT(*) as c FROM edges WHERE source_id IN (SELECT id FROM nodes WHERE file = ?)',
-    ),
-    findNodeInFile: db.prepare(
-      "SELECT id, kind, file FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant') AND file = ?",
-    ),
-    findNodeByName: db.prepare(
-      "SELECT id, file, kind FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
-    ),
-    listSymbols: db.prepare("SELECT name, kind, line FROM nodes WHERE file = ? AND kind != 'file'"),
-    upsertFileHash: db.prepare(
-      'INSERT OR REPLACE INTO file_hashes (file, hash, mtime, size) VALUES (?, ?, ?, ?)',
-    ),
-    deleteFileHash: db.prepare('DELETE FROM file_hashes WHERE file = ?'),
-  };
-}
-
 describe('Issue #1731: watch-mode rebuildFile keeps file_hashes in sync with edges', () => {
   let tmpDir: string;
   let dbPath: string;
@@ -220,7 +189,7 @@ describe('Issue #1731: watch-mode rebuildFile keeps file_hashes in sync with edg
     const db = openDb(dbPath);
     try {
       initSchema(db);
-      const stmts = makeStmts(db);
+      const stmts = createIncrementalStmts(db);
       await rebuildFile(db, tmpDir, path.join(tmpDir, 'a.js'), stmts, { engine: 'wasm' }, null);
     } finally {
       db.close();
@@ -240,7 +209,7 @@ describe('Issue #1731: watch-mode rebuildFile keeps file_hashes in sync with edg
     const db = openDb(dbPath);
     try {
       initSchema(db);
-      const stmts = makeStmts(db);
+      const stmts = createIncrementalStmts(db);
       await rebuildFile(db, tmpDir, path.join(tmpDir, 'a.js'), stmts, { engine: 'wasm' }, null);
     } finally {
       db.close();

--- a/tests/integration/issue-1744-incremental-edge-technique.test.ts
+++ b/tests/integration/issue-1744-incremental-edge-technique.test.ts
@@ -46,11 +46,12 @@ import os from 'node:os';
 import path from 'node:path';
 import Database from 'better-sqlite3';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { getNodeId as getNodeIdQuery, initSchema, openDb } from '../../src/db/index.js';
+import { initSchema, openDb } from '../../src/db/index.js';
 import { rebuildFile } from '../../src/domain/graph/builder/incremental.js';
 import { buildGraph } from '../../src/domain/graph/builder.js';
 import { isNativeAvailable } from '../../src/infrastructure/native.js';
 import type { EngineMode } from '../../src/types.js';
+import { createIncrementalStmts } from '../helpers/incremental-stmts.js';
 
 function writeFixture(dir: string, calleeMarker: string): void {
   fs.mkdirSync(dir, { recursive: true });
@@ -92,38 +93,6 @@ function readCallEdges(dbPath: string): CallEdgeRow[] {
   } finally {
     db.close();
   }
-}
-
-function makeStmts(db: ReturnType<typeof openDb>) {
-  return {
-    insertNode: db.prepare(
-      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
-    ),
-    getNodeId: {
-      get: (name: string, kind: string, file: string, line: number) => {
-        const id = getNodeIdQuery(db, name, kind, file, line);
-        return id != null ? { id } : undefined;
-      },
-    },
-    insertEdge: db.prepare(
-      'INSERT INTO edges (source_id, target_id, kind, confidence, dynamic) VALUES (?, ?, ?, ?, ?)',
-    ),
-    countNodes: db.prepare('SELECT COUNT(*) as c FROM nodes WHERE file = ?'),
-    countEdges: db.prepare(
-      'SELECT COUNT(*) as c FROM edges WHERE source_id IN (SELECT id FROM nodes WHERE file = ?)',
-    ),
-    findNodeInFile: db.prepare(
-      "SELECT id, kind, file FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant') AND file = ?",
-    ),
-    findNodeByName: db.prepare(
-      "SELECT id, file, kind FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
-    ),
-    listSymbols: db.prepare("SELECT name, kind, line FROM nodes WHERE file = ? AND kind != 'file'"),
-    upsertFileHash: db.prepare(
-      'INSERT OR REPLACE INTO file_hashes (file, hash, mtime, size) VALUES (?, ?, ?, ?)',
-    ),
-    deleteFileHash: db.prepare('DELETE FROM file_hashes WHERE file = ?'),
-  };
 }
 
 // ── Suite 1: codegraph build --engine native (native orchestrator's own
@@ -189,7 +158,7 @@ function runWatchScenario(engine: EngineMode): void {
       const db = openDb(dbPath);
       try {
         initSchema(db);
-        const stmts = makeStmts(db);
+        const stmts = createIncrementalStmts(db);
         await rebuildFile(db, projDir, path.join(projDir, 'callee.js'), stmts, { engine }, null);
       } finally {
         db.close();

--- a/tests/integration/issue-1765-incremental-same-class-barecall.test.ts
+++ b/tests/integration/issue-1765-incremental-same-class-barecall.test.ts
@@ -21,11 +21,12 @@ import os from 'node:os';
 import path from 'node:path';
 import Database from 'better-sqlite3';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { getNodeId as getNodeIdQuery, initSchema, openDb } from '../../src/db/index.js';
+import { initSchema, openDb } from '../../src/db/index.js';
 import { rebuildFile } from '../../src/domain/graph/builder/incremental.js';
 import { buildGraph } from '../../src/domain/graph/builder.js';
 import { isNativeAvailable } from '../../src/infrastructure/native.js';
 import type { EngineMode } from '../../src/types.js';
+import { createIncrementalStmts } from '../helpers/incremental-stmts.js';
 
 function writeFixture(dir: string, marker: string): void {
   fs.mkdirSync(dir, { recursive: true });
@@ -72,38 +73,6 @@ function readCallEdges(dbPath: string): CallEdgeRow[] {
   }
 }
 
-function makeStmts(db: ReturnType<typeof openDb>) {
-  return {
-    insertNode: db.prepare(
-      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
-    ),
-    getNodeId: {
-      get: (name: string, kind: string, file: string, line: number) => {
-        const id = getNodeIdQuery(db, name, kind, file, line);
-        return id != null ? { id } : undefined;
-      },
-    },
-    insertEdge: db.prepare(
-      'INSERT INTO edges (source_id, target_id, kind, confidence, dynamic) VALUES (?, ?, ?, ?, ?)',
-    ),
-    countNodes: db.prepare('SELECT COUNT(*) as c FROM nodes WHERE file = ?'),
-    countEdges: db.prepare(
-      'SELECT COUNT(*) as c FROM edges WHERE source_id IN (SELECT id FROM nodes WHERE file = ?)',
-    ),
-    findNodeInFile: db.prepare(
-      "SELECT id, kind, file FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant') AND file = ?",
-    ),
-    findNodeByName: db.prepare(
-      "SELECT id, file, kind FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
-    ),
-    listSymbols: db.prepare("SELECT name, kind, line FROM nodes WHERE file = ? AND kind != 'file'"),
-    upsertFileHash: db.prepare(
-      'INSERT OR REPLACE INTO file_hashes (file, hash, mtime, size) VALUES (?, ?, ?, ?)',
-    ),
-    deleteFileHash: db.prepare('DELETE FROM file_hashes WHERE file = ?'),
-  };
-}
-
 function runWatchScenario(engine: EngineMode): void {
   describe(`codegraph watch (rebuildFile): same-class bare-call fallback matches full rebuild (#1765) — ${engine}`, () => {
     let projDir: string;
@@ -121,7 +90,7 @@ function runWatchScenario(engine: EngineMode): void {
       const db = openDb(dbPath);
       try {
         initSchema(db);
-        const stmts = makeStmts(db);
+        const stmts = createIncrementalStmts(db);
         await rebuildFile(
           db,
           projDir,

--- a/tests/integration/issue-1766-defineproperty-kind-filter-parity.test.ts
+++ b/tests/integration/issue-1766-defineproperty-kind-filter-parity.test.ts
@@ -40,11 +40,12 @@ import os from 'node:os';
 import path from 'node:path';
 import Database from 'better-sqlite3';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { getNodeId as getNodeIdQuery, initSchema, openDb } from '../../src/db/index.js';
+import { initSchema, openDb } from '../../src/db/index.js';
 import { rebuildFile } from '../../src/domain/graph/builder/incremental.js';
 import { buildGraph } from '../../src/domain/graph/builder.js';
 import { isNativeAvailable } from '../../src/infrastructure/native.js';
 import type { EngineMode } from '../../src/types.js';
+import { createIncrementalStmts } from '../helpers/incremental-stmts.js';
 
 function writeFixture(dir: string, marker: string): void {
   fs.mkdirSync(dir, { recursive: true });
@@ -99,38 +100,6 @@ function readCallEdges(dbPath: string): CallEdgeRow[] {
   }
 }
 
-function makeStmts(db: ReturnType<typeof openDb>) {
-  return {
-    insertNode: db.prepare(
-      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
-    ),
-    getNodeId: {
-      get: (name: string, kind: string, file: string, line: number) => {
-        const id = getNodeIdQuery(db, name, kind, file, line);
-        return id != null ? { id } : undefined;
-      },
-    },
-    insertEdge: db.prepare(
-      'INSERT INTO edges (source_id, target_id, kind, confidence, dynamic) VALUES (?, ?, ?, ?, ?)',
-    ),
-    countNodes: db.prepare('SELECT COUNT(*) as c FROM nodes WHERE file = ?'),
-    countEdges: db.prepare(
-      'SELECT COUNT(*) as c FROM edges WHERE source_id IN (SELECT id FROM nodes WHERE file = ?)',
-    ),
-    findNodeInFile: db.prepare(
-      "SELECT id, kind, file FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant') AND file = ?",
-    ),
-    findNodeByName: db.prepare(
-      "SELECT id, file, kind FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
-    ),
-    listSymbols: db.prepare("SELECT name, kind, line FROM nodes WHERE file = ? AND kind != 'file'"),
-    upsertFileHash: db.prepare(
-      'INSERT OR REPLACE INTO file_hashes (file, hash, mtime, size) VALUES (?, ?, ?, ?)',
-    ),
-    deleteFileHash: db.prepare('DELETE FROM file_hashes WHERE file = ?'),
-  };
-}
-
 function runWatchScenario(engine: EngineMode): void {
   describe(`codegraph watch (rebuildFile): Object.defineProperty accessor fallback matches full rebuild (#1766) — ${engine}`, () => {
     let projDir: string;
@@ -148,7 +117,7 @@ function runWatchScenario(engine: EngineMode): void {
       const db = openDb(dbPath);
       try {
         initSchema(db);
-        const stmts = makeStmts(db);
+        const stmts = createIncrementalStmts(db);
         await rebuildFile(db, projDir, path.join(projDir, 'accessor.js'), stmts, { engine }, null);
       } finally {
         db.close();

--- a/tests/integration/issue-1852-watch-cha-pts-dynamic-sink.test.ts
+++ b/tests/integration/issue-1852-watch-cha-pts-dynamic-sink.test.ts
@@ -25,11 +25,12 @@ import os from 'node:os';
 import path from 'node:path';
 import Database from 'better-sqlite3';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { getNodeId as getNodeIdQuery, initSchema, openDb } from '../../src/db/index.js';
+import { initSchema, openDb } from '../../src/db/index.js';
 import { rebuildFile } from '../../src/domain/graph/builder/incremental.js';
 import { buildGraph } from '../../src/domain/graph/builder.js';
 import { isNativeAvailable } from '../../src/infrastructure/native.js';
 import type { EngineMode } from '../../src/types.js';
+import { createIncrementalStmts } from '../helpers/incremental-stmts.js';
 
 const CHA_FIXTURE_DIR = path.join(import.meta.dirname, '..', 'fixtures', 'cha-dispatch');
 
@@ -89,45 +90,12 @@ function withoutTechnique(edges: CallEdgeRow[]): Array<Omit<CallEdgeRow, 'techni
   return edges.map(({ technique: _technique, ...rest }) => rest);
 }
 
-/** Build the prepared statements object that watcher.ts normally provides. */
-function makeStmts(db: ReturnType<typeof openDb>) {
-  return {
-    insertNode: db.prepare(
-      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
-    ),
-    getNodeId: {
-      get: (name: string, kind: string, file: string, line: number) => {
-        const id = getNodeIdQuery(db, name, kind, file, line);
-        return id != null ? { id } : undefined;
-      },
-    },
-    insertEdge: db.prepare(
-      'INSERT INTO edges (source_id, target_id, kind, confidence, dynamic) VALUES (?, ?, ?, ?, ?)',
-    ),
-    countNodes: db.prepare('SELECT COUNT(*) as c FROM nodes WHERE file = ?'),
-    countEdges: db.prepare(
-      'SELECT COUNT(*) as c FROM edges WHERE source_id IN (SELECT id FROM nodes WHERE file = ?)',
-    ),
-    findNodeInFile: db.prepare(
-      "SELECT id, kind, file FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant') AND file = ?",
-    ),
-    findNodeByName: db.prepare(
-      "SELECT id, file, kind FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
-    ),
-    listSymbols: db.prepare("SELECT name, kind, line FROM nodes WHERE file = ? AND kind != 'file'"),
-    upsertFileHash: db.prepare(
-      'INSERT OR REPLACE INTO file_hashes (file, hash, mtime, size) VALUES (?, ?, ?, ?)',
-    ),
-    deleteFileHash: db.prepare('DELETE FROM file_hashes WHERE file = ?'),
-  };
-}
-
 async function rebuildOneFile(dir: string, relFile: string, engine: EngineMode): Promise<void> {
   const dbPath = path.join(dir, '.codegraph', 'graph.db');
   const db = openDb(dbPath);
   try {
     initSchema(db);
-    const stmts = makeStmts(db);
+    const stmts = createIncrementalStmts(db);
     await rebuildFile(db, dir, path.join(dir, relFile), stmts, { engine } as never, null);
   } finally {
     db.close();

--- a/tests/integration/issue-1893-getter-setter-property-read.test.ts
+++ b/tests/integration/issue-1893-getter-setter-property-read.test.ts
@@ -18,11 +18,12 @@ import os from 'node:os';
 import path from 'node:path';
 import Database from 'better-sqlite3';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { getNodeId as getNodeIdQuery, initSchema, openDb } from '../../src/db/index.js';
+import { initSchema, openDb } from '../../src/db/index.js';
 import { rebuildFile } from '../../src/domain/graph/builder/incremental.js';
 import { buildGraph } from '../../src/domain/graph/builder.js';
 import { isNativeAvailable } from '../../src/infrastructure/native.js';
 import type { EngineMode } from '../../src/types.js';
+import { createIncrementalStmts } from '../helpers/incremental-stmts.js';
 
 function writeFixture(dir: string): void {
   fs.mkdirSync(dir, { recursive: true });
@@ -144,38 +145,6 @@ describe.skipIf(!isNativeAvailable())('native engine coverage', () => {
   runScenario('native');
 });
 
-function makeStmts(db: ReturnType<typeof openDb>) {
-  return {
-    insertNode: db.prepare(
-      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
-    ),
-    getNodeId: {
-      get: (name: string, kind: string, file: string, line: number) => {
-        const id = getNodeIdQuery(db, name, kind, file, line);
-        return id != null ? { id } : undefined;
-      },
-    },
-    insertEdge: db.prepare(
-      'INSERT INTO edges (source_id, target_id, kind, confidence, dynamic) VALUES (?, ?, ?, ?, ?)',
-    ),
-    countNodes: db.prepare('SELECT COUNT(*) as c FROM nodes WHERE file = ?'),
-    countEdges: db.prepare(
-      'SELECT COUNT(*) as c FROM edges WHERE source_id IN (SELECT id FROM nodes WHERE file = ?)',
-    ),
-    findNodeInFile: db.prepare(
-      "SELECT id, kind, file FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant') AND file = ?",
-    ),
-    findNodeByName: db.prepare(
-      "SELECT id, file, kind FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
-    ),
-    listSymbols: db.prepare("SELECT name, kind, line FROM nodes WHERE file = ? AND kind != 'file'"),
-    upsertFileHash: db.prepare(
-      'INSERT OR REPLACE INTO file_hashes (file, hash, mtime, size) VALUES (?, ?, ?, ?)',
-    ),
-    deleteFileHash: db.prepare('DELETE FROM file_hashes WHERE file = ?'),
-  };
-}
-
 function runIncrementalParityScenario(engine: EngineMode): void {
   describe(`incremental rebuild matches full build for accessor reads (#1893) — ${engine}`, () => {
     let incDir: string;
@@ -193,7 +162,7 @@ function runIncrementalParityScenario(engine: EngineMode): void {
       const db = openDb(dbPath);
       try {
         initSchema(db);
-        const stmts = makeStmts(db);
+        const stmts = createIncrementalStmts(db);
         await rebuildFile(db, incDir, filePath, stmts, { engine }, null);
       } finally {
         db.close();

--- a/tests/integration/issue-1967-watch-barrel-rename.test.ts
+++ b/tests/integration/issue-1967-watch-barrel-rename.test.ts
@@ -38,10 +38,11 @@ import os from 'node:os';
 import path from 'node:path';
 import Database from 'better-sqlite3';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { getNodeId as getNodeIdQuery, initSchema, openDb } from '../../src/db/index.js';
+import { initSchema, openDb } from '../../src/db/index.js';
 import { rebuildFile } from '../../src/domain/graph/builder/incremental.js';
 import { buildGraph } from '../../src/domain/graph/builder.js';
 import type { EngineMode } from '../../src/types.js';
+import { createIncrementalStmts } from '../helpers/incremental-stmts.js';
 
 const FILES: Record<string, string> = {
   'underlying.ts': `
@@ -108,38 +109,6 @@ function readReexportRenames(dbPath: string) {
   }
 }
 
-function makeStmts(db: ReturnType<typeof openDb>) {
-  return {
-    insertNode: db.prepare(
-      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
-    ),
-    getNodeId: {
-      get: (name: string, kind: string, file: string, line: number) => {
-        const id = getNodeIdQuery(db, name, kind, file, line);
-        return id != null ? { id } : undefined;
-      },
-    },
-    insertEdge: db.prepare(
-      'INSERT INTO edges (source_id, target_id, kind, confidence, dynamic) VALUES (?, ?, ?, ?, ?)',
-    ),
-    countNodes: db.prepare('SELECT COUNT(*) as c FROM nodes WHERE file = ?'),
-    countEdges: db.prepare(
-      'SELECT COUNT(*) as c FROM edges WHERE source_id IN (SELECT id FROM nodes WHERE file = ?)',
-    ),
-    findNodeInFile: db.prepare(
-      "SELECT id, kind, file FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant') AND file = ?",
-    ),
-    findNodeByName: db.prepare(
-      "SELECT id, file, kind FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
-    ),
-    listSymbols: db.prepare("SELECT name, kind, line FROM nodes WHERE file = ? AND kind != 'file'"),
-    upsertFileHash: db.prepare(
-      'INSERT OR REPLACE INTO file_hashes (file, hash, mtime, size) VALUES (?, ?, ?, ?)',
-    ),
-    deleteFileHash: db.prepare('DELETE FROM file_hashes WHERE file = ?'),
-  };
-}
-
 const ENGINES: EngineMode[] = ['wasm', 'native'];
 
 describe.each(ENGINES)(
@@ -177,7 +146,7 @@ describe.each(ENGINES)(
       // Run the watch-mode single-file rebuild path directly.
       const db = openDb(dbPath);
       initSchema(db);
-      await rebuildFile(db, watchDir, consumerFile, makeStmts(db), { engine }, null);
+      await rebuildFile(db, watchDir, consumerFile, createIncrementalStmts(db), { engine }, null);
       db.close();
     }, 60_000);
 
@@ -296,7 +265,7 @@ describe.each(ENGINES)(
 
       const db = openDb(dbPath);
       initSchema(db);
-      await rebuildFile(db, watchDir, barrelFile, makeStmts(db), { engine }, null);
+      await rebuildFile(db, watchDir, barrelFile, createIncrementalStmts(db), { engine }, null);
       db.close();
     }, 60_000);
 
@@ -352,7 +321,7 @@ describe.each(ENGINES)(
 
       const db = openDb(dbPath);
       initSchema(db);
-      await rebuildFile(db, watchDir, consumerFile, makeStmts(db), { engine }, null);
+      await rebuildFile(db, watchDir, consumerFile, createIncrementalStmts(db), { engine }, null);
       db.close();
     }, 60_000);
 

--- a/tests/integration/issue-2030-cross-file-accessor-recognition.test.ts
+++ b/tests/integration/issue-2030-cross-file-accessor-recognition.test.ts
@@ -27,6 +27,7 @@ import { rebuildFile } from '../../src/domain/graph/builder/incremental.js';
 import { buildGraph } from '../../src/domain/graph/builder.js';
 import { isNativeAvailable } from '../../src/infrastructure/native.js';
 import type { EngineMode } from '../../src/types.js';
+import { createIncrementalStmts } from '../helpers/incremental-stmts.js';
 
 function writeFixture(dir: string): void {
   fs.mkdirSync(dir, { recursive: true });
@@ -163,40 +164,6 @@ describe.skipIf(!isNativeAvailable())('native engine coverage', () => {
   runScenario('native');
 });
 
-function makeStmts(db: ReturnType<typeof openDb>) {
-  return {
-    insertNode: db.prepare(
-      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
-    ),
-    getNodeId: {
-      get: (name: string, kind: string, file: string, line: number) => {
-        const row = db
-          .prepare('SELECT id FROM nodes WHERE name = ? AND kind = ? AND file = ? AND line = ?')
-          .get(name, kind, file, line) as { id: number } | undefined;
-        return row ? { id: row.id } : undefined;
-      },
-    },
-    insertEdge: db.prepare(
-      'INSERT INTO edges (source_id, target_id, kind, confidence, dynamic) VALUES (?, ?, ?, ?, ?)',
-    ),
-    countNodes: db.prepare('SELECT COUNT(*) as c FROM nodes WHERE file = ?'),
-    countEdges: db.prepare(
-      'SELECT COUNT(*) as c FROM edges WHERE source_id IN (SELECT id FROM nodes WHERE file = ?)',
-    ),
-    findNodeInFile: db.prepare(
-      "SELECT id, kind, file, line, accessor_kind AS accessorKind FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant') AND file = ?",
-    ),
-    findNodeByName: db.prepare(
-      "SELECT id, file, kind, line, accessor_kind AS accessorKind FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
-    ),
-    listSymbols: db.prepare("SELECT name, kind, line FROM nodes WHERE file = ? AND kind != 'file'"),
-    upsertFileHash: db.prepare(
-      'INSERT OR REPLACE INTO file_hashes (file, hash, mtime, size) VALUES (?, ?, ?, ?)',
-    ),
-    deleteFileHash: db.prepare('DELETE FROM file_hashes WHERE file = ?'),
-  };
-}
-
 function runIncrementalParityScenario(engine: EngineMode): void {
   describe(`incremental rebuild matches full build for cross-file accessor reads (#2030) — ${engine}`, () => {
     let incDir: string;
@@ -217,7 +184,7 @@ function runIncrementalParityScenario(engine: EngineMode): void {
       const db = openDb(dbPath);
       try {
         initSchema(db);
-        const stmts = makeStmts(db);
+        const stmts = createIncrementalStmts(db);
         await rebuildFile(db, incDir, filePath, stmts, { engine }, null);
       } finally {
         db.close();

--- a/tests/integration/issue-2077-watch-points-to-max-iterations.test.ts
+++ b/tests/integration/issue-2077-watch-points-to-max-iterations.test.ts
@@ -25,9 +25,10 @@ import os from 'node:os';
 import path from 'node:path';
 import Database from 'better-sqlite3';
 import { afterAll, describe, expect, it } from 'vitest';
-import { getNodeId as getNodeIdQuery, initSchema, openDb } from '../../src/db/index.js';
+import { initSchema, openDb } from '../../src/db/index.js';
 import { rebuildFile } from '../../src/domain/graph/builder/incremental.js';
 import { buildGraph } from '../../src/domain/graph/builder.js';
+import { createIncrementalStmts } from '../helpers/incremental-stmts.js';
 
 // 8-hop alias chain: a0 requires exactly 8 fixed-point iterations to resolve
 // to `handler` (one hop propagates per solver iteration).
@@ -62,38 +63,6 @@ function writeFixture(dir: string): void {
   fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(path.join(dir, 'handler.js'), HANDLER_JS);
   fs.writeFileSync(path.join(dir, 'consumer.js'), CONSUMER_JS);
-}
-
-function makeStmts(db: ReturnType<typeof openDb>) {
-  return {
-    insertNode: db.prepare(
-      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
-    ),
-    getNodeId: {
-      get: (name: string, kind: string, file: string, line: number) => {
-        const id = getNodeIdQuery(db, name, kind, file, line);
-        return id != null ? { id } : undefined;
-      },
-    },
-    insertEdge: db.prepare(
-      'INSERT OR IGNORE INTO edges (source_id, target_id, kind, confidence, dynamic) VALUES (?, ?, ?, ?, ?)',
-    ),
-    countNodes: db.prepare('SELECT COUNT(*) as c FROM nodes WHERE file = ?'),
-    countEdges: db.prepare(
-      'SELECT COUNT(*) as c FROM edges WHERE source_id IN (SELECT id FROM nodes WHERE file = ?)',
-    ),
-    findNodeInFile: db.prepare(
-      "SELECT id, kind, file FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant') AND file = ?",
-    ),
-    findNodeByName: db.prepare(
-      "SELECT id, file, kind FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
-    ),
-    listSymbols: db.prepare("SELECT name, kind, line FROM nodes WHERE file = ? AND kind != 'file'"),
-    upsertFileHash: db.prepare(
-      'INSERT OR REPLACE INTO file_hashes (file, hash, mtime, size) VALUES (?, ?, ?, ?)',
-    ),
-    deleteFileHash: db.prepare('DELETE FROM file_hashes WHERE file = ?'),
-  };
 }
 
 function hasAliasChainEdge(dbPath: string): boolean {
@@ -144,7 +113,7 @@ describe('Incremental buildCallEdges honors EngineOpts.pointsToMaxIterations (#2
       db,
       dir,
       consumerFile,
-      makeStmts(db),
+      createIncrementalStmts(db),
       { engine: 'wasm', pointsToMaxIterations: 3 },
       null,
     );
@@ -177,7 +146,7 @@ describe('Incremental buildCallEdges honors EngineOpts.pointsToMaxIterations (#2
       db,
       dir,
       handlerFile,
-      makeStmts(db),
+      createIncrementalStmts(db),
       { engine: 'wasm', pointsToMaxIterations: 3 },
       null,
     );
@@ -206,7 +175,7 @@ describe('Incremental buildCallEdges honors EngineOpts.pointsToMaxIterations (#2
       db,
       dir,
       consumerFile,
-      makeStmts(db),
+      createIncrementalStmts(db),
       { engine: 'wasm', pointsToMaxIterations: CHAIN_LENGTH },
       null,
     );

--- a/tests/integration/issue-2078-cha-sibling-caller.test.ts
+++ b/tests/integration/issue-2078-cha-sibling-caller.test.ts
@@ -25,11 +25,12 @@ import os from 'node:os';
 import path from 'node:path';
 import Database from 'better-sqlite3';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { getNodeId as getNodeIdQuery, initSchema, openDb } from '../../src/db/index.js';
+import { initSchema, openDb } from '../../src/db/index.js';
 import { rebuildFile } from '../../src/domain/graph/builder/incremental.js';
 import { buildGraph } from '../../src/domain/graph/builder.js';
 import { isNativeAvailable } from '../../src/infrastructure/native.js';
 import type { EngineMode } from '../../src/types.js';
+import { createIncrementalStmts } from '../helpers/incremental-stmts.js';
 
 const CHA_FIXTURE_DIR = path.join(import.meta.dirname, '..', 'fixtures', 'cha-dispatch');
 
@@ -104,45 +105,12 @@ function readCallEdges(dbPath: string): CallEdgeRow[] {
   }
 }
 
-/** Build the prepared statements object that watcher.ts normally provides. */
-function makeStmts(db: ReturnType<typeof openDb>) {
-  return {
-    insertNode: db.prepare(
-      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
-    ),
-    getNodeId: {
-      get: (name: string, kind: string, file: string, line: number) => {
-        const id = getNodeIdQuery(db, name, kind, file, line);
-        return id != null ? { id } : undefined;
-      },
-    },
-    insertEdge: db.prepare(
-      'INSERT INTO edges (source_id, target_id, kind, confidence, dynamic) VALUES (?, ?, ?, ?, ?)',
-    ),
-    countNodes: db.prepare('SELECT COUNT(*) as c FROM nodes WHERE file = ?'),
-    countEdges: db.prepare(
-      'SELECT COUNT(*) as c FROM edges WHERE source_id IN (SELECT id FROM nodes WHERE file = ?)',
-    ),
-    findNodeInFile: db.prepare(
-      "SELECT id, kind, file FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant') AND file = ?",
-    ),
-    findNodeByName: db.prepare(
-      "SELECT id, file, kind FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
-    ),
-    listSymbols: db.prepare("SELECT name, kind, line FROM nodes WHERE file = ? AND kind != 'file'"),
-    upsertFileHash: db.prepare(
-      'INSERT OR REPLACE INTO file_hashes (file, hash, mtime, size) VALUES (?, ?, ?, ?)',
-    ),
-    deleteFileHash: db.prepare('DELETE FROM file_hashes WHERE file = ?'),
-  };
-}
-
 async function rebuildOneFile(dir: string, relFile: string, engine: EngineMode): Promise<void> {
   const dbPath = path.join(dir, '.codegraph', 'graph.db');
   const db = openDb(dbPath);
   try {
     initSchema(db);
-    const stmts = makeStmts(db);
+    const stmts = createIncrementalStmts(db);
     await rebuildFile(db, dir, path.join(dir, relFile), stmts, { engine } as never, null);
   } finally {
     db.close();

--- a/tests/integration/issue-2079-pts-direct-confidence-upgrade.test.ts
+++ b/tests/integration/issue-2079-pts-direct-confidence-upgrade.test.ts
@@ -19,11 +19,12 @@ import os from 'node:os';
 import path from 'node:path';
 import Database from 'better-sqlite3';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { getNodeId as getNodeIdQuery, initSchema, openDb } from '../../src/db/index.js';
+import { initSchema, openDb } from '../../src/db/index.js';
 import { rebuildFile } from '../../src/domain/graph/builder/incremental.js';
 import { buildGraph } from '../../src/domain/graph/builder.js';
 import { isNativeAvailable } from '../../src/infrastructure/native.js';
 import type { EngineMode } from '../../src/types.js';
+import { createIncrementalStmts } from '../helpers/incremental-stmts.js';
 
 function writeFixture(dir: string): void {
   fs.mkdirSync(dir, { recursive: true });
@@ -74,45 +75,12 @@ function readCallEdges(dbPath: string): CallEdgeRow[] {
   }
 }
 
-/** Build the prepared statements object that watcher.ts normally provides. */
-function makeStmts(db: ReturnType<typeof openDb>) {
-  return {
-    insertNode: db.prepare(
-      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
-    ),
-    getNodeId: {
-      get: (name: string, kind: string, file: string, line: number) => {
-        const id = getNodeIdQuery(db, name, kind, file, line);
-        return id != null ? { id } : undefined;
-      },
-    },
-    insertEdge: db.prepare(
-      'INSERT INTO edges (source_id, target_id, kind, confidence, dynamic) VALUES (?, ?, ?, ?, ?)',
-    ),
-    countNodes: db.prepare('SELECT COUNT(*) as c FROM nodes WHERE file = ?'),
-    countEdges: db.prepare(
-      'SELECT COUNT(*) as c FROM edges WHERE source_id IN (SELECT id FROM nodes WHERE file = ?)',
-    ),
-    findNodeInFile: db.prepare(
-      "SELECT id, kind, file FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant') AND file = ?",
-    ),
-    findNodeByName: db.prepare(
-      "SELECT id, file, kind FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
-    ),
-    listSymbols: db.prepare("SELECT name, kind, line FROM nodes WHERE file = ? AND kind != 'file'"),
-    upsertFileHash: db.prepare(
-      'INSERT OR REPLACE INTO file_hashes (file, hash, mtime, size) VALUES (?, ?, ?, ?)',
-    ),
-    deleteFileHash: db.prepare('DELETE FROM file_hashes WHERE file = ?'),
-  };
-}
-
 async function rebuildOneFile(dir: string, relFile: string, engine: EngineMode): Promise<void> {
   const dbPath = path.join(dir, '.codegraph', 'graph.db');
   const db = openDb(dbPath);
   try {
     initSchema(db);
-    const stmts = makeStmts(db);
+    const stmts = createIncrementalStmts(db);
     await rebuildFile(db, dir, path.join(dir, relFile), stmts, { engine } as never, null);
   } finally {
     db.close();

--- a/tests/integration/issue-2087-incremental-invoked-property-persistence.test.ts
+++ b/tests/integration/issue-2087-incremental-invoked-property-persistence.test.ts
@@ -33,10 +33,11 @@ import os from 'node:os';
 import path from 'node:path';
 import Database from 'better-sqlite3';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { getNodeId as getNodeIdQuery, initSchema, openDb } from '../../src/db/index.js';
+import { initSchema, openDb } from '../../src/db/index.js';
 import { rebuildFile } from '../../src/domain/graph/builder/incremental.js';
 import { buildGraph } from '../../src/domain/graph/builder.js';
 import type { EngineMode } from '../../src/types.js';
+import { createIncrementalStmts } from '../helpers/incremental-stmts.js';
 
 const FILES: Record<string, string> = {
   'factory.js': `
@@ -95,38 +96,6 @@ function readInvokedPropertyNames(dbPath: string) {
   }
 }
 
-function makeStmts(db: ReturnType<typeof openDb>) {
-  return {
-    insertNode: db.prepare(
-      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
-    ),
-    getNodeId: {
-      get: (name: string, kind: string, file: string, line: number) => {
-        const id = getNodeIdQuery(db, name, kind, file, line);
-        return id != null ? { id } : undefined;
-      },
-    },
-    insertEdge: db.prepare(
-      'INSERT INTO edges (source_id, target_id, kind, confidence, dynamic) VALUES (?, ?, ?, ?, ?)',
-    ),
-    countNodes: db.prepare('SELECT COUNT(*) as c FROM nodes WHERE file = ?'),
-    countEdges: db.prepare(
-      'SELECT COUNT(*) as c FROM edges WHERE source_id IN (SELECT id FROM nodes WHERE file = ?)',
-    ),
-    findNodeInFile: db.prepare(
-      "SELECT id, kind, file FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant') AND file = ?",
-    ),
-    findNodeByName: db.prepare(
-      "SELECT id, file, kind FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
-    ),
-    listSymbols: db.prepare("SELECT name, kind, line FROM nodes WHERE file = ? AND kind != 'file'"),
-    upsertFileHash: db.prepare(
-      'INSERT OR REPLACE INTO file_hashes (file, hash, mtime, size) VALUES (?, ?, ?, ?)',
-    ),
-    deleteFileHash: db.prepare('DELETE FROM file_hashes WHERE file = ?'),
-  };
-}
-
 const ENGINES: EngineMode[] = ['wasm', 'native'];
 
 describe.each(ENGINES)(
@@ -160,7 +129,7 @@ describe.each(ENGINES)(
       // Run the watch-mode single-file rebuild path directly.
       const db = openDb(dbPath);
       initSchema(db);
-      await rebuildFile(db, watchDir, factoryFile, makeStmts(db), { engine }, null);
+      await rebuildFile(db, watchDir, factoryFile, createIncrementalStmts(db), { engine }, null);
       db.close();
     }, 60_000);
 

--- a/tests/integration/issue-2138-incremental-return-type-persistence.test.ts
+++ b/tests/integration/issue-2138-incremental-return-type-persistence.test.ts
@@ -46,10 +46,11 @@ import os from 'node:os';
 import path from 'node:path';
 import Database from 'better-sqlite3';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { getNodeId as getNodeIdQuery, initSchema, openDb } from '../../src/db/index.js';
+import { initSchema, openDb } from '../../src/db/index.js';
 import { rebuildFile } from '../../src/domain/graph/builder/incremental.js';
 import { buildGraph } from '../../src/domain/graph/builder.js';
 import type { EngineMode } from '../../src/types.js';
+import { createIncrementalStmts } from '../helpers/incremental-stmts.js';
 
 const FILES: Record<string, string> = {
   'producer.js': `
@@ -128,38 +129,6 @@ function readReturnTypes(dbPath: string) {
   } finally {
     db.close();
   }
-}
-
-function makeStmts(db: ReturnType<typeof openDb>) {
-  return {
-    insertNode: db.prepare(
-      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
-    ),
-    getNodeId: {
-      get: (name: string, kind: string, file: string, line: number) => {
-        const id = getNodeIdQuery(db, name, kind, file, line);
-        return id != null ? { id } : undefined;
-      },
-    },
-    insertEdge: db.prepare(
-      'INSERT INTO edges (source_id, target_id, kind, confidence, dynamic) VALUES (?, ?, ?, ?, ?)',
-    ),
-    countNodes: db.prepare('SELECT COUNT(*) as c FROM nodes WHERE file = ?'),
-    countEdges: db.prepare(
-      'SELECT COUNT(*) as c FROM edges WHERE source_id IN (SELECT id FROM nodes WHERE file = ?)',
-    ),
-    findNodeInFile: db.prepare(
-      "SELECT id, kind, file FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant') AND file = ?",
-    ),
-    findNodeByName: db.prepare(
-      "SELECT id, file, kind FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
-    ),
-    listSymbols: db.prepare("SELECT name, kind, line FROM nodes WHERE file = ? AND kind != 'file'"),
-    upsertFileHash: db.prepare(
-      'INSERT OR REPLACE INTO file_hashes (file, hash, mtime, size) VALUES (?, ?, ?, ?)',
-    ),
-    deleteFileHash: db.prepare('DELETE FROM file_hashes WHERE file = ?'),
-  };
 }
 
 const ENGINES: EngineMode[] = ['wasm', 'native'];
@@ -249,7 +218,14 @@ describe('codegraph watch restores return_types after purging it (#2138 review)'
     fs.appendFileSync(producerFile, '\n// touch\n');
     const db = openDb(dbPath);
     initSchema(db);
-    await rebuildFile(db, watchDir, producerFile, makeStmts(db), { engine: 'wasm' }, null);
+    await rebuildFile(
+      db,
+      watchDir,
+      producerFile,
+      createIncrementalStmts(db),
+      { engine: 'wasm' },
+      null,
+    );
     db.close();
   }, 60_000);
 

--- a/tests/integration/issue-2216-watch-rust-crate-path.test.ts
+++ b/tests/integration/issue-2216-watch-rust-crate-path.test.ts
@@ -34,10 +34,11 @@ import os from 'node:os';
 import path from 'node:path';
 import Database from 'better-sqlite3';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { getNodeId as getNodeIdQuery, initSchema, openDb } from '../../src/db/index.js';
+import { initSchema, openDb } from '../../src/db/index.js';
 import { rebuildFile } from '../../src/domain/graph/builder/incremental.js';
 import { buildGraph } from '../../src/domain/graph/builder.js';
 import type { EngineMode } from '../../src/types.js';
+import { createIncrementalStmts } from '../helpers/incremental-stmts.js';
 
 const FILES: Record<string, string> = {
   'main.rs': `
@@ -87,38 +88,6 @@ function readCallEdges(dbPath: string) {
   }
 }
 
-function makeStmts(db: ReturnType<typeof openDb>) {
-  return {
-    insertNode: db.prepare(
-      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
-    ),
-    getNodeId: {
-      get: (name: string, kind: string, file: string, line: number) => {
-        const id = getNodeIdQuery(db, name, kind, file, line);
-        return id != null ? { id } : undefined;
-      },
-    },
-    insertEdge: db.prepare(
-      'INSERT INTO edges (source_id, target_id, kind, confidence, dynamic) VALUES (?, ?, ?, ?, ?)',
-    ),
-    countNodes: db.prepare('SELECT COUNT(*) as c FROM nodes WHERE file = ?'),
-    countEdges: db.prepare(
-      'SELECT COUNT(*) as c FROM edges WHERE source_id IN (SELECT id FROM nodes WHERE file = ?)',
-    ),
-    findNodeInFile: db.prepare(
-      "SELECT id, kind, file FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant') AND file = ?",
-    ),
-    findNodeByName: db.prepare(
-      "SELECT id, file, kind FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
-    ),
-    listSymbols: db.prepare("SELECT name, kind, line FROM nodes WHERE file = ? AND kind != 'file'"),
-    upsertFileHash: db.prepare(
-      'INSERT OR REPLACE INTO file_hashes (file, hash, mtime, size) VALUES (?, ?, ?, ?)',
-    ),
-    deleteFileHash: db.prepare('DELETE FROM file_hashes WHERE file = ?'),
-  };
-}
-
 const ENGINES: EngineMode[] = ['wasm', 'native'];
 
 describe.each(ENGINES)(
@@ -146,7 +115,7 @@ describe.each(ENGINES)(
 
       const db = openDb(dbPath);
       initSchema(db);
-      await rebuildFile(db, watchDir, mainFile, makeStmts(db), { engine }, null);
+      await rebuildFile(db, watchDir, mainFile, createIncrementalStmts(db), { engine }, null);
       db.close();
     }, 60_000);
 

--- a/tests/integration/issue-2220-watch-insertnode-columns.test.ts
+++ b/tests/integration/issue-2220-watch-insertnode-columns.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Regression test for #2220: `codegraph watch`'s single-file rebuild path
+ * (`insertFileNodes` in `src/domain/graph/builder/incremental.ts`, via
+ * `rebuildFile`) never populated `qualified_name`/`scope`/`visibility`/
+ * `parent_id`/`content_hash` on `nodes`, nor set `exported = 1` — unlike the
+ * full-build path (`insertDefinitionsAndExports`/`collectChildRowsAndFileEdges`
+ * in `stages/insert-nodes.ts`). A symbol touched only by a watch-mode
+ * rebuild would silently diverge from one touched by a full or regular
+ * incremental `codegraph build`, breaking any downstream query that
+ * filters/joins on those columns.
+ *
+ * Fixture: a top-level exported function (`topLevel`), and a class
+ * (`Greeter`) with a method (`greet`) that takes a parameter (`name`). The
+ * JS extractor represents a method as its own top-level, dotted-name
+ * definition (`Greeter.greet`, scoped via that dot) rather than nesting it
+ * under the class's `children` — `def.children` is where a definition's
+ * *parameters* live, which is what actually exercises the `parent_id`/
+ * per-child `qualified_name` path here.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { initSchema, openDb } from '../../src/db/index.js';
+import { rebuildFile } from '../../src/domain/graph/builder/incremental.js';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+import { createIncrementalStmts } from '../helpers/incremental-stmts.js';
+
+const SOURCE = `
+export function topLevel() {
+  return 42;
+}
+
+class Greeter {
+  greet(name) {
+    return 'hi ' + name;
+  }
+}
+`;
+
+interface NodeRow {
+  id: number;
+  name: string;
+  kind: string;
+  parent_id: number | null;
+  qualified_name: string | null;
+  scope: string | null;
+  content_hash: string | null;
+  exported: number;
+}
+
+function readNodes(dbPath: string): NodeRow[] {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return db
+      .prepare(
+        "SELECT id, name, kind, parent_id, qualified_name, scope, content_hash, exported FROM nodes WHERE kind != 'file' ORDER BY name, kind",
+      )
+      .all() as NodeRow[];
+  } finally {
+    db.close();
+  }
+}
+
+describe('watch-mode rebuild populates qualified_name/scope/visibility/parent_id/content_hash/exported (#2220)', () => {
+  let dir: string;
+  let dbPath: string;
+  let nodes: NodeRow[];
+
+  beforeAll(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-2220-'));
+    fs.writeFileSync(path.join(dir, 'greeter.js'), SOURCE);
+
+    await buildGraph(dir, { incremental: false, skipRegistry: true, engine: 'wasm' });
+    dbPath = path.join(dir, '.codegraph', 'graph.db');
+
+    // Touch the file and rebuild via the watch-mode path (rebuildFile) —
+    // the code path #2220 is about, not the initial full build above.
+    const filePath = path.join(dir, 'greeter.js');
+    fs.appendFileSync(filePath, '\n// touch\n');
+
+    const db = openDb(dbPath);
+    initSchema(db);
+    await rebuildFile(db, dir, filePath, createIncrementalStmts(db), { engine: 'wasm' }, null);
+    db.close();
+
+    nodes = readNodes(dbPath);
+  }, 30_000);
+
+  afterAll(() => {
+    try {
+      if (dir) fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it('gives a top-level definition its own name as qualified_name and exported = 1', () => {
+    const topLevel = nodes.find((n) => n.name === 'topLevel');
+    expect(
+      topLevel,
+      `Expected a topLevel node\nActual: ${JSON.stringify(nodes, null, 2)}`,
+    ).toBeDefined();
+    expect(topLevel?.qualified_name).toBe('topLevel');
+    expect(topLevel?.parent_id).toBeNull();
+    expect(topLevel?.content_hash).toBeTruthy();
+    expect(topLevel?.exported).toBe(1);
+  });
+
+  it('gives a dotted method definition a scope derived from its class prefix', () => {
+    const greet = nodes.find((n) => n.name === 'Greeter.greet');
+    expect(
+      greet,
+      `Expected a Greeter.greet node\nActual: ${JSON.stringify(nodes, null, 2)}`,
+    ).toBeDefined();
+    expect(greet?.qualified_name).toBe('Greeter.greet');
+    expect(greet?.scope).toBe('Greeter');
+    expect(greet?.content_hash).toBeTruthy();
+    expect(greet?.exported).toBe(0);
+  });
+
+  it('gives a parameter child its defining method as parent_id and a dotted qualified_name', () => {
+    const greet = nodes.find((n) => n.name === 'Greeter.greet');
+    const param = nodes.find((n) => n.name === 'name' && n.kind === 'parameter');
+    expect(
+      greet,
+      `Expected a Greeter.greet node\nActual: ${JSON.stringify(nodes, null, 2)}`,
+    ).toBeDefined();
+    expect(
+      param,
+      `Expected a 'name' parameter node\nActual: ${JSON.stringify(nodes, null, 2)}`,
+    ).toBeDefined();
+    expect(param?.parent_id).toBe(greet?.id);
+    expect(param?.qualified_name).toBe('Greeter.greet.name');
+    expect(param?.scope).toBe('Greeter.greet');
+  });
+});

--- a/tests/integration/watcher-fk-embeddings.test.ts
+++ b/tests/integration/watcher-fk-embeddings.test.ts
@@ -13,9 +13,10 @@ import os from 'node:os';
 import path from 'node:path';
 import Database from 'better-sqlite3';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { getNodeId as getNodeIdQuery, initSchema, openDb } from '../../src/db/index.js';
+import { initSchema, openDb } from '../../src/db/index.js';
 import { rebuildFile } from '../../src/domain/graph/builder/incremental.js';
 import { buildGraph } from '../../src/domain/graph/builder.js';
+import { createIncrementalStmts } from '../helpers/incremental-stmts.js';
 
 const FIXTURE_DIR = path.join(import.meta.dirname, '..', 'fixtures', 'deep-deps-project');
 
@@ -27,38 +28,6 @@ function copyDirSync(src: string, dest: string): void {
     if (entry.isDirectory()) copyDirSync(s, d);
     else fs.copyFileSync(s, d);
   }
-}
-
-function makeStmts(db: Database.Database): Parameters<typeof rebuildFile>[3] {
-  return {
-    insertNode: db.prepare(
-      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
-    ),
-    getNodeId: {
-      get: (name: string, kind: string, file: string, line: number) => {
-        const id = getNodeIdQuery(db, name, kind, file, line);
-        return id != null ? { id } : undefined;
-      },
-    },
-    insertEdge: db.prepare(
-      'INSERT INTO edges (source_id, target_id, kind, confidence, dynamic) VALUES (?, ?, ?, ?, ?)',
-    ),
-    countNodes: db.prepare('SELECT COUNT(*) as c FROM nodes WHERE file = ?'),
-    countEdges: db.prepare(
-      'SELECT COUNT(*) as c FROM edges WHERE source_id IN (SELECT id FROM nodes WHERE file = ?)',
-    ),
-    findNodeInFile: db.prepare(
-      "SELECT id, file FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant') AND file = ?",
-    ),
-    findNodeByName: db.prepare(
-      "SELECT id, file FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
-    ),
-    listSymbols: db.prepare("SELECT name, kind, line FROM nodes WHERE file = ? AND kind != 'file'"),
-    upsertFileHash: db.prepare(
-      'INSERT OR REPLACE INTO file_hashes (file, hash, mtime, size) VALUES (?, ?, ?, ?)',
-    ),
-    deleteFileHash: db.prepare('DELETE FROM file_hashes WHERE file = ?'),
-  } as Parameters<typeof rebuildFile>[3];
 }
 
 describe('rebuildFile FK safety with embeddings (#1176)', () => {
@@ -115,7 +84,7 @@ describe('rebuildFile FK safety with embeddings (#1176)', () => {
     // keys by default in v9+. Set explicitly so this test catches a regression
     // even on older builds.
     db.pragma('foreign_keys = ON');
-    const stmts = makeStmts(db);
+    const stmts = createIncrementalStmts(db);
     const leafPath = path.join(workDir, 'shared', 'constants.js');
     fs.appendFileSync(leafPath, '\n// touched\n');
 

--- a/tests/integration/watcher-rebuild.test.ts
+++ b/tests/integration/watcher-rebuild.test.ts
@@ -14,9 +14,10 @@ import os from 'node:os';
 import path from 'node:path';
 import Database from 'better-sqlite3';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { getNodeId as getNodeIdQuery, initSchema, openDb } from '../../src/db/index.js';
+import { initSchema, openDb } from '../../src/db/index.js';
 import { rebuildFile } from '../../src/domain/graph/builder/incremental.js';
 import { buildGraph } from '../../src/domain/graph/builder.js';
+import { createIncrementalStmts } from '../helpers/incremental-stmts.js';
 
 const FIXTURE_DIR = path.join(import.meta.dirname, '..', 'fixtures', 'deep-deps-project');
 
@@ -51,39 +52,6 @@ function readGraph(dbPath) {
   }
 }
 
-/** Build the prepared statements object that watcher.js normally provides. */
-function makeStmts(db) {
-  return {
-    insertNode: db.prepare(
-      'INSERT OR IGNORE INTO nodes (name, kind, file, line, end_line, accessor_kind) VALUES (?, ?, ?, ?, ?, ?)',
-    ),
-    getNodeId: {
-      get: (name, kind, file, line) => {
-        const id = getNodeIdQuery(db, name, kind, file, line);
-        return id != null ? { id } : undefined;
-      },
-    },
-    insertEdge: db.prepare(
-      'INSERT INTO edges (source_id, target_id, kind, confidence, dynamic) VALUES (?, ?, ?, ?, ?)',
-    ),
-    countNodes: db.prepare('SELECT COUNT(*) as c FROM nodes WHERE file = ?'),
-    countEdges: db.prepare(
-      'SELECT COUNT(*) as c FROM edges WHERE source_id IN (SELECT id FROM nodes WHERE file = ?)',
-    ),
-    findNodeInFile: db.prepare(
-      "SELECT id, kind, file FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant') AND file = ?",
-    ),
-    findNodeByName: db.prepare(
-      "SELECT id, kind, file FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
-    ),
-    listSymbols: db.prepare("SELECT name, kind, line FROM nodes WHERE file = ? AND kind != 'file'"),
-    upsertFileHash: db.prepare(
-      'INSERT OR REPLACE INTO file_hashes (file, hash, mtime, size) VALUES (?, ?, ?, ?)',
-    ),
-    deleteFileHash: db.prepare('DELETE FROM file_hashes WHERE file = ?'),
-  };
-}
-
 describe('Watcher rebuildFile parity (#533)', () => {
   let fullDir: string;
   let watcherDir: string;
@@ -108,7 +76,7 @@ describe('Watcher rebuildFile parity (#533)', () => {
     const dbPath = path.join(watcherDir, '.codegraph', 'graph.db');
     const db = openDb(dbPath);
     initSchema(db);
-    const stmts = makeStmts(db);
+    const stmts = createIncrementalStmts(db);
     await rebuildFile(db, watcherDir, leafPath, stmts, { engine: 'auto' }, null);
     db.close();
 


### PR DESCRIPTION
Closes #2220

## Root cause

`codegraph watch`'s single-file rebuild path (`prepareWatcherStatements` in `src/domain/graph/watcher.ts`, `insertFileNodes` in `src/domain/graph/builder/incremental.ts`) only ever inserted `(name, kind, file, line, end_line, accessor_kind)` into `nodes`, and never set `exported = 1` on an exported symbol. The full-build path (`insertDefinitionsAndExports`/`collectChildRowsAndFileEdges` in `stages/insert-nodes.ts`) additionally populates `qualified_name`, `scope`, `visibility`, `parent_id`, `content_hash`, and `exported`.

A symbol touched only by a watch-mode rebuild would silently diverge from one touched by a full or regular incremental `codegraph build` — any downstream query that filters/joins on those columns (cross-file reference lookups, "go to definition", exported-symbol queries) could behave differently depending purely on which rebuild path last touched it.

## Fix

- `insertNode`'s column set now mirrors the full-build path's `getNodeStmt` exactly: `(name,kind,file,line,end_line,parent_id,qualified_name,scope,visibility,content_hash,accessor_kind)`.
- `insertFileNodes` computes `qualified_name`/`scope` the same way `insertDefinitionsAndExports` does (a dotted definition name yields a scope from everything before the last dot), and resolves a child's `parent_id` via a real post-insert `getNodeId` lookup — not `lastInsertRowid`, which `INSERT OR IGNORE` makes unreliable when a definition already exists from a prior rebuild.
- Added a `markExported` statement (mirroring the full-build path's `getExportStmt`) so an exported symbol gets `exported = 1` regardless of which rebuild path touched it.

## Test infrastructure cleanup

Fixing the schema meant every one of the ~18 watch-mode integration test files needed the same update to their local, hand-rolled `makeStmts(db)` helper (each duplicated the same prepared-statement set, one paste away from drifting out of sync with production the next time this schema changes — which is exactly what happened here). Extracted them into a single shared `tests/helpers/incremental-stmts.ts`.

## Test plan

- New `tests/integration/issue-2220-watch-insertnode-columns.test.ts`: verifies a watch-mode rebuild gives a top-level exported function `qualified_name`/`exported = 1`, a dotted method definition the correct `scope`, and a parameter child the correct `parent_id`/`qualified_name`.
- Verified this new test fails (crashes on a bind-parameter arity mismatch) with the production fix reverted, and passes with it restored.
- All 18 migrated test files individually verified passing.
- Full local suite: `npm test` (292 files / 4749 tests passed), `tsc --noEmit`, `biome check` all clean.
- No native-engine changes needed — watch mode's rebuild path is JS-only end-to-end (verified no native dispatch in `watcher.ts`/`incremental.ts`).