### PR TITLE
fix(fixer-skill): guard 2g's state.json write before shifting queue.json

### DIFF
--- a/.claude/skills/fixer/SKILL.md
+++ b/.claude/skills/fixer/SKILL.md
@@ -1058,9 +1058,19 @@ PR=$(cat .codegraph/fixer/current-pr 2>/dev/null)
 # across concurrent sessions and fails outright on re-run.
 TMP_STATE=$(mktemp "${TMPDIR:-/tmp}/fixer-state.XXXXXXXXXX")
 trap 'rm -f "$TMP_STATE"' EXIT
-jq --argjson issue "$ISSUE" --arg status "$STATUS" --argjson pr "$PR" \
+# Guarded explicitly (issue #2229): queue.json must never be shifted unless this
+# write actually succeeded — an unguarded `&&` chain here still fell through to
+# the queue-shift below on failure, silently losing the issue from both files.
+if ! jq --argjson issue "$ISSUE" --arg status "$STATUS" --argjson pr "$PR" \
   '.issues += [{issue: $issue, status: $status, pr: $pr}]' \
-  .codegraph/fixer/state.json > "$TMP_STATE" && mv "$TMP_STATE" .codegraph/fixer/state.json
+  .codegraph/fixer/state.json > "$TMP_STATE"; then
+  echo "ERROR: failed to build updated state.json for issue #$ISSUE — queue.json left untouched, so this issue will be retried rather than lost."
+  exit 1
+fi
+if ! mv "$TMP_STATE" .codegraph/fixer/state.json; then
+  echo "ERROR: failed to write state.json for issue #$ISSUE — queue.json left untouched, so this issue will be retried rather than lost."
+  exit 1
+fi
 trap - EXIT
 
 if [ "$STATUS" = "parked" ] && [ "$PR" != "null" ]; then
@@ -1070,7 +1080,17 @@ fi
 
 TMP_QUEUE=$(mktemp "${TMPDIR:-/tmp}/fixer-queue.XXXXXXXXXX")
 trap 'rm -f "$TMP_QUEUE"' EXIT
-jq '.[1:]' .codegraph/fixer/queue.json > "$TMP_QUEUE" && mv "$TMP_QUEUE" .codegraph/fixer/queue.json
+# Guarded the same way: if this fails after state.json already succeeded above,
+# queue.json[0] is still this (already-resolved) issue — exactly the case Phase 2's
+# own resume-detection note (above step 2a) already filters out on the next run.
+if ! jq '.[1:]' .codegraph/fixer/queue.json > "$TMP_QUEUE"; then
+  echo "ERROR: failed to build updated queue.json — issue #$ISSUE was already recorded as $STATUS in state.json. The next run's resume-detection will filter this already-resolved queue head."
+  exit 1
+fi
+if ! mv "$TMP_QUEUE" .codegraph/fixer/queue.json; then
+  echo "ERROR: failed to write queue.json — issue #$ISSUE was already recorded as $STATUS in state.json. The next run's resume-detection will filter this already-resolved queue head."
+  exit 1
+fi
 trap - EXIT
 rm -f .codegraph/fixer/current-pr .codegraph/fixer/gate-fail .codegraph/fixer/outcome .codegraph/fixer/round \
       .codegraph/fixer/stall-count .codegraph/fixer/gate-signature .codegraph/fixer/prev-gate-signature \

