### PR TITLE
fix(db): derive rootDir correctly for a non-conventional --db file path

### DIFF
--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -406,17 +406,20 @@ interface ResolvedDbSettings {
 }
 
 /**
- * Walk up from `startDir` toward `ceiling` looking for a project config file
- * (any name in CONFIG_FILES) — mirrors walkUpForDbPath's structure/ceiling
- * handling, but the marker being searched for is the project's config file
- * rather than .codegraph/graph.db itself.
+ * Walk up from `startDir` looking for a project config file (any name in
+ * CONFIG_FILES), stopping at `ceiling` (the git root) if one is given —
+ * but, unlike walkUpForDbPath's search for .codegraph/graph.db (an
+ * auto-generated build artifact, where walking past an unknown boundary
+ * risks attaching to a stale one from an unrelated ancestor), an explicit,
+ * user-authored .codegraphrc.json carries no such risk: a --db file nested
+ * under a non-git project's root legitimately expects config resolution to
+ * walk all the way up to the filesystem root to find it (issue #2224).
  */
 function walkUpForConfigDir(startDir: string, ceiling: string | null): string | null {
   let dir = startDir;
   while (true) {
     if (CONFIG_FILES.some((name) => fs.existsSync(path.join(dir, name)))) return dir;
     if (ceiling && isSameDirectory(dir, ceiling)) return null;
-    if (!ceiling) return null;
     const parent = path.dirname(dir);
     if (parent === dir) return null;
     dir = parent;

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -2,7 +2,7 @@ import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { DEFAULTS, loadConfig } from '../infrastructure/config.js';
+import { CONFIG_FILES, DEFAULTS, loadConfig } from '../infrastructure/config.js';
 import { debug, warn } from '../infrastructure/logger.js';
 import { getNative, isNativeAvailable } from '../infrastructure/native.js';
 import { DbError, toErrorMessage } from '../shared/errors.js';
@@ -406,15 +406,55 @@ interface ResolvedDbSettings {
 }
 
 /**
+ * Walk up from `startDir` toward `ceiling` looking for a project config file
+ * (any name in CONFIG_FILES) — mirrors walkUpForDbPath's structure/ceiling
+ * handling, but the marker being searched for is the project's config file
+ * rather than .codegraph/graph.db itself.
+ */
+function walkUpForConfigDir(startDir: string, ceiling: string | null): string | null {
+  let dir = startDir;
+  while (true) {
+    if (CONFIG_FILES.some((name) => fs.existsSync(path.join(dir, name)))) return dir;
+    if (ceiling && isSameDirectory(dir, ceiling)) return null;
+    if (!ceiling) return null;
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+/**
  * Derive the project rootDir from a possibly-custom DB path, for loadConfig().
- * Using findDbPath (not path.resolve(customDbPath)) ensures directory inputs like
- * --db /path/to/repo are normalised to .codegraph/graph.db before we strip two levels.
- * Convention: resolvedDbPath = <rootDir>/.codegraph/graph.db
+ *
+ * Using findDbPath (not path.resolve(customDbPath)) ensures directory inputs
+ * like --db /path/to/repo are normalized through the same resolution findDbPath
+ * itself uses elsewhere. Two cases:
+ *
+ * - Convention: resolvedDbPath is exactly <rootDir>/.codegraph/<anything> (the
+ *   layout `codegraph build` creates, or a bare directory input normalized to
+ *   it) — strip the two known levels.
+ * - Non-conventional: an explicit --db pointing at a real file that isn't
+ *   inside a .codegraph/ directory at all (issue #2224 — resolveCustomDbPath
+ *   returns such a file as-is, so the "strip two levels" assumption silently
+ *   derived the file's grandparent directory as rootDir, one level too high
+ *   whenever the file sits directly in the project root). Walk up looking
+ *   for a project config file first (the more authoritative signal of "this
+ *   is the codegraph project root," even for a project outside git), falling
+ *   back to the git root, and finally to the file's own directory rather
+ *   than giving up and returning undefined — which would silently re-derive
+ *   from process.cwd() right back into this same bug.
+ *
  * Shared by resolveDbSettings() and resolveBusyTimeoutMs() so rootDir derivation can't drift.
  */
 function deriveRootDirFromDbPath(customDbPath: string | undefined): string | undefined {
   const resolvedDbPath = customDbPath ? findDbPath(customDbPath) : undefined;
-  return resolvedDbPath ? path.dirname(path.dirname(resolvedDbPath)) : undefined;
+  if (!resolvedDbPath) return undefined;
+  const dir = path.dirname(resolvedDbPath);
+  if (path.basename(dir) === '.codegraph') return path.dirname(dir);
+
+  const startDir = resolveDbSearchStartDir(dir);
+  const ceiling = resolveDbSearchCeiling(findRepoRoot(startDir));
+  return walkUpForConfigDir(startDir, ceiling) ?? findRepoRoot(startDir) ?? dir;
 }
 
 /**

--- a/tests/unit/loadconfig-dbpath-resolution-2224.test.ts
+++ b/tests/unit/loadconfig-dbpath-resolution-2224.test.ts
@@ -84,4 +84,31 @@ describe('resolveDbConfig / deriveRootDirFromDbPath (#2224)', () => {
       fs.rmSync(conventionalDir, { recursive: true, force: true });
     }
   });
+
+  it('walks up past a --db file nested several levels deep in a non-git project', () => {
+    // os.tmpdir() is not itself inside a git repository, so findRepoRoot
+    // returns null here — the walk-up must not stop after just one
+    // directory in that case (Greptile review: a null git ceiling
+    // previously made the search give up immediately).
+    const nonGitRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-2224-nogit-'));
+    try {
+      fs.writeFileSync(
+        path.join(nonGitRoot, '.codegraphrc.json'),
+        JSON.stringify({ db: { busyTimeoutMs: REPO_BUSY_TIMEOUT_MS } }),
+      );
+      const nestedDir = path.join(nonGitRoot, 'nested', 'deep');
+      fs.mkdirSync(nestedDir, { recursive: true });
+      const nestedDbFile = path.join(nestedDir, 'custom.db');
+      fs.writeFileSync(nestedDbFile, '');
+
+      const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(unrelatedCwd);
+      try {
+        expect(resolveDbConfig(nestedDbFile).db?.busyTimeoutMs).toBe(REPO_BUSY_TIMEOUT_MS);
+      } finally {
+        cwdSpy.mockRestore();
+      }
+    } finally {
+      fs.rmSync(nonGitRoot, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/unit/loadconfig-dbpath-resolution-2224.test.ts
+++ b/tests/unit/loadconfig-dbpath-resolution-2224.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Regression tests for issue #2224: `deriveRootDirFromDbPath()` (used by
+ * `resolveDbConfig()`/`resolveBusyTimeoutMs()`) unconditionally stripped
+ * exactly two path components from the resolved `--db` path, assuming the
+ * `<rootDir>/.codegraph/graph.db` convention. `resolveCustomDbPath()`
+ * returns an explicit *file* path as-is when it already exists, so
+ * `--db /repo/custom.db` (a real file, just not named/located per
+ * convention) resolved to rootDir `/repo/..` — the repo's parent, not the
+ * repo itself — silently reading the wrong (or no) `.codegraphrc.json`.
+ *
+ * Mirrors loadconfig-dbpath-resolution.test.ts's style: mock
+ * `process.cwd()` to an unrelated, unconfigured directory to prove
+ * resolution comes from the `--db` path, not cwd (and not the `--db`
+ * path's grandparent either).
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { resolveDbConfig } from '../../src/db/index.js';
+
+const REPO_BUSY_TIMEOUT_MS = 24680;
+const PARENT_BUSY_TIMEOUT_MS = 99999;
+
+let repoDir: string;
+let parentDir: string;
+let customDbFile: string;
+let unrelatedCwd: string;
+
+beforeAll(() => {
+  // repoDir's OWN parent also has a .codegraphrc.json, with a DIFFERENT
+  // busyTimeoutMs — if the bug's "grandparent" derivation were still active,
+  // resolution would silently pick this one up instead of repoDir's.
+  parentDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-2224-parent-'));
+  repoDir = fs.mkdtempSync(path.join(parentDir, 'repo-'));
+  customDbFile = path.join(repoDir, 'custom.db'); // NOT inside .codegraph/
+  fs.writeFileSync(customDbFile, ''); // resolveCustomDbPath requires it to exist as a file
+
+  fs.writeFileSync(
+    path.join(parentDir, '.codegraphrc.json'),
+    JSON.stringify({ db: { busyTimeoutMs: PARENT_BUSY_TIMEOUT_MS } }),
+  );
+  fs.writeFileSync(
+    path.join(repoDir, '.codegraphrc.json'),
+    JSON.stringify({ db: { busyTimeoutMs: REPO_BUSY_TIMEOUT_MS } }),
+  );
+
+  unrelatedCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-2224-unrelated-'));
+});
+
+afterAll(() => {
+  fs.rmSync(parentDir, { recursive: true, force: true });
+  fs.rmSync(unrelatedCwd, { recursive: true, force: true });
+});
+
+describe('resolveDbConfig / deriveRootDirFromDbPath (#2224)', () => {
+  it('derives rootDir from a non-conventional --db file (not inside .codegraph/), not its grandparent', () => {
+    const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(unrelatedCwd);
+    try {
+      const config = resolveDbConfig(customDbFile);
+      expect(config.db?.busyTimeoutMs).toBe(REPO_BUSY_TIMEOUT_MS);
+    } finally {
+      cwdSpy.mockRestore();
+    }
+  });
+
+  it('still derives the correct rootDir for the conventional <rootDir>/.codegraph/graph.db layout', () => {
+    const conventionalDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-2224-conventional-'));
+    try {
+      fs.mkdirSync(path.join(conventionalDir, '.codegraph'), { recursive: true });
+      const dbPath = path.join(conventionalDir, '.codegraph', 'graph.db');
+      fs.writeFileSync(dbPath, '');
+      fs.writeFileSync(
+        path.join(conventionalDir, '.codegraphrc.json'),
+        JSON.stringify({ db: { busyTimeoutMs: REPO_BUSY_TIMEOUT_MS } }),
+      );
+      const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(unrelatedCwd);
+      try {
+        expect(resolveDbConfig(dbPath).db?.busyTimeoutMs).toBe(REPO_BUSY_TIMEOUT_MS);
+      } finally {
+        cwdSpy.mockRestore();
+      }
+    } finally {
+      fs.rmSync(conventionalDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Closes #2224

## Root cause

`deriveRootDirFromDbPath()` (`src/db/connection.ts`), used by `resolveDbConfig()`/`resolveBusyTimeoutMs()` to derive `loadConfig()`'s rootDir from a `--db` path, unconditionally stripped exactly two path components:

```ts
function deriveRootDirFromDbPath(customDbPath: string | undefined): string | undefined {
  const resolvedDbPath = customDbPath ? findDbPath(customDbPath) : undefined;
  return resolvedDbPath ? path.dirname(path.dirname(resolvedDbPath)) : undefined;
}
```

This assumes every resolved DB path matches the `<rootDir>/.codegraph/graph.db` convention. `findDbPath()` normalizes directory-style `--db` inputs to that convention, but `resolveCustomDbPath()` returns an explicit **file** path as-is when it already exists — so `--db /repo/custom.db` (a real file, just not named/located per convention) resolved to rootDir `/repo/..`, the repo's parent, not `/repo` — silently reading the wrong (or no) `.codegraphrc.json`. This affects every `resolveDbConfig()` consumer (both #1881's original six call sites and #2017/#2222's newly-migrated ones) whenever `--db` points at a real, non-conventionally-named/located database file.

## Fix

- Detect the conventional case first: if the candidate's parent directory is literally named `.codegraph`, strip to its parent (unchanged, fast path).
- Otherwise, walk up from the file's own directory looking for a project config file (`CONFIG_FILES` — `.codegraphrc.json`/`.codegraphrc`/`codegraph.config.json`), bounded by the same git-root ceiling `findDbPath` itself already uses.
- If no config file is found, fall back to the git root (`findRepoRoot`).
- If neither succeeds, fall back to the file's own directory rather than returning `undefined` — which would silently re-derive from `process.cwd()`, landing right back in this same bug.

## Test plan

- New `tests/unit/loadconfig-dbpath-resolution-2224.test.ts`, mirroring #1881/#2017's existing test style: a project with `.codegraphrc.json` set at the repo root, a `--db` file directly in that root (not inside `.codegraph/`), and a **different** `.codegraphrc.json` at the repo's own parent directory (to prove the old grandparent-derivation bug doesn't silently "succeed" by reading the wrong file) — plus `process.cwd()` mocked to a third, unrelated directory.
- Verified the new test fails (reads the parent's config, not the repo's) with the fix reverted, and passes with it restored.
- All existing #1881/#2017 regression suites (`loadconfig-dbpath-resolution*.test.ts`, `busy-timeout-*.test.ts`, `withrepo-config-resolution.test.ts`, `cli-shared-options-config-resolution.test.ts`) still pass — the conventional `.codegraph/graph.db` path is unaffected.
- Full local suite: `npm test` (293 files / 4754 tests passed), `tsc --noEmit`, `biome check` clean.
- No native-engine (Rust) mirror needed — config/rootDir resolution for CLI/query purposes is TS-only; `crates/codegraph-core/src/db/connection.rs` covers only DB connection/schema, not this logic.