### PR TITLE
fix(typemap): scope same-named locals/params by enclosing function

### DIFF
--- a/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
@@ -357,10 +357,12 @@ fn resolve_cha_dispatch<'a>(
 /// separately (and already correctly) by `runPostNativeThisDispatch`
 /// (native-orchestrator.ts); mixing the two would risk duplicate or
 /// conflicting edges for the same call site.
+#[allow(clippy::too_many_arguments)]
 fn emit_cha_dispatch_edges(
     ctx: &EdgeContext,
     call: &CallInfo,
     caller_id: u32,
+    caller_name: &str,
     type_map: &HashMap<&str, (&str, f64)>,
     seen_edges: &mut HashSet<u64>,
     pts_edge_map: &HashMap<u64, usize>,
@@ -377,7 +379,20 @@ fn emit_cha_dispatch_edges(
         return;
     }
 
-    let Some(&(type_name, _)) = type_map.get(receiver.as_str()) else {
+    // Function-scoped key checked before the bare key, same as
+    // emit_receiver_edge/resolve_call_targets_core — otherwise a same-named
+    // local/parameter in a DIFFERENT function can still leak its (wrong)
+    // hierarchy into this call's additive CHA expansion (#2235 follow-up).
+    let scoped_key = if caller_name.is_empty() {
+        None
+    } else {
+        Some(format!("{}::{}", caller_name, receiver))
+    };
+    let type_entry = scoped_key
+        .as_deref()
+        .and_then(|k| type_map.get(k))
+        .or_else(|| type_map.get(receiver.as_str()));
+    let Some(&(type_name, _)) = type_entry else {
         return;
     };
 
@@ -1212,6 +1227,7 @@ fn process_file<'a>(
             ctx,
             call,
             caller_id,
+            caller_name,
             &fc.type_map,
             &mut seen_edges,
             &pts_edge_map,

--- a/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
@@ -1250,6 +1250,7 @@ fn process_file<'a>(
             ctx,
             call,
             caller_id,
+            caller_name,
             fc.rel_path,
             &fc.type_map,
             &fc.imported_names,
@@ -1764,18 +1765,23 @@ fn resolve_call_targets_core<'a>(
         } else {
             None
         };
+        // Function-scoped key (`callerName::name`) is consulted before the bare
+        // fallback keys below so a same-named local/parameter/rest-binding in a
+        // DIFFERENT function in this file can't shadow the correct entry for the
+        // function actually making this call (Phase 8.3f rest-param collision,
+        // #1358; generalized to plain locals/parameters, #2235).
         let type_lookup = class_scoped_key
             .as_deref()
             .and_then(|k| type_map.get(k))
-            .or_else(|| type_map.get(effective_receiver))
-            .or_else(|| type_map.get(receiver.as_str()))
             .or_else(|| {
                 if caller_name.is_empty() {
                     None
                 } else {
                     type_map.get(rest_param_key.as_str())
                 }
-            });
+            })
+            .or_else(|| type_map.get(effective_receiver))
+            .or_else(|| type_map.get(receiver.as_str()));
         // Inline new-expression receiver: `(new Foo).bar()` — extract the constructor name
         // when no typeMap entry exists for the complex receiver expression.
         // Mirrors the regex `/^\(?\s*new\s+([A-Z_$][A-Za-z0-9_$]*)/` in call-resolver.ts.
