### PR TITLE
fix(cha): scope CHA implementor map by file, walk ancestors for inherited methods

### DIFF
--- a/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
@@ -192,11 +192,24 @@ struct EdgeContext<'a> {
     /// pass from every file's `classes` (`extends`/`implements`). Used by
     /// `resolve_call_targets_core`'s CHA fallback tier only — mirrors the
     /// `implementors` half of `ChaContext`/`buildChaContext` in
-    /// `src/domain/graph/builder/cha.ts` (the `parents` half, used for
-    /// `this`/`self`/`super` dispatch, has no native equivalent here — that
-    /// dispatch is handled separately by `runPostNativeThisDispatch` in
-    /// `native-orchestrator.ts`).
+    /// `src/domain/graph/builder/cha.ts`.
     cha_implementors: HashMap<&'a str, Vec<&'a str>>,
+    /// `${parentName}|${parentDeclaringFile}` → concrete classes recorded
+    /// while that same file ALSO locally declares a class/interface named
+    /// `parentName` — disambiguates two unrelated files each declaring their
+    /// own same-named interface/base class (issue #2237). Mirrors
+    /// `ChaContext.implementorsByFile` in `cha.ts`. Owned `String` key since
+    /// it's a composite built at map-construction time.
+    cha_implementors_by_file: HashMap<String, Vec<&'a str>>,
+    /// Class name → direct parent class name (from `extends`), first-write-
+    /// wins across the whole build pass. Used only to walk up to a declaring
+    /// ancestor when an instantiated concrete class inherits the dispatched
+    /// method without overriding it (issue #2237's Issue 2) — mirrors the
+    /// `parents` half of `ChaContext`/`buildChaContext` in `cha.ts` (file-
+    /// scoped disambiguation, `parentsByFile`, is not needed here: this walk
+    /// starts from a class already uniquely identified by the BFS above, not
+    /// from an ambiguous bare name).
+    cha_parents: HashMap<&'a str, &'a str>,
     /// RTA: class names that appear as a high-confidence (>= 0.9) typeMap
     /// target anywhere in this build pass — mirrors the typeMap fallback
     /// branch of `collectInstantiatedTypes` in `cha.ts` (the native
@@ -226,6 +239,7 @@ impl<'a> EdgeContext<'a> {
             .iter()
             .copied()
             .collect();
+        let cha = build_cha_context(files);
         Self {
             nodes_by_name,
             nodes_by_name_and_file,
@@ -235,41 +249,98 @@ impl<'a> EdgeContext<'a> {
                 files,
                 extra_invoked_property_names,
             ),
-            cha_implementors: build_cha_implementors_map(files),
+            cha_implementors: cha.implementors,
+            cha_implementors_by_file: cha.implementors_by_file,
+            cha_parents: cha.parents,
             cha_instantiated_types: collect_cha_instantiated_types(files),
         }
     }
 }
 
-/// Build the CHA implementors map: interface/class name → concrete classes
-/// that implement or extend it. Both `implements` and `extends` relationships
-/// feed the same map (an abstract base class dispatches to its subclasses
-/// exactly like an interface dispatches to its implementors) so a multi-level
-/// hierarchy (`IFoo` → `AbstractFoo` → `ConcreteFoo`) is BFS-reachable in one
-/// structure. Mirrors `recordImplements`/`recordExtends`'s shared
-/// contribution to `ChaContext.implementors` in `cha.ts`'s `buildChaContext`
-/// (the separate `parents` map `buildChaContext` also produces is only used
-/// for `this`/`self`/`super` walking, which is out of scope here — see
-/// `EdgeContext.cha_implementors` doc comment).
-fn build_cha_implementors_map<'a>(files: &'a [FileEdgeInput]) -> HashMap<&'a str, Vec<&'a str>> {
+/// Output of [`build_cha_context`] — mirrors `ChaContext` in `cha.ts`.
+struct ChaBuildOutput<'a> {
+    implementors: HashMap<&'a str, Vec<&'a str>>,
+    implementors_by_file: HashMap<String, Vec<&'a str>>,
+    parents: HashMap<&'a str, &'a str>,
+}
+
+/// Build the CHA implementors/parents maps: interface/class name → concrete
+/// classes that implement or extend it (`implementors`), class name → direct
+/// parent (`parents`), and the file-scoped variant of `implementors`
+/// (`implementors_by_file`). Both `implements` and `extends` relationships
+/// feed the same `implementors` map (an abstract base class dispatches to its
+/// subclasses exactly like an interface dispatches to its implementors) so a
+/// multi-level hierarchy (`IFoo` → `AbstractFoo` → `ConcreteFoo`) is
+/// BFS-reachable in one structure. Mirrors `recordImplements`/`recordExtends`
+/// in `cha.ts`'s `buildChaContext`.
+///
+/// `implementors_by_file` is populated only when the child's own file ALSO
+/// locally declares a class/interface named `parent` — the child's heritage
+/// reference most plausibly means that co-located declaration, not an
+/// unrelated same-named one elsewhere (issue #2237). `parents` is bare-name,
+/// first-write-wins — used only by `resolve_method_via_ancestors`'s walk from
+/// an already-disambiguated concrete class, not for `this`/`self`/`super`
+/// dispatch (handled separately by `runPostNativeThisDispatch`).
+fn build_cha_context<'a>(files: &'a [FileEdgeInput]) -> ChaBuildOutput<'a> {
     let mut implementors: HashMap<&str, Vec<&str>> = HashMap::new();
+    let mut implementors_by_file: HashMap<String, Vec<&str>> = HashMap::new();
+    let mut parents: HashMap<&str, &str> = HashMap::new();
+
     for file in files {
+        // `file.classes` only lists class RELATIONS (entries with an
+        // extends/implements clause) — a bare `interface Handler {}` with no
+        // heritage never appears there, so a same-file-anchor check against
+        // it alone would miss the exact "plain interface, no relation"
+        // shape that's the whole point of the collision this map protects
+        // against (#2237). `file.definitions` covers every declared symbol
+        // regardless of heritage; filtering to receiver-like kinds mirrors
+        // `EdgeContext::receiver_kinds`'s own literal set.
+        let local_names: HashSet<&str> = file
+            .definitions
+            .iter()
+            .filter(|d| matches!(d.kind.as_str(), "class" | "struct" | "interface" | "type" | "module"))
+            .map(|d| d.name.as_str())
+            .collect();
         for cls in &file.classes {
             if let Some(ref parent) = cls.implements {
                 let list = implementors.entry(parent.as_str()).or_default();
                 if !list.contains(&cls.name.as_str()) {
                     list.push(&cls.name);
                 }
+                if local_names.contains(parent.as_str()) {
+                    add_to_file_scoped(&mut implementors_by_file, parent, &file.file, &cls.name);
+                }
             }
             if let Some(ref parent) = cls.extends {
+                parents.entry(cls.name.as_str()).or_insert(parent.as_str());
                 let list = implementors.entry(parent.as_str()).or_default();
                 if !list.contains(&cls.name.as_str()) {
                     list.push(&cls.name);
                 }
+                if local_names.contains(parent.as_str()) {
+                    add_to_file_scoped(&mut implementors_by_file, parent, &file.file, &cls.name);
+                }
             }
         }
     }
-    implementors
+    ChaBuildOutput {
+        implementors,
+        implementors_by_file,
+        parents,
+    }
+}
+
+fn add_to_file_scoped<'a>(
+    implementors_by_file: &mut HashMap<String, Vec<&'a str>>,
+    parent: &str,
+    file: &str,
+    child: &'a str,
+) {
+    let key = format!("{}|{}", parent, file);
+    let list = implementors_by_file.entry(key).or_default();
+    if !list.contains(&child) {
+        list.push(child);
+    }
 }
 
 /// RTA: collect instantiated class names from every file's typeMap, keeping
@@ -289,30 +360,85 @@ fn collect_cha_instantiated_types<'a>(files: &'a [FileEdgeInput]) -> HashSet<&'a
     instantiated
 }
 
+/// Resolve `${method_name}` on `cls` or, if `cls` inherits it without
+/// overriding, the nearest ancestor (via `ctx.cha_parents`) that actually
+/// declares it. A direct qualified lookup alone (`${cls}.${method_name}`)
+/// misses whenever `cls` is instantiated but doesn't override the dispatched
+/// method — the method node is registered under the declaring ANCESTOR's
+/// qualified name, not `cls`'s (issue #2237). Mirrors
+/// `resolveMethodViaAncestors` in `cha.ts`.
+fn resolve_method_via_ancestors<'a>(
+    ctx: &EdgeContext<'a>,
+    cls: &'a str,
+    method_name: &str,
+) -> Vec<&'a NodeInfo> {
+    let mut current = Some(cls);
+    let mut visited: HashSet<&str> = HashSet::new();
+    while let Some(cur) = current {
+        if !visited.insert(cur) {
+            break;
+        }
+        let qualified = format!("{}.{}", cur, method_name);
+        if let Some(found) = ctx.nodes_by_name.get(qualified.as_str()) {
+            let methods: Vec<&'a NodeInfo> =
+                found.iter().copied().filter(|n| n.kind == "method").collect();
+            if !methods.is_empty() {
+                return methods;
+            }
+        }
+        current = ctx.cha_parents.get(cur).copied();
+    }
+    Vec::new()
+}
+
 /// CHA + RTA: given a receiver's resolved type name (interface or class),
 /// return all concrete method implementations reachable via the class
 /// hierarchy, filtered to types that are actually instantiated somewhere in
 /// the project (RTA). BFS over the implementors map so multi-level
 /// hierarchies (`IFoo` → `AbstractFoo` → `ConcreteFoo`) transparently skip
 /// non-instantiated intermediate classes while still reaching their
-/// instantiated concrete subclasses. Mirrors `resolveChaTargets` in `cha.ts`
-/// exactly (including the "always traverse children, even non-instantiated
-/// ones" rule) — no confidence filtering is applied here; callers use the
+/// instantiated concrete subclasses. When an instantiated class inherits the
+/// dispatched method rather than overriding it, `resolve_method_via_ancestors`
+/// walks up to find the declaring ancestor instead of missing the edge
+/// entirely (#2237). No confidence filtering is applied here; callers use the
 /// flat `CHA_TYPED_DISPATCH_CONFIDENCE` for any edge built from this tier's
 /// results (file proximity is not meaningful for virtual dispatch).
+///
+/// When `caller_file` is provided and that file ALSO locally declares a
+/// class/interface named `type_name`, the ROOT level of the BFS prefers
+/// `ctx.cha_implementors_by_file` over the bare (project-wide) `cha_implementors`
+/// map — disambiguating two unrelated files that each declare their own
+/// same-named interface/base class (#2237; mirrors `resolveChaTargets`'s
+/// identical root-only scoping in `cha.ts` — see that function's doc comment
+/// for why only the root level is scoped this way).
 fn resolve_cha_dispatch<'a>(
     ctx: &EdgeContext<'a>,
     type_name: &str,
     method_name: &str,
+    caller_file: Option<&str>,
 ) -> Vec<&'a NodeInfo> {
     let mut results: Vec<&'a NodeInfo> = Vec::new();
     let mut queue: VecDeque<&str> = VecDeque::from([type_name]);
     let mut visited: HashSet<&str> = HashSet::new();
     visited.insert(type_name);