--- a/tests/unit/fixer-skill-2g-queue-guard-2229.test.ts
+++ b/tests/unit/fixer-skill-2g-queue-guard-2229.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Regression test for issue #2229: `.claude/skills/fixer/SKILL.md` step
+ * 2g's state-recording bash block wrote `state.json` and then
+ * unconditionally shifted `queue.json`, even when the `state.json` write
+ * itself failed (e.g. a malformed/unreadable `state.json`). The queue-shift
+ * line ran regardless, silently losing the issue from both files: never
+ * recorded as resolved, and no longer queued to be retried.
+ *
+ * Extracts the actual 2g bash block from the real SKILL.md (not a
+ * reimplementation of its logic) and executes it against a sandboxed
+ * `.codegraph/fixer/` directory, so this test breaks the moment someone
+ * reintroduces the unguarded `&&`/unconditional-shift pattern — not just
+ * the moment someone changes prose around it.
+ */
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = path.join(import.meta.dirname, '../..');
+const SKILL_PATH = path.join(REPO_ROOT, '.claude/skills/fixer/SKILL.md');
+
+/** Extract the first ```bash fenced block following a given section heading. */
+function extractBashBlockAfterHeading(markdown: string, heading: string): string {
+  const headingIdx = markdown.indexOf(heading);
+  if (headingIdx === -1) {
+    throw new Error(`Heading not found in SKILL.md: ${heading}`);
+  }
+  const rest = markdown.slice(headingIdx);
+  const fenceStart = rest.indexOf('```bash');
+  if (fenceStart === -1) {
+    throw new Error(`No \`\`\`bash fence found after heading: ${heading}`);
+  }
+  const bodyStart = rest.indexOf('\n', fenceStart) + 1;
+  const fenceEnd = rest.indexOf('```', bodyStart);
+  if (fenceEnd === -1) {
+    throw new Error(`Unterminated \`\`\`bash fence after heading: ${heading}`);
+  }
+  return rest.slice(bodyStart, fenceEnd);
+}
+
+function runBlock(
+  block: string,
+  sandbox: string,
+): { exitCode: number; stdout: string; stderr: string } {
+  try {
+    const stdout = execFileSync('bash', ['-c', block], { cwd: sandbox, encoding: 'utf8' });
+    return { exitCode: 0, stdout, stderr: '' };
+  } catch (err) {
+    const e = err as { status: number; stdout: string; stderr: string };
+    return { exitCode: e.status, stdout: e.stdout ?? '', stderr: e.stderr ?? '' };
+  }
+}
+
+function setupSandbox(stateJsonContent: string): string {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'fixer-2g-sandbox-'));
+  fs.mkdirSync(path.join(sandbox, '.codegraph/fixer'), { recursive: true });
+  fs.writeFileSync(path.join(sandbox, '.codegraph/fixer/state.json'), stateJsonContent);
+  fs.writeFileSync(
+    path.join(sandbox, '.codegraph/fixer/queue.json'),
+    JSON.stringify([
+      { issue: 100, title: 'first' },
+      { issue: 200, title: 'second' },
+    ]),
+  );
+  fs.writeFileSync(path.join(sandbox, '.codegraph/fixer/outcome'), 'merged');
+  fs.writeFileSync(path.join(sandbox, '.codegraph/fixer/current-pr'), '999');
+  return sandbox;
+}
+
+describe('fixer skill 2g state/queue write guards (#2229)', () => {
+  const skillContent = fs.readFileSync(SKILL_PATH, 'utf-8');
+  const block = extractBashBlockAfterHeading(
+    skillContent,
+    '### 2g. Record the outcome and advance',
+  );
+
+  it('extracted a non-trivial block containing the state.json and queue.json writes', () => {
+    expect(block).toContain('.codegraph/fixer/state.json');
+    expect(block).toContain('.codegraph/fixer/queue.json');
+  });
+
+  it('happy path: records the issue in state.json and shifts queue.json', () => {
+    const sandbox = setupSandbox('{"issues":[]}');
+    try {
+      const result = runBlock(block, sandbox);
+      expect(result.exitCode).toBe(0);
+
+      const state = JSON.parse(
+        fs.readFileSync(path.join(sandbox, '.codegraph/fixer/state.json'), 'utf-8'),
+      );
+      expect(state.issues).toEqual([{ issue: 100, status: 'merged', pr: 999 }]);
+
+      const queue = JSON.parse(
+        fs.readFileSync(path.join(sandbox, '.codegraph/fixer/queue.json'), 'utf-8'),
+      );
+      expect(queue).toEqual([{ issue: 200, title: 'second' }]);
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+
+  it('does not shift queue.json when the state.json write fails', () => {
+    const sandbox = setupSandbox('{invalid json here');
+    try {
+      const result = runBlock(block, sandbox);
+      expect(result.exitCode).not.toBe(0);
+
+      // state.json is left as whatever it was — still malformed, not silently
+      // "fixed" by a failed write, and definitely not recording a fabricated
+      // success.
+      const stateRaw = fs.readFileSync(path.join(sandbox, '.codegraph/fixer/state.json'), 'utf-8');
+      expect(stateRaw).toBe('{invalid json here');
+
+      // The bug this test guards against: queue.json must still have issue
+      // #100 at its head, not silently shifted to #200.
+      const queue = JSON.parse(
+        fs.readFileSync(path.join(sandbox, '.codegraph/fixer/queue.json'), 'utf-8'),
+      );
+      expect(queue).toEqual([
+        { issue: 100, title: 'first' },
+        { issue: 200, title: 'second' },
+      ]);
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Closes #2229

## Root cause

`.claude/skills/fixer/SKILL.md` step 2g's state-recording bash block wrote `state.json` and then unconditionally shifted `queue.json`, even if the `state.json` write failed:

```bash
jq --argjson issue "$ISSUE" --arg status "$STATUS" --argjson pr "$PR" \
  '.issues += [{issue: $issue, status: $status, pr: $pr}]' \
  .codegraph/fixer/state.json > "$TMP_STATE" && mv "$TMP_STATE" .codegraph/fixer/state.json
trap - EXIT
...
jq '.[1:]' .codegraph/fixer/queue.json > "$TMP_QUEUE" && mv "$TMP_QUEUE" .codegraph/fixer/queue.json
```

If the first `jq ... && mv` fails (e.g. malformed/unreadable `state.json`), `state.json` is left unchanged, but the script continues past it unconditionally. The queue-shift line then still runs, removing the issue from `queue.json` — so the issue silently disappears from both files: never recorded as resolved, and no longer queued to be retried.

## Fix

Guard both writes explicitly (`if ! jq ...; then echo ERROR...; exit 1; fi` before each `mv`), so a failed `state.json` write stops the run before `queue.json` is ever touched. If `queue.json`'s own write fails *after* `state.json` already succeeded, that specific case is already handled by Phase 2's existing resume-detection note (a resumed run already filters out a queue head that's already recorded as resolved in `state.json`), so exiting there too is safe rather than needing anything more elaborate.

## Test plan

- New `tests/unit/fixer-skill-2g-queue-guard-2229.test.ts`: extracts the *actual* 2g bash block from the real `SKILL.md` (not a reimplementation of its logic) and executes it against a sandboxed `.codegraph/fixer/` directory — so this breaks the moment someone reintroduces the unguarded pattern, not just when the surrounding prose changes. Covers the happy path (records + shifts) and the failure path (malformed `state.json` → non-zero exit, `queue.json` left untouched).
- Manually verified against the *unmodified* script text (via `git show main:...`) that this exact scenario reproduces the bug: it prints a false "issue #100 recorded as merged" and shifts `queue.json` to drop issue #100, despite `state.json` never actually being updated.
- Ran `.claude/skills/create-skill/scripts/lint-skill.sh` against both the before and after versions of the skill file — identical pre-existing findings, no new lint issues introduced.
- Full local suite: `npm test` (294 files / 4758 tests passed), `tsc --noEmit`, `biome check` clean.