@@ -2295,6 +2301,7 @@ fn emit_receiver_edge(
     ctx: &EdgeContext,
     call: &CallInfo,
     caller_id: u32,
+    caller_name: &str,
     rel_path: &str,
     type_map: &HashMap<&str, (&str, f64)>,
     imported_names: &HashMap<&str, &str>,
@@ -2312,7 +2319,19 @@ fn emit_receiver_edge(
         return;
     }
 
-    let type_entry = type_map.get(receiver.as_str());
+    // Function-scoped key (`callerName::receiver`) checked before the bare key
+    // so a same-named local/parameter in a DIFFERENT function in this file
+    // can't shadow the entry seeded for the function actually making this
+    // call (#2235; mirrors resolveReceiverEdge in call-resolver.ts).
+    let scoped_key = if caller_name.is_empty() {
+        None
+    } else {
+        Some(format!("{}::{}", caller_name, receiver))
+    };
+    let type_entry = scoped_key
+        .as_deref()
+        .and_then(|k| type_map.get(k))
+        .or_else(|| type_map.get(receiver.as_str()));
     let effective_receiver = type_entry.map(|&(t, _)| t).unwrap_or(receiver.as_str());
 
     // Block global fallback only when the same-file node is a local definition,

--- a/crates/codegraph-core/src/extractors/helpers.rs
+++ b/crates/codegraph-core/src/extractors/helpers.rs
@@ -1098,6 +1098,34 @@ pub fn push_type_map_entry(
     set_type_map_entry(symbols, name, type_name, 0.9);
 }
 
+/// Push a type-map entry for a plain local variable/parameter under both its
+/// bare name AND, when `qualifier` is `Some`, a function-scoped key
+/// `${qualifier}::${name}` — mirroring the existing `ClassName.field`
+/// (class-scoped) and `callerName::name` (rest-param-scoped) key conventions
+/// already used elsewhere in this typeMap. The bare key alone is a flat,
+/// per-file, name-only slot: two different functions in the same file each
+/// declaring their own differently-typed local/parameter of the same name
+/// silently collide under it, with whichever [`dedup_type_map`] keeps (by
+/// confidence, then first-write-wins) shadowing the other's entry at every
+/// call site, in either function, that resolves through the bare key alone.
+/// The scoped key lets the receiver-resolution consumers (`resolve_call_targets_core`,
+/// `emit_receiver_edge`) disambiguate by the calling function's own qualifier
+/// when one is available. Mirrors `setScopedTypeMapEntry` in
+/// `src/extractors/helpers.ts` (#2235).
+pub fn push_scoped_type_map_entry(
+    symbols: &mut FileSymbols,
+    qualifier: Option<&str>,
+    name: &str,
+    type_name: impl Into<String>,
+    confidence: f64,
+) {
+    let type_name = type_name.into();
+    set_type_map_entry(symbols, name.to_string(), type_name.clone(), confidence);
+    if let Some(q) = qualifier {
+        set_type_map_entry(symbols, format!("{}::{}", q, name), type_name, confidence);
+    }
+}
+
 /// Deduplicate a type-map `Vec` in-place, keeping the highest-confidence
 /// entry per key (first-write-wins on ties, matching `setTypeMapEntry` in
 /// `src/extractors/helpers.ts`).

--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -154,6 +154,17 @@ impl SymbolExtractor for JsExtractor {
 
 // ── Type inference helpers ──────────────────────────────────────────────────
 
+/// Generic type wrappers that transform their argument into an unrelated
+/// opaque type (`ReturnType<typeof fn>`, `InstanceType<typeof Ctor>`, …) —
+/// their own name is never a legitimate receiver type, so `extract_simple_type_name`
+/// must return `None` rather than the wrapper's own name (#2235).
+const OPAQUE_TYPE_TRANSFORM_WRAPPERS: [&str; 4] = [
+    "ReturnType",
+    "InstanceType",
+    "Parameters",
+    "ConstructorParameters",
+];
+
 /// Extract simple type name from a type_annotation node.
 /// Returns the type name for simple types and generics, None for unions/intersections/arrays.
 fn extract_simple_type_name<'a>(node: &Node<'a>, source: &'a [u8]) -> Option<&'a str> {
@@ -162,7 +173,8 @@ fn extract_simple_type_name<'a>(node: &Node<'a>, source: &'a [u8]) -> Option<&'a
             match child.kind() {
                 "type_identifier" | "identifier" => return Some(node_text(&child, source)),
                 "generic_type" => {
-                    return child.child(0).map(|n| node_text(&n, source));
+                    let base = child.child(0).map(|n| node_text(&n, source));
+                    return base.filter(|b| !OPAQUE_TYPE_TRANSFORM_WRAPPERS.contains(b));
                 }
                 "parenthesized_type" => return extract_simple_type_name(&child, source),
                 _ => {}
@@ -247,10 +259,21 @@ fn handle_var_declarator_type_map(node: &Node, source: &[u8], symbols: &mut File
         return;
     }
     let var_name = node_text(&name_n, source);
+    // Also seed a function-scoped key alongside the bare one (#2235) — two
+    // different functions in this file each declaring their own
+    // differently-typed local of this same name would otherwise silently
+    // collide under the bare key. Mirrors TS handleVarDeclaratorTypeMap.
+    let enclosing_qualifier = find_enclosing_function_qualifier(node, source);
     // Type annotation: confidence 0.9
     if let Some(type_anno) = find_child(node, "type_annotation") {
         if let Some(type_name) = extract_simple_type_name(&type_anno, source) {
-            push_type_map_entry(symbols, var_name.to_string(), type_name.to_string());
+            push_scoped_type_map_entry(
+                symbols,
+                enclosing_qualifier.as_deref(),
+                var_name,
+                type_name.to_string(),
+                0.9,
+            );
         }
     }
     let Some(value_n) = node.child_by_field_name("value") else {
@@ -259,11 +282,13 @@ fn handle_var_declarator_type_map(node: &Node, source: &[u8], symbols: &mut File
     // Constructor: confidence 1.0 (overrides annotation in edge builder)
     if value_n.kind() == "new_expression" {
         if let Some(type_name) = extract_new_expr_type_name(&value_n, source) {
-            symbols.type_map.push(TypeMapEntry {
-                name: var_name.to_string(),
-                type_name: type_name.to_string(),
-                confidence: 1.0,
-            });
+            push_scoped_type_map_entry(
+                symbols,
+                enclosing_qualifier.as_deref(),
+                var_name,
+                type_name.to_string(),
+                1.0,
+            );
         }
     }
     // Phase 8.3e: Object.create({ key: fn }) → composite pts key per property
@@ -291,11 +316,13 @@ fn handle_var_declarator_type_map(node: &Node, source: &[u8], symbols: &mut File
                 if let Some((type_name, confidence)) = same_file_entry {
                     let propagated = confidence - PROPAGATION_HOP_PENALTY;
                     if propagated > 0.0 {
-                        symbols.type_map.push(TypeMapEntry {
-                            name: var_name.to_string(),
+                        push_scoped_type_map_entry(
+                            symbols,
+                            enclosing_qualifier.as_deref(),
+                            var_name,
                             type_name,
-                            confidence: propagated,
-                        });
+                            propagated,
+                        );
                     }
                 }
             }
@@ -337,6 +364,11 @@ fn handle_var_declarator_type_map(node: &Node, source: &[u8], symbols: &mut File
 /// on the rest binding's own name. Mirrors `handleParamTypeMap` in
 /// `src/extractors/javascript.ts`.
 fn handle_param_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
+    // Also seed a function-scoped key alongside the bare one (#2235) — see
+    // handle_var_declarator_type_map's identical rationale for local
+    // variables, which applies equally to two different functions' own
+    // same-named typed parameters.
+    let enclosing_qualifier = find_enclosing_function_qualifier(node, source);
     let name_node = node
         .child_by_field_name("pattern")
         .or_else(|| node.child_by_field_name("left"))
@@ -347,10 +379,12 @@ fn handle_param_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
             return;
         };
         if let Some(type_name) = extract_simple_type_name(&type_anno, source) {
-            push_type_map_entry(
+            push_scoped_type_map_entry(
                 symbols,
-                node_text(&name_node, source).to_string(),
+                enclosing_qualifier.as_deref(),
+                node_text(&name_node, source),
                 type_name.to_string(),
+                0.9,
             );
         }
         return;
@@ -394,10 +428,12 @@ fn handle_param_type_map(node: &Node, source: &[u8], symbols: &mut FileSymbols) 
             let rest_id = inner.child(1).or_else(|| inner.child_by_field_name("name"));
             if let Some(rest_id) = rest_id {
                 if rest_id.kind() == "identifier" {
-                    push_type_map_entry(
+                    push_scoped_type_map_entry(
                         symbols,
-                        node_text(&rest_id, source).to_string(),
+                        enclosing_qualifier.as_deref(),
+                        node_text(&rest_id, source),
                         type_name.to_string(),
+                        0.9,
                     );
                 }
             }
@@ -9678,6 +9714,92 @@ mod tests {
             "type_map should not seed the full annotation type onto 'rest' when a sibling property is destructured out; got: {:?}",
             s.type_map
         );
+    }
+
+    // #2235: a same-named parameter/local in two different functions in the
+    // same file collides under the bare typeMap key — the function-scoped
+    // key (`callerName::name`) disambiguates them. Mirrors the TS test suite
+    // in tests/parsers/javascript.test.ts.
+    #[test]
+    fn typed_parameter_seeds_a_function_scoped_key_alongside_the_bare_key() {
+        let s = parse_ts("function processOrder(db: OrderDb) {}");
+        let bare = s.type_map.iter().find(|t| t.name == "db");
+        assert_eq!(
+            bare.map(|t| (t.type_name.as_str(), t.confidence)),
+            Some(("OrderDb", 0.9))
+        );
+        let scoped = s.type_map.iter().find(|t| t.name == "processOrder::db");
+        assert_eq!(
+            scoped.map(|t| (t.type_name.as_str(), t.confidence)),
+            Some(("OrderDb", 0.9)),
+            "expected a processOrder::db scoped entry; got: {:?}",
+            s.type_map
+        );
+    }
+
+    #[test]
+    fn typed_local_seeds_a_function_scoped_key_alongside_the_bare_key() {
+        let s = parse_ts("function makeOrder() { const db: OrderDb = getDb(); }");
+        let scoped = s.type_map.iter().find(|t| t.name == "makeOrder::db");
+        assert_eq!(
+            scoped.map(|t| (t.type_name.as_str(), t.confidence)),
+            Some(("OrderDb", 0.9)),
+            "expected a makeOrder::db scoped entry; got: {:?}",
+            s.type_map
+        );
+    }
+
+    #[test]
+    fn constructor_typed_local_seeds_a_function_scoped_key_alongside_the_bare_key() {
+        let s = parse_ts("function makeOrderConn() { const conn = new OrderDb(); }");
+        let scoped = s.type_map.iter().find(|t| t.name == "makeOrderConn::conn");
+        assert_eq!(
+            scoped.map(|t| (t.type_name.as_str(), t.confidence)),
+            Some(("OrderDb", 1.0)),
+            "expected a makeOrderConn::conn scoped entry; got: {:?}",
+            s.type_map
+        );
+    }
+
+    #[test]
+    fn prevents_cross_function_collision_for_same_named_parameters() {
+        let s = parse_ts(
+            "function processOrder(db: OrderDb) { db.commit(); } \
+             function processUser(db: UserDb) { db.commit(); }",
+        );
+        let order_scoped = s.type_map.iter().find(|t| t.name == "processOrder::db");
+        assert_eq!(
+            order_scoped.map(|t| (t.type_name.as_str(), t.confidence)),
+            Some(("OrderDb", 0.9))
+        );
+        let user_scoped = s.type_map.iter().find(|t| t.name == "processUser::db");
+        assert_eq!(
+            user_scoped.map(|t| (t.type_name.as_str(), t.confidence)),
+            Some(("UserDb", 0.9)),
+            "expected each function to keep its own scoped entry despite the shared param name; got: {:?}",
+            s.type_map
+        );
+    }
+
+    // #2235: ReturnType<typeof fn>/InstanceType<typeof Ctor>/Parameters<typeof
+    // fn>/ConstructorParameters<typeof Ctor> transform their argument into an
+    // unrelated type — the wrapper's own name is never a legitimate receiver
+    // type, unlike an ordinary generic (Map<string, number> -> Map).
+    #[test]
+    fn does_not_seed_a_type_map_entry_for_opaque_generic_type_transform_wrappers() {
+        let s = parse_ts(
+            "function processOrder(db: ReturnType<typeof makeConn>) {} \
+             function processInstance(x: InstanceType<typeof Ctor>) {} \
+             function processArgs(a: Parameters<typeof fn>) {} \
+             function processCtorArgs(a: ConstructorParameters<typeof Ctor>) {}",
+        );
+        for name in ["db", "x", "a"] {
+            assert!(
+                s.type_map.iter().find(|t| t.name == name).is_none(),
+                "expected no type_map entry for '{name}'; got: {:?}",
+                s.type_map
+            );
+        }
     }
 
     // The object_rest_param_bindings extraction itself (the value-chase

--- a/src/domain/graph/builder/call-resolver.ts
+++ b/src/domain/graph/builder/call-resolver.ts
@@ -614,13 +614,19 @@ export function resolveCallTargets(
 export function resolveReceiverEdge(
   lookup: CallNodeLookup,
   call: { name: string; receiver: string },
-  caller: { id: number },
+  caller: { id: number; callerName?: string | null },
   relPath: string,
   typeMap: Map<string, unknown>,
   seenCallEdges: Set<string>,
   importedNames: ReadonlyMap<string, unknown>,
 ): { callerId: number; receiverId: number; confidence: number } | null {
-  const typeEntry = typeMap.get(call.receiver);
+  // Function-scoped key (`callerName::receiver`) checked before the bare key
+  // so a same-named local/parameter in a DIFFERENT function in this file
+  // can't shadow the entry seeded for the function actually making this call
+  // (#2235; mirrors resolveReceiverTypeName in resolver/strategy.ts).
+  const typeEntry =
+    (caller.callerName ? typeMap.get(`${caller.callerName}::${call.receiver}`) : undefined) ??
+    typeMap.get(call.receiver);
   const typeName = typeEntry
     ? typeof typeEntry === 'string'
       ? typeEntry

--- a/src/domain/graph/builder/incremental.ts
+++ b/src/domain/graph/builder/incremental.ts
@@ -1939,7 +1939,11 @@ function emitChaDispatchForCall(
       relPath,
     );
   } else {
-    const typeEntry = typeMap.get(call.receiver);
+    // Function-scoped key checked before the bare key (#2235 follow-up) —
+    // mirrors emitChaCallEdgesForCall (stages/build-edges.ts, full-build path).
+    const typeEntry = caller.callerName
+      ? (typeMap.get(`${caller.callerName}::${call.receiver}`) ?? typeMap.get(call.receiver))
+      : typeMap.get(call.receiver);
     const typeName = typeEntry
       ? typeof typeEntry === 'string'
         ? typeEntry

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -1006,7 +1006,11 @@ function buildChaPostPass(
           relPath,
         );
       } else {
-        const typeEntry = typeMap.get(call.receiver);
+        // Function-scoped key checked before the bare key (#2235 follow-up)
+        // — see emitChaCallEdgesForCall's identical comment.
+        const typeEntry = caller.callerName
+          ? (typeMap.get(`${caller.callerName}::${call.receiver}`) ?? typeMap.get(call.receiver))
+          : typeMap.get(call.receiver);
         const typeName = typeEntry
           ? typeof typeEntry === 'string'
             ? typeEntry
@@ -1851,7 +1855,13 @@ function emitChaCallEdgesForCall(
       relPath,
     );
   } else if (!BUILTIN_RECEIVERS.has(call.receiver!)) {
-    const typeEntry = typeMap.get(call.receiver!);
+    // Function-scoped key checked before the bare key, mirroring
+    // resolveReceiverEdge/resolveReceiverTypeName — otherwise a same-named
+    // local/parameter in a DIFFERENT function can still leak its (wrong)
+    // hierarchy into this call's additive CHA expansion (#2235 follow-up).
+    const typeEntry = caller.callerName
+      ? (typeMap.get(`${caller.callerName}::${call.receiver}`) ?? typeMap.get(call.receiver!))
+      : typeMap.get(call.receiver!);
     const typeName = typeEntry
       ? typeof typeEntry === 'string'
         ? typeEntry

--- a/src/domain/graph/resolver/strategy.ts
+++ b/src/domain/graph/resolver/strategy.ts
@@ -284,12 +284,15 @@ function resolveReceiverTypeName(
       typeEntry = typeMap.get(`${callerClass}.${effectiveReceiver}`);
     }
   }
-  typeEntry ??=
-    typeMap.get(effectiveReceiver) ??
-    typeMap.get(receiver) ??
-    // Phase 8.3f: callee-scoped rest-param key (`callee::restName`) to avoid
-    // same-name rest-binding collision across functions in the same file (#1358).
-    (callerName ? typeMap.get(`${callerName}::${effectiveReceiver}`) : undefined);
+  // Function-scoped key (`callerName::name`) — checked before the bare
+  // fallback keys below so a same-named local/parameter/rest-binding in a
+  // DIFFERENT function in this file can't shadow the correct entry for the
+  // function actually calling here (Phase 8.3f rest-param collision, #1358;
+  // generalized to plain locals/parameters, #2235).
+  if (callerName) {
+    typeEntry ??= typeMap.get(`${callerName}::${effectiveReceiver}`);
+  }
+  typeEntry ??= typeMap.get(effectiveReceiver) ?? typeMap.get(receiver);
 
   let typeName = unwrapTypeEntry(typeEntry);
 

--- a/src/extractors/helpers.ts
+++ b/src/extractors/helpers.ts
@@ -98,6 +98,34 @@ export function setTypeMapEntry(
 }
 
 /**
+ * Merge a type-map entry for a plain local variable/parameter under both its
+ * bare name AND, when `enclosingQualifier` is non-null, a function-scoped key
+ * `${enclosingQualifier}::${name}` — mirroring the existing `ClassName.field`
+ * (class-scoped) and `callerName::name` (rest-param-scoped) key conventions
+ * already used elsewhere in this file's typeMap. The bare key alone is a flat,
+ * per-file, name-only slot: two different functions in the same file each
+ * declaring their own differently-typed local/parameter of the same name
+ * silently collide under it, with whichever has the higher confidence (or was
+ * inserted first, on a tie) winning for BOTH functions' call resolution —
+ * wrongly for whichever loses (issue #2235). The scoped key gives a caller
+ * with `callerName` in scope (already available at nearly every real
+ * call-resolution site) an unambiguous, collision-proof lookup; the bare key
+ * remains as a fallback for callers without that context.
+ */
+export function setScopedTypeMapEntry(
+  typeMap: Map<string, TypeMapEntry>,
+  enclosingQualifier: string | null,
+  name: string,
+  type: string,
+  confidence: number,
+): void {
+  setTypeMapEntry(typeMap, name, type, confidence);
+  if (enclosingQualifier) {
+    setTypeMapEntry(typeMap, `${enclosingQualifier}::${name}`, type, confidence);
+  }
+}
+
+/**
  * Extract visibility from a node by scanning its children for modifier keywords.
  * Works for Java, C#, PHP, and similar languages where modifiers are child nodes.
  * @param {object} node - tree-sitter node

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -29,6 +29,7 @@ import {
   MAX_WALK_DEPTH,
   nodeEndLine,
   nodeStartLine,
+  setScopedTypeMapEntry,
   setTypeMapEntry,
 } from './helpers.js';
 
@@ -2525,6 +2526,28 @@ function extractImplementsFromNode(node: TreeSitterNode): string[] {
 
 // ── Type inference helpers ───────────────────────────────────────────────
 
+/**
+ * TypeScript utility types that describe another type through a type-level
+ * transform rather than naming a concrete class/interface with its own
+ * methods — `ReturnType<typeof fn>`/`InstanceType<typeof Cls>` are this
+ * codebase's own idiomatic way to type a variable/parameter as "whatever
+ * this other function returns" (see e.g. tests/helpers/incremental-stmts.ts's
+ * `db: ReturnType<typeof openDb>`). Returning the wrapper's own name here
+ * ("ReturnType") previously seeded the typeMap with a resolvable-looking but
+ * meaningless type — defeating class-hierarchy method lookup for that
+ * variable directly, and, when it wins the bare per-file key, silently
+ * poisoning cross-file return-type propagation for every other same-named
+ * local in the file too (issue #2235). Returning null here instead defers to
+ * whatever other, more specific typeMap entry exists for the name (a
+ * `new Foo()` constructor call, a scoped entry, or cross-file propagation).
+ */
+const OPAQUE_TYPE_TRANSFORM_WRAPPERS = new Set([
+  'ReturnType',
+  'InstanceType',
+  'Parameters',
+  'ConstructorParameters',
+]);
+
 function extractSimpleTypeName(typeAnnotationNode: TreeSitterNode): string | null {
   if (!typeAnnotationNode) return null;
   for (let i = 0; i < typeAnnotationNode.childCount; i++) {
@@ -2532,7 +2555,10 @@ function extractSimpleTypeName(typeAnnotationNode: TreeSitterNode): string | nul
     if (!child) continue;
     const t = child.type;
     if (t === 'type_identifier' || t === 'identifier') return child.text;
-    if (t === 'generic_type') return child.child(0)?.text || null;
+    if (t === 'generic_type') {
+      const base = child.child(0)?.text || null;
+      return base && OPAQUE_TYPE_TRANSFORM_WRAPPERS.has(base) ? null : base;
+    }
     if (t === 'parenthesized_type') return extractSimpleTypeName(child);
     // Skip union, intersection, and array types — too ambiguous
   }
@@ -3340,6 +3366,7 @@ function handleCallExprTypeMap(
   typeMap: Map<string, TypeMapEntry>,
   returnTypeMap: Map<string, TypeMapEntry> | undefined,
   callAssignments: CallAssignment[] | undefined,
+  enclosingQualifier: string | null,
 ): void {
   const createFn = valueN.childForFieldName('function');
   // Phase 8.3e: Object.create({ f1, f2 }) — seed composite pts keys obj.f1 → f1, etc.
@@ -3369,7 +3396,7 @@ function handleCallExprTypeMap(
   if (returnTypeMap) {
     const result = resolveCallExprReturnType(valueN, typeMap, returnTypeMap, 0);
     if (result) {
-      setTypeMapEntry(typeMap, lhsName, result.type, result.confidence);
+      setScopedTypeMapEntry(typeMap, enclosingQualifier, lhsName, result.type, result.confidence);
       return;
     }
   }
@@ -3383,7 +3410,7 @@ function handleCallExprTypeMap(
     if (obj?.type === 'identifier') {
       const objName = obj.text;
       if (objName[0] && objName[0] !== objName[0].toLowerCase() && !BUILTIN_GLOBALS.has(objName)) {
-        setTypeMapEntry(typeMap, lhsName, objName, 0.7);
+        setScopedTypeMapEntry(typeMap, enclosingQualifier, lhsName, objName, 0.7);
       }
     }
   }
@@ -3475,11 +3502,16 @@ function handleVarDeclaratorTypeMap(
     collectFnRefBindings(nameN.text, valueN, fnRefBindings);
   }
 
+  // Also seed a function-scoped key alongside the bare one (issue #2235) — two
+  // different functions in this file each declaring their own differently-typed
+  // local of this same name would otherwise silently collide under the bare key.
+  const enclosingQualifier = findEnclosingFunctionQualifier(node);
+
   // 2. Constructor wins over annotation: `const x: Base = new Derived()` resolves to Derived.
   if (valueN?.type === 'new_expression') {
     const ctorType = extractNewExprTypeName(valueN);
     if (ctorType) {
-      setTypeMapEntry(typeMap, nameN.text, ctorType, 1.0);
+      setScopedTypeMapEntry(typeMap, enclosingQualifier, nameN.text, ctorType, 1.0);
       return;
     }
   }
@@ -3488,7 +3520,7 @@ function handleVarDeclaratorTypeMap(
   if (typeAnno) {
     const typeName = extractSimpleTypeName(typeAnno);
     if (typeName) {
-      setTypeMapEntry(typeMap, nameN.text, typeName, 0.9);
+      setScopedTypeMapEntry(typeMap, enclosingQualifier, nameN.text, typeName, 0.9);
       return;
     }
   }
@@ -3498,7 +3530,14 @@ function handleVarDeclaratorTypeMap(
 
   // 4a. call_expression — Object.create / return-type propagation / factory heuristic.
   if (valueN.type === 'call_expression') {
-    handleCallExprTypeMap(nameN.text, valueN, typeMap, returnTypeMap, callAssignments);
+    handleCallExprTypeMap(
+      nameN.text,
+      valueN,
+      typeMap,
+      returnTypeMap,
+      callAssignments,
+      enclosingQualifier,
+    );
     return;
   }
 
@@ -3535,13 +3574,19 @@ function handleVarDeclaratorTypeMap(
  * a false edge via CHA dispatch (#2080 review).
  */
 function handleParamTypeMap(node: TreeSitterNode, typeMap: Map<string, TypeMapEntry>): void {
+  // Also seed a function-scoped key alongside the bare one (issue #2235) — see
+  // handleVarDeclaratorTypeMap's identical rationale for local variables, which
+  // applies equally to two different functions' same-named typed parameters.
+  const enclosingQualifier = findEnclosingFunctionQualifier(node);
   const nameNode =
     node.childForFieldName('pattern') || node.childForFieldName('left') || node.child(0);
   if (nameNode?.type === 'identifier') {
     const typeAnno = findChild(node, 'type_annotation');
     if (typeAnno) {
       const typeName = extractSimpleTypeName(typeAnno);
-      if (typeName) setTypeMapEntry(typeMap, nameNode.text, typeName, 0.9);
+      if (typeName) {
+        setScopedTypeMapEntry(typeMap, enclosingQualifier, nameNode.text, typeName, 0.9);
+      }
     }
     return;
   }
@@ -3564,7 +3609,9 @@ function handleParamTypeMap(node: TreeSitterNode, typeMap: Map<string, TypeMapEn
       // rest_pattern/rest_element node: `...identifier` — the identifier is
       // at child index 1 (mirrors collectObjectRestParams's own extraction).
       const restId = inner.child(1) ?? inner.childForFieldName('name');
-      if (restId?.type === 'identifier') setTypeMapEntry(typeMap, restId.text, typeName, 0.9);
+      if (restId?.type === 'identifier') {
+        setScopedTypeMapEntry(typeMap, enclosingQualifier, restId.text, typeName, 0.9);
+      }
     }
   }
 }

--- a/tests/integration/issue-2235-typemap-scoping-collision.test.ts
+++ b/tests/integration/issue-2235-typemap-scoping-collision.test.ts
@@ -22,6 +22,14 @@
  * name (`"ReturnType"`) were a real receiver type, seeding a bogus bare-key
  * entry that could win the collision over a legitimate same-named parameter
  * elsewhere in the file.
+ *
+ * Also covers a Greptile review finding on the fix itself: the additive
+ * CHA/RTA dispatch pass (`emitChaCallEdgesForCall` / `buildChaPostPass` /
+ * `emitChaDispatchForCall` / Rust `emit_cha_dispatch_edges`) reads the
+ * typeMap independently of the primary receiver resolution above and
+ * originally checked only the bare key, so a same-named receiver in a
+ * different function could still cross-contaminate which class hierarchy
+ * got expanded even after the primary-resolution fix.
  */
 
 import fs from 'node:fs';
@@ -51,6 +59,50 @@ export function makeUserConn(): UserDb {
 }
 export function processOpaque(db: ReturnType<typeof makeUserConn>) {
   db.commit();
+}
+`,
+  'cha.ts': `
+export interface OrderRepo {
+  commit(): void;
+}
+export class OrderRepoA implements OrderRepo {
+  commit() {}
+}
+export class OrderRepoB implements OrderRepo {
+  commit() {}
+}
+export interface UserRepo {
+  commit(): void;
+}
+export class UserRepoA implements UserRepo {
+  commit() {}
+}
+export class UserRepoB implements UserRepo {
+  commit() {}
+}
+export function chaProcessOrder(repo: OrderRepo) {
+  repo.commit();
+}
+export function chaProcessUser(repo: UserRepo) {
+  repo.commit();
+}
+// RTA (Rapid Type Analysis) only expands CHA dispatch to implementors that
+// are actually instantiated somewhere in the project — without this
+// evidence for ALL FOUR concrete classes, the "no RTA evidence anywhere in
+// the project" fallback (treat every implementor as eligible) would mask
+// a real scoping bug in the additive CHA dispatch pass behind a fallback
+// that happens to expand everything regardless of type.
+export function makeOrderRepoA(): OrderRepo {
+  return new OrderRepoA();
+}
+export function makeOrderRepoB(): OrderRepo {
+  return new OrderRepoB();
+}
+export function makeUserRepoA(): UserRepo {
+  return new UserRepoA();
+}
+export function makeUserRepoB(): UserRepo {
+  return new UserRepoB();
 }
 `,
 };
@@ -132,6 +184,45 @@ function runSuite(engine: 'wasm' | 'native') {
       // file: it must not silently start losing to it.
       expect(edges.some((e) => e.src === 'processUser' && e.tgt === 'UserDb.commit')).toBe(true);
       expect(edges.some((e) => e.src === 'processUser' && e.tgt === 'OrderDb.commit')).toBe(false);
+    });
+
+    // The additive CHA/RTA dispatch pass (Phase 8.5) expands a typed-interface
+    // receiver to every concrete implementer — it reads the typeMap
+    // independently of the primary receiver resolution above, and originally
+    // only checked the bare key, so it could still cross-contaminate even
+    // after the primary resolution fix (Greptile finding on PR #2398).
+    it('CHA dispatch expands chaProcessOrder.repo.commit() to both OrderRepo implementers only', () => {
+      const dbPath = path.join(tmpDir, '.codegraph', 'graph.db');
+      const edges = getReceiverLikeEdges(dbPath);
+      expect(edges.some((e) => e.src === 'chaProcessOrder' && e.tgt === 'OrderRepoA.commit')).toBe(
+        true,
+      );
+      expect(edges.some((e) => e.src === 'chaProcessOrder' && e.tgt === 'OrderRepoB.commit')).toBe(
+        true,
+      );
+      expect(edges.some((e) => e.src === 'chaProcessOrder' && e.tgt === 'UserRepoA.commit')).toBe(
+        false,
+      );
+      expect(edges.some((e) => e.src === 'chaProcessOrder' && e.tgt === 'UserRepoB.commit')).toBe(
+        false,
+      );
+    });
+
+    it('CHA dispatch expands chaProcessUser.repo.commit() to both UserRepo implementers only', () => {
+      const dbPath = path.join(tmpDir, '.codegraph', 'graph.db');
+      const edges = getReceiverLikeEdges(dbPath);
+      expect(edges.some((e) => e.src === 'chaProcessUser' && e.tgt === 'UserRepoA.commit')).toBe(
+        true,
+      );
+      expect(edges.some((e) => e.src === 'chaProcessUser' && e.tgt === 'UserRepoB.commit')).toBe(
+        true,
+      );
+      expect(edges.some((e) => e.src === 'chaProcessUser' && e.tgt === 'OrderRepoA.commit')).toBe(
+        false,
+      );
+      expect(edges.some((e) => e.src === 'chaProcessUser' && e.tgt === 'OrderRepoB.commit')).toBe(
+        false,
+      );
     });
   });
 }

--- a/tests/integration/issue-2235-typemap-scoping-collision.test.ts
+++ b/tests/integration/issue-2235-typemap-scoping-collision.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Integration test for #2235: typeMap collisions across same-named locals in
+ * different functions cause native/wasm divergence.
+ *
+ * The typeMap is a flat, per-file, name-only structure (`Map<string,
+ * TypeMapEntry>` in TS / `HashMap<&str, (&str, f64)>` in Rust). Two different
+ * functions in the same file each declaring their own differently-typed
+ * local/parameter of the same name collide under the bare key — whichever one
+ * is written first (or has higher confidence) wins, and the *other*
+ * function's receiver-type resolution silently uses the wrong type.
+ *
+ * Fix: both engines now additionally seed a function-scoped key
+ * (`${enclosingFunctionQualifier}::${name}`) alongside the bare key
+ * (`setScopedTypeMapEntry` / `push_scoped_type_map_entry`), and the
+ * consumption side (`resolveReceiverTypeName` in resolver/strategy.ts,
+ * `resolveReceiverEdge` in call-resolver.ts, and their Rust mirrors in
+ * build_edges.rs) checks that scoped key *before* the bare fallback keys —
+ * mirroring the existing `ClassName.field` class-scoped precedent (#1458).
+ *
+ * Also covers the issue's second repro: `ReturnType<typeof fn>` (and the
+ * other opaque generic-wrapper utility types) was extracted as if its own
+ * name (`"ReturnType"`) were a real receiver type, seeding a bogus bare-key
+ * entry that could win the collision over a legitimate same-named parameter
+ * elsewhere in the file.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+import { isNativeAvailable } from '../../src/infrastructure/native.js';
+
+const FIXTURE = {
+  'db.ts': `
+export class OrderDb {
+  commit() {}
+}
+export class UserDb {
+  commit() {}
+}
+export function processOrder(db: OrderDb) {
+  db.commit();
+}
+export function processUser(db: UserDb) {
+  db.commit();
+}
+export function makeUserConn(): UserDb {
+  return new UserDb();
+}
+export function processOpaque(db: ReturnType<typeof makeUserConn>) {
+  db.commit();
+}
+`,
+};
+
+function writeFixture(rootDir: string) {
+  for (const [rel, content] of Object.entries(FIXTURE)) {
+    const abs = path.join(rootDir, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, content);
+  }
+}
+
+function getReceiverLikeEdges(dbPath: string) {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return db
+      .prepare(
+        `SELECT n1.name AS src, n2.name AS tgt, e.kind AS kind
+         FROM edges e
+         JOIN nodes n1 ON e.source_id = n1.id
+         JOIN nodes n2 ON e.target_id = n2.id
+         WHERE e.kind IN ('calls', 'receiver') AND n2.name LIKE '%.commit'
+         ORDER BY n1.name, n2.name`,
+      )
+      .all() as Array<{ src: string; tgt: string; kind: string }>;
+  } finally {
+    db.close();
+  }
+}
+
+function runSuite(engine: 'wasm' | 'native') {
+  describe(`typeMap scoping collision (#2235) — ${engine}`, () => {
+    let tmpDir: string;
+
+    beforeAll(async () => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2235-${engine}-`));
+      writeFixture(tmpDir);
+      await buildGraph(tmpDir, { engine, incremental: false, skipRegistry: true });
+    }, 60_000);
+
+    afterAll(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('resolves processOrder.db.commit() to OrderDb.commit', () => {
+      const dbPath = path.join(tmpDir, '.codegraph', 'graph.db');
+      const edges = getReceiverLikeEdges(dbPath);
+      expect(
+        edges.some((e) => e.src === 'processOrder' && e.tgt === 'OrderDb.commit'),
+        `Expected processOrder -> OrderDb.commit; got: ${JSON.stringify(edges)}`,
+      ).toBe(true);
+    });
+
+    it('resolves processUser.db.commit() to UserDb.commit despite the colliding param name', () => {
+      const dbPath = path.join(tmpDir, '.codegraph', 'graph.db');
+      const edges = getReceiverLikeEdges(dbPath);
+      expect(
+        edges.some((e) => e.src === 'processUser' && e.tgt === 'UserDb.commit'),
+        `Expected processUser -> UserDb.commit; got: ${JSON.stringify(edges)}`,
+      ).toBe(true);
+    });
+
+    it('does not cross-resolve processOrder to UserDb.commit or processUser to OrderDb.commit', () => {
+      const dbPath = path.join(tmpDir, '.codegraph', 'graph.db');
+      const edges = getReceiverLikeEdges(dbPath);
+      expect(edges.some((e) => e.src === 'processOrder' && e.tgt === 'UserDb.commit')).toBe(false);
+      expect(edges.some((e) => e.src === 'processUser' && e.tgt === 'OrderDb.commit')).toBe(false);
+    });
+
+    it('does not let a ReturnType<typeof fn>-typed param poison a same-named param elsewhere', () => {
+      const dbPath = path.join(tmpDir, '.codegraph', 'graph.db');
+      const edges = getReceiverLikeEdges(dbPath);
+      // processOpaque's own `db: ReturnType<typeof makeUserConn>` annotation is
+      // unresolvable by design (actually inferring through ReturnType<typeof fn>
+      // is a separate, still-open gap — see the issue's scope note) — it may
+      // legitimately fall back to whatever bare "db" happens to hold elsewhere
+      // in the file. What #2235 guarantees is that processUser's OWN resolution
+      // stays correct despite that unresolvable annotation existing in the same
+      // file: it must not silently start losing to it.
+      expect(edges.some((e) => e.src === 'processUser' && e.tgt === 'UserDb.commit')).toBe(true);
+      expect(edges.some((e) => e.src === 'processUser' && e.tgt === 'OrderDb.commit')).toBe(false);
+    });
+  });
+}
+
+runSuite('wasm');
+
+describe.skipIf(!isNativeAvailable())('native engine parity', () => {
+  runSuite('native');
+});

--- a/tests/parsers/javascript.test.ts
+++ b/tests/parsers/javascript.test.ts
@@ -588,6 +588,90 @@ describe('JavaScript parser', () => {
       expect(symbols.typeMap.has('Foo.repo')).toBe(false);
     });
 
+    it('seeds a function-scoped key alongside the bare key for a typed parameter (issue #2235)', () => {
+      const symbols = parseTS(`function processOrder(db: OrderDb) {}`);
+      expect(symbols.typeMap.get('db')).toEqual({ type: 'OrderDb', confidence: 0.9 });
+      expect(symbols.typeMap.get('processOrder::db')).toEqual({
+        type: 'OrderDb',
+        confidence: 0.9,
+      });
+    });
+
+    it('seeds a function-scoped key alongside the bare key for a typed local (issue #2235)', () => {
+      const symbols = parseTS(`function makeOrder() { const db: OrderDb = getDb(); }`);
+      expect(symbols.typeMap.get('db')).toEqual({ type: 'OrderDb', confidence: 0.9 });
+      expect(symbols.typeMap.get('makeOrder::db')).toEqual({
+        type: 'OrderDb',
+        confidence: 0.9,
+      });
+    });
+
+    it('prevents cross-function collision for same-named parameters (issue #2235)', () => {
+      const symbols = parseTS(`
+        function processOrder(db: OrderDb) { db.commit(); }
+        function processUser(db: UserDb) { db.commit(); }
+      `);
+      // Each function gets its own scoped key — no collision.
+      expect(symbols.typeMap.get('processOrder::db')).toEqual({
+        type: 'OrderDb',
+        confidence: 0.9,
+      });
+      expect(symbols.typeMap.get('processUser::db')).toEqual({
+        type: 'UserDb',
+        confidence: 0.9,
+      });
+      // Bare "db" key holds the first function's type (second write is same
+      // confidence, no overwrite) — exactly why the scoped key is needed.
+      expect(symbols.typeMap.get('db')).toEqual({ type: 'OrderDb', confidence: 0.9 });
+    });
+
+    it('prevents cross-function collision for same-named constructor-typed locals (issue #2235)', () => {
+      const symbols = parseTS(`
+        function makeOrderConn() { const conn = new OrderDb(); conn.commit(); }
+        function makeUserConn() { const conn = new UserDb(); conn.commit(); }
+      `);
+      expect(symbols.typeMap.get('makeOrderConn::conn')).toEqual({
+        type: 'OrderDb',
+        confidence: 1.0,
+      });
+      expect(symbols.typeMap.get('makeUserConn::conn')).toEqual({
+        type: 'UserDb',
+        confidence: 1.0,
+      });
+    });
+
+    it('does not seed a typeMap entry for opaque generic type-transform wrappers (issue #2235)', () => {
+      // ReturnType<typeof fn>/InstanceType<typeof Ctor>/Parameters<typeof fn>/
+      // ConstructorParameters<typeof Ctor> transform their argument into an
+      // unrelated type — the wrapper's own name is never a legitimate receiver
+      // type, unlike an ordinary generic (`Map<string, number>` → `Map`, still
+      // extracted above).
+      const symbols = parseTS(`
+        function processOrder(db: ReturnType<typeof makeConn>) {}
+        function processInstance(x: InstanceType<typeof Ctor>) {}
+        function processArgs(a: Parameters<typeof fn>) {}
+        function processCtorArgs(a: ConstructorParameters<typeof Ctor>) {}
+      `);
+      expect(symbols.typeMap.has('db')).toBe(false);
+      expect(symbols.typeMap.has('x')).toBe(false);
+      expect(symbols.typeMap.has('a')).toBe(false);
+    });
+
+    it('opaque generic wrapper on one function does not poison a same-named parameter elsewhere (issue #2235)', () => {
+      const symbols = parseTS(`
+        function processOrder(db: ReturnType<typeof makeConn>) { db.commit(); }
+        function processUser(db: UserDb) { db.commit(); }
+      `);
+      // processOrder's bogus annotation seeds nothing, so processUser's bare
+      // "db" entry is uncontested.
+      expect(symbols.typeMap.get('db')).toEqual({ type: 'UserDb', confidence: 0.9 });
+      expect(symbols.typeMap.get('processUser::db')).toEqual({
+        type: 'UserDb',
+        confidence: 0.9,
+      });
+      expect(symbols.typeMap.has('processOrder::db')).toBe(false);
+    });
+
     it('returns empty typeMap when no annotations', () => {
       const symbols = parseJS(`const x = 42; function foo(a, b) {}`);
       expect(symbols.typeMap).toBeInstanceOf(Map);


### PR DESCRIPTION
## Summary

- Two different functions in the same file each declaring a local or parameter of the same name collided under the typeMap's flat, per-file, name-only bare key — whichever one won the collision silently leaked its type into every other function's receiver-type resolution (both engines).
- Seed a function-scoped key (`${enclosingQualifier}::${name}`) alongside the bare key wherever a plain local/parameter type is extracted (`setScopedTypeMapEntry` / `push_scoped_type_map_entry`), and check that scoped key **before** the bare fallback on the consumption side (`resolveReceiverTypeName`, `resolveReceiverEdge`, and their Rust mirrors in `build_edges.rs`) — mirroring the existing `ClassName.field` / `callerName::restName` scoped-key precedents already used elsewhere in the same typeMap (#1458, #1358).
- Also fixes `extractSimpleTypeName`/`extract_simple_type_name` treating opaque generic type-transform wrappers (`ReturnType<typeof fn>`, `InstanceType<typeof Ctor>`, `Parameters<typeof fn>`, `ConstructorParameters<typeof Ctor>`) as if the wrapper's own name were a real receiver type.
- Mirrored identically into the Rust engine (extraction + consumption) — verified native/wasm parity on the new fixtures and on the existing `scripts/parity-compare.mjs` JS/TS suites.

## Scope note

While verifying against this repo's own self-build (the original repro in #2235), I found the *specific* `db/connection.ts` divergence survives this fix — it's caused by a separate mechanism (an `as`-cast contributing nothing to the typeMap, plus a return-type-propagation confidence/insertion-order discrepancy between engines), not the scoping-collision architecture this PR fixes. Filed as #2397 rather than expanding this PR's scope. Also filed #2396 (Rust missing a factory-method typeMap heuristic TS has) as an unrelated pre-existing parity gap found while reading both engines side by side.

## Test plan

- [x] New unit tests in `tests/parsers/javascript.test.ts` (6 cases) — verified fail-without-fix via patch revert, pass-with-fix.
- [x] New dual-engine integration test `tests/integration/issue-2235-typemap-scoping-collision.test.ts` (8 cases, wasm + native) — verified fail-without-fix, pass-with-fix.
- [x] New Rust unit tests in `crates/codegraph-core/src/extractors/javascript.rs` (5 cases) — verified fail-without-fix, pass-with-fix.
- [x] Full suite: `npm test` (4772 passed), `npx tsc --noEmit`, `npm run lint`, `cargo test --release` (865 passed), `cargo clippy` (no new warnings).
- [x] `node scripts/parity-compare.mjs --langs javascript,typescript` — parity OK.