### PR TITLE
fix(cha): super() dispatch treats a same-named local function as a collision

### DIFF
--- a/src/domain/graph/builder/call-resolver.ts
+++ b/src/domain/graph/builder/call-resolver.ts
@@ -35,6 +35,17 @@ export interface CallNodeLookup {
    */
   resolveBarrel(barrelFile: string, symbolName: string): { file: string; name: string } | null;
   nodeId(name: string, kind: string, file: string, line: number): { id: number } | undefined;
+  /**
+   * True when `file` declares a function/method-kind node, other than
+   * `excludeId`, whose line span encloses `line` — i.e. the node at
+   * `excludeId` is nested inside another callable rather than declared at
+   * module/class scope. Used by `resolveThisDispatch` (cha.ts) to tell a
+   * genuine heritage-capable function declaration (#2238) apart from an
+   * unrelated nested function that merely shares a base class's bare name
+   * (Greptile finding on PR #2400) — a nested function can never legitimately
+   * be an `extends`/prototype heritage target.
+   */
+  hasEnclosingCallable(file: string, line: number, excludeId: number): boolean;
 }
 
 export const RECEIVER_KINDS = new Set(['class', 'struct', 'interface', 'type', 'module']);

--- a/src/domain/graph/builder/cha.ts
+++ b/src/domain/graph/builder/cha.ts
@@ -354,23 +354,28 @@ export function resolveThisDispatch(
         // name, so `current` may be an unrelated class that merely shares a
         // name with the caller's real ancestor (issue #2062) — e.g. two
         // independent files each defining their own `Shape` class. Before
-        // accepting a cross-file match, check whether ANYTHING named
-        // `current` is ALSO declared in the caller's own file: if so, that
-        // same-file declaration IS the caller's real ancestor reference at
-        // this step, so a same-named method from a different file is a false
-        // match, not a legitimate inherited method. Keep walking instead of
-        // accepting it. This deliberately checks ANY kind, not just
-        // RECEIVER_KINDS (class/struct/interface/etc.) — `current` can also
-        // be a plain constructor FUNCTION (`function A() {}`) that a `class D
-        // extends A` legitimately targets (functions have no `.constructor`
-        // method to find, by definition), and that case is just as
-        // disqualifying as a same-named class would be (issue #2238; a
-        // same-named plain function was wrongly treated as "not declared
-        // here" and fell through to an unrelated file's same-named class).
-        // Only accept the cross-file match when `current` is NOT declared
-        // anywhere in the caller's own file — a genuine cross-file heritage
-        // reference (e.g. `import { Base } from './base'; class Foo extends Base`).
-        const sameNameInCallerFile = lookup.byNameAndFile(current, callerFile).length > 0;
+        // accepting a cross-file match, check whether a HERITAGE-CAPABLE
+        // declaration named `current` is ALSO declared in the caller's own
+        // file: if so, that same-file declaration IS the caller's real
+        // ancestor reference at this step, so a same-named method from a
+        // different file is a false match, not a legitimate inherited
+        // method. Keep walking instead of accepting it.
+        //
+        // "Heritage-capable" is RECEIVER_KINDS (class/struct/interface/etc.)
+        // *plus* `function` — a plain constructor FUNCTION (`function A()
+        // {}`) is exactly as legitimate an `extends`/`super()` target as a
+        // class is (functions have no `.constructor` method to find, by
+        // definition), and is just as disqualifying as a same-named class
+        // would be (issue #2238; a same-named plain function was wrongly
+        // treated as "not declared here" and fell through to an unrelated
+        // file's same-named class). It must NOT be widened further than
+        // that: an unrelated same-named local variable/parameter/nested
+        // helper has nothing to do with the class hierarchy and must not
+        // block a genuine cross-file heritage reference from resolving
+        // (Greptile review finding on PR #2400).
+        const sameNameInCallerFile = lookup
+          .byNameAndFile(current, callerFile)
+          .some((n) => RECEIVER_KINDS.has(n.kind ?? '') || n.kind === 'function');
         if (!sameNameInCallerFile) return found;
         // `current` is a same-named collision: it's genuinely declared in
         // callerFile but a different, unrelated file's class of the same

--- a/src/domain/graph/builder/cha.ts
+++ b/src/domain/graph/builder/cha.ts
@@ -354,19 +354,23 @@ export function resolveThisDispatch(
         // name, so `current` may be an unrelated class that merely shares a
         // name with the caller's real ancestor (issue #2062) — e.g. two
         // independent files each defining their own `Shape` class. Before
-        // accepting a cross-file match, check whether a class named
+        // accepting a cross-file match, check whether ANYTHING named
         // `current` is ALSO declared in the caller's own file: if so, that
-        // same-file class IS the caller's real ancestor at this step (it
-        // simply doesn't define `methodName` — an implicit default
-        // constructor, for instance), so a same-named method from a
-        // different file is a false match, not a legitimate inherited
-        // method. Keep walking instead of accepting it. Only accept the
-        // cross-file match when `current` is NOT declared anywhere in the
-        // caller's own file — a genuine cross-file heritage reference
-        // (e.g. `import { Base } from './base'; class Foo extends Base`).
-        const sameNameInCallerFile = lookup
-          .byNameAndFile(current, callerFile)
-          .some((n) => RECEIVER_KINDS.has(n.kind ?? ''));
+        // same-file declaration IS the caller's real ancestor reference at
+        // this step, so a same-named method from a different file is a false
+        // match, not a legitimate inherited method. Keep walking instead of
+        // accepting it. This deliberately checks ANY kind, not just
+        // RECEIVER_KINDS (class/struct/interface/etc.) — `current` can also
+        // be a plain constructor FUNCTION (`function A() {}`) that a `class D
+        // extends A` legitimately targets (functions have no `.constructor`
+        // method to find, by definition), and that case is just as
+        // disqualifying as a same-named class would be (issue #2238; a
+        // same-named plain function was wrongly treated as "not declared
+        // here" and fell through to an unrelated file's same-named class).
+        // Only accept the cross-file match when `current` is NOT declared
+        // anywhere in the caller's own file — a genuine cross-file heritage
+        // reference (e.g. `import { Base } from './base'; class Foo extends Base`).
+        const sameNameInCallerFile = lookup.byNameAndFile(current, callerFile).length > 0;
         if (!sameNameInCallerFile) return found;
         // `current` is a same-named collision: it's genuinely declared in
         // callerFile but a different, unrelated file's class of the same

--- a/src/domain/graph/builder/cha.ts
+++ b/src/domain/graph/builder/cha.ts
@@ -362,20 +362,27 @@ export function resolveThisDispatch(
         // method. Keep walking instead of accepting it.
         //
         // "Heritage-capable" is RECEIVER_KINDS (class/struct/interface/etc.)
-        // *plus* `function` — a plain constructor FUNCTION (`function A()
-        // {}`) is exactly as legitimate an `extends`/`super()` target as a
-        // class is (functions have no `.constructor` method to find, by
-        // definition), and is just as disqualifying as a same-named class
-        // would be (issue #2238; a same-named plain function was wrongly
-        // treated as "not declared here" and fell through to an unrelated
-        // file's same-named class). It must NOT be widened further than
-        // that: an unrelated same-named local variable/parameter/nested
-        // helper has nothing to do with the class hierarchy and must not
-        // block a genuine cross-file heritage reference from resolving
-        // (Greptile review finding on PR #2400).
+        // *plus* a MODULE/CLASS-SCOPE `function` — a plain constructor
+        // FUNCTION (`function A() {}`) is exactly as legitimate an
+        // `extends`/`super()` target as a class is (functions have no
+        // `.constructor` method to find, by definition), and is just as
+        // disqualifying as a same-named class would be (issue #2238; a
+        // same-named plain function was wrongly treated as "not declared
+        // here" and fell through to an unrelated file's same-named class).
+        // It must NOT be widened further than that: an unrelated same-named
+        // local variable/parameter (Greptile finding on PR #2400) — nor a
+        // NESTED function declared inside some other, unrelated function or
+        // method body (a nested function can never be an `extends`/prototype
+        // target; second Greptile finding on the same PR) — has anything to
+        // do with the class hierarchy, and must not block a genuine
+        // cross-file heritage reference from resolving.
         const sameNameInCallerFile = lookup
           .byNameAndFile(current, callerFile)
-          .some((n) => RECEIVER_KINDS.has(n.kind ?? '') || n.kind === 'function');
+          .some(
+            (n) =>
+              RECEIVER_KINDS.has(n.kind ?? '') ||
+              (n.kind === 'function' && !lookup.hasEnclosingCallable(callerFile, n.line, n.id)),
+          );
         if (!sameNameInCallerFile) return found;
         // `current` is a same-named collision: it's genuinely declared in
         // callerFile but a different, unrelated file's class of the same

--- a/src/domain/graph/builder/context.ts
+++ b/src/domain/graph/builder/context.ts
@@ -83,6 +83,13 @@ export class PipelineContext {
   // ── Node lookup (set by insertNodes / buildEdges stages) ───────────
   nodesByName!: Map<string, NodeRow[]>;
   nodesByNameAndFile!: Map<string, NodeRow[]>;
+  /**
+   * Function/method-kind nodes grouped by file, for the "is this node nested
+   * inside another callable" containment check `resolveThisDispatch` (cha.ts)
+   * needs via `CallNodeLookup.hasEnclosingCallable` (issue #2238 follow-up,
+   * Greptile finding on PR #2400).
+   */
+  callablesByFile!: Map<string, Array<{ id: number; line: number; endLine: number | null }>>;
 
   // ── Reverse-dep edge reconnection (set by detectChanges) ───────────
   /**

--- a/src/domain/graph/builder/incremental.ts
+++ b/src/domain/graph/builder/incremental.ts
@@ -78,6 +78,13 @@ export interface IncrementalStmts {
   findNodeInFile: { all: (...params: unknown[]) => unknown[] };
   findNodeByName: { all: (...params: unknown[]) => unknown[] };
   /**
+   * True when `file` has a function/method-kind node other than `excludeId`
+   * whose span encloses `line` — backs `CallNodeLookup.hasEnclosingCallable`
+   * for the watch-mode path (issue #2238 follow-up, Greptile finding on PR
+   * #2400). Params: `(file, excludeId, line, line)`.
+   */
+  hasEnclosingCallable: { get: (...params: unknown[]) => unknown };
+  /**
    * Upsert a `file_hashes` row: `(relPath, hash, mtime, size)`. Called only
    * after a file's edges have been fully rebuilt (#1731) — see the call site
    * in `rebuildFile` for why this can't happen any earlier.
@@ -1072,6 +1079,8 @@ function makeIncrementalLookup(db: BetterSqlite3Database, stmts: IncrementalStmt
     resolveBarrel: (barrelFile, symbolName) => resolveBarrelTarget(db, barrelFile, symbolName),
     nodeId: (name, kind, file, line) =>
       stmts.getNodeId.get(name, kind, file, line) as { id: number } | undefined,
+    hasEnclosingCallable: (file, line, excludeId) =>
+      stmts.hasEnclosingCallable.get(file, excludeId, line, line) !== undefined,
   };
 }
 

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -14,7 +14,11 @@ import { debug } from '../../../../infrastructure/logger.js';
 import { loadNative } from '../../../../infrastructure/native.js';
 import { getOrCreatePerDbChunkStmt } from '../../../../shared/chunked-stmt-cache.js';
 import { TS_NATIVE_CONFIDENCE_FLOOR } from '../../../../shared/constants.js';
-import { FLAG_ONLY_DYNAMIC_KINDS, isTypeErasedImportTarget } from '../../../../shared/kinds.js';
+import {
+  CALLABLE_SYMBOL_KINDS,
+  FLAG_ONLY_DYNAMIC_KINDS,
+  isTypeErasedImportTarget,
+} from '../../../../shared/kinds.js';
 import type {
   ArrayCallbackBinding,
   ArrayElemBinding,
@@ -101,6 +105,8 @@ interface QueryNodeRow {
   line: number;
   /** `get`/`set` for an ES6 accessor node, `null` otherwise (issue #2030). */
   accessorKind?: string | null;
+  /** Only fetched to build `ctx.callablesByFile` — absent from ResolvedCandidate. */
+  endLine?: number | null;
 }
 
 /** Shape fed to the native buildCallEdges FFI. */
@@ -162,10 +168,17 @@ function setupNodeLookups(ctx: PipelineContext, allNodes: QueryNodeRow[]): void 
     ctx.nodesByName.get(node.name)!.push(node as unknown as NodeRow);
   }
   ctx.nodesByNameAndFile = new Map();
+  ctx.callablesByFile = new Map();
   for (const node of allNodes) {
     const key = `${node.name}|${node.file}`;
     if (!ctx.nodesByNameAndFile.has(key)) ctx.nodesByNameAndFile.set(key, []);
     ctx.nodesByNameAndFile.get(key)!.push(node as unknown as NodeRow);
+    if (CALLABLE_SYMBOL_KINDS.has(node.kind)) {
+      if (!ctx.callablesByFile.has(node.file)) ctx.callablesByFile.set(node.file, []);
+      ctx.callablesByFile
+        .get(node.file)!
+        .push({ id: node.id, line: node.line, endLine: node.endLine ?? null });
+    }
   }
 }
 
@@ -1361,6 +1374,10 @@ function makeContextLookup(ctx: PipelineContext, getNodeIdStmt: NodeIdStmt): Cal
     resolveBarrel: (barrelFile, symbolName) =>
       resolveBarrelExportCached(ctx, barrelFile, symbolName),
     nodeId: (name, kind, file, line) => getNodeIdStmt.get(name, kind, file, line),
+    hasEnclosingCallable: (file, line, excludeId) =>
+      (ctx.callablesByFile.get(file) ?? []).some(
+        (c) => c.id !== excludeId && c.line <= line && (c.endLine == null || c.endLine >= line),
+      ),
   };
 }
 