+    let mut is_root = true;
 
     while let Some(current) = queue.pop_front() {
-        let Some(children) = ctx.cha_implementors.get(current) else {
-            continue;
+        let scoped = if is_root {
+            caller_file.and_then(|f| {
+                ctx.cha_implementors_by_file
+                    .get(&format!("{}|{}", current, f))
+            })
+        } else {
+            None
+        };
+        is_root = false;
+        let children = match scoped {
+            Some(list) => list,
+            None => match ctx.cha_implementors.get(current) {
+                Some(list) => list,
+                None => continue,
+            },
         };
         for &cls in children {
             if visited.contains(cls) {
@@ -321,10 +447,7 @@ fn resolve_cha_dispatch<'a>(
             visited.insert(cls);
 
             if ctx.cha_instantiated_types.contains(cls) {
-                let qualified = format!("{}.{}", cls, method_name);
-                if let Some(found) = ctx.nodes_by_name.get(qualified.as_str()) {
-                    results.extend(found.iter().filter(|n| n.kind == "method"));
-                }
+                results.extend(resolve_method_via_ancestors(ctx, cls, method_name));
             }
 
             // Always traverse children — non-instantiated classes may have
@@ -363,6 +486,7 @@ fn emit_cha_dispatch_edges(
     call: &CallInfo,
     caller_id: u32,
     caller_name: &str,
+    caller_file: &str,
     type_map: &HashMap<&str, (&str, f64)>,
     seen_edges: &mut HashSet<u64>,
     pts_edge_map: &HashMap<u64, usize>,
@@ -396,7 +520,7 @@ fn emit_cha_dispatch_edges(
         return;
     };
 
-    for t in resolve_cha_dispatch(ctx, type_name, call.name.as_str()) {
+    for t in resolve_cha_dispatch(ctx, type_name, call.name.as_str(), Some(caller_file)) {
         let edge_key = ((caller_id as u64) << 32) | (t.id as u64);
         if t.id != caller_id
             && !seen_edges.contains(&edge_key)
@@ -1228,6 +1352,7 @@ fn process_file<'a>(
             call,
             caller_id,
             caller_name,
+            fc.rel_path,
             &fc.type_map,
             &mut seen_edges,
             &pts_edge_map,
@@ -1872,7 +1997,8 @@ fn resolve_call_targets_core<'a>(
             // genuine receiver (`this`/`self`/`super` dispatch is handled
             // separately by `runPostNativeThisDispatch`).
             if has_concrete_receiver {
-                let cha_targets = resolve_cha_dispatch(ctx, type_name, call.name.as_str());
+                let cha_targets =
+                    resolve_cha_dispatch(ctx, type_name, call.name.as_str(), Some(rel_path));
                 if !cha_targets.is_empty() {
                     *confidence_override = Some(CHA_TYPED_DISPATCH_CONFIDENCE);
                     return prefer_type_aware_over_bare(&bare_targets, cha_targets);
@@ -5331,6 +5457,122 @@ mod call_edge_tests {
         assert!(
             to_real.is_some(),
             "expected BFS to reach RealWorker.doWork through the non-instantiated AbstractWorker; got: {:?}",
+            edges.iter().map(|e| (&e.kind, e.source_id, e.target_id)).collect::<Vec<_>>()
+        );
+    }
+
+    // ── CHA implementor collision + inherited-method walk (issue #2237) ────
+
+    /// Two files each declare their own UNRELATED `Handler` interface + a
+    /// concrete implementer of the same name pattern — dispatching from the
+    /// caller's own file must reach only its own co-located implementer, not
+    /// the other file's unrelated same-named `Handler`'s implementer.
+    #[test]
+    fn cha_dispatch_does_not_merge_two_unrelated_same_named_interfaces() {
+        let all_nodes = vec![
+            node(1, "main", "function", "src/mod1/caller.ts", 1),
+            node(2, "HandlerA.run", "method", "src/mod1/caller.ts", 5),
+            node(3, "HandlerB.run", "method", "src/mod2/other.ts", 5),
+        ];
+
+        let caller_file = make_file(
+            "src/mod1/caller.ts",
+            10,
+            // `Handler` (a bare interface with no heritage of its own) must
+            // still appear in `definitions` — mirrors real extraction, where
+            // `classes` only lists RELATIONS (entries with extends/implements),
+            // never a plain interface/class declaration on its own (#2237).
+            vec![
+                def("main", "function", 1, 10),
+                def("Handler", "interface", 2, 2),
+            ],
+            vec![call("run", 3, Some("h"))],
+            vec![
+                type_map_entry("h", "Handler", 0.9),
+                type_map_entry("a", "HandlerA", 1.0),
+            ],
+            vec![class_info("HandlerA", None, Some("Handler"))],
+        );
+        let other_file = make_file(
+            "src/mod2/other.ts",
+            20,
+            vec![def("Handler", "interface", 2, 2)],
+            vec![],
+            vec![type_map_entry("b", "HandlerB", 1.0)],
+            vec![class_info("HandlerB", None, Some("Handler"))],
+        );
+
+        let edges = build_call_edges(
+            vec![caller_file, other_file],
+            all_nodes,
+            vec![],
+            MAX_SOLVER_ITERATIONS,
+            None,
+        );
+
+        let to_a = edges.iter().any(|e| e.kind == "calls" && e.target_id == 2);
+        let to_b = edges.iter().any(|e| e.kind == "calls" && e.target_id == 3);
+        assert!(
+            to_a,
+            "expected a calls edge to HandlerA.run; got: {:?}",
+            edges.iter().map(|e| (&e.kind, e.source_id, e.target_id)).collect::<Vec<_>>()
+        );
+        assert!(
+            !to_b,
+            "did not expect a calls edge to the unrelated file's HandlerB.run; got: {:?}",
+            edges.iter().map(|e| (&e.kind, e.source_id, e.target_id)).collect::<Vec<_>>()
+        );
+    }
+
+    /// An instantiated concrete class that inherits the dispatched method
+    /// from an ancestor without overriding it must still resolve to that
+    /// ancestor's declaration — a direct qualified lookup on the concrete
+    /// class alone would miss entirely.
+    #[test]
+    fn cha_dispatch_walks_up_to_declaring_ancestor_for_inherited_method() {
+        let all_nodes = vec![
+            node(1, "main", "function", "src/caller.ts", 1),
+            node(2, "AbstractHandler.run", "method", "src/abstract.ts", 3),
+        ];
+
+        let caller_file = make_file(
+            "src/caller.ts",
+            10,
+            vec![def("main", "function", 1, 10)],
+            vec![call("run", 3, Some("h"))],
+            vec![type_map_entry("h", "IHandler", 0.9)],
+            vec![class_info("IHandler", None, None)],
+        );
+        let abstract_file = make_file(
+            "src/abstract.ts",
+            20,
+            vec![],
+            vec![],
+            vec![],
+            vec![class_info("AbstractHandler", None, Some("IHandler"))],
+        );
+        let concrete_file = make_file(
+            "src/concrete.ts",
+            30,
+            vec![],
+            vec![],
+            // Only ConcreteHandler is instantiated — AbstractHandler never is.
+            vec![type_map_entry("c", "ConcreteHandler", 1.0)],
+            vec![class_info("ConcreteHandler", Some("AbstractHandler"), None)],
+        );
+
+        let edges = build_call_edges(
+            vec![caller_file, abstract_file, concrete_file],
+            all_nodes,
+            vec![],
+            MAX_SOLVER_ITERATIONS,
+            None,
+        );
+
+        let to_abstract = edges.iter().find(|e| e.kind == "calls" && e.target_id == 2);
+        assert!(
+            to_abstract.is_some(),
+            "expected the inherited method walk to reach AbstractHandler.run; got: {:?}",
             edges.iter().map(|e| (&e.kind, e.source_id, e.target_id)).collect::<Vec<_>>()
         );
     }

--- a/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
@@ -202,14 +202,19 @@ struct EdgeContext<'a> {
     /// it's a composite built at map-construction time.
     cha_implementors_by_file: HashMap<String, Vec<&'a str>>,
     /// Class name → direct parent class name (from `extends`), first-write-
-    /// wins across the whole build pass. Used only to walk up to a declaring
+    /// wins across the whole build pass. Used to walk up to a declaring
     /// ancestor when an instantiated concrete class inherits the dispatched
     /// method without overriding it (issue #2237's Issue 2) — mirrors the
-    /// `parents` half of `ChaContext`/`buildChaContext` in `cha.ts` (file-
-    /// scoped disambiguation, `parentsByFile`, is not needed here: this walk
-    /// starts from a class already uniquely identified by the BFS above, not
-    /// from an ambiguous bare name).
+    /// `parents` half of `ChaContext`/`buildChaContext` in `cha.ts`. Serves
+    /// as the fallback when `cha_parents_by_file` has no entry for a given
+    /// (class, file) pair.
     cha_parents: HashMap<&'a str, &'a str>,
+    /// `${childName}|${childDeclaringFile}` → direct parent class name (from
+    /// `extends`) — disambiguates two unrelated files each declaring their
+    /// own same-named class with different parents (issue #2237, Greptile
+    /// review finding on PR #2399). Mirrors `ChaContext.parentsByFile` in
+    /// `cha.ts`.
+    cha_parents_by_file: HashMap<String, &'a str>,
     /// RTA: class names that appear as a high-confidence (>= 0.9) typeMap
     /// target anywhere in this build pass — mirrors the typeMap fallback
     /// branch of `collectInstantiatedTypes` in `cha.ts` (the native
@@ -252,6 +257,7 @@ impl<'a> EdgeContext<'a> {
             cha_implementors: cha.implementors,
             cha_implementors_by_file: cha.implementors_by_file,
             cha_parents: cha.parents,
+            cha_parents_by_file: cha.parents_by_file,
             cha_instantiated_types: collect_cha_instantiated_types(files),
         }
     }
@@ -262,6 +268,7 @@ struct ChaBuildOutput<'a> {
     implementors: HashMap<&'a str, Vec<&'a str>>,
     implementors_by_file: HashMap<String, Vec<&'a str>>,
     parents: HashMap<&'a str, &'a str>,
+    parents_by_file: HashMap<String, &'a str>,
 }
 
 /// Build the CHA implementors/parents maps: interface/class name → concrete
@@ -285,6 +292,7 @@ fn build_cha_context<'a>(files: &'a [FileEdgeInput]) -> ChaBuildOutput<'a> {
     let mut implementors: HashMap<&str, Vec<&str>> = HashMap::new();
     let mut implementors_by_file: HashMap<String, Vec<&str>> = HashMap::new();
     let mut parents: HashMap<&str, &str> = HashMap::new();
+    let mut parents_by_file: HashMap<String, &str> = HashMap::new();
 
     for file in files {
         // `file.classes` only lists class RELATIONS (entries with an
@@ -298,7 +306,12 @@ fn build_cha_context<'a>(files: &'a [FileEdgeInput]) -> ChaBuildOutput<'a> {
         let local_names: HashSet<&str> = file
             .definitions
             .iter()
-            .filter(|d| matches!(d.kind.as_str(), "class" | "struct" | "interface" | "type" | "module"))
+            .filter(|d| {
+                matches!(
+                    d.kind.as_str(),
+                    "class" | "struct" | "interface" | "type" | "module"
+                )
+            })
             .map(|d| d.name.as_str())
             .collect();
         for cls in &file.classes {
@@ -313,6 +326,7 @@ fn build_cha_context<'a>(files: &'a [FileEdgeInput]) -> ChaBuildOutput<'a> {
             }
             if let Some(ref parent) = cls.extends {
                 parents.entry(cls.name.as_str()).or_insert(parent.as_str());
+                parents_by_file.insert(format!("{}|{}", cls.name, file.file), parent.as_str());
                 let list = implementors.entry(parent.as_str()).or_default();
                 if !list.contains(&cls.name.as_str()) {
                     list.push(&cls.name);
@@ -327,6 +341,7 @@ fn build_cha_context<'a>(files: &'a [FileEdgeInput]) -> ChaBuildOutput<'a> {
         implementors,
         implementors_by_file,
         parents,
+        parents_by_file,
     }
 }
 
@@ -367,12 +382,26 @@ fn collect_cha_instantiated_types<'a>(files: &'a [FileEdgeInput]) -> HashSet<&'a
 /// method — the method node is registered under the declaring ANCESTOR's
 /// qualified name, not `cls`'s (issue #2237). Mirrors
 /// `resolveMethodViaAncestors` in `cha.ts`.
+/// `cls_file`, when known (propagated from a file-scoped BFS hop in
+/// `resolve_cha_dispatch`), is used to prefer a same-file qualified-method
+/// lookup and a same-file parent-edge lookup at each step — otherwise an
+/// unrelated file's identically-named class (with its own identically-named
+/// method, or its own different parent chain) can still leak in even after
+/// `resolve_cha_dispatch` has correctly scoped which concrete class to walk
+/// from (Greptile review finding on PR #2399). Each step falls back to the
+/// bare/global lookup when the scoped one finds nothing — never a regression
+/// versus the pre-fix behavior. The ancestor's own file is not generally
+/// knowable (it may be an unrelated imported base), so `cls_file` is carried
+/// forward as an optimistic guess for the next hop only when a same-file
+/// parent edge was actually found; otherwise it is cleared to `None`.
 fn resolve_method_via_ancestors<'a>(
     ctx: &EdgeContext<'a>,
     cls: &'a str,
+    cls_file: Option<&str>,
     method_name: &str,
 ) -> Vec<&'a NodeInfo> {
     let mut current = Some(cls);
+    let mut current_file = cls_file;
     let mut visited: HashSet<&str> = HashSet::new();
     while let Some(cur) = current {
         if !visited.insert(cur) {
@@ -380,13 +409,40 @@ fn resolve_method_via_ancestors<'a>(
         }
         let qualified = format!("{}.{}", cur, method_name);
         if let Some(found) = ctx.nodes_by_name.get(qualified.as_str()) {
-            let methods: Vec<&'a NodeInfo> =
-                found.iter().copied().filter(|n| n.kind == "method").collect();
+            let scoped_methods: Vec<&'a NodeInfo> = current_file
+                .map(|f| {
+                    found
+                        .iter()
+                        .copied()
+                        .filter(|n| n.kind == "method" && n.file == f)
+                        .collect()
+                })
+                .unwrap_or_default();
+            let methods = if !scoped_methods.is_empty() {
+                scoped_methods
+            } else {
+                found
+                    .iter()
+                    .copied()
+                    .filter(|n| n.kind == "method")
+                    .collect()
+            };
             if !methods.is_empty() {
                 return methods;
             }
         }
-        current = ctx.cha_parents.get(cur).copied();
+        let scoped_parent = current_file.and_then(|f| {
+            ctx.cha_parents_by_file
+                .get(&format!("{}|{}", cur, f))
+                .copied()
+        });
+        let next_file = if scoped_parent.is_some() {
+            current_file
+        } else {
+            None
+        };
+        current = scoped_parent.or_else(|| ctx.cha_parents.get(cur).copied());
+        current_file = next_file;
     }
     Vec::new()
 }
@@ -404,13 +460,17 @@ fn resolve_method_via_ancestors<'a>(
 /// flat `CHA_TYPED_DISPATCH_CONFIDENCE` for any edge built from this tier's
 /// results (file proximity is not meaningful for virtual dispatch).
 ///
-/// When `caller_file` is provided and that file ALSO locally declares a
-/// class/interface named `type_name`, the ROOT level of the BFS prefers
-/// `ctx.cha_implementors_by_file` over the bare (project-wide) `cha_implementors`
-/// map — disambiguating two unrelated files that each declare their own
-/// same-named interface/base class (#2237; mirrors `resolveChaTargets`'s
-/// identical root-only scoping in `cha.ts` — see that function's doc comment
-/// for why only the root level is scoped this way).
+/// At every BFS level (not just the root), when the current node's file is
+/// known, this prefers `ctx.cha_implementors_by_file` over the bare
+/// (project-wide) `cha_implementors` map — disambiguating two unrelated
+/// files that each declare their own same-named interface/base class
+/// (#2237; mirrors `resolveChaTargets`'s identical scoping in `cha.ts` — see
+/// that function's doc comment for the full rationale and non-regression
+/// guarantee). The starting node's file is `caller_file` (when provided); a
+/// discovered child's file is known ONLY when its parent was found via the
+/// scoped bucket — `cha_implementors_by_file` is populated exactly when the
+/// child's own file also locally declares that parent, so the child is
+/// *guaranteed* to live in that same file.
 fn resolve_cha_dispatch<'a>(
     ctx: &EdgeContext<'a>,
     type_name: &str,
@@ -418,21 +478,15 @@ fn resolve_cha_dispatch<'a>(
     caller_file: Option<&str>,
 ) -> Vec<&'a NodeInfo> {
     let mut results: Vec<&'a NodeInfo> = Vec::new();
-    let mut queue: VecDeque<&str> = VecDeque::from([type_name]);
+    let mut queue: VecDeque<(&str, Option<&str>)> = VecDeque::from([(type_name, caller_file)]);
     let mut visited: HashSet<&str> = HashSet::new();
     visited.insert(type_name);
-    let mut is_root = true;
 
-    while let Some(current) = queue.pop_front() {
-        let scoped = if is_root {
-            caller_file.and_then(|f| {
-                ctx.cha_implementors_by_file
-                    .get(&format!("{}|{}", current, f))
-            })
-        } else {
-            None
-        };
-        is_root = false;
+    while let Some((current, current_file)) = queue.pop_front() {
+        let scoped = current_file.and_then(|f| {
+            ctx.cha_implementors_by_file
+                .get(&format!("{}|{}", current, f))
+        });
         let children = match scoped {
             Some(list) => list,
             None => match ctx.cha_implementors.get(current) {
@@ -440,6 +494,7 @@ fn resolve_cha_dispatch<'a>(
                 None => continue,
             },
         };
+        let child_file = if scoped.is_some() { current_file } else { None };
         for &cls in children {
             if visited.contains(cls) {
                 continue;
@@ -447,12 +502,17 @@ fn resolve_cha_dispatch<'a>(
             visited.insert(cls);
 
             if ctx.cha_instantiated_types.contains(cls) {
-                results.extend(resolve_method_via_ancestors(ctx, cls, method_name));
+                results.extend(resolve_method_via_ancestors(
+                    ctx,
+                    cls,
+                    child_file,
+                    method_name,
+                ));
             }
 
             // Always traverse children — non-instantiated classes may have
             // instantiated subclasses.
-            queue.push_back(cls);
+            queue.push_back((cls, child_file));
         }
     }
 
@@ -5515,12 +5575,18 @@ mod call_edge_tests {
         assert!(
             to_a,
             "expected a calls edge to HandlerA.run; got: {:?}",
-            edges.iter().map(|e| (&e.kind, e.source_id, e.target_id)).collect::<Vec<_>>()
+            edges
+                .iter()
+                .map(|e| (&e.kind, e.source_id, e.target_id))
+                .collect::<Vec<_>>()
         );
         assert!(
             !to_b,
             "did not expect a calls edge to the unrelated file's HandlerB.run; got: {:?}",
-            edges.iter().map(|e| (&e.kind, e.source_id, e.target_id)).collect::<Vec<_>>()
+            edges
+                .iter()
+                .map(|e| (&e.kind, e.source_id, e.target_id))
+                .collect::<Vec<_>>()
         );
     }
 
@@ -5573,6 +5639,145 @@ mod call_edge_tests {
         assert!(
             to_abstract.is_some(),
             "expected the inherited method walk to reach AbstractHandler.run; got: {:?}",
+            edges
+                .iter()
+                .map(|e| (&e.kind, e.source_id, e.target_id))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    /// Greptile review finding on PR #2399: both file1 and file2
+    /// independently declare their own HandlerA implementing their own
+    /// (unrelated) Handler interface, each with its own `run` method.
+    /// Scoping the root to file1 must also carry that file identity into
+    /// the qualified-method lookup — otherwise `nodes_by_name["HandlerA.run"]`
+    /// returns both files' methods.
+    #[test]
+    fn cha_dispatch_preserves_file_identity_through_method_lookup() {
+        let all_nodes = vec![
+            node(1, "main", "function", "src/mod1/caller.ts", 1),
+            node(2, "HandlerA.run", "method", "src/mod1/caller.ts", 5),
+            node(3, "HandlerA.run", "method", "src/mod2/other.ts", 5),
+        ];
+
+        let caller_file = make_file(
+            "src/mod1/caller.ts",
+            10,
+            vec![
+                def("main", "function", 1, 10),
+                def("Handler", "interface", 2, 2),
+            ],
+            vec![call("run", 3, Some("h"))],
+            vec![
+                type_map_entry("h", "Handler", 0.9),
+                type_map_entry("a", "HandlerA", 1.0),
+            ],
+            vec![class_info("HandlerA", None, Some("Handler"))],
+        );
+        let other_file = make_file(
+            "src/mod2/other.ts",
+            20,
+            vec![def("Handler", "interface", 2, 2)],
+            vec![],
+            vec![type_map_entry("a2", "HandlerA", 1.0)],
+            vec![class_info("HandlerA", None, Some("Handler"))],
+        );
+
+        let edges = build_call_edges(
+            vec![caller_file, other_file],
+            all_nodes,
+            vec![],
+            MAX_SOLVER_ITERATIONS,
+            None,
+        );
+
+        let to_own = edges.iter().any(|e| e.kind == "calls" && e.target_id == 2);
+        let to_other = edges.iter().any(|e| e.kind == "calls" && e.target_id == 3);
+        assert!(
+            to_own,
+            "expected a calls edge to mod1's own HandlerA.run; got: {:?}",
+            edges
+                .iter()
+                .map(|e| (&e.kind, e.source_id, e.target_id))
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            !to_other,
+            "did not expect a calls edge to the unrelated file's HandlerA.run; got: {:?}",
+            edges
+                .iter()
+                .map(|e| (&e.kind, e.source_id, e.target_id))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    /// Greptile review finding on PR #2399: file1's ConcreteHandler extends
+    /// RealBase; an unrelated file2 also declares its own ConcreteHandler
+    /// extending a different OtherBase, recorded FIRST (file2 appears before
+    /// file1 in the input vec) so the bare `parents` map's first-write-wins
+    /// entry deliberately points the wrong way. The file-scoped
+    /// `parents_by_file` entry for file1 must still win.
+    #[test]
+    fn cha_dispatch_preserves_file_identity_through_ancestor_walk() {
+        let all_nodes = vec![
+            node(1, "main", "function", "src/mod1/caller.ts", 1),
+            node(2, "RealBase.run", "method", "src/mod1/base.ts", 3),
+            node(3, "OtherBase.run", "method", "src/mod2/other.ts", 3),
+        ];
+
+        // Recorded FIRST so the bare (first-write-wins) `parents` map's
+        // ConcreteHandler entry deliberately points the wrong way.
+        let other_file = make_file(
+            "src/mod2/other.ts",
+            20,
+            vec![],
+            vec![],
+            vec![],
+            vec![class_info("ConcreteHandler", Some("OtherBase"), None)],
+        );
+        // file1's OWN ConcreteHandler: implements Handler (reachable from the
+        // BFS root) AND extends RealBase (its real ancestor) — a single
+        // declaration, exactly as real extraction would record it.
+        let caller_file = make_file(
+            "src/mod1/caller.ts",
+            10,
+            vec![
+                def("main", "function", 1, 10),
+                def("Handler", "interface", 2, 2),
+            ],
+            vec![call("run", 3, Some("h"))],
+            vec![
+                type_map_entry("h", "Handler", 0.9),
+                type_map_entry("c", "ConcreteHandler", 1.0),
+            ],
+            vec![class_info(
+                "ConcreteHandler",
+                Some("RealBase"),
+                Some("Handler"),
+            )],
+        );
+
+        let edges = build_call_edges(
+            vec![other_file, caller_file],
+            all_nodes,
+            vec![],
+            MAX_SOLVER_ITERATIONS,
+            None,
+        );
+
+        let to_real = edges.iter().any(|e| e.kind == "calls" && e.target_id == 2);
+        let to_wrong = edges.iter().any(|e| e.kind == "calls" && e.target_id == 3);
+        assert!(
+            to_real,
+            "expected the ancestor walk to reach file1's own RealBase.run; got: {:?}",
+            edges
+                .iter()
+                .map(|e| (&e.kind, e.source_id, e.target_id))
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            !to_wrong,
+            "did not expect the ancestor walk to cross into the unrelated file's OtherBase.run; got: {:?}",
             edges.iter().map(|e| (&e.kind, e.source_id, e.target_id)).collect::<Vec<_>>()
         );
     }

--- a/src/domain/graph/builder/cha.ts
+++ b/src/domain/graph/builder/cha.ts
@@ -24,8 +24,21 @@ import { RECEIVER_KINDS } from './call-resolver.js';
 // ── CHA context ──────────────────────────────────────────────────────────────
 
 export interface ChaContext {
-  /** interface/class name → concrete classes that implement or extend it */
+  /** interface/class name → concrete classes that implement or extend it.
+   * Ambiguous when two unrelated files each declare their own class/interface
+   * of the same bare name — prefer `implementorsByFile` whenever the caller's
+   * own file locally declares a matching root type (issue #2237). */
   readonly implementors: ReadonlyMap<string, readonly string[]>;
+  /** `${parentName}|${parentDeclaringFile}` → concrete classes recorded while
+   * that same file ALSO locally declares a class/interface named `parentName`
+   * — i.e. the child's `implements`/`extends` reference most plausibly means
+   * THIS file's own declaration, not an unrelated same-named one elsewhere.
+   * Disambiguates two independent files each declaring their own same-named
+   * interface/base class (issue #2237); mirrors `parentsByFile`'s composite
+   * key, applied to the inverse (parent → children) direction. Empty/missing
+   * for a given `${parentName}|${file}` pair means no local anchor was found
+   * for that file — callers fall back to the bare `implementors` map. */
+  readonly implementorsByFile: ReadonlyMap<string, readonly string[]>;
   /**
    * class name → direct parent class name (from `extends`), first-write-wins
    * across the whole project. Ambiguous when the same bare class name is
@@ -43,6 +56,7 @@ export interface ChaContext {
 
 export const EMPTY_CHA_CONTEXT: ChaContext = {
   implementors: new Map(),
+  implementorsByFile: new Map(),
   parents: new Map(),
   parentsByFile: new Map(),
   instantiatedTypes: new Set(),
@@ -50,9 +64,16 @@ export const EMPTY_CHA_CONTEXT: ChaContext = {
 
 /**
  * Record a class's `implements` relationship into the implementors map
- * (interface/class name → concrete classes that implement it).
+ * (interface/class name → concrete classes that implement it), plus the
+ * file-scoped map when `file` also locally declares a same-named parent.
  */
-function recordImplements(cls: ClassRelation, implementors: Map<string, string[]>): void {
+function recordImplements(
+  cls: ClassRelation,
+  implementors: Map<string, string[]>,
+  implementorsByFile: Map<string, string[]>,
+  file: string,
+  localClassNames: ReadonlySet<string>,
+): void {
   if (!cls.implements) return;
   let list = implementors.get(cls.implements);
   if (!list) {
@@ -60,20 +81,30 @@ function recordImplements(cls: ClassRelation, implementors: Map<string, string[]
     implementors.set(cls.implements, list);
   }
   if (!list.includes(cls.name)) list.push(cls.name);
+
+  // File-scoped: only when this file ALSO locally declares a class/interface
+  // named `cls.implements` — the child's reference most plausibly means that
+  // co-located declaration, not an unrelated same-named one elsewhere (#2237).
+  if (localClassNames.has(cls.implements)) {
+    addToFileScoped(implementorsByFile, cls.implements, file, cls.name);
+  }
 }
 
 /**
  * Record a class's `extends` relationship into the parents map (child →
  * direct parent, for this/super hierarchy walking), the file-scoped parents
  * map (same, but disambiguated by the declaring file), and the implementors
- * map (parent → children, for CHA dispatch expansion via extends).
+ * map (parent → children, for CHA dispatch expansion via extends) — plus its
+ * own file-scoped map, mirroring `recordImplements`.
  */
 function recordExtends(
   cls: ClassRelation,
   implementors: Map<string, string[]>,
+  implementorsByFile: Map<string, string[]>,
   parents: Map<string, string>,
   parentsByFile: Map<string, string>,
   file: string,
+  localClassNames: ReadonlySet<string>,
 ): void {
   if (!cls.extends) return;
   // child → parent (for this/super hierarchy walking)
@@ -86,6 +117,25 @@ function recordExtends(
     implementors.set(cls.extends, list);
   }
   if (!list.includes(cls.name)) list.push(cls.name);
+
+  if (localClassNames.has(cls.extends)) {
+    addToFileScoped(implementorsByFile, cls.extends, file, cls.name);
+  }
+}
+
+function addToFileScoped(
+  implementorsByFile: Map<string, string[]>,
+  parentName: string,
+  file: string,
+  childName: string,
+): void {
+  const key = `${parentName}|${file}`;
+  let scoped = implementorsByFile.get(key);
+  if (!scoped) {
+    scoped = [];
+    implementorsByFile.set(key, scoped);
+  }
+  if (!scoped.includes(childName)) scoped.push(childName);
 }
 
 /**
@@ -117,19 +167,38 @@ function collectInstantiatedTypes(symbols: ExtractorOutput, instantiatedTypes: S
  */
 export function buildChaContext(fileSymbols: ReadonlyMap<string, ExtractorOutput>): ChaContext {
   const implementors = new Map<string, string[]>();
+  const implementorsByFile = new Map<string, string[]>();
   const parents = new Map<string, string>();
   const parentsByFile = new Map<string, string>();
   const instantiatedTypes = new Set<string>();
 
   for (const [file, symbols] of fileSymbols) {
+    // `symbols.classes` only lists class RELATIONS (entries with an extends/
+    // implements clause) — a bare `interface Handler {}` with no heritage
+    // never appears there, so a same-file-anchor check against it alone
+    // would miss the exact "plain interface, no relation" shape that's the
+    // whole point of the collision this map protects against (#2237).
+    // `symbols.definitions` covers every declared symbol regardless of
+    // heritage; RECEIVER_KINDS narrows it to class/interface/struct/etc.
+    const localClassNames = new Set(
+      symbols.definitions.filter((d) => RECEIVER_KINDS.has(d.kind)).map((d) => d.name),
+    );
     for (const cls of symbols.classes) {
-      recordImplements(cls, implementors);
-      recordExtends(cls, implementors, parents, parentsByFile, file);
+      recordImplements(cls, implementors, implementorsByFile, file, localClassNames);
+      recordExtends(
+        cls,
+        implementors,
+        implementorsByFile,
+        parents,
+        parentsByFile,
+        file,
+        localClassNames,
+      );
     }
     collectInstantiatedTypes(symbols, instantiatedTypes);
   }
 
-  return { implementors, parents, parentsByFile, instantiatedTypes };
+  return { implementors, implementorsByFile, parents, parentsByFile, instantiatedTypes };
 }
 
 /**
@@ -171,7 +240,30 @@ export function buildChaContextFromDb(db: BetterSqlite3Database): ChaContext {
   }>;
   if (hierarchyRows.length === 0) return EMPTY_CHA_CONTEXT;
 
+  // Per-file locally-declared class/interface/struct/etc. names — used to
+  // build implementorsByFile below: a child's implements/extends reference
+  // most plausibly means a same-file declaration when one exists, rather
+  // than an unrelated same-named declaration elsewhere (#2237).
+  const receiverKindsList = [...RECEIVER_KINDS];
+  const localNameRows = db
+    .prepare(`
+      SELECT file, name
+      FROM nodes
+      WHERE kind IN (${receiverKindsList.map(() => '?').join(',')})
+    `)
+    .all(...receiverKindsList) as Array<{ file: string; name: string }>;
+  const localNamesByFile = new Map<string, Set<string>>();
+  for (const row of localNameRows) {
+    let names = localNamesByFile.get(row.file);
+    if (!names) {
+      names = new Set();
+      localNamesByFile.set(row.file, names);
+    }
+    names.add(row.name);
+  }
+
   const implementors = new Map<string, string[]>();
+  const implementorsByFile = new Map<string, string[]>();
   const parents = new Map<string, string>();
   const parentsByFile = new Map<string, string>();
   for (const row of hierarchyRows) {
@@ -181,6 +273,9 @@ export function buildChaContextFromDb(db: BetterSqlite3Database): ChaContext {
       implementors.set(row.parent_name, list);
     }
     if (!list.includes(row.child_name)) list.push(row.child_name);
+    if (localNamesByFile.get(row.child_file)?.has(row.parent_name)) {
+      addToFileScoped(implementorsByFile, row.parent_name, row.child_file, row.child_name);
+    }
     if (row.edge_kind === 'extends') {
       if (!parents.has(row.child_name)) parents.set(row.child_name, row.parent_name);
       parentsByFile.set(`${row.child_name}|${row.child_file}`, row.parent_name);
@@ -197,7 +292,7 @@ export function buildChaContextFromDb(db: BetterSqlite3Database): ChaContext {
     .all() as Array<{ name: string }>;
   const instantiatedTypes = new Set(rtaRows.map((r) => r.name));
 
-  return { implementors, parents, parentsByFile, instantiatedTypes };
+  return { implementors, implementorsByFile, parents, parentsByFile, instantiatedTypes };
 }
 
 // ── this / self / super resolution ──────────────────────────────────────────
@@ -292,6 +387,33 @@ export function resolveThisDispatch(
 // ── CHA dispatch expansion ───────────────────────────────────────────────────
 
 /**
+ * Resolve `${methodName}` on `cls` or, if `cls` inherits it without
+ * overriding, the nearest ancestor (via `chaCtx.parents`) that actually
+ * declares it. A direct qualified lookup alone (`${cls}.${methodName}`)
+ * misses whenever `cls` is instantiated but doesn't override the dispatched
+ * method — the method node is registered under the declaring ANCESTOR's
+ * qualified name, not `cls`'s (issue #2237). Mirrors the ancestor-walk in
+ * `resolveThisDispatch`'s own `while` loop.
+ */
+function resolveMethodViaAncestors(
+  cls: string,
+  methodName: string,
+  chaCtx: ChaContext,
+  lookup: CallNodeLookup,
+): ReadonlyArray<ResolvedCandidate> {
+  let current: string | undefined = cls;
+  const visited = new Set<string>();
+  while (current && !visited.has(current)) {
+    visited.add(current);
+    const qualified = `${current}.${methodName}`;
+    const found = lookup.byName(qualified).filter((n) => n.kind === 'method');
+    if (found.length > 0) return found;
+    current = chaCtx.parents.get(current);
+  }
+  return [];
+}
+
+/**
  * CHA + RTA: given a receiver type (class or interface), return all concrete
  * method implementations reachable via the class hierarchy.
  *
@@ -302,22 +424,46 @@ export function resolveThisDispatch(
  * BFS over the implementors map handles multi-level hierarchies (e.g.
  * IFoo → AbstractFoo → ConcreteFoo) so that abstract intermediate classes
  * are transparently skipped while their concrete subclasses are still reached.
+ * When an instantiated class inherits the dispatched method rather than
+ * overriding it, `resolveMethodViaAncestors` walks up to find the declaring
+ * ancestor instead of missing the edge entirely (#2237).
+ *
+ * When `callerFile` is provided and that file ALSO locally declares a
+ * class/interface named `typeName`, the ROOT level of the BFS prefers
+ * `chaCtx.implementorsByFile` over the bare (project-wide) `implementors`
+ * map — disambiguating two unrelated files that each declare their own
+ * same-named interface/base class (#2237; mirrors `resolveThisDispatch`'s
+ * same-file preference). Only the root level is scoped this way: the
+ * collision this guards against is specifically a colliding TOP-LEVEL type
+ * name, and legitimate multi-file hierarchies (a shared interface's
+ * implementors declared across many files, e.g. issue #2078) must keep
+ * resolving through the bare map at every level below the root — a
+ * same-named collision several hops down the same hierarchy is a rarer,
+ * compound scenario left out of scope here (same as #2062's fix, which is
+ * also a single-hop heuristic). When `typeName` has no local declaration in
+ * `callerFile` (the common cross-file-dispatch case), the scoped bucket is
+ * empty and this falls through to the prior, unchanged behavior.
  */
 export function resolveChaTargets(
   typeName: string,
   methodName: string,
   chaCtx: ChaContext,
   lookup: CallNodeLookup,
+  callerFile?: string | null,
 ): ReadonlyArray<ResolvedCandidate> {
   const results: Array<ResolvedCandidate> = [];
 
   const queue: string[] = [typeName];
   const visited = new Set<string>();
   visited.add(typeName);
+  let isRoot = true;
 
   while (queue.length > 0) {
     const current = queue.shift()!;
-    const children = chaCtx.implementors.get(current);
+    const scoped =
+      isRoot && callerFile ? chaCtx.implementorsByFile.get(`${current}|${callerFile}`) : undefined;
+    const children = scoped ?? chaCtx.implementors.get(current);
+    isRoot = false;
     if (!children?.length) continue;
 
     for (const cls of children) {
@@ -325,9 +471,7 @@ export function resolveChaTargets(
       visited.add(cls);
 
       if (chaCtx.instantiatedTypes.has(cls)) {
-        const qualified = `${cls}.${methodName}`;
-        const found = lookup.byName(qualified).filter((n) => n.kind === 'method');
-        results.push(...found);
+        results.push(...resolveMethodViaAncestors(cls, methodName, chaCtx, lookup));
       }
 
       // Traverse even non-instantiated classes — they may have instantiated subclasses.

--- a/src/domain/graph/builder/cha.ts
+++ b/src/domain/graph/builder/cha.ts
@@ -388,27 +388,51 @@ export function resolveThisDispatch(
 
 /**
  * Resolve `${methodName}` on `cls` or, if `cls` inherits it without
- * overriding, the nearest ancestor (via `chaCtx.parents`) that actually
- * declares it. A direct qualified lookup alone (`${cls}.${methodName}`)
- * misses whenever `cls` is instantiated but doesn't override the dispatched
- * method — the method node is registered under the declaring ANCESTOR's
- * qualified name, not `cls`'s (issue #2237). Mirrors the ancestor-walk in
- * `resolveThisDispatch`'s own `while` loop.
+ * overriding, the nearest ancestor (via `chaCtx.parents`/`parentsByFile`)
+ * that actually declares it. A direct qualified lookup alone
+ * (`${cls}.${methodName}`) misses whenever `cls` is instantiated but doesn't
+ * override the dispatched method — the method node is registered under the
+ * declaring ANCESTOR's qualified name, not `cls`'s (issue #2237). Mirrors
+ * the ancestor-walk in `resolveThisDispatch`'s own `while` loop.
+ *
+ * `clsFile`, when known (propagated from a file-scoped BFS hop in
+ * `resolveChaTargets`), is used to prefer a same-file qualified-method
+ * lookup and a same-file parent-edge lookup at each step — otherwise an
+ * unrelated file's identically-named class (with its own identically-named
+ * method, or its own different parent chain) can still leak in even after
+ * `resolveChaTargets` has correctly scoped which concrete class to walk
+ * from (Greptile review finding on PR #2399). Each step falls back to the
+ * bare/global lookup when the scoped one finds nothing — never a regression
+ * versus the pre-fix behavior, only a preference when file identity is
+ * actually known. The ancestor's own file is not generally knowable (it may
+ * be an unrelated imported base), so `clsFile` is carried forward as an
+ * optimistic guess for the next hop only when a same-file parent edge was
+ * actually found; otherwise it is cleared to `null`.
  */
 function resolveMethodViaAncestors(
   cls: string,
+  clsFile: string | null,
   methodName: string,
   chaCtx: ChaContext,
   lookup: CallNodeLookup,
 ): ReadonlyArray<ResolvedCandidate> {
   let current: string | undefined = cls;
+  let currentFile = clsFile;
   const visited = new Set<string>();
   while (current && !visited.has(current)) {
     visited.add(current);
     const qualified = `${current}.${methodName}`;
-    const found = lookup.byName(qualified).filter((n) => n.kind === 'method');
+    const scopedFound = currentFile ? lookup.byNameAndFile(qualified, currentFile) : [];
+    const found = (scopedFound.length > 0 ? scopedFound : lookup.byName(qualified)).filter(
+      (n) => n.kind === 'method',
+    );
     if (found.length > 0) return found;
-    current = chaCtx.parents.get(current);
+    const scopedParent: string | undefined = currentFile
+      ? chaCtx.parentsByFile.get(`${current}|${currentFile}`)
+      : undefined;
+    const nextFile = scopedParent ? currentFile : null;
+    current = scopedParent ?? chaCtx.parents.get(current);
+    currentFile = nextFile;
   }
   return [];
 }
@@ -428,21 +452,23 @@ function resolveMethodViaAncestors(
  * overriding it, `resolveMethodViaAncestors` walks up to find the declaring
  * ancestor instead of missing the edge entirely (#2237).
  *
- * When `callerFile` is provided and that file ALSO locally declares a
- * class/interface named `typeName`, the ROOT level of the BFS prefers
- * `chaCtx.implementorsByFile` over the bare (project-wide) `implementors`
- * map — disambiguating two unrelated files that each declare their own
- * same-named interface/base class (#2237; mirrors `resolveThisDispatch`'s
- * same-file preference). Only the root level is scoped this way: the
- * collision this guards against is specifically a colliding TOP-LEVEL type
- * name, and legitimate multi-file hierarchies (a shared interface's
- * implementors declared across many files, e.g. issue #2078) must keep
- * resolving through the bare map at every level below the root — a
- * same-named collision several hops down the same hierarchy is a rarer,
- * compound scenario left out of scope here (same as #2062's fix, which is
- * also a single-hop heuristic). When `typeName` has no local declaration in
- * `callerFile` (the common cross-file-dispatch case), the scoped bucket is
- * empty and this falls through to the prior, unchanged behavior.
+ * At every BFS level (not just the root), when the current node's file is
+ * known, this prefers `chaCtx.implementorsByFile` over the bare
+ * (project-wide) `implementors` map — disambiguating two unrelated files
+ * that each declare their own same-named interface/base class (#2237;
+ * mirrors `resolveThisDispatch`'s same-file preference). The starting node's
+ * file is `callerFile` (when provided); a discovered child's file is known
+ * ONLY when its parent was found via the scoped bucket — `implementorsByFile`
+ * is populated exactly when the child's own file also locally declares that
+ * parent, so the child is *guaranteed* to live in that same file. A child
+ * reached only through the bare map has an unknown file, and the walk keeps
+ * resolving through the bare map for its own children (and their eventual
+ * method resolution — see `resolveMethodViaAncestors`) exactly as before:
+ * legitimate multi-file hierarchies (a shared interface's implementors
+ * declared across many files, e.g. issue #2078) must keep working. Every
+ * scoped lookup falls back to the bare one when it finds nothing, so this is
+ * never a regression — only a precision gain when file identity happens to
+ * be known.
  */
 export function resolveChaTargets(
   typeName: string,
@@ -453,17 +479,19 @@ export function resolveChaTargets(
 ): ReadonlyArray<ResolvedCandidate> {
   const results: Array<ResolvedCandidate> = [];
 
-  const queue: string[] = [typeName];
+  const queue: Array<{ name: string; file: string | null }> = [
+    { name: typeName, file: callerFile ?? null },
+  ];
   const visited = new Set<string>();
   visited.add(typeName);
-  let isRoot = true;
 
   while (queue.length > 0) {
-    const current = queue.shift()!;
-    const scoped =
-      isRoot && callerFile ? chaCtx.implementorsByFile.get(`${current}|${callerFile}`) : undefined;
+    const { name: current, file: currentFile } = queue.shift()!;
+    const scoped = currentFile
+      ? chaCtx.implementorsByFile.get(`${current}|${currentFile}`)
+      : undefined;
     const children = scoped ?? chaCtx.implementors.get(current);
-    isRoot = false;
+    const childFile = scoped ? currentFile : null;
     if (!children?.length) continue;
 
     for (const cls of children) {
@@ -471,11 +499,11 @@ export function resolveChaTargets(
       visited.add(cls);
 
       if (chaCtx.instantiatedTypes.has(cls)) {
-        results.push(...resolveMethodViaAncestors(cls, methodName, chaCtx, lookup));
+        results.push(...resolveMethodViaAncestors(cls, childFile, methodName, chaCtx, lookup));
       }
 
       // Traverse even non-instantiated classes — they may have instantiated subclasses.
-      queue.push(cls);
+      queue.push({ name: cls, file: childFile });
     }
   }
 

--- a/src/domain/graph/builder/helpers.ts
+++ b/src/domain/graph/builder/helpers.ts
@@ -479,6 +479,7 @@ function buildImplementorMap(db: BetterSqlite3Database): {
   implementorSets: Map<string, Set<string>>;
   implementorsByFile: Map<string, string[]>;
   parents: Map<string, string>;
+  parentsByFile: Map<string, string>;
 } | null {
   const hasHierarchy = db
     .prepare(`SELECT 1 FROM edges WHERE kind IN ('extends', 'implements') LIMIT 1`)
@@ -519,6 +520,7 @@ function buildImplementorMap(db: BetterSqlite3Database): {
   const implementorSets = new Map<string, Set<string>>();
   const implementorsByFile = new Map<string, string[]>();
   const parents = new Map<string, string>();
+  const parentsByFile = new Map<string, string>();
   for (const row of hierarchyRows) {
     let set = implementorSets.get(row.parent_name);
     if (!set) {
@@ -536,15 +538,18 @@ function buildImplementorMap(db: BetterSqlite3Database): {
       }
       if (!scoped.includes(row.child_name)) scoped.push(row.child_name);
     }
-    if (row.edge_kind === 'extends' && !parents.has(row.child_name)) {
-      parents.set(row.child_name, row.parent_name);
+    if (row.edge_kind === 'extends') {
+      if (!parents.has(row.child_name)) {
+        parents.set(row.child_name, row.parent_name);
+      }
+      parentsByFile.set(`${row.child_name}|${row.child_file}`, row.parent_name);
     }
   }
   if (implementorSets.size === 0) return null;
 
   // Convert to arrays for iteration compatibility
   const implementors = new Map([...implementorSets.entries()].map(([k, v]) => [k, [...v]]));
-  return { implementors, implementorSets, implementorsByFile, parents };
+  return { implementors, implementorSets, implementorsByFile, parents, parentsByFile };
 }
 
 /**
@@ -603,26 +608,45 @@ function collectRtaInstantiated(
 
 /**
  * Resolve `${methodSuffix}` on `cls` or, if `cls` inherits it without
- * overriding, the nearest ancestor (via `parents`) that actually declares
- * it. A direct qualified lookup alone (`${cls}.${methodSuffix}`) misses
- * whenever `cls` is instantiated but doesn't override the dispatched method
- * — the method node is registered under the declaring ANCESTOR's qualified
- * name, not `cls`'s (issue #2237). Mirrors `resolveMethodViaAncestors` in
+ * overriding, the nearest ancestor (via `parents`/`parentsByFile`) that
+ * actually declares it. A direct qualified lookup alone
+ * (`${cls}.${methodSuffix}`) misses whenever `cls` is instantiated but
+ * doesn't override the dispatched method — the method node is registered
+ * under the declaring ANCESTOR's qualified name, not `cls`'s (issue #2237).
+ *
+ * `clsFile`, when known (propagated from a file-scoped BFS hop in
+ * `expandChaCall`), is used to prefer a same-file qualified-method lookup
+ * and a same-file parent-edge lookup at each step — otherwise an unrelated
+ * file's identically-named class can still leak in even after the BFS has
+ * correctly scoped which concrete class to walk from (Greptile review
+ * finding on PR #2399). Falls back to the bare/global lookup at each step
+ * when the scoped one finds nothing. Mirrors `resolveMethodViaAncestors` in
  * `cha.ts`.
  */
 function findMethodViaAncestors(
   cls: string,
+  clsFile: string | null,
   methodSuffix: string,
   parents: Map<string, string>,
+  parentsByFile: Map<string, string>,
   findMethodStmt: { all(name: string): unknown[] },
-): Array<{ id: number }> {
+): Array<{ id: number; file: string | null }> {
   let current: string | undefined = cls;
+  let currentFile = clsFile;
   const visited = new Set<string>();
   while (current && !visited.has(current)) {
     visited.add(current);
-    const found = findMethodStmt.all(`${current}.${methodSuffix}`) as Array<{ id: number }>;
+    const qualified = `${current}.${methodSuffix}`;
+    const allFound = findMethodStmt.all(qualified) as Array<{ id: number; file: string | null }>;
+    const scopedFound = currentFile ? allFound.filter((n) => n.file === currentFile) : [];
+    const found = scopedFound.length > 0 ? scopedFound : allFound;
     if (found.length > 0) return found;
-    current = parents.get(current);
+    const scopedParent: string | undefined = currentFile
+      ? parentsByFile.get(`${current}|${currentFile}`)
+      : undefined;
+    const nextFile = scopedParent ? currentFile : null;
+    current = scopedParent ?? parents.get(current);
+    currentFile = nextFile;
   }
   return [];
 }
@@ -635,12 +659,12 @@ function findMethodViaAncestors(
  * RTA filter.  New edges are appended to `newEdges`; `seen` is updated in
  * place to prevent duplicate insertions within the same pass.
  *
- * When `callerFile` is provided and that file ALSO locally declares a
- * class/interface named `typeName`, the ROOT level of the BFS prefers
- * `implementorsByFile` over the bare (project-wide) `implementors` map —
- * disambiguating two unrelated files that each declare their own same-named
- * interface/base class (#2237; mirrors `resolveChaTargets`'s identical
- * root-only scoping in `cha.ts`).
+ * At every BFS level (not just the root), when the current node's file is
+ * known, this prefers `implementorsByFile` over the bare (project-wide)
+ * `implementors` map — disambiguating two unrelated files that each declare
+ * their own same-named interface/base class (#2237; mirrors
+ * `resolveChaTargets`'s identical scoping in `cha.ts` — see that function's
+ * doc comment for the full rationale and non-regression guarantee).
  */
 function expandChaCall(
   sourceId: number,
@@ -649,6 +673,7 @@ function expandChaCall(
   implementors: Map<string, string[]>,
   implementorsByFile: Map<string, string[]>,
   parents: Map<string, string>,
+  parentsByFile: Map<string, string>,
   callerFile: string | undefined,
   instantiated: Set<string>,
   noRtaEvidence: boolean,
@@ -659,15 +684,15 @@ function expandChaCall(
   // BFS over the implementors map — handles multi-level hierarchies where
   // abstract/non-instantiated classes sit between the call-site type and
   // the concrete leaf implementations (matches runPostNativeCha, issue #1311).
-  const bfsQueue: string[] = [typeName];
+  const bfsQueue: Array<{ name: string; file: string | null }> = [
+    { name: typeName, file: callerFile ?? null },
+  ];
   const bfsVisited = new Set<string>([typeName]);
-  let isRoot = true;
   while (bfsQueue.length > 0) {
-    const current = bfsQueue.shift()!;
-    const scoped =
-      isRoot && callerFile ? implementorsByFile.get(`${current}|${callerFile}`) : undefined;
+    const { name: current, file: currentFile } = bfsQueue.shift()!;
+    const scoped = currentFile ? implementorsByFile.get(`${current}|${currentFile}`) : undefined;
     const children = scoped ?? implementors.get(current);
-    isRoot = false;
+    const childFile = scoped ? currentFile : null;
     if (!children?.length) continue;
 
     for (const cls of children) {
@@ -675,7 +700,14 @@ function expandChaCall(
       bfsVisited.add(cls);
 
       if (noRtaEvidence || instantiated.has(cls)) {
-        const methodNodes = findMethodViaAncestors(cls, methodSuffix, parents, findMethodStmt);
+        const methodNodes = findMethodViaAncestors(
+          cls,
+          childFile,
+          methodSuffix,
+          parents,
+          parentsByFile,
+          findMethodStmt,
+        );
         for (const methodNode of methodNodes) {
           if (methodNode.id === sourceId) continue; // skip self-loops
           const key = `${sourceId}|${methodNode.id}`;
@@ -699,7 +731,7 @@ function expandChaCall(
       }
 
       // Always traverse children — non-instantiated classes may have instantiated subclasses.
-      bfsQueue.push(cls);
+      bfsQueue.push({ name: cls, file: childFile });
     }
   }
 }
@@ -722,7 +754,7 @@ function expandChaCall(
 export function runChaPostPass(db: BetterSqlite3Database): number {
   const hierarchy = buildImplementorMap(db);
   if (!hierarchy) return 0;
-  const { implementors, implementorSets, implementorsByFile, parents } = hierarchy;
+  const { implementors, implementorSets, implementorsByFile, parents, parentsByFile } = hierarchy;
 
   const instantiated = collectRtaInstantiated(db, implementorSets);
   const noRtaEvidence = instantiated.size === 0;
@@ -780,7 +812,9 @@ export function runChaPostPass(db: BetterSqlite3Database): number {
   }
 
   // No LIMIT: multiple files can define the same qualified name in a monorepo.
-  const findMethodStmt = db.prepare(`SELECT id FROM nodes WHERE name = ? AND kind = 'method'`);
+  const findMethodStmt = db.prepare(
+    `SELECT id, file FROM nodes WHERE name = ? AND kind = 'method'`,
+  );
   const newEdges: Array<[number, number, string, number, number, string]> = [];
 
   for (const { source_id, caller_file, method_name } of callToMethods) {
@@ -803,6 +837,7 @@ export function runChaPostPass(db: BetterSqlite3Database): number {
       implementors,
       implementorsByFile,
       parents,
+      parentsByFile,
       caller_file,
       instantiated,
       noRtaEvidence,

--- a/src/domain/graph/builder/helpers.ts
+++ b/src/domain/graph/builder/helpers.ts
@@ -20,6 +20,7 @@ import type {
   SqliteStatement,
 } from '../../../types.js';
 import { isConstructorMethodSuffix } from '../resolver/strategy.js';
+import { RECEIVER_KINDS } from './call-resolver.js';
 
 export const BUILTIN_RECEIVERS: Set<string> = new Set([
   'console',
@@ -460,12 +461,25 @@ export function markExportedSymbols(db: BetterSqlite3Database, exportKeys: unkno
 export const CHA_DISPATCH_CONFIDENCE = 0.8;
 
 /**
- * Build the parent→children implementor map from `extends`/`implements` edges.
- * Returns null if no hierarchy edges exist.
+ * Build the parent→children implementor map from `extends`/`implements` edges,
+ * plus its file-scoped variant and the child→parent map used to walk up to a
+ * declaring ancestor. Returns null if no hierarchy edges exist.
+ *
+ * `implementorsByFile` (`${parentName}|${childFile}` → children) is
+ * populated only when `childFile` ALSO locally declares a class/interface
+ * named `parentName` — the child's heritage reference most plausibly means
+ * that co-located declaration, not an unrelated same-named one elsewhere
+ * (issue #2237). Mirrors `ChaContext.implementorsByFile` in `cha.ts` /
+ * `EdgeContext.cha_implementors_by_file` in the Rust engine — this DB-driven
+ * post-pass has its own independent implementor-map construction and must
+ * carry the identical fix.
  */
-function buildImplementorMap(
-  db: BetterSqlite3Database,
-): { implementors: Map<string, string[]>; implementorSets: Map<string, Set<string>> } | null {
+function buildImplementorMap(db: BetterSqlite3Database): {
+  implementors: Map<string, string[]>;
+  implementorSets: Map<string, Set<string>>;
+  implementorsByFile: Map<string, string[]>;
+  parents: Map<string, string>;
+} | null {
   const hasHierarchy = db
     .prepare(`SELECT 1 FROM edges WHERE kind IN ('extends', 'implements') LIMIT 1`)
     .get();
@@ -473,15 +487,38 @@ function buildImplementorMap(
 
   const hierarchyRows = db
     .prepare(
-      `SELECT src.name AS child_name, tgt.name AS parent_name
+      `SELECT src.name AS child_name, src.file AS child_file, tgt.name AS parent_name, e.kind AS edge_kind
        FROM edges e
        JOIN nodes src ON e.source_id = src.id
        JOIN nodes tgt ON e.target_id = tgt.id
        WHERE e.kind IN ('extends', 'implements')`,
     )
-    .all() as Array<{ child_name: string; parent_name: string }>;
+    .all() as Array<{
+    child_name: string;
+    child_file: string;
+    parent_name: string;
+    edge_kind: string;
+  }>;
+
+  const receiverKindsList = [...RECEIVER_KINDS];
+  const localNameRows = db
+    .prepare(
+      `SELECT file, name FROM nodes WHERE kind IN (${receiverKindsList.map(() => '?').join(',')})`,
+    )
+    .all(...receiverKindsList) as Array<{ file: string; name: string }>;
+  const localNamesByFile = new Map<string, Set<string>>();
+  for (const row of localNameRows) {
+    let names = localNamesByFile.get(row.file);
+    if (!names) {
+      names = new Set();
+      localNamesByFile.set(row.file, names);
+    }
+    names.add(row.name);
+  }
 
   const implementorSets = new Map<string, Set<string>>();
+  const implementorsByFile = new Map<string, string[]>();
+  const parents = new Map<string, string>();
   for (const row of hierarchyRows) {
     let set = implementorSets.get(row.parent_name);
     if (!set) {
@@ -489,12 +526,25 @@ function buildImplementorMap(
       implementorSets.set(row.parent_name, set);
     }
     set.add(row.child_name);
+
+    if (localNamesByFile.get(row.child_file)?.has(row.parent_name)) {
+      const key = `${row.parent_name}|${row.child_file}`;
+      let scoped = implementorsByFile.get(key);
+      if (!scoped) {
+        scoped = [];
+        implementorsByFile.set(key, scoped);
+      }
+      if (!scoped.includes(row.child_name)) scoped.push(row.child_name);
+    }
+    if (row.edge_kind === 'extends' && !parents.has(row.child_name)) {
+      parents.set(row.child_name, row.parent_name);
+    }
   }
   if (implementorSets.size === 0) return null;
 
   // Convert to arrays for iteration compatibility
   const implementors = new Map([...implementorSets.entries()].map(([k, v]) => [k, [...v]]));
-  return { implementors, implementorSets };
+  return { implementors, implementorSets, implementorsByFile, parents };
 }
 
 /**
@@ -552,18 +602,54 @@ function collectRtaInstantiated(
 }
 
 /**
+ * Resolve `${methodSuffix}` on `cls` or, if `cls` inherits it without
+ * overriding, the nearest ancestor (via `parents`) that actually declares
+ * it. A direct qualified lookup alone (`${cls}.${methodSuffix}`) misses
+ * whenever `cls` is instantiated but doesn't override the dispatched method
+ * — the method node is registered under the declaring ANCESTOR's qualified
+ * name, not `cls`'s (issue #2237). Mirrors `resolveMethodViaAncestors` in
+ * `cha.ts`.
+ */
+function findMethodViaAncestors(
+  cls: string,
+  methodSuffix: string,
+  parents: Map<string, string>,
+  findMethodStmt: { all(name: string): unknown[] },
+): Array<{ id: number }> {
+  let current: string | undefined = cls;
+  const visited = new Set<string>();
+  while (current && !visited.has(current)) {
+    visited.add(current);
+    const found = findMethodStmt.all(`${current}.${methodSuffix}`) as Array<{ id: number }>;
+    if (found.length > 0) return found;
+    current = parents.get(current);
+  }
+  return [];
+}
+
+/**
  * BFS-expand a single call-to-qualified-method into CHA dispatch edges.
  *
  * For `source_id` calling `typeName.methodSuffix`, walks the implementors
  * map (BFS) and emits an edge for each concrete override that passes the
  * RTA filter.  New edges are appended to `newEdges`; `seen` is updated in
  * place to prevent duplicate insertions within the same pass.
+ *
+ * When `callerFile` is provided and that file ALSO locally declares a
+ * class/interface named `typeName`, the ROOT level of the BFS prefers
+ * `implementorsByFile` over the bare (project-wide) `implementors` map —
+ * disambiguating two unrelated files that each declare their own same-named
+ * interface/base class (#2237; mirrors `resolveChaTargets`'s identical
+ * root-only scoping in `cha.ts`).
  */
 function expandChaCall(
   sourceId: number,
   typeName: string,
   methodSuffix: string,
   implementors: Map<string, string[]>,
+  implementorsByFile: Map<string, string[]>,
+  parents: Map<string, string>,
+  callerFile: string | undefined,
   instantiated: Set<string>,
   noRtaEvidence: boolean,
   findMethodStmt: { all(name: string): unknown[] },
@@ -575,9 +661,13 @@ function expandChaCall(
   // the concrete leaf implementations (matches runPostNativeCha, issue #1311).
   const bfsQueue: string[] = [typeName];
   const bfsVisited = new Set<string>([typeName]);
+  let isRoot = true;
   while (bfsQueue.length > 0) {
     const current = bfsQueue.shift()!;
-    const children = implementors.get(current);
+    const scoped =
+      isRoot && callerFile ? implementorsByFile.get(`${current}|${callerFile}`) : undefined;
+    const children = scoped ?? implementors.get(current);
+    isRoot = false;
     if (!children?.length) continue;
 
     for (const cls of children) {
@@ -585,8 +675,7 @@ function expandChaCall(
       bfsVisited.add(cls);
 
       if (noRtaEvidence || instantiated.has(cls)) {
-        const qualifiedName = `${cls}.${methodSuffix}`;
-        const methodNodes = findMethodStmt.all(qualifiedName) as Array<{ id: number }>;
+        const methodNodes = findMethodViaAncestors(cls, methodSuffix, parents, findMethodStmt);
         for (const methodNode of methodNodes) {
           if (methodNode.id === sourceId) continue; // skip self-loops
           const key = `${sourceId}|${methodNode.id}`;
@@ -633,7 +722,7 @@ function expandChaCall(
 export function runChaPostPass(db: BetterSqlite3Database): number {
   const hierarchy = buildImplementorMap(db);
   if (!hierarchy) return 0;
-  const { implementors, implementorSets } = hierarchy;
+  const { implementors, implementorSets, implementorsByFile, parents } = hierarchy;
 
   const instantiated = collectRtaInstantiated(db, implementorSets);
   const noRtaEvidence = instantiated.size === 0;
@@ -655,14 +744,19 @@ export function runChaPostPass(db: BetterSqlite3Database): number {
   // orchestrator's equivalent, `fetchChaCallToMethods`).
   const callToMethods = db
     .prepare(
-      `SELECT e.source_id, src.name AS caller_name, tgt.name AS method_name
+      `SELECT e.source_id, src.name AS caller_name, src.file AS caller_file, tgt.name AS method_name
        FROM edges e
        JOIN nodes tgt ON e.target_id = tgt.id
        JOIN nodes src ON e.source_id = src.id
        WHERE e.kind = 'calls' AND tgt.kind = 'method'
        AND INSTR(tgt.name, '.') > 0`,
     )
-    .all() as Array<{ source_id: number; caller_name: string; method_name: string }>;
+    .all() as Array<{
+    source_id: number;
+    caller_name: string;
+    caller_file: string;
+    method_name: string;
+  }>;
 
   // Scope deduplication to only the source_ids we are about to expand, avoiding
   // a full-table scan. CHA only inserts edges FROM callers that already call a
@@ -689,7 +783,7 @@ export function runChaPostPass(db: BetterSqlite3Database): number {
   const findMethodStmt = db.prepare(`SELECT id FROM nodes WHERE name = ? AND kind = 'method'`);
   const newEdges: Array<[number, number, string, number, number, string]> = [];
 
-  for (const { source_id, method_name } of callToMethods) {
+  for (const { source_id, caller_file, method_name } of callToMethods) {
     const dotIdx = method_name.indexOf('.');
     if (dotIdx === -1) continue;
     const typeName = method_name.slice(0, dotIdx);
@@ -707,6 +801,9 @@ export function runChaPostPass(db: BetterSqlite3Database): number {
       typeName,
       methodSuffix,
       implementors,
+      implementorsByFile,
+      parents,
+      caller_file,
       instantiated,
       noRtaEvidence,
       findMethodStmt,

--- a/src/domain/graph/builder/incremental.ts
+++ b/src/domain/graph/builder/incremental.ts
@@ -1950,7 +1950,7 @@ function emitChaDispatchForCall(
         : (typeEntry as { type?: string }).type
       : null;
     if (typeName) {
-      chaTargets = resolveChaTargets(typeName, call.name, chaCtx, lookup);
+      chaTargets = resolveChaTargets(typeName, call.name, chaCtx, lookup, relPath);
       isTypedReceiverDispatch = true;
     }
   }

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -1017,7 +1017,7 @@ function buildChaPostPass(
             : (typeEntry as { type?: string }).type
           : null;
         if (typeName) {
-          chaTargets = resolveChaTargets(typeName, call.name, chaCtx, lookup);
+          chaTargets = resolveChaTargets(typeName, call.name, chaCtx, lookup, relPath);
           isTypedReceiverDispatch = true;
         }
       }
@@ -1868,7 +1868,7 @@ function emitChaCallEdgesForCall(
         : (typeEntry as { type?: string }).type
       : null;
     if (typeName) {
-      chaTargets = resolveChaTargets(typeName, call.name, chaCtx, lookup);
+      chaTargets = resolveChaTargets(typeName, call.name, chaCtx, lookup, relPath);
       isTypedReceiverDispatch = true;
     }
   }

--- a/src/domain/graph/builder/stages/native-orchestrator.ts
+++ b/src/domain/graph/builder/stages/native-orchestrator.ts
@@ -671,6 +671,7 @@ function buildChaImplementorsMap(db: BetterSqlite3Database): {
   implementors: Map<string, string[]>;
   implementorsByFile: Map<string, string[]>;
   parents: Map<string, string>;
+  parentsByFile: Map<string, string>;
 } {
   const hierarchyRows = db
     .prepare(`
@@ -706,6 +707,7 @@ function buildChaImplementorsMap(db: BetterSqlite3Database): {
   const implementors = new Map<string, string[]>();
   const implementorsByFile = new Map<string, string[]>();
   const parents = new Map<string, string>();
+  const parentsByFile = new Map<string, string>();
   for (const row of hierarchyRows) {
     let list = implementors.get(row.parent_name);
     if (!list) {
@@ -723,11 +725,14 @@ function buildChaImplementorsMap(db: BetterSqlite3Database): {
       }
       if (!scoped.includes(row.child_name)) scoped.push(row.child_name);
     }
-    if (row.edge_kind === 'extends' && !parents.has(row.child_name)) {
-      parents.set(row.child_name, row.parent_name);
+    if (row.edge_kind === 'extends') {
+      if (!parents.has(row.child_name)) {
+        parents.set(row.child_name, row.parent_name);
+      }
+      parentsByFile.set(`${row.child_name}|${row.child_file}`, row.parent_name);
     }
   }
-  return { implementors, implementorsByFile, parents };
+  return { implementors, implementorsByFile, parents, parentsByFile };
 }
 
 /**
@@ -913,6 +918,7 @@ function expandChaEdges(
   implementors: Map<string, string[]>,
   implementorsByFile: Map<string, string[]>,
   parents: Map<string, string>,
+  parentsByFile: Map<string, string>,
   instantiated: Set<string>,
   noRtaEvidence: boolean,
 ): { newEdgeCount: number; affectedFiles: Set<string> } {
@@ -962,19 +968,24 @@ function expandChaEdges(
     // abstract/non-instantiated classes sit between the call-site type and
     // the concrete leaf implementations (issue #1311).
     //
-    // Root level prefers implementorsByFile when caller_file also locally
-    // declares typeName — disambiguates two unrelated files that each
-    // declare their own same-named interface/base class (#2237; mirrors
-    // resolveChaTargets's identical root-only scoping in cha.ts).
-    const bfsQueue: string[] = [typeName];
+    // Every BFS level (not just the root) prefers implementorsByFile when
+    // the current node's file is known — disambiguating two unrelated files
+    // that each declare their own same-named interface/base class (#2237;
+    // mirrors resolveChaTargets's identical scoping in cha.ts). A child's
+    // file is known ONLY when its parent was found via the scoped bucket —
+    // implementorsByFile is populated exactly when the child's own file also
+    // locally declares that parent, so the child is guaranteed to live
+    // there. Every scoped lookup falls back to the bare one when it finds
+    // nothing, so this is never a regression.
+    const bfsQueue: Array<{ name: string; file: string | null }> = [
+      { name: typeName, file: caller_file },
+    ];
     const bfsVisited = new Set<string>([typeName]);
-    let isRoot = true;
     while (bfsQueue.length > 0) {
-      const current = bfsQueue.shift()!;
-      const scoped =
-        isRoot && caller_file ? implementorsByFile.get(`${current}|${caller_file}`) : undefined;
+      const { name: current, file: currentFile } = bfsQueue.shift()!;
+      const scoped = currentFile ? implementorsByFile.get(`${current}|${currentFile}`) : undefined;
       const children = scoped ?? implementors.get(current);
-      isRoot = false;
+      const childFile = scoped ? currentFile : null;
       if (!children?.length) continue;
 
       for (const cls of children) {
@@ -986,20 +997,35 @@ function expandChaEdges(
           // dispatched method without overriding it (#2237) — a direct
           // qualified lookup alone misses since the method node is
           // registered under the ancestor's qualified name, not `cls`'s.
+          // `ancestorFile`, when known, prefers a same-file method lookup
+          // and a same-file parent-edge lookup at each step (Greptile review
+          // finding on PR #2399) — otherwise an unrelated file's identically
+          // -named class can still leak in even after the BFS above has
+          // correctly scoped which concrete class to walk from.
           let ancestor: string | undefined = cls;
+          let ancestorFile = childFile;
           const ancestorVisited = new Set<string>();
           let methodNodes: Array<{ id: number; method_file: string | null }> = [];
           while (ancestor && !ancestorVisited.has(ancestor)) {
             ancestorVisited.add(ancestor);
-            const found = findMethodStmt.all(`${ancestor}.${methodSuffix}`) as Array<{
+            const allFound = findMethodStmt.all(`${ancestor}.${methodSuffix}`) as Array<{
               id: number;
               method_file: string | null;
             }>;
+            const scopedFound = ancestorFile
+              ? allFound.filter((n) => n.method_file === ancestorFile)
+              : [];
+            const found = scopedFound.length > 0 ? scopedFound : allFound;
             if (found.length > 0) {
               methodNodes = found;
               break;
             }
-            ancestor = parents.get(ancestor);
+            const scopedParent: string | undefined = ancestorFile
+              ? parentsByFile.get(`${ancestor}|${ancestorFile}`)
+              : undefined;
+            const nextFile = scopedParent ? ancestorFile : null;
+            ancestor = scopedParent ?? parents.get(ancestor);
+            ancestorFile = nextFile;
           }
           for (const methodNode of methodNodes) {
             if (methodNode.id === source_id) continue; // skip self-loops
@@ -1019,7 +1045,7 @@ function expandChaEdges(
         }
 
         // Always traverse children — non-instantiated classes may have instantiated subclasses.
-        bfsQueue.push(cls);
+        bfsQueue.push({ name: cls, file: childFile });
       }
     }
   }
@@ -1079,7 +1105,7 @@ function runPostNativeCha(
     .get();
   if (!hasHierarchy) return empty;
 
-  const { implementors, implementorsByFile, parents } = buildChaImplementorsMap(db);
+  const { implementors, implementorsByFile, parents, parentsByFile } = buildChaImplementorsMap(db);
   if (implementors.size === 0) return empty;
 
   const { instantiated, noRtaEvidence } = buildChaRtaSet(db);
@@ -1092,6 +1118,7 @@ function runPostNativeCha(
     implementors,
     implementorsByFile,
     parents,
+    parentsByFile,
     instantiated,
     noRtaEvidence,
   );

--- a/src/domain/graph/builder/stages/native-orchestrator.ts
+++ b/src/domain/graph/builder/stages/native-orchestrator.ts
@@ -48,7 +48,7 @@ import {
 import { computeConfidence, getWorkspacesForNative } from '../../resolve.js';
 import { isConstructorMethodSuffix, type ResolvedCandidate } from '../../resolver/strategy.js';
 import type { CallNodeLookup } from '../call-resolver.js';
-import { resolveDefinePropertyAccessorTarget } from '../call-resolver.js';
+import { RECEIVER_KINDS, resolveDefinePropertyAccessorTarget } from '../call-resolver.js';
 import type { ChaContext } from '../cha.js';
 import { resolveThisDispatch } from '../cha.js';
 import type { PipelineContext } from '../context.js';
@@ -652,19 +652,60 @@ export async function runPostNativeAnalysis(
 
 // ── CHA post-pass helpers ────────────────────────────────────────────────────
 
-/** Build implementors map: parent/interface name → [child/implementing class names]. */
-function buildChaImplementorsMap(db: BetterSqlite3Database): Map<string, string[]> {
+/**
+ * Build implementors map: parent/interface name → [child/implementing class
+ * names], plus its file-scoped variant and the child→parent map used to walk
+ * up to a declaring ancestor.
+ *
+ * `implementorsByFile` (`${parentName}|${childFile}` → children) is
+ * populated only when `childFile` ALSO locally declares a class/interface
+ * named `parentName` — the child's heritage reference most plausibly means
+ * that co-located declaration, not an unrelated same-named one elsewhere
+ * (issue #2237). Mirrors `ChaContext.implementorsByFile` in `cha.ts` and the
+ * equivalent fix in `builder/helpers.ts`'s `buildImplementorMap` (the
+ * WASM-path twin of this function) — both are independent implementations
+ * of the same DB-driven CHA post-pass pattern and must carry the identical
+ * fix.
+ */
+function buildChaImplementorsMap(db: BetterSqlite3Database): {
+  implementors: Map<string, string[]>;
+  implementorsByFile: Map<string, string[]>;
+  parents: Map<string, string>;
+} {
   const hierarchyRows = db
     .prepare(`
-      SELECT src.name AS child_name, tgt.name AS parent_name
+      SELECT src.name AS child_name, src.file AS child_file, tgt.name AS parent_name, e.kind AS edge_kind
       FROM edges e
       JOIN nodes src ON e.source_id = src.id
       JOIN nodes tgt ON e.target_id = tgt.id
       WHERE e.kind IN ('extends', 'implements')
     `)
-    .all() as Array<{ child_name: string; parent_name: string }>;
+    .all() as Array<{
+    child_name: string;
+    child_file: string;
+    parent_name: string;
+    edge_kind: string;
+  }>;
+
+  const receiverKindsList = [...RECEIVER_KINDS];
+  const localNameRows = db
+    .prepare(
+      `SELECT file, name FROM nodes WHERE kind IN (${receiverKindsList.map(() => '?').join(',')})`,
+    )
+    .all(...receiverKindsList) as Array<{ file: string; name: string }>;
+  const localNamesByFile = new Map<string, Set<string>>();
+  for (const row of localNameRows) {
+    let names = localNamesByFile.get(row.file);
+    if (!names) {
+      names = new Set();
+      localNamesByFile.set(row.file, names);
+    }
+    names.add(row.name);
+  }
 
   const implementors = new Map<string, string[]>();
+  const implementorsByFile = new Map<string, string[]>();
+  const parents = new Map<string, string>();
   for (const row of hierarchyRows) {
     let list = implementors.get(row.parent_name);
     if (!list) {
@@ -672,8 +713,21 @@ function buildChaImplementorsMap(db: BetterSqlite3Database): Map<string, string[
       implementors.set(row.parent_name, list);
     }
     if (!list.includes(row.child_name)) list.push(row.child_name);
+
+    if (localNamesByFile.get(row.child_file)?.has(row.parent_name)) {
+      const key = `${row.parent_name}|${row.child_file}`;
+      let scoped = implementorsByFile.get(key);
+      if (!scoped) {
+        scoped = [];
+        implementorsByFile.set(key, scoped);
+      }
+      if (!scoped.includes(row.child_name)) scoped.push(row.child_name);
+    }
+    if (row.edge_kind === 'extends' && !parents.has(row.child_name)) {
+      parents.set(row.child_name, row.parent_name);
+    }
   }
-  return implementors;
+  return { implementors, implementorsByFile, parents };
 }
 
 /**
@@ -857,6 +911,8 @@ function expandChaEdges(
   db: BetterSqlite3Database,
   callToMethods: ChaCallRow[],
   implementors: Map<string, string[]>,
+  implementorsByFile: Map<string, string[]>,
+  parents: Map<string, string>,
   instantiated: Set<string>,
   noRtaEvidence: boolean,
 ): { newEdgeCount: number; affectedFiles: Set<string> } {
@@ -905,11 +961,20 @@ function expandChaEdges(
     // BFS over the implementors map — handles multi-level hierarchies where
     // abstract/non-instantiated classes sit between the call-site type and
     // the concrete leaf implementations (issue #1311).
+    //
+    // Root level prefers implementorsByFile when caller_file also locally
+    // declares typeName — disambiguates two unrelated files that each
+    // declare their own same-named interface/base class (#2237; mirrors
+    // resolveChaTargets's identical root-only scoping in cha.ts).
     const bfsQueue: string[] = [typeName];
     const bfsVisited = new Set<string>([typeName]);
+    let isRoot = true;
     while (bfsQueue.length > 0) {
       const current = bfsQueue.shift()!;
-      const children = implementors.get(current);
+      const scoped =
+        isRoot && caller_file ? implementorsByFile.get(`${current}|${caller_file}`) : undefined;
+      const children = scoped ?? implementors.get(current);
+      isRoot = false;
       if (!children?.length) continue;
 
       for (const cls of children) {
@@ -917,11 +982,25 @@ function expandChaEdges(
         bfsVisited.add(cls);
 
         if (noRtaEvidence || instantiated.has(cls)) {
-          const qualifiedName = `${cls}.${methodSuffix}`;
-          const methodNodes = findMethodStmt.all(qualifiedName) as Array<{
-            id: number;
-            method_file: string | null;
-          }>;
+          // Walk up to the declaring ancestor when `cls` inherits the
+          // dispatched method without overriding it (#2237) — a direct
+          // qualified lookup alone misses since the method node is
+          // registered under the ancestor's qualified name, not `cls`'s.
+          let ancestor: string | undefined = cls;
+          const ancestorVisited = new Set<string>();
+          let methodNodes: Array<{ id: number; method_file: string | null }> = [];
+          while (ancestor && !ancestorVisited.has(ancestor)) {
+            ancestorVisited.add(ancestor);
+            const found = findMethodStmt.all(`${ancestor}.${methodSuffix}`) as Array<{
+              id: number;
+              method_file: string | null;
+            }>;
+            if (found.length > 0) {
+              methodNodes = found;
+              break;
+            }
+            ancestor = parents.get(ancestor);
+          }
           for (const methodNode of methodNodes) {
             if (methodNode.id === source_id) continue; // skip self-loops
             const key = `${source_id}|${methodNode.id}`;
@@ -1000,14 +1079,22 @@ function runPostNativeCha(
     .get();
   if (!hasHierarchy) return empty;
 
-  const implementors = buildChaImplementorsMap(db);
+  const { implementors, implementorsByFile, parents } = buildChaImplementorsMap(db);
   if (implementors.size === 0) return empty;
 
   const { instantiated, noRtaEvidence } = buildChaRtaSet(db);
   const scopeToChangedFiles = computeChaScope(db, changedFiles);
   const callToMethods = fetchChaCallToMethods(db, changedFiles, scopeToChangedFiles);
 
-  return expandChaEdges(db, callToMethods, implementors, instantiated, noRtaEvidence);
+  return expandChaEdges(
+    db,
+    callToMethods,
+    implementors,
+    implementorsByFile,
+    parents,
+    instantiated,
+    noRtaEvidence,
+  );
 }
 
 // Extensions covered by the JS/TS extractor — the only extractor that
@@ -1338,6 +1425,7 @@ async function runPostNativeThisDispatch(
 
   const chaCtx: ChaContext = {
     implementors: new Map(), // not needed for this/super resolution
+    implementorsByFile: new Map(), // not needed for this/super resolution
     parents,
     parentsByFile,
     instantiatedTypes: new Set(), // not needed for this/super resolution

--- a/tests/integration/issue-2237-cha-implementor-scoping.test.ts
+++ b/tests/integration/issue-2237-cha-implementor-scoping.test.ts
@@ -72,6 +72,67 @@ export function makeConcrete(): IHandler {
   return new ConcreteHandler();
 }
 `,
+  // Greptile review finding on PR #2399: mod3 and mod4 each independently
+  // declare their own SAME-named "Recv" interface AND their own same-named
+  // "RecvA" class implementing it, each with its own "process" method.
+  // Scoping the BFS root to mod3 must also carry that file identity into
+  // the qualified-method lookup — otherwise a bare lookup for "RecvA.process"
+  // returns both files' methods.
+  'mod3/samename.ts': `
+export interface Recv {
+  process(): void;
+}
+export class RecvA implements Recv {
+  process() {}
+}
+export function handleSame(r: Recv) {
+  r.process();
+}
+export function makeRecvA(): Recv {
+  return new RecvA();
+}
+`,
+  'mod4/samename-other.ts': `
+export interface Recv {
+  process(): void;
+}
+export class RecvA implements Recv {
+  process() {}
+}
+export function makeOtherRecvA(): Recv {
+  return new RecvA();
+}
+`,
+  // Greptile review finding on PR #2399: mod6 declares its own UNRELATED
+  // "AncestorTarget" extending "OtherAncestor" (with its own "go" method) —
+  // an entirely different hierarchy from mod5's, which merely happens to
+  // share the concrete class's bare name. mod5's own ancestor walk for its
+  // "AncestorTarget" (extending RealAncestor, implementing IAncestor) must
+  // not cross into mod6's unrelated OtherAncestor.go.
+  'mod5/ancestor.ts': `
+export interface IAncestor {
+  go(): void;
+}
+export class RealAncestor implements IAncestor {
+  go() {}
+}
+export class AncestorTarget extends RealAncestor {}
+export function dispatchAncestor(a: IAncestor) {
+  a.go();
+}
+export function makeAncestorTarget(): IAncestor {
+  return new AncestorTarget();
+}
+`,
+  'mod6/ancestor-other.ts': `
+export class OtherAncestor {
+  go() {}
+}
+export class AncestorTarget extends OtherAncestor {}
+export function makeOtherAncestorTarget(): OtherAncestor {
+  return new AncestorTarget();
+}
+`,
 };
 
 function writeFixture(rootDir: string) {
@@ -131,6 +192,28 @@ function runSuite(engine: 'wasm' | 'native') {
         edges.some((e) => e.src === 'dispatch' && e.tgt === 'AbstractHandler.run'),
         `Expected dispatch -> AbstractHandler.run; got: ${JSON.stringify(edges)}`,
       ).toBe(true);
+    });
+
+    it('preserves file identity through the method lookup for two files sharing the same implementor class name (Greptile finding on PR #2399)', () => {
+      const dbPath = path.join(tmpDir, '.codegraph', 'graph.db');
+      const edges = getCallEdges(dbPath);
+      const ownEdges = edges.filter((e) => e.src === 'handleSame' && e.tgt === 'RecvA.process');
+      expect(
+        ownEdges.length,
+        `Expected exactly one handleSame -> RecvA.process edge (its own file's); got: ${JSON.stringify(edges)}`,
+      ).toBe(1);
+    });
+
+    it('preserves file identity through the ancestor walk for two files sharing the same concrete class name (Greptile finding on PR #2399)', () => {
+      const dbPath = path.join(tmpDir, '.codegraph', 'graph.db');
+      const edges = getCallEdges(dbPath);
+      expect(
+        edges.some((e) => e.src === 'dispatchAncestor' && e.tgt === 'RealAncestor.go'),
+        `Expected dispatchAncestor -> RealAncestor.go; got: ${JSON.stringify(edges)}`,
+      ).toBe(true);
+      expect(edges.some((e) => e.src === 'dispatchAncestor' && e.tgt === 'OtherAncestor.go')).toBe(
+        false,
+      );
     });
   });
 }

--- a/tests/integration/issue-2237-cha-implementor-scoping.test.ts
+++ b/tests/integration/issue-2237-cha-implementor-scoping.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Integration test for #2237: CHA (Class Hierarchy Analysis) dispatch had
+ * two bugs, present identically in both engines:
+ *
+ * 1. The implementors map (interface/base-class name → concrete classes)
+ *    was keyed by bare simple name, scanning every file in the build with no
+ *    file/module scoping. Two unrelated files each declaring their own
+ *    same-named interface would have their implementor sets merged,
+ *    producing a false call edge into the wrong file's method.
+ *
+ * 2. CHA dispatch did a direct qualified lookup (`${concreteClass}.${method}`)
+ *    for every RTA-instantiated concrete class — when that class INHERITS
+ *    the dispatched method from an ancestor without overriding it, no node
+ *    exists under the concrete class's own qualified name, so the lookup
+ *    missed and the edge was never emitted.
+ *
+ * Fix: `ChaContext` gained `implementorsByFile` (a `${parentName}|${file}`
+ * scoped map, populated only when the child's own file also locally
+ * declares a same-named parent) which `resolveChaTargets`/
+ * `resolve_cha_dispatch` prefer at the BFS root when the caller's file has a
+ * matching local declaration; and a `resolveMethodViaAncestors`/
+ * `resolve_method_via_ancestors` walk that follows `parents` up to the
+ * declaring ancestor when a direct qualified lookup misses.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+import { isNativeAvailable } from '../../src/infrastructure/native.js';
+
+const FIXTURE = {
+  'mod1/caller.ts': `
+export interface Handler {
+  run(): void;
+}
+export class HandlerA implements Handler {
+  run() {}
+}
+export function main(h: Handler) {
+  h.run();
+}
+export function makeHandlerA(): Handler {
+  return new HandlerA();
+}
+`,
+  'mod2/other.ts': `
+export interface Handler {
+  run(): void;
+}
+export class HandlerB implements Handler {
+  run() {}
+}
+export function makeHandlerB(): Handler {
+  return new HandlerB();
+}
+`,
+  'inherited.ts': `
+export interface IHandler {
+  run(): void;
+}
+export abstract class AbstractHandler implements IHandler {
+  run() {}
+}
+export class ConcreteHandler extends AbstractHandler {}
+export function dispatch(h: IHandler) {
+  h.run();
+}
+export function makeConcrete(): IHandler {
+  return new ConcreteHandler();
+}
+`,
+};
+
+function writeFixture(rootDir: string) {
+  for (const [rel, content] of Object.entries(FIXTURE)) {
+    const abs = path.join(rootDir, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, content);
+  }
+}
+
+function getCallEdges(dbPath: string) {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return db
+      .prepare(
+        `SELECT n1.name AS src, n2.name AS tgt, e.technique AS technique
+         FROM edges e
+         JOIN nodes n1 ON e.source_id = n1.id
+         JOIN nodes n2 ON e.target_id = n2.id
+         WHERE e.kind = 'calls'
+         ORDER BY n1.name, n2.name`,
+      )
+      .all() as Array<{ src: string; tgt: string; technique: string | null }>;
+  } finally {
+    db.close();
+  }
+}
+
+function runSuite(engine: 'wasm' | 'native') {
+  describe(`CHA implementor scoping + inherited-method walk (#2237) — ${engine}`, () => {
+    let tmpDir: string;
+
+    beforeAll(async () => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2237-${engine}-`));
+      writeFixture(tmpDir);
+      await buildGraph(tmpDir, { engine, incremental: false, skipRegistry: true });
+    }, 60_000);
+
+    afterAll(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('resolves main.h.run() to HandlerA.run only, not the unrelated HandlerB.run', () => {
+      const dbPath = path.join(tmpDir, '.codegraph', 'graph.db');
+      const edges = getCallEdges(dbPath);
+      expect(
+        edges.some((e) => e.src === 'main' && e.tgt === 'HandlerA.run'),
+        `Expected main -> HandlerA.run; got: ${JSON.stringify(edges)}`,
+      ).toBe(true);
+      expect(edges.some((e) => e.src === 'main' && e.tgt === 'HandlerB.run')).toBe(false);
+    });
+
+    it('resolves dispatch.h.run() to AbstractHandler.run via the inherited-method walk', () => {
+      const dbPath = path.join(tmpDir, '.codegraph', 'graph.db');
+      const edges = getCallEdges(dbPath);
+      expect(
+        edges.some((e) => e.src === 'dispatch' && e.tgt === 'AbstractHandler.run'),
+        `Expected dispatch -> AbstractHandler.run; got: ${JSON.stringify(edges)}`,
+      ).toBe(true);
+    });
+  });
+}
+
+runSuite('wasm');
+
+describe.skipIf(!isNativeAvailable())('native engine parity', () => {
+  runSuite('native');
+});

--- a/tests/unit/cha.test.ts
+++ b/tests/unit/cha.test.ts
@@ -61,13 +61,14 @@ function makeChaTargetsCtx(opts: {
   implementors?: Record<string, string[]>;
   implementorsByFile?: Record<string, string[]>;
   parents?: Record<string, string>;
+  parentsByFile?: Record<string, string>;
   instantiatedTypes?: string[];
 }): ChaContext {
   return {
     implementors: new Map(Object.entries(opts.implementors ?? {})),
     implementorsByFile: new Map(Object.entries(opts.implementorsByFile ?? {})),
     parents: new Map(Object.entries(opts.parents ?? {})),
-    parentsByFile: new Map(),
+    parentsByFile: new Map(Object.entries(opts.parentsByFile ?? {})),
     instantiatedTypes: new Set(opts.instantiatedTypes ?? []),
   };
 }
@@ -232,9 +233,10 @@ describe('resolveChaTargets — cross-file same-name collision (issue #2237, par
     expect(result).toEqual([{ id: 1, file: 'file1.ts', kind: 'method', line: 1 }]);
   });
 
-  it('only scopes the root level — deeper BFS hops still use the bare map', () => {
-    // Handler is ambiguous (two files), but AbstractHandler (one hop down)
-    // is not — its own children must still resolve via the bare map so a
+  it('falls back to the bare map for a deeper hop with no scoped entry of its own', () => {
+    // Handler is ambiguous (two files) and scoped at the root, but
+    // AbstractHandler (one hop down) has no implementorsByFile entry of its
+    // own — its children must still resolve via the bare map so a
     // legitimate multi-file transitive hierarchy below the disambiguated
     // root keeps working.
     const lookup = makeLookup({
@@ -251,6 +253,57 @@ describe('resolveChaTargets — cross-file same-name collision (issue #2237, par
 
     const result = resolveChaTargets('Handler', 'run', chaCtx, lookup, 'file1.ts');
     expect(result).toEqual([{ id: 1, file: 'concrete.ts', kind: 'method', line: 1 }]);
+  });
+
+  it('preserves file identity through the method lookup when two files declare the same implementor class name (Greptile finding on PR #2399)', () => {
+    // Both file1.ts and file2.ts independently declare their own HandlerA
+    // implementing their own (unrelated) Handler interface, each with its
+    // own `run` method. Scoping the root to file1.ts must also carry that
+    // file identity into the qualified-method lookup — otherwise
+    // lookup.byName('HandlerA.run') returns both files' methods.
+    const lookup = makeLookup(
+      {
+        'HandlerA.run': [
+          { id: 1, file: 'file1.ts', kind: 'method', line: 1 },
+          { id: 2, file: 'file2.ts', kind: 'method', line: 2 },
+        ],
+      },
+      {
+        'HandlerA.run': {
+          'file1.ts': [{ id: 1, file: 'file1.ts', kind: 'method', line: 1 }],
+        },
+      },
+    );
+    const chaCtx = makeChaTargetsCtx({
+      implementors: { Handler: ['HandlerA'] },
+      implementorsByFile: { 'Handler|file1.ts': ['HandlerA'] },
+      instantiatedTypes: ['HandlerA'],
+    });
+
+    const result = resolveChaTargets('Handler', 'run', chaCtx, lookup, 'file1.ts');
+    expect(result).toEqual([{ id: 1, file: 'file1.ts', kind: 'method', line: 1 }]);
+  });
+
+  it('preserves file identity through the ancestor walk when two files declare the same class with different parents (Greptile finding on PR #2399)', () => {
+    // file1.ts's ConcreteHandler extends RealBase; an unrelated file2.ts also
+    // declares its own ConcreteHandler extending a different OtherBase. The
+    // bare parents map is first-write-wins and here (deliberately) points
+    // the wrong way, as if file2's edge were recorded first project-wide —
+    // the file-scoped parentsByFile entry for file1 must still win.
+    const lookup = makeLookup({
+      'RealBase.run': [{ id: 1, file: 'file1.ts', kind: 'method', line: 1 }],
+      'OtherBase.run': [{ id: 2, file: 'file2.ts', kind: 'method', line: 2 }],
+    });
+    const chaCtx = makeChaTargetsCtx({
+      implementors: { Handler: ['ConcreteHandler'] },
+      implementorsByFile: { 'Handler|file1.ts': ['ConcreteHandler'] },
+      parents: { ConcreteHandler: 'OtherBase' },
+      parentsByFile: { 'ConcreteHandler|file1.ts': 'RealBase' },
+      instantiatedTypes: ['ConcreteHandler'],
+    });
+
+    const result = resolveChaTargets('Handler', 'run', chaCtx, lookup, 'file1.ts');
+    expect(result).toEqual([{ id: 1, file: 'file1.ts', kind: 'method', line: 1 }]);
   });
 });
 

--- a/tests/unit/cha.test.ts
+++ b/tests/unit/cha.test.ts
@@ -10,7 +10,11 @@
  */
 import { describe, expect, it } from 'vitest';
 import type { CallNodeLookup } from '../../src/domain/graph/builder/call-resolver.js';
-import { type ChaContext, resolveThisDispatch } from '../../src/domain/graph/builder/cha.js';
+import {
+  type ChaContext,
+  resolveChaTargets,
+  resolveThisDispatch,
+} from '../../src/domain/graph/builder/cha.js';
 
 type Candidate = { id: number; file: string; kind: string; line: number };
 
@@ -45,9 +49,26 @@ function makeChaCtx(
 ): ChaContext {
   return {
     implementors: new Map(),
+    implementorsByFile: new Map(),
     parents: new Map(Object.entries(parents)),
     parentsByFile: new Map(Object.entries(parentsByFile)),
     instantiatedTypes: new Set(),
+  };
+}
+
+/** Build a ChaContext for resolveChaTargets tests (implementors-focused). */
+function makeChaTargetsCtx(opts: {
+  implementors?: Record<string, string[]>;
+  implementorsByFile?: Record<string, string[]>;
+  parents?: Record<string, string>;
+  instantiatedTypes?: string[];
+}): ChaContext {
+  return {
+    implementors: new Map(Object.entries(opts.implementors ?? {})),
+    implementorsByFile: new Map(Object.entries(opts.implementorsByFile ?? {})),
+    parents: new Map(Object.entries(opts.parents ?? {})),
+    parentsByFile: new Map(),
+    instantiatedTypes: new Set(opts.instantiatedTypes ?? []),
   };
 }
 
@@ -155,5 +176,139 @@ describe('resolveThisDispatch — cross-file name collision (issue #2062)', () =
     const lookup = makeLookup({});
     const chaCtx = makeChaCtx({});
     expect(resolveThisDispatch('bar', 'plainFunction', 'this', chaCtx, lookup, 'x.ts')).toEqual([]);
+  });
+});
+
+describe('resolveChaTargets — cross-file same-name collision (issue #2237, part 1)', () => {
+  it('does not merge two unrelated same-named interfaces declared in different files', () => {
+    // file1.ts declares its own Handler + HandlerA implements Handler.
+    // file2.ts independently declares an UNRELATED Handler + HandlerB implements Handler.
+    // Dispatching from a caller in file1.ts must reach only HandlerA, never HandlerB.
+    const lookup = makeLookup({
+      'HandlerA.run': [{ id: 1, file: 'file1.ts', kind: 'method', line: 1 }],
+      'HandlerB.run': [{ id: 2, file: 'file2.ts', kind: 'method', line: 2 }],
+    });
+    const chaCtx = makeChaTargetsCtx({
+      implementors: { Handler: ['HandlerA', 'HandlerB'] },
+      implementorsByFile: { 'Handler|file1.ts': ['HandlerA'] },
+      instantiatedTypes: ['HandlerA', 'HandlerB'],
+    });
+
+    const result = resolveChaTargets('Handler', 'run', chaCtx, lookup, 'file1.ts');
+    expect(result).toEqual([{ id: 1, file: 'file1.ts', kind: 'method', line: 1 }]);
+  });
+
+  it('falls back to the bare implementors map when the caller file has no local declaration', () => {
+    // Legitimate cross-file dispatch (issue #2078): the caller's file never
+    // declares IWorker locally at all, so there is no scoped bucket to
+    // prefer — all implementors declared anywhere must still be reachable.
+    const lookup = makeLookup({
+      'ConcreteWorker.doWork': [{ id: 1, file: 'concrete.ts', kind: 'method', line: 1 }],
+      'MockWorker.doWork': [{ id: 2, file: 'mock.ts', kind: 'method', line: 2 }],
+    });
+    const chaCtx = makeChaTargetsCtx({
+      implementors: { IWorker: ['ConcreteWorker', 'MockWorker'] },
+      instantiatedTypes: ['ConcreteWorker', 'MockWorker'],
+    });
+
+    const result = resolveChaTargets('IWorker', 'doWork', chaCtx, lookup, 'dispatcher.ts');
+    expect(result).toEqual([
+      { id: 1, file: 'concrete.ts', kind: 'method', line: 1 },
+      { id: 2, file: 'mock.ts', kind: 'method', line: 2 },
+    ]);
+  });
+
+  it('falls back to the bare implementors map when callerFile is not provided', () => {
+    const lookup = makeLookup({
+      'HandlerA.run': [{ id: 1, file: 'file1.ts', kind: 'method', line: 1 }],
+    });
+    const chaCtx = makeChaTargetsCtx({
+      implementors: { Handler: ['HandlerA'] },
+      implementorsByFile: { 'Handler|file1.ts': ['HandlerA'] },
+      instantiatedTypes: ['HandlerA'],
+    });
+
+    const result = resolveChaTargets('Handler', 'run', chaCtx, lookup);
+    expect(result).toEqual([{ id: 1, file: 'file1.ts', kind: 'method', line: 1 }]);
+  });
+
+  it('only scopes the root level — deeper BFS hops still use the bare map', () => {
+    // Handler is ambiguous (two files), but AbstractHandler (one hop down)
+    // is not — its own children must still resolve via the bare map so a
+    // legitimate multi-file transitive hierarchy below the disambiguated
+    // root keeps working.
+    const lookup = makeLookup({
+      'ConcreteHandler.run': [{ id: 1, file: 'concrete.ts', kind: 'method', line: 1 }],
+    });
+    const chaCtx = makeChaTargetsCtx({
+      implementors: {
+        Handler: ['AbstractHandler'],
+        AbstractHandler: ['ConcreteHandler'],
+      },
+      implementorsByFile: { 'Handler|file1.ts': ['AbstractHandler'] },
+      instantiatedTypes: ['ConcreteHandler'],
+    });
+
+    const result = resolveChaTargets('Handler', 'run', chaCtx, lookup, 'file1.ts');
+    expect(result).toEqual([{ id: 1, file: 'concrete.ts', kind: 'method', line: 1 }]);
+  });
+});
+
+describe('resolveChaTargets — inherited (non-overriding) method walk (issue #2237, part 2)', () => {
+  it('walks up to the declaring ancestor when the instantiated class inherits without overriding', () => {
+    // ConcreteHandler is instantiated and implements Handler transitively via
+    // AbstractHandler, but never defines its own `run` — only AbstractHandler
+    // does. A direct qualified lookup on ConcreteHandler.run must fall
+    // through to AbstractHandler.run instead of missing the edge entirely.
+    const lookup = makeLookup({
+      'AbstractHandler.run': [{ id: 1, file: 'abstract.ts', kind: 'method', line: 1 }],
+    });
+    const chaCtx = makeChaTargetsCtx({
+      implementors: { Handler: ['ConcreteHandler'] },
+      parents: { ConcreteHandler: 'AbstractHandler' },
+      instantiatedTypes: ['ConcreteHandler'],
+    });
+
+    const result = resolveChaTargets('Handler', 'run', chaCtx, lookup);
+    expect(result).toEqual([{ id: 1, file: 'abstract.ts', kind: 'method', line: 1 }]);
+  });
+
+  it('prefers the concrete class own override over an ancestor default when both exist', () => {
+    const lookup = makeLookup({
+      'ConcreteHandler.run': [{ id: 1, file: 'concrete.ts', kind: 'method', line: 1 }],
+      'AbstractHandler.run': [{ id: 2, file: 'abstract.ts', kind: 'method', line: 2 }],
+    });
+    const chaCtx = makeChaTargetsCtx({
+      implementors: { Handler: ['ConcreteHandler'] },
+      parents: { ConcreteHandler: 'AbstractHandler' },
+      instantiatedTypes: ['ConcreteHandler'],
+    });
+
+    const result = resolveChaTargets('Handler', 'run', chaCtx, lookup);
+    expect(result).toEqual([{ id: 1, file: 'concrete.ts', kind: 'method', line: 1 }]);
+  });
+
+  it('returns [] when neither the class nor any ancestor declares the method', () => {
+    const lookup = makeLookup({});
+    const chaCtx = makeChaTargetsCtx({
+      implementors: { Handler: ['ConcreteHandler'] },
+      parents: { ConcreteHandler: 'AbstractHandler' },
+      instantiatedTypes: ['ConcreteHandler'],
+    });
+
+    const result = resolveChaTargets('Handler', 'run', chaCtx, lookup);
+    expect(result).toEqual([]);
+  });
+
+  it('does not infinite-loop on a cyclic parents chain', () => {
+    const lookup = makeLookup({});
+    const chaCtx = makeChaTargetsCtx({
+      implementors: { Handler: ['A'] },
+      parents: { A: 'B', B: 'A' },
+      instantiatedTypes: ['A'],
+    });
+
+    const result = resolveChaTargets('Handler', 'run', chaCtx, lookup);
+    expect(result).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Two bugs in Class Hierarchy Analysis (CHA) dispatch (issue #2237), present identically in both engines and across all four independent implementations of the same implementors-map + BFS pattern found while researching the fix:

- **WASM inline** (`emitChaCallEdgesForCall`, `buildChaPostPass` in `stages/build-edges.ts`)
- **WASM/JS-orchestrated-native DB-driven post-pass** (`runChaPostPass` in `helpers.ts`)
- **Native orchestrator DB-driven post-pass** (`runPostNativeCha` in `stages/native-orchestrator.ts`)
- **Rust native additive dispatch + fallback tier** (`emit_cha_dispatch_edges`, `resolve_call_targets_core` tier 3.7 in `build_edges.rs`)

**Issue 1 — implementor-map collision:** the implementors map (interface/base-class name → concrete classes) was keyed by bare simple name, scanning every file with no file/module scoping. Two unrelated files each declaring their own same-named interface had their implementor sets merged, producing a false call edge into the wrong file's method.

**Issue 2 — missed inherited methods:** CHA dispatch did a direct qualified lookup (`${concreteClass}.${method}`) for every RTA-instantiated concrete class. When that class inherits the dispatched method from an ancestor without overriding it, no node exists under the concrete class's own qualified name, so the lookup missed and the edge was never emitted.

## Fix

- Added a file-scoped implementors map (`${parentName}|${file}`, populated only when that file also locally declares a same-named parent) that the BFS root prefers over the bare map — mirrors the existing `parentsByFile` composite-key precedent from #2062, applied to the inverse (parent → children) direction.
- Added an ancestor-walk fallback that follows the class hierarchy up to the declaring ancestor when a direct qualified lookup misses — mirrors `resolveThisDispatch`'s existing walk.
- Mirrored identically across all four implementation sites in both engines.
- A subtlety caught only by the end-to-end integration test: "locally declared names" must be derived from each file's full **definitions** list (filtered to class/interface/struct/etc. kinds), not the **classes-relations** list (`ClassRelation[]`/`ClassInfo[]`) — a bare interface with no `extends`/`implements` clause of its own never appears in the relations list, so the very shape this fix targets (`interface Handler {}` with a concrete implementor) was invisible to the first version of the file-scoping check.

## Test plan

- [x] New unit tests in `tests/unit/cha.test.ts` (8 cases: 2 bug-specific + 6 preserved-behavior/regression) — verified fail-without-fix, pass-with-fix.
- [x] New dual-engine integration test `tests/integration/issue-2237-cha-implementor-scoping.test.ts` (4 cases, wasm + native) — verified all 4 fail without the fix on both engines, pass with it.
- [x] New Rust unit tests in `crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs` (2 cases) — verified fail-without-fix, pass-with-fix.
- [x] Existing CHA regression suites unaffected: `tests/unit/cha.test.ts` (pre-existing #2062 cases), `tests/integration/phase-8.5-cha-dispatch.test.ts`, `tests/integration/issue-2078-cha-sibling-caller.test.ts` (legitimate cross-file dispatch through a shared interface name, which this fix must not break).
- [x] Full suite: `npm test` (4788 passed), `npx tsc --noEmit`, `npm run lint`, `cargo test --release` (867 passed), `cargo clippy` (no new warnings).
- [x] `node scripts/parity-compare.mjs --langs javascript,typescript` — parity OK.