### PR TITLE
fix(cli): resolve display config from customDbPath, not process.cwd()

### DIFF
--- a/src/cli/commands/co-change.ts
+++ b/src/cli/commands/co-change.ts
@@ -65,12 +65,12 @@ export const command: CommandDefinition = {
 
     if (file) {
       const data = coChangeData(file, opts.db, queryOpts);
-      if (!ctx.outputResult(data, 'partners', opts)) {
+      if (!ctx.outputResult(data, 'partners', opts, opts.db)) {
         console.log(formatCoChange(data as unknown as Parameters<typeof formatCoChange>[0]));
       }
     } else {
       const data = coChangeTopData(opts.db, queryOpts);
-      if (!ctx.outputResult(data, 'pairs', opts)) {
+      if (!ctx.outputResult(data, 'pairs', opts, opts.db)) {
         console.log(formatCoChangeTop(data as unknown as Parameters<typeof formatCoChangeTop>[0]));
       }
     }

--- a/src/cli/commands/structure.ts
+++ b/src/cli/commands/structure.ts
@@ -32,7 +32,7 @@ export const command: CommandDefinition = {
       const data = moduleBoundariesData(opts.db, {
         threshold: parsed,
       });
-      if (!ctx.outputResult(data, 'modules', opts)) {
+      if (!ctx.outputResult(data, 'modules', opts, opts.db)) {
         console.log(formatModuleBoundaries(data));
       }
       return;
@@ -48,7 +48,7 @@ export const command: CommandDefinition = {
       limit: qOpts.limit,
       offset: qOpts.offset,
     });
-    if (!ctx.outputResult(data, 'directories', opts)) {
+    if (!ctx.outputResult(data, 'directories', opts, opts.db)) {
       console.log(formatStructure(data));
     }
   },

--- a/src/cli/commands/triage.ts
+++ b/src/cli/commands/triage.ts
@@ -31,7 +31,7 @@ async function runHotspots(opts: CommandOpts, ctx: CliContext): Promise<void> {
     offset: opts.offset ? parseInt(opts.offset as string, 10) : undefined,
     noTests: ctx.resolveNoTests(opts),
   });
-  if (!ctx.outputResult(data, 'items', opts)) {
+  if (!ctx.outputResult(data, 'items', opts, opts.db)) {
     console.log(formatHotspots(data));
   }
 }

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -17,7 +17,7 @@ export interface CliContext {
   resolveNoTests: (opts: CommandOpts) => boolean;
   resolveQueryOpts: (opts: CommandOpts) => CommandOpts;
   formatSize: (bytes: number) => string;
-  outputResult: (data: unknown, key: string, opts: CommandOpts) => boolean;
+  outputResult: (data: unknown, key: string, opts: CommandOpts, customDbPath?: string) => boolean;
   program: Command;
 }
 

--- a/src/features/ast.ts
+++ b/src/features/ast.ts
@@ -380,7 +380,7 @@ export function astQuery(
 ): void {
   const data = astQueryData(pattern, customDbPath, opts);
 
-  if (outputResult(data, 'results', opts)) return;
+  if (outputResult(data, 'results', opts, customDbPath)) return;
 
   if (data.results.length === 0) {
     process.stdout.write(`No AST nodes found${pattern ? ` matching "${pattern}"` : ''}.\n`);

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -11,8 +11,7 @@ const require = createRequire(import.meta.url);
 const { version: PKG_VERSION } = require('../../package.json') as { version: string };
 
 import { getDatabase } from '../db/better-sqlite3.js';
-import { findDbPath } from '../db/index.js';
-import { loadConfig } from '../infrastructure/config.js';
+import { findDbPath, resolveDbConfig } from '../db/index.js';
 import { debug } from '../infrastructure/logger.js';
 import { CodegraphError, ConfigError, toErrorMessage } from '../shared/errors.js';
 import { MCP_MAX_LIMIT } from '../shared/paginate.js';
@@ -204,8 +203,10 @@ export async function startMCPServer(
   const { allowedRepos } = options;
   const multiRepo = options.multiRepo || !!allowedRepos;
 
-  // Apply config-based MCP page-size overrides
-  const config = options.config || loadConfig();
+  // Apply config-based MCP page-size overrides. Resolves rootDir from the
+  // (possibly custom) db path rather than process.cwd() — the MCP server
+  // may be invoked from an arbitrary working directory (issue #2222).
+  const config = options.config || resolveDbConfig(customDbPath);
   initMcpDefaults(config.mcp?.defaults ? { ...config.mcp.defaults } : undefined);
   const disabledTools = [...(config.mcp?.disabledTools ?? [])];
   const enabledTools = buildToolList(multiRepo, disabledTools);

--- a/src/presentation/audit.ts
+++ b/src/presentation/audit.ts
@@ -94,7 +94,7 @@ export function audit(
 ): void {
   const data: AuditResult = auditData(target, customDbPath, opts);
 
-  if (outputResult(data, null, opts)) return;
+  if (outputResult(data, null, opts, customDbPath)) return;
 
   if (data.functions.length === 0) {
     if (data.found === false) {

--- a/src/presentation/branch-compare.ts
+++ b/src/presentation/branch-compare.ts
@@ -137,7 +137,7 @@ export async function branchCompare(
   const data = await branchCompareData(baseRef, targetRef, opts);
 
   if (opts.format === 'json') opts = { ...opts, json: true };
-  if (outputResult(data, null, opts)) return;
+  if (outputResult(data, null, opts, opts.dbPath)) return;
 
   if (opts.format === 'mermaid') {
     console.log(branchCompareMermaid(data));

--- a/src/presentation/branch-compare.ts
+++ b/src/presentation/branch-compare.ts
@@ -124,7 +124,6 @@ interface BranchCompareCliOpts {
   format?: string;
   repoRoot?: string;
   noTests?: boolean;
-  dbPath?: string;
   engine?: string;
   depth?: number;
 }
@@ -137,7 +136,7 @@ export async function branchCompare(
   const data = await branchCompareData(baseRef, targetRef, opts);
 
   if (opts.format === 'json') opts = { ...opts, json: true };
-  if (outputResult(data, null, opts, opts.dbPath)) return;
+  if (outputResult(data, null, opts, opts.repoRoot)) return;
 
   if (opts.format === 'mermaid') {
     console.log(branchCompareMermaid(data));

--- a/src/presentation/brief.ts
+++ b/src/presentation/brief.ts
@@ -25,7 +25,7 @@ interface BriefResult {
 
 export function brief(file: string, customDbPath: string | undefined, opts: BriefOpts = {}): void {
   const data = briefData(file, customDbPath as string, opts);
-  if (outputResult(data, 'results', opts)) return;
+  if (outputResult(data, 'results', opts, customDbPath)) return;
 
   if (data.results.length === 0) {
     console.log(`No file matching "${file}" in graph`);

--- a/src/presentation/cfg.ts
+++ b/src/presentation/cfg.ts
@@ -84,7 +84,7 @@ function tryRenderGraphFormat(format: string, data: CfgData): boolean {
 export function cfg(name: string, customDbPath: string | undefined, opts: CfgCliOpts = {}): void {
   const data = cfgData(name, customDbPath, opts);
 
-  if (outputResult(data, 'results', opts)) return;
+  if (outputResult(data, 'results', opts, customDbPath)) return;
 
   if (data.warning) {
     console.log(`⚠  ${data.warning}`);

--- a/src/presentation/check.ts
+++ b/src/presentation/check.ts
@@ -129,7 +129,7 @@ export function check(customDbPath: string | undefined, opts: CheckCliOpts = {})
     throw new AnalysisError(data.error);
   }
 
-  if (outputResult(data, null, opts)) {
+  if (outputResult(data, null, opts, customDbPath)) {
     if (!data.passed) process.exitCode = 1;
     return;
   }

--- a/src/presentation/communities.ts
+++ b/src/presentation/communities.ts
@@ -89,7 +89,7 @@ function renderDriftAnalysis(d: DriftAnalysis, driftScore: number): void {
 export function communities(customDbPath: string | undefined, opts: CommunitiesCliOpts = {}): void {
   const data = communitiesData(customDbPath, opts) as unknown as CommunitiesResult;
 
-  if (outputResult(data, 'communities', opts)) return;
+  if (outputResult(data, 'communities', opts, customDbPath)) return;
 
   if (data.summary.communityCount === 0) {
     console.log(

--- a/src/presentation/complexity.ts
+++ b/src/presentation/complexity.ts
@@ -88,7 +88,7 @@ function renderDefaultTable(functions: ComplexityFunction[]): void {
 export function complexity(customDbPath: string | undefined, opts: ComplexityCliOpts = {}): void {
   const data = complexityData(customDbPath, opts as any) as unknown as ComplexityResult;
 
-  if (outputResult(data, 'functions', opts)) return;
+  if (outputResult(data, 'functions', opts, customDbPath)) return;
 
   if (data.functions.length === 0) {
     if (data.summary === null) {

--- a/src/presentation/dataflow.ts
+++ b/src/presentation/dataflow.ts
@@ -120,7 +120,7 @@ export function dataflow(
     results: DataflowResultEntry[];
   };
 
-  if (outputResult(data, 'results', opts)) return;
+  if (outputResult(data, 'results', opts, customDbPath)) return;
 
   if (data.warning) {
     console.log(`\u26A0  ${data.warning}`);
@@ -154,7 +154,7 @@ function dataflowImpact(
     offset: opts.offset,
   }) as { warning?: string; results: DataflowImpactEntry[] };
 
-  if (outputResult(data, 'results', opts)) return;
+  if (outputResult(data, 'results', opts, customDbPath)) return;
 
   if (data.warning) {
     console.log(`\u26A0  ${data.warning}`);

--- a/src/presentation/flow.ts
+++ b/src/presentation/flow.ts
@@ -57,7 +57,7 @@ function runListEntryPoints(dbPath: string | undefined, opts: FlowOpts): void {
     limit: opts.limit,
     offset: opts.offset,
   }) as { count: number; byType: Record<string, EntryPoint[]> };
-  if (outputResult(data, 'entries', opts)) return;
+  if (outputResult(data, 'entries', opts, dbPath)) return;
   if (data.count === 0) {
     console.log('No entry points found. Run "codegraph build" first.');
     return;
@@ -132,7 +132,7 @@ export function flow(
   }
 
   const data = flowData(name, dbPath, opts) as unknown as FlowResult;
-  if (outputResult(data, 'steps', opts)) return;
+  if (outputResult(data, 'steps', opts, dbPath)) return;
 
   if (!data.entry) {
     console.log(`No matching entry point or function found for "${name}".`);

--- a/src/presentation/manifesto.ts
+++ b/src/presentation/manifesto.ts
@@ -77,7 +77,7 @@ function renderViolations(violations: ManifestoViolationRow[]): void {
 export function manifesto(customDbPath: string | undefined, opts: ManifestoOpts = {}): void {
   const data = manifestoData(customDbPath, opts as any) as any;
 
-  if (outputResult(data, 'violations', opts)) {
+  if (outputResult(data, 'violations', opts, customDbPath)) {
     if (!data.passed) process.exitCode = 1;
     return;
   }

--- a/src/presentation/owners.ts
+++ b/src/presentation/owners.ts
@@ -43,7 +43,7 @@ interface OwnersResult {
 
 export function owners(customDbPath: string | undefined, opts: OwnersOpts = {}): void {
   const data = ownersData(customDbPath, opts as any) as OwnersResult;
-  if (outputResult(data, null, opts)) return;
+  if (outputResult(data, null, opts, customDbPath)) return;
 
   if (!data.codeownersFile) {
     console.log('No CODEOWNERS file found.');

--- a/src/presentation/queries-cli/exports.ts
+++ b/src/presentation/queries-cli/exports.ts
@@ -138,7 +138,7 @@ function printReexportedSection(data: ExportsDataResult, opts: ExportsOpts): voi
 
 export function fileExports(file: string, customDbPath: string, opts: ExportsOpts = {}): void {
   const data = exportsData(file, customDbPath, opts) as ExportsDataResult;
-  if (outputResult(data, 'results', opts)) return;
+  if (outputResult(data, 'results', opts, customDbPath)) return;
 
   const hasReexported = data.reexportedSymbols && data.reexportedSymbols.length > 0;
 

--- a/src/presentation/queries-cli/impact.ts
+++ b/src/presentation/queries-cli/impact.ts
@@ -126,7 +126,7 @@ interface OutputOpts {
 
 export function fileDeps(file: string, customDbPath: string, opts: OutputOpts = {}): void {
   const data = fileDepsData(file, customDbPath, opts) as unknown as FileDepsData;
-  if (outputResult(data, 'results', opts)) return;
+  if (outputResult(data, 'results', opts, customDbPath)) return;
 
   if (data.results.length === 0) {
     console.log(`No file matching "${file}" in graph`);
@@ -181,7 +181,7 @@ function printFnDepsTransitive(transitiveCallers: Record<string, SymbolRef[]>): 
 
 export function fnDeps(name: string, customDbPath: string, opts: OutputOpts = {}): void {
   const data = fnDepsData(name, customDbPath, opts) as unknown as FnDepsData;
-  if (outputResult(data, 'results', opts)) return;
+  if (outputResult(data, 'results', opts, customDbPath)) return;
 
   if (data.results.length === 0) {
     console.log(`No function/method/class matching "${name}"`);
@@ -202,7 +202,7 @@ export function fnDeps(name: string, customDbPath: string, opts: OutputOpts = {}
 
 export function impactAnalysis(file: string, customDbPath: string, opts: OutputOpts = {}): void {
   const data = impactAnalysisData(file, customDbPath, opts) as unknown as ImpactData;
-  if (outputResult(data, 'sources', opts)) return;
+  if (outputResult(data, 'sources', opts, customDbPath)) return;
 
   if (data.sources.length === 0) {
     console.log(`No file matching "${file}" in graph`);
@@ -231,7 +231,7 @@ export function impactAnalysis(file: string, customDbPath: string, opts: OutputO
 
 export function fnImpact(name: string, customDbPath: string, opts: OutputOpts = {}): void {
   const data = fnImpactData(name, customDbPath, opts) as unknown as FnImpactData;
-  if (outputResult(data, 'results', opts)) return;
+  if (outputResult(data, 'results', opts, customDbPath)) return;
 
   if (data.results.length === 0) {
     console.log(`No function/method/class matching "${name}"`);
@@ -302,7 +302,7 @@ export function diffImpact(customDbPath: string, opts: OutputOpts = {}): void {
   }
   const data = diffImpactData(customDbPath, opts) as unknown as DiffImpactData;
   if (opts.format === 'json') opts = { ...opts, json: true };
-  if (outputResult(data, 'affectedFunctions', opts)) return;
+  if (outputResult(data, 'affectedFunctions', opts, customDbPath)) return;
 
   if (data.error) {
     console.log(data.error);

--- a/src/presentation/queries-cli/inspect.ts
+++ b/src/presentation/queries-cli/inspect.ts
@@ -222,7 +222,7 @@ function renderWhereFileResults(results: WhereFileResult[]): void {
 
 export function where(target: string, customDbPath: string, opts: OutputOpts = {}): void {
   const data = whereData(target, customDbPath, opts as Record<string, unknown>) as WhereData;
-  if (outputResult(data, 'results', opts)) return;
+  if (outputResult(data, 'results', opts, customDbPath)) return;
 
   if (data.results.length === 0) {
     console.log(
@@ -247,7 +247,7 @@ export function queryName(name: string, customDbPath: string, opts: OutputOpts =
     limit: opts.limit,
     offset: opts.offset,
   }) as QueryNameData;
-  if (outputResult(data, 'results', opts)) return;
+  if (outputResult(data, 'results', opts, customDbPath)) return;
 
   if (data.results.length === 0) {
     console.log(`No results for "${name}"`);
@@ -275,7 +275,7 @@ export function queryName(name: string, customDbPath: string, opts: OutputOpts =
 
 export function context(name: string, customDbPath: string, opts: OutputOpts = {}): void {
   const data = contextData(name, customDbPath, opts as Record<string, unknown>) as ContextData;
-  if (outputResult(data, 'results', opts)) return;
+  if (outputResult(data, 'results', opts, customDbPath)) return;
 
   if (data.results.length === 0) {
     console.log(`No function/method/class matching "${name}"`);
@@ -289,7 +289,7 @@ export function context(name: string, customDbPath: string, opts: OutputOpts = {
 
 export function children(name: string, customDbPath: string, opts: OutputOpts = {}): void {
   const data = childrenData(name, customDbPath, opts as Record<string, unknown>) as ChildrenData;
-  if (outputResult(data, 'results', opts)) return;
+  if (outputResult(data, 'results', opts, customDbPath)) return;
 
   if (data.results.length === 0) {
     console.log(`No symbol matching "${name}"`);
@@ -505,7 +505,7 @@ function renderFunctionExplain(r: FunctionExplainResult, indent = ''): void {
 
 export function explain(target: string, customDbPath: string, opts: OutputOpts = {}): void {
   const data = explainData(target, customDbPath, opts as Record<string, unknown>) as ExplainData;
-  if (outputResult(data, 'results', opts)) return;
+  if (outputResult(data, 'results', opts, customDbPath)) return;
 
   if (data.results.length === 0) {
     console.log(`No ${data.kind === 'file' ? 'file' : 'function/symbol'} matching "${target}"`);
@@ -529,7 +529,7 @@ export function implementations(name: string, customDbPath: string, opts: Output
     customDbPath,
     opts as Record<string, unknown>,
   ) as ImplementationsData;
-  if (outputResult(data, 'results', opts)) return;
+  if (outputResult(data, 'results', opts, customDbPath)) return;
 
   if (data.results.length === 0) {
     console.log(`No symbol matching "${name}"`);
@@ -556,7 +556,7 @@ export function interfaces(name: string, customDbPath: string, opts: OutputOpts 
     customDbPath,
     opts as Record<string, unknown>,
   ) as InterfacesData;
-  if (outputResult(data, 'results', opts)) return;
+  if (outputResult(data, 'results', opts, customDbPath)) return;
 
   if (data.results.length === 0) {
     console.log(`No symbol matching "${name}"`);

--- a/src/presentation/queries-cli/overview.ts
+++ b/src/presentation/queries-cli/overview.ts
@@ -262,7 +262,7 @@ export async function stats(customDbPath: string, opts: OutputOpts = {}): Promis
     debug(`stats: community detection failed (optional): ${toErrorMessage(e)}`);
   }
 
-  if (outputResult(data, null, opts)) return;
+  if (outputResult(data, null, opts, customDbPath)) return;
 
   console.log('\n# Codegraph Stats\n');
   printNodes(data);
@@ -280,7 +280,7 @@ export async function stats(customDbPath: string, opts: OutputOpts = {}): Promis
 
 export function moduleMap(customDbPath: string, limit = 20, opts: OutputOpts = {}): void {
   const data = moduleMapData(customDbPath, limit, { noTests: opts.noTests }) as ModuleMapData;
-  if (outputResult(data, 'topNodes', opts)) return;
+  if (outputResult(data, 'topNodes', opts, customDbPath)) return;
 
   console.log(`\nModule map (top ${limit} most-connected nodes):\n`);
   const dirs = new Map<string, TopNode[]>();
@@ -326,7 +326,7 @@ function printRoleGroup(role: string, symbols: RoleSymbol[]): void {
 export function dynamicCalls(customDbPath: string, opts: OutputOpts = {}): void {
   const rows = dynamicCallsData(customDbPath);
   if (opts.json || opts.ndjson) {
-    outputResult({ dynamic_calls: rows }, 'dynamic_calls', opts);
+    outputResult({ dynamic_calls: rows }, 'dynamic_calls', opts, customDbPath);
     return;
   }
   if (rows.length === 0) {
@@ -349,7 +349,7 @@ export function dynamicCalls(customDbPath: string, opts: OutputOpts = {}): void 
 
 export function roles(customDbPath: string, opts: OutputOpts = {}): void {
   const data = rolesData(customDbPath, opts) as RolesData;
-  if (outputResult(data, 'symbols', opts)) return;
+  if (outputResult(data, 'symbols', opts, customDbPath)) return;
 
   if (data.count === 0) {
     console.log('No classified symbols found. Run "codegraph build" first.');

--- a/src/presentation/queries-cli/path.ts
+++ b/src/presentation/queries-cli/path.ts
@@ -86,7 +86,7 @@ export function symbolPath(
   }
 
   const data = pathData(from, to, customDbPath, opts) as PathDataResult;
-  if (outputResult(data, null, opts)) return;
+  if (outputResult(data, null, opts, customDbPath)) return;
 
   if (data.error) {
     console.log(data.error);
@@ -160,7 +160,7 @@ function printFilePathSteps(data: FilePathDataResult): void {
 
 function filePath(from: string, to: string, customDbPath: string, opts: PathOpts = {}): void {
   const data = filePathData(from, to, customDbPath, opts) as FilePathDataResult;
-  if (outputResult(data, null, opts)) return;
+  if (outputResult(data, null, opts, customDbPath)) return;
 
   if (data.error) {
     console.log(data.error);

--- a/src/presentation/result-formatter.ts
+++ b/src/presentation/result-formatter.ts
@@ -1,4 +1,4 @@
-import { loadConfig } from '../infrastructure/config.js';
+import { resolveDbConfig } from '../db/index.js';
 import type { PaginationMeta } from '../shared/paginate.js';
 import { formatTable, truncEnd } from './table.js';
 
@@ -132,7 +132,12 @@ export interface OutputOpts {
   display?: DisplayOpts;
 }
 
-export function outputResult(data: object, field: string | null, opts: OutputOpts): boolean {
+export function outputResult(
+  data: object,
+  field: string | null,
+  opts: OutputOpts,
+  customDbPath?: string,
+): boolean {
   // The formatting helpers below need key/index access (NDJSON field pluck, CSV/table
   // flattening). Callers only ever hand off a concrete result shape for serialization,
   // so the cast lives here once instead of as a defensive `as unknown as Record<...>`
@@ -155,7 +160,10 @@ export function outputResult(data: object, field: string | null, opts: OutputOpt
     return printCsv(record, field) !== false;
   }
   if (opts.table) {
-    const displayOpts = opts.display ?? (loadConfig() as { display: DisplayOpts }).display;
+    // Resolves rootDir from customDbPath rather than process.cwd() — a
+    // caller invoked from an arbitrary working directory must still pick up
+    // that repo's own display config (issue #2222).
+    const displayOpts = opts.display ?? resolveDbConfig(customDbPath).display;
     return printAutoTable(record, field, displayOpts) !== false;
   }
   return false;

--- a/src/presentation/sequence.ts
+++ b/src/presentation/sequence.ts
@@ -18,7 +18,7 @@ interface SequenceOpts {
 export function sequence(name: string, dbPath: string | undefined, opts: SequenceOpts = {}): void {
   const data = sequenceData(name, dbPath, opts) as any;
 
-  if (outputResult(data, 'messages', opts)) return;
+  if (outputResult(data, 'messages', opts, dbPath)) return;
 
   // Default: mermaid format
   if (!data.entry) {

--- a/src/presentation/triage.ts
+++ b/src/presentation/triage.ts
@@ -42,7 +42,7 @@ export function triage(customDbPath: string | undefined, opts: TriageOpts = {}):
     summary: TriageSummary;
   };
 
-  if (outputResult(data, 'items', opts)) return;
+  if (outputResult(data, 'items', opts, customDbPath)) return;
 
   if (data.items.length === 0) {
     if (data.summary.total === 0) {

--- a/tests/presentation/result-formatter.test.ts
+++ b/tests/presentation/result-formatter.test.ts
@@ -3,9 +3,12 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Mock the config loader so it doesn't touch disk
-vi.mock('../../src/infrastructure/config.js', () => ({
-  loadConfig: () => ({ display: { maxColWidth: 40 } }),
+// Mock the config resolver so it doesn't touch disk. outputResult resolves
+// its fallback display config via resolveDbConfig(customDbPath) — not a bare
+// loadConfig() off process.cwd() — since #2222.
+const resolveDbConfigMock = vi.fn(() => ({ display: { maxColWidth: 40 } }));
+vi.mock('../../src/db/index.js', () => ({
+  resolveDbConfig: resolveDbConfigMock,
 }));
 
 const { outputResult } = await import('../../src/presentation/result-formatter.js');
@@ -15,6 +18,8 @@ describe('outputResult', () => {
 
   beforeEach(() => {
     logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    resolveDbConfigMock.mockClear();
+    resolveDbConfigMock.mockReturnValue({ display: { maxColWidth: 40 } });
   });
 
   afterEach(() => {
@@ -73,6 +78,27 @@ describe('outputResult', () => {
     // Should contain table formatting (box-drawing chars)
     const output = logSpy.mock.calls[0][0];
     expect(output).toContain('\u2500');
+  });
+
+  it('resolves the fallback display config from customDbPath, not process.cwd() (#2222)', () => {
+    const data = { items: [{ file: 'a.js', lines: 10 }] };
+    outputResult(data, 'items', { table: true }, '/some/other/repo');
+    expect(resolveDbConfigMock).toHaveBeenCalledWith('/some/other/repo');
+  });
+
+  it('does not call resolveDbConfig when opts.display is already provided', () => {
+    const data = { items: [{ file: 'a.js', lines: 10 }] };
+    outputResult(data, 'items', { table: true, display: { maxColWidth: 3 } }, '/some/other/repo');
+    expect(resolveDbConfigMock).not.toHaveBeenCalled();
+  });
+
+  it('uses the resolved config\u2019s maxColWidth to truncate table cells', () => {
+    resolveDbConfigMock.mockReturnValue({ display: { maxColWidth: 5 } });
+    const data = { items: [{ name: 'ThisIsALongSymbolName' }] };
+    outputResult(data, 'items', { table: true }, '/some/other/repo');
+    const output = logSpy.mock.calls[0][0];
+    expect(output).not.toContain('ThisIsALongSymbolName');
+    expect(output).toContain('This\u2026'); // truncEnd: (maxColWidth - 1) chars + ellipsis
   });
 
   it('csv escapes commas and quotes in values', () => {


### PR DESCRIPTION
Closes #2222

## Root cause

Two remaining `loadConfig()` call sites resolved config relative to `process.cwd()` instead of the resolved `--db`/`customDbPath` target — the same class of bug #1881/#2017 already fixed at a named list of other call sites.

- `startMCPServer()` (`src/mcp/server.ts`): `const config = options.config || loadConfig();` — the function already takes `customDbPath` as its first parameter, so this was the exact mechanical fix #2017 already established elsewhere.
- `outputResult()`'s `--table` rendering (`src/presentation/result-formatter.ts`): `opts.display ?? (loadConfig() as ...).display` — this function had no `customDbPath`/`dbPath` parameter at all, since it's a shared formatter called from ~40 places after each caller already fetched its own data.

## Fix

- `startMCPServer`: `options.config || resolveDbConfig(customDbPath)`.
- `outputResult`: added an optional 4th `customDbPath` argument; falls back to `resolveDbConfig(customDbPath).display` instead of `loadConfig()`. Threaded the caller's already-in-scope db-path variable into every one of `outputResult`'s call sites (18 files calling it directly, plus 3 more going through `CliContext.outputResult`'s DI indirection) — leaving any subset unfixed would just mean those specific commands kept silently resolving from cwd.

## Test plan

- `tests/presentation/result-formatter.test.ts`: fixed a now-inert `vi.mock` (it mocked `loadConfig` from `infrastructure/config.js`, which `outputResult` no longer imports — the mock had gone silently dead, letting the test touch real disk/cwd config without any assertion catching it) to mock `resolveDbConfig` from `db/index.js` instead. Added 3 new tests: `outputResult` calls `resolveDbConfig` with the passed `customDbPath`, skips calling it entirely when `opts.display` is already provided, and a resolved config's `maxColWidth` is honored in the rendered table output.
- Verified the new tests fail with the fix reverted and pass with it restored.
- Full local suite: `npm test` (292 files / 4752 tests passed), `tsc --noEmit`, `biome check` clean.