@@ -2550,7 +2567,7 @@ function loadNodes(ctx: PipelineContext): { rows: QueryNodeRow[]; scoped: boolea
       const placeholders = [...relevantFiles].map(() => '?').join(',');
       const rows = db
         .prepare(
-          `SELECT id, name, kind, file, line, accessor_kind AS accessorKind FROM nodes WHERE ${nodeKindFilter} AND file IN (${placeholders})`,
+          `SELECT id, name, kind, file, line, end_line AS endLine, accessor_kind AS accessorKind FROM nodes WHERE ${nodeKindFilter} AND file IN (${placeholders})`,
         )
         .all(...relevantFiles) as QueryNodeRow[];
       return { rows, scoped: true };
@@ -2559,7 +2576,7 @@ function loadNodes(ctx: PipelineContext): { rows: QueryNodeRow[]; scoped: boolea
 
   const rows = db
     .prepare(
-      `SELECT id, name, kind, file, line, accessor_kind AS accessorKind FROM nodes WHERE ${nodeKindFilter}`,
+      `SELECT id, name, kind, file, line, end_line AS endLine, accessor_kind AS accessorKind FROM nodes WHERE ${nodeKindFilter}`,
     )
     .all() as QueryNodeRow[];
   return { rows, scoped: false };

--- a/src/domain/graph/builder/stages/native-orchestrator.ts
+++ b/src/domain/graph/builder/stages/native-orchestrator.ts
@@ -1318,19 +1318,28 @@ function prepareCallerByLineStmt(db: BetterSqlite3Database) {
  * {@link prepareCallerByLineStmt} instead of `findCaller`'s per-file
  * `definitions` array) so it is intentionally left unimplemented.
  */
+/** Callable (function/method) span, for the containment check `hasEnclosingCallable` needs. */
+interface CallableSpan {
+  id: number;
+  line: number;
+  endLine: number | null;
+}
+
 function makePostNativeCallLookup(db: BetterSqlite3Database): CallNodeLookup {
   const findByNameStmt = db.prepare(`SELECT id, file, kind, line FROM nodes WHERE name = ?`);
-  // Mirrors prepareCallerByLineStmt's containment shape but excludes the
-  // candidate's own id — used by resolveThisDispatch (cha.ts) to tell a
-  // module/class-scope function declaration apart from a nested one that
-  // merely shares a base class's bare name (issue #2238 follow-up, Greptile
-  // finding on PR #2400).
-  const hasEnclosingCallableStmt = db.prepare(`
-    SELECT 1 FROM nodes
-    WHERE file = ? AND kind IN ('method', 'function') AND id != ?
-    AND line <= ? AND (end_line IS NULL OR end_line >= ?)
-    LIMIT 1
-  `);
+  // Loaded once per post-pass (not per resolveThisDispatch candidate) —
+  // querying per-candidate caused a 49%/166% full/incremental-build
+  // regression on the native benchmark (issue #2238 follow-up, Greptile
+  // finding on PR #2400). Mirrors build-edges.ts's ctx.callablesByFile.
+  const callablesByFile = new Map<string, CallableSpan[]>();
+  for (const row of db
+    .prepare(
+      `SELECT id, file, line, end_line AS endLine FROM nodes WHERE kind IN ('method', 'function')`,
+    )
+    .all() as Array<{ id: number; file: string; line: number; endLine: number | null }>) {
+    if (!callablesByFile.has(row.file)) callablesByFile.set(row.file, []);
+    callablesByFile.get(row.file)!.push({ id: row.id, line: row.line, endLine: row.endLine });
+  }
   return {
     byName: (name) => findByNameStmt.all(name) as Array<ResolvedCandidate>,
     byNameAndFile: (name, file) =>
@@ -1339,7 +1348,9 @@ function makePostNativeCallLookup(db: BetterSqlite3Database): CallNodeLookup {
     resolveBarrel: () => null,
     nodeId: () => undefined,
     hasEnclosingCallable: (file, line, excludeId) =>
-      hasEnclosingCallableStmt.get(file, excludeId, line, line) !== undefined,
+      (callablesByFile.get(file) ?? []).some(
+        (c) => c.id !== excludeId && c.line <= line && (c.endLine == null || c.endLine >= line),
+      ),
   };
 }
 

--- a/src/domain/graph/builder/stages/native-orchestrator.ts
+++ b/src/domain/graph/builder/stages/native-orchestrator.ts
@@ -1320,6 +1320,17 @@ function prepareCallerByLineStmt(db: BetterSqlite3Database) {
  */
 function makePostNativeCallLookup(db: BetterSqlite3Database): CallNodeLookup {
   const findByNameStmt = db.prepare(`SELECT id, file, kind, line FROM nodes WHERE name = ?`);
+  // Mirrors prepareCallerByLineStmt's containment shape but excludes the
+  // candidate's own id — used by resolveThisDispatch (cha.ts) to tell a
+  // module/class-scope function declaration apart from a nested one that
+  // merely shares a base class's bare name (issue #2238 follow-up, Greptile
+  // finding on PR #2400).
+  const hasEnclosingCallableStmt = db.prepare(`
+    SELECT 1 FROM nodes
+    WHERE file = ? AND kind IN ('method', 'function') AND id != ?
+    AND line <= ? AND (end_line IS NULL OR end_line >= ?)
+    LIMIT 1
+  `);
   return {
     byName: (name) => findByNameStmt.all(name) as Array<ResolvedCandidate>,
     byNameAndFile: (name, file) =>
@@ -1327,6 +1338,8 @@ function makePostNativeCallLookup(db: BetterSqlite3Database): CallNodeLookup {
     isBarrel: () => false,
     resolveBarrel: () => null,
     nodeId: () => undefined,
+    hasEnclosingCallable: (file, line, excludeId) =>
+      hasEnclosingCallableStmt.get(file, excludeId, line, line) !== undefined,
   };
 }
 

--- a/src/domain/graph/watcher.ts
+++ b/src/domain/graph/watcher.ts
@@ -67,6 +67,14 @@ function prepareWatcherStatements(db: ReturnType<typeof openDb>): IncrementalStm
       "SELECT id, file, kind, line, accessor_kind AS accessorKind FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
     ),
     listSymbols: db.prepare("SELECT name, kind, line FROM nodes WHERE file = ? AND kind != 'file'"),
+    // Mirrors native-orchestrator.ts's makePostNativeCallLookup containment
+    // query (issue #2238 follow-up, Greptile finding on PR #2400).
+    hasEnclosingCallable: db.prepare(`
+      SELECT 1 FROM nodes
+      WHERE file = ? AND kind IN ('method', 'function') AND id != ?
+      AND line <= ? AND (end_line IS NULL OR end_line >= ?)
+      LIMIT 1
+    `),
     upsertFileHash: db.prepare(
       'INSERT OR REPLACE INTO file_hashes (file, hash, mtime, size) VALUES (?, ?, ?, ?)',
     ),

--- a/tests/helpers/incremental-stmts.ts
+++ b/tests/helpers/incremental-stmts.ts
@@ -37,6 +37,12 @@ export function createIncrementalStmts(db: ReturnType<typeof openDb>): Increment
       "SELECT id, file, kind, line, accessor_kind AS accessorKind FROM nodes WHERE name = ? AND kind IN ('function', 'method', 'class', 'interface', 'type', 'struct', 'enum', 'trait', 'record', 'module', 'constant')",
     ),
     listSymbols: db.prepare("SELECT name, kind, line FROM nodes WHERE file = ? AND kind != 'file'"),
+    hasEnclosingCallable: db.prepare(`
+      SELECT 1 FROM nodes
+      WHERE file = ? AND kind IN ('method', 'function') AND id != ?
+      AND line <= ? AND (end_line IS NULL OR end_line >= ?)
+      LIMIT 1
+    `),
     upsertFileHash: db.prepare(
       'INSERT OR REPLACE INTO file_hashes (file, hash, mtime, size) VALUES (?, ?, ?, ?)',
     ),

--- a/tests/unit/call-resolver.test.ts
+++ b/tests/unit/call-resolver.test.ts
@@ -44,6 +44,9 @@ function makeLookup(
     nodeId() {
       return undefined;
     },
+    hasEnclosingCallable() {
+      return false;
+    },
   };
 }
 
@@ -403,6 +406,9 @@ function makeReceiverLookup(
     nodeId() {
       return undefined;
     },
+    hasEnclosingCallable() {
+      return false;
+    },
   };
 }
 
@@ -761,6 +767,9 @@ function makeLineAwareReceiverLookup(
     nodeId() {
       return undefined;
     },
+    hasEnclosingCallable() {
+      return false;
+    },
   };
 }
 
@@ -907,6 +916,9 @@ describe('resolveCallTargets — constructor attribution through a renaming barr
       },
       nodeId() {
         return undefined;
+      },
+      hasEnclosingCallable() {
+        return false;
       },
     };
   }
@@ -1108,6 +1120,9 @@ function makeAccessorLookup(
     },
     nodeId() {
       return undefined;
+    },
+    hasEnclosingCallable() {
+      return false;
     },
   };
 }

--- a/tests/unit/cha.test.ts
+++ b/tests/unit/cha.test.ts
@@ -94,6 +94,30 @@ describe('resolveThisDispatch — cross-file name collision (issue #2062)', () =
     expect(result).toEqual([]);
   });
 
+  it('does not resolve super() to an unrelated same-named class when the base is a plain constructor function (issue #2238)', () => {
+    // classes.js's own `A` is a plain function constructor (`function A(x)
+    // {...}`) — functions have no `.constructor` method to find, by
+    // definition. An unrelated file's `class A { constructor() {} }` must
+    // not be treated as the real ancestor just because the #2062 same-file
+    // check only looked for a class/interface/etc.-kind `A`, not a
+    // function-kind one.
+    const lookup = makeLookup(
+      { 'A.constructor': [{ id: 1, file: 'super.js', kind: 'method', line: 1 }] },
+      { A: { 'classes.js': [{ id: 2, file: 'classes.js', kind: 'function', line: 1 }] } },
+    );
+    const chaCtx = makeChaCtx({ D: 'A' }, { 'D|classes.js': 'A' });
+
+    const result = resolveThisDispatch(
+      'constructor',
+      'D.constructor',
+      'super',
+      chaCtx,
+      lookup,
+      'classes.js',
+    );
+    expect(result).toEqual([]);
+  });
+
   it('resolves a legitimate cross-file super call when the base class is not declared in the caller file at all', () => {
     // dog.ts imports Animal from base.ts — Animal is genuinely absent from
     // dog.ts, so the cross-file match is legitimate heritage, not a

--- a/tests/unit/cha.test.ts
+++ b/tests/unit/cha.test.ts
@@ -17,12 +17,21 @@ import {
 } from '../../src/domain/graph/builder/cha.js';
 
 type Candidate = { id: number; file: string; kind: string; line: number };
+/** `{file}|{line}` entries describing a function/method's OWN enclosing
+ * callable, if any — the fixture-level equivalent of the DB's `end_line`
+ * containment query `hasEnclosingCallable` backs (issue #2238 follow-up,
+ * Greptile finding on PR #2400). */
+type EnclosingKey = string;
 
 /** Build a CallNodeLookup backed by two maps: qualified-name → candidates
- * (byName), and bare-name+file → candidates (byNameAndFile). */
+ * (byName), and bare-name+file → candidates (byNameAndFile). `nestedLines`
+ * lists `${file}|${line}` keys for candidates that are themselves nested
+ * inside another callable — `hasEnclosingCallable` returns true for exactly
+ * those. */
 function makeLookup(
   byNameMap: Record<string, Candidate[]>,
   byNameAndFileMap: Record<string, Record<string, Candidate[]>> = {},
+  nestedLines: ReadonlySet<EnclosingKey> = new Set(),
 ): CallNodeLookup {
   return {
     byName(name) {
@@ -39,6 +48,9 @@ function makeLookup(
     },
     nodeId() {
       return undefined;
+    },
+    hasEnclosingCallable(file, line) {
+      return nestedLines.has(`${file}|${line}`);
     },
   };
 }
@@ -142,6 +154,24 @@ describe('resolveThisDispatch — cross-file name collision (issue #2062)', () =
     const lookup = makeLookup(
       { 'Animal.speak': [{ id: 5, file: 'base.ts', kind: 'method', line: 5 }] },
       { Animal: { 'dog.ts': [{ id: 9, file: 'dog.ts', kind: 'variable', line: 3 }] } },
+    );
+    const chaCtx = makeChaCtx({ Dog: 'Animal' }, { 'Dog|dog.ts': 'Animal' });
+
+    const result = resolveThisDispatch('speak', 'Dog.speak', 'super', chaCtx, lookup, 'dog.ts');
+    expect(result).toEqual([{ id: 5, file: 'base.ts', kind: 'method', line: 5 }]);
+  });
+
+  it('resolves a legitimate cross-file super call even when an unrelated NESTED function shares the base name (Greptile finding on PR #2400)', () => {
+    // dog.ts imports Animal from base.ts and extends it. Somewhere else in
+    // dog.ts, an unrelated method has its own local helper function also
+    // named `Animal` (pure coincidence, nothing to do with the class
+    // hierarchy). A nested function can never be a legitimate `extends`
+    // target — unlike issue #2238's plain TOP-LEVEL constructor function —
+    // so it must not block the real cross-file heritage resolution either.
+    const lookup = makeLookup(
+      { 'Animal.speak': [{ id: 5, file: 'base.ts', kind: 'method', line: 5 }] },
+      { Animal: { 'dog.ts': [{ id: 9, file: 'dog.ts', kind: 'function', line: 12 }] } },
+      new Set(['dog.ts|12']),
     );
     const chaCtx = makeChaCtx({ Dog: 'Animal' }, { 'Dog|dog.ts': 'Animal' });
 

--- a/tests/unit/cha.test.ts
+++ b/tests/unit/cha.test.ts
@@ -132,6 +132,23 @@ describe('resolveThisDispatch — cross-file name collision (issue #2062)', () =
     expect(result).toEqual([{ id: 5, file: 'base.ts', kind: 'method', line: 5 }]);
   });
 
+  it('resolves a legitimate cross-file super call even when an unrelated local variable shares the base name (Greptile finding on PR #2400)', () => {
+    // dog.ts imports Animal from base.ts, and ALSO happens to declare an
+    // unrelated top-level `const Animal = ...` (or similarly non-heritage-
+    // capable local) for some other purpose. That local has nothing to do
+    // with the class hierarchy and must not be mistaken for the real
+    // heritage declaration — only a class/interface/etc.-kind or function
+    // -kind same-named local is disqualifying (issue #2238's own fix).
+    const lookup = makeLookup(
+      { 'Animal.speak': [{ id: 5, file: 'base.ts', kind: 'method', line: 5 }] },
+      { Animal: { 'dog.ts': [{ id: 9, file: 'dog.ts', kind: 'variable', line: 3 }] } },
+    );
+    const chaCtx = makeChaCtx({ Dog: 'Animal' }, { 'Dog|dog.ts': 'Animal' });
+
+    const result = resolveThisDispatch('speak', 'Dog.speak', 'super', chaCtx, lookup, 'dog.ts');
+    expect(result).toEqual([{ id: 5, file: 'base.ts', kind: 'method', line: 5 }]);
+  });
+
   it('still prefers the same-file candidate when both same-file and cross-file candidates exist', () => {
     const sameFile = { id: 1, file: 'a.ts', kind: 'method', line: 1 };
     const crossFile = { id: 2, file: 'b.ts', kind: 'method', line: 2 };


### PR DESCRIPTION
## Summary

`resolveThisDispatch`'s cross-file collision guard (added for #2062) only checked whether the caller's own file also declared a class/interface/etc.-kind symbol (`RECEIVER_KINDS`) of the same name before accepting a cross-file method match. It missed the case where the local same-named symbol is a plain constructor **function** instead:

```js
function A(x) { this.f44 = x; }     // classes.js — a plain function constructor
class D extends A {
  constructor(y) { super(y); }      // D.constructor -> should NOT resolve cross-file
}
```

`A` here has no `A.constructor` method to find by definition (functions aren't classes), so the guard's `RECEIVER_KINDS`-only check let the same-file `A` be treated as "not really declared here," and the lookup fell through to an unrelated file's `class A { constructor() {} }` (found via a global, name-only `lookup.byName('A.constructor')`).

## Fix

Widen the check to "is ANYTHING named `current` declared in the caller's own file" — a same-named plain function is exactly as disqualifying as a same-named class for this purpose. Single, minimal change to `resolveThisDispatch` in `src/domain/graph/builder/cha.ts`, shared by both engines (native delegates `this`/`super` dispatch to this same function via `runPostNativeThisDispatch`).

Fixes the wasm/native parity divergence on the `jelly-micro` `classes` fixture reported in #2238 (3 spurious `super()` constructor edges to unrelated fixtures under the same corpus root).

## Test plan

- [x] New unit test in `tests/unit/cha.test.ts` reproducing the exact repro shape — verified fail-without-fix, pass-with-fix.
- [x] `node scripts/parity-compare.mjs --langs jelly-micro` — divergence resolved (879 edges both engines, was 882/879).
- [x] `node scripts/parity-compare.mjs` (full 42-fixture run) — parity OK, no regressions elsewhere.
- [x] `npx vitest run tests/benchmarks/resolution/jelly-micro.test.ts -t classes` — recall floor unaffected (the removed edge was a false positive, not a ground-truth match).
- [x] Full suite: `npm test` (4795 passed), `npx tsc --noEmit`, `npm run lint`.