### PR TITLE
fix(watch): thread real tsconfig/jsconfig aliases into incremental rebuild

### DIFF
--- a/src/domain/graph/builder/helpers.ts
+++ b/src/domain/graph/builder/helpers.ts
@@ -298,6 +298,31 @@ export function loadPathAliases(rootDir: string): PathAliases {
 }
 
 /**
+ * Merge `.codegraphrc.json`'s own `aliases` config field into `aliases.paths`
+ * (mutating in place), matching `pipeline.ts`'s `loadAliases` stage exactly —
+ * shared so `rebuildFile` (watch-mode single-file rebuild, `incremental.ts`)
+ * resolves the SAME alias set a full build does, not just tsconfig/jsconfig
+ * (issue #2242 review — codegraph-configured aliases were silently excluded
+ * from watch rebuilds even after tsconfig/jsconfig aliases were fixed).
+ */
+export function mergeConfigAliases(
+  aliases: PathAliases,
+  configAliases: Record<string, unknown> | undefined,
+  rootDir: string,
+): void {
+  if (!configAliases) return;
+  for (const [key, value] of Object.entries(configAliases)) {
+    if (typeof value !== 'string') {
+      warn(`Alias target for "${key}" must be a string, got ${typeof value}. Skipping.`);
+      continue;
+    }
+    const pattern = key.endsWith('/') ? `${key}*` : key;
+    const target = path.resolve(rootDir, value);
+    aliases.paths[pattern] = [target.endsWith('/') ? `${target}*` : `${target}/*`];
+  }
+}
+
+/**
  * Compute MD5 hash of file contents for incremental builds.
  */
 export function fileHash(content: string): string {

--- a/src/domain/graph/builder/incremental.ts
+++ b/src/domain/graph/builder/incremental.ts
@@ -333,6 +333,12 @@ function rebuildReverseDepEdges(
   skipBarrel: boolean,
   // #2216: see getKnownFilesForIncremental's doc comment.
   knownFiles: readonly string[],
+  // #2242: real tsconfig/jsconfig aliases, loaded once per rebuildFile
+  // invocation and threaded through — a hardcoded empty PathAliases here
+  // silently dropped every edge kind for an alias-based import, not just
+  // reexports (contrast with persistReexportRenamesForFile's own narrower
+  // #1967 fix, just above).
+  aliases: PathAliases,
   // #2077: forwarded to buildCallEdges — see its own param doc.
   maxIterations?: number,
 ): number {
@@ -343,7 +349,6 @@ function rebuildReverseDepEdges(
   // it's itself a barrel — independent of the edges rebuilt below.
   persistReexportRenamesForFile(db, depRelPath, symbols, rootDir, knownFiles);
 
-  const aliases: PathAliases = { baseUrl: null, paths: {} };
   let edgesAdded = buildContainmentEdges(db, stmts, depRelPath, symbols);
   // Don't rebuild dir->file containment for reverse-deps (it was never deleted)
   edgesAdded += buildImportEdges(
@@ -1732,6 +1737,8 @@ function rebuildEdgesForTargetFile(
   // #2216: project-wide known-files list, needed for Rust crate::/self::/
   // super:: resolution (#2007) — see getKnownFilesForIncremental's doc comment.
   knownFiles: readonly string[],
+  // #2242: real tsconfig/jsconfig aliases — see rebuildReverseDepEdges' param doc.
+  aliases: PathAliases,
   // #2077: forwarded to buildCallEdges — see its own param doc.
   maxIterations?: number,
 ): number {
@@ -1739,7 +1746,6 @@ function rebuildEdgesForTargetFile(
   // itself a barrel — independent of the edges rebuilt below.
   persistReexportRenamesForFile(db, relPath, symbols, rootDir, knownFiles);
 
-  const aliases: PathAliases = { baseUrl: null, paths: {} };
   let edgesAdded = buildContainmentEdges(db, stmts, relPath, symbols);
   edgesAdded += rebuildDirContainment(db, stmts, relPath);
   edgesAdded += buildImportEdges(
@@ -1820,19 +1826,20 @@ function emitBarrelImportEdgesForReverseDeps(
   depSymbols: Map<string, ExtractorOutput>,
   rootDir: string,
   knownFiles: readonly string[],
+  // #2242: real tsconfig/jsconfig aliases — see rebuildReverseDepEdges' param doc.
+  aliases: PathAliases,
 ): number {
   let edgesAdded = 0;
   for (const [depRelPath, symbols_] of depSymbols) {
     const fileNodeRow_ = stmts.getNodeId.get(depRelPath, 'file', depRelPath, 0);
     if (!fileNodeRow_) continue;
-    const aliases_: PathAliases = { baseUrl: null, paths: {} };
     for (const imp of symbols_.imports) {
       if (imp.reexport) continue;
       const resolvedPath = resolveImportPath(
         path.join(rootDir, depRelPath),
         imp.source,
         rootDir,
-        aliases_,
+        aliases,
         knownFiles,
       );
       edgesAdded += resolveBarrelImportEdges(db, stmts, fileNodeRow_.id, resolvedPath, imp);
@@ -1859,6 +1866,8 @@ async function runReverseDepCascade(
   cache: unknown,
   // #2216: see getKnownFilesForIncremental's doc comment.
   knownFiles: readonly string[],
+  // #2242: real tsconfig/jsconfig aliases — see rebuildReverseDepEdges' param doc.
+  aliases: PathAliases,
 ): Promise<{
   edgesAdded: number;
   reverseDepsEdgesBefore: number;
@@ -1884,11 +1893,19 @@ async function runReverseDepCascade(
       stmts,
       true,
       knownFiles,
+      aliases,
       engineOpts.pointsToMaxIterations,
     );
   }
   // Pass 2: add barrel import edges (reexports edges now exist)
-  edgesAdded += emitBarrelImportEdgesForReverseDeps(db, stmts, depSymbols, rootDir, knownFiles);
+  edgesAdded += emitBarrelImportEdgesForReverseDeps(
+    db,
+    stmts,
+    depSymbols,
+    rootDir,
+    knownFiles,
+    aliases,
+  );
   return { edgesAdded, reverseDepsEdgesBefore, depSymbols };
 }
 
@@ -2257,6 +2274,11 @@ export async function rebuildFile(
   // just Rust ones — means the very next Rust file to change (a near-certain
   // companion edit to any real Cargo.toml target change) re-scans fresh.
   clearCargoTargetOverridesCache();
+  // #2242: real tsconfig/jsconfig aliases, loaded once per rebuild (mirrors
+  // knownFiles just above) and threaded through every edge-building call
+  // below — a hardcoded empty PathAliases previously dropped every edge
+  // kind (not just reexports) for any file whose imports use an alias.
+  const aliases = loadPathAliases(rootDir);
 
   let edgesAdded = rebuildEdgesForTargetFile(
     db,
@@ -2266,13 +2288,23 @@ export async function rebuildFile(
     fileNodeRow,
     rootDir,
     knownFiles,
+    aliases,
     engineOpts.pointsToMaxIterations,
   );
   const {
     edgesAdded: cascadeEdges,
     reverseDepsEdgesBefore,
     depSymbols,
-  } = await runReverseDepCascade(db, rootDir, reverseDeps, stmts, engineOpts, cache, knownFiles);
+  } = await runReverseDepCascade(
+    db,
+    rootDir,
+    reverseDeps,
+    stmts,
+    engineOpts,
+    cache,
+    knownFiles,
+    aliases,
+  );
   edgesAdded += cascadeEdges;
 
   // Phase 8.5 CHA + RTA dispatch expansion post-pass (#1852) — runs after all

--- a/src/domain/graph/builder/incremental.ts
+++ b/src/domain/graph/builder/incremental.ts
@@ -62,6 +62,7 @@ import {
   fileHash,
   fileStat,
   loadPathAliases,
+  mergeConfigAliases,
   readFileSafe,
 } from './helpers.js';
 import { importNamePairs } from './import-utils.js';
@@ -333,11 +334,11 @@ function rebuildReverseDepEdges(
   skipBarrel: boolean,
   // #2216: see getKnownFilesForIncremental's doc comment.
   knownFiles: readonly string[],
-  // #2242: real tsconfig/jsconfig aliases, loaded once per rebuildFile
-  // invocation and threaded through — a hardcoded empty PathAliases here
-  // silently dropped every edge kind for an alias-based import, not just
-  // reexports (contrast with persistReexportRenamesForFile's own narrower
-  // #1967 fix, just above).
+  // #2242: real tsconfig/jsconfig + codegraph-configured aliases, loaded
+  // once per rebuildFile invocation and threaded through — a hardcoded
+  // empty PathAliases here silently dropped every edge kind for an
+  // alias-based import, not just renamed reexports (#1967's narrower fix,
+  // now also using this same shared aliases — see persistReexportRenamesForFile).
   aliases: PathAliases,
   // #2077: forwarded to buildCallEdges — see its own param doc.
   maxIterations?: number,
@@ -347,7 +348,7 @@ function rebuildReverseDepEdges(
 
   // #1967: keep this reverse-dep's persisted barrel rename table current if
   // it's itself a barrel — independent of the edges rebuilt below.
-  persistReexportRenamesForFile(db, depRelPath, symbols, rootDir, knownFiles);
+  persistReexportRenamesForFile(db, depRelPath, symbols, rootDir, knownFiles, aliases);
 
   let edgesAdded = buildContainmentEdges(db, stmts, depRelPath, symbols);
   // Don't rebuild dir->file containment for reverse-deps (it was never deleted)
@@ -613,6 +614,16 @@ function persistReexportRenamesForFile(
   symbols: ExtractorOutput,
   rootDir: string,
   knownFiles: readonly string[],
+  // Real tsconfig/jsconfig + codegraph-configured aliases (#1967 review,
+  // #2242) — using an empty aliases object here would resolve an
+  // alias-based reexport source (e.g. `@utils/foo`) to a bogus non-file
+  // specifier, overwriting a correct full-build row with one
+  // `resolveBarrelTarget` can never match to a graph node. Callers load
+  // this once per rebuildFile invocation (mirroring knownFiles) rather than
+  // this function loading its own — a stale cache spanning a whole
+  // long-running `codegraph watch` session would be the wrong tradeoff
+  // (#1967 review), but a fresh load per rebuild event is exactly as fresh.
+  aliases: PathAliases,
 ): void {
   const { renameDeleteStmt, renameInsertStmt } = getBarrelStmts(db);
   renameDeleteStmt.run(relPath);
@@ -620,17 +631,6 @@ function persistReexportRenamesForFile(
   const reexports = symbols.imports.filter((imp) => imp.reexport);
   if (reexports.length === 0) return;
 
-  // Real tsconfig/jsconfig aliases (#1967 review) — using an empty aliases
-  // object here would resolve an alias-based reexport source (e.g.
-  // `@utils/foo`) to a bogus non-file specifier, overwriting a correct
-  // full-build row with one `resolveBarrelTarget` can never match to a
-  // graph node. Loaded fresh (not cached) on every call: this branch only
-  // runs for files that are actually barrels with renamed specifiers — rare
-  // enough that the disk read is negligible — and a stale cache could
-  // otherwise persist a wrong `source_file` for the rest of a long-running
-  // `codegraph watch` session after a mid-session tsconfig/jsconfig edit
-  // (#1967 review).
-  const aliases = loadPathAliases(rootDir);
   for (const imp of reexports) {
     if (!imp.renamedImports?.length) continue;
     const source = resolveImportPath(
@@ -1744,7 +1744,7 @@ function rebuildEdgesForTargetFile(
 ): number {
   // #1967: keep this file's persisted barrel rename table current if it's
   // itself a barrel — independent of the edges rebuilt below.
-  persistReexportRenamesForFile(db, relPath, symbols, rootDir, knownFiles);
+  persistReexportRenamesForFile(db, relPath, symbols, rootDir, knownFiles, aliases);
 
   let edgesAdded = buildContainmentEdges(db, stmts, relPath, symbols);
   edgesAdded += rebuildDirContainment(db, stmts, relPath);
@@ -2274,11 +2274,17 @@ export async function rebuildFile(
   // just Rust ones — means the very next Rust file to change (a near-certain
   // companion edit to any real Cargo.toml target change) re-scans fresh.
   clearCargoTargetOverridesCache();
-  // #2242: real tsconfig/jsconfig aliases, loaded once per rebuild (mirrors
-  // knownFiles just above) and threaded through every edge-building call
-  // below — a hardcoded empty PathAliases previously dropped every edge
-  // kind (not just reexports) for any file whose imports use an alias.
+  // #2242: real tsconfig/jsconfig + codegraph-configured aliases, loaded
+  // once per rebuild (mirrors knownFiles just above) and threaded through
+  // every edge-building call below — a hardcoded empty PathAliases
+  // previously dropped every edge kind (not just reexports) for any file
+  // whose imports use an alias. engineOpts.aliases carries
+  // `.codegraphrc.json`'s own `aliases` field (mirroring pipeline.ts's
+  // full-build loadAliases stage, which merges the same on top of
+  // tsconfig/jsconfig) since rebuildFile has no PipelineContext to read
+  // `ctx.config` from directly.
   const aliases = loadPathAliases(rootDir);
+  mergeConfigAliases(aliases, engineOpts.aliases, rootDir);
 
   let edgesAdded = rebuildEdgesForTargetFile(
     db,

--- a/src/domain/graph/builder/pipeline.ts
+++ b/src/domain/graph/builder/pipeline.ts
@@ -32,7 +32,7 @@ import { getActiveEngine } from '../../parser.js';
 import { writeJournalHeader } from '../journal.js';
 import { setWorkspaces } from '../resolve.js';
 import { PipelineContext } from './context.js';
-import { loadPathAliases } from './helpers.js';
+import { loadPathAliases, mergeConfigAliases } from './helpers.js';
 import { buildEdges } from './stages/build-edges.js';
 import { buildStructure } from './stages/build-structure.js';
 // Pipeline stages
@@ -157,17 +157,7 @@ function warnOnEmbeddingsWipe(ctx: PipelineContext): void {
 
 function loadAliases(ctx: PipelineContext): void {
   ctx.aliases = loadPathAliases(ctx.rootDir);
-  if (ctx.config.aliases) {
-    for (const [key, value] of Object.entries(ctx.config.aliases)) {
-      if (typeof value !== 'string') {
-        warn(`Alias target for "${key}" must be a string, got ${typeof value}. Skipping.`);
-        continue;
-      }
-      const pattern = key.endsWith('/') ? `${key}*` : key;
-      const target = path.resolve(ctx.rootDir, value);
-      ctx.aliases.paths[pattern] = [target.endsWith('/') ? `${target}*` : `${target}/*`];
-    }
-  }
+  mergeConfigAliases(ctx.aliases, ctx.config.aliases, ctx.rootDir);
   if (ctx.aliases.baseUrl || Object.keys(ctx.aliases.paths).length > 0) {
     info(
       `Loaded path aliases: baseUrl=${ctx.aliases.baseUrl || 'none'}, ${Object.keys(ctx.aliases.paths).length} path mappings`,

--- a/src/domain/graph/watcher.ts
+++ b/src/domain/graph/watcher.ts
@@ -231,6 +231,10 @@ function setupWatcher(rootDir: string, opts: { engine?: string; dbPath?: string 
     // buildPointsToMapForFile's own default parameter instead of honoring a
     // .codegraphrc.json override, diverging from the full-build path below.
     pointsToMaxIterations: config.analysis.pointsToMaxIterations,
+    // #2242: without this, rebuildFile only resolved tsconfig/jsconfig
+    // aliases, silently excluding aliases configured via .codegraphrc.json's
+    // own `aliases` field that a full build does honor.
+    aliases: config.aliases,
   };
   const { name: engineName, version: engineVersion } = getActiveEngine(engineOpts);
   info(`Watch mode using ${engineName} engine${engineVersion ? ` (v${engineVersion})` : ''}`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1342,6 +1342,16 @@ export interface EngineOpts {
    * (`DEFAULTS.analysis.pointsToMaxIterations`).
    */
   pointsToMaxIterations?: number;
+  /**
+   * `.codegraphrc.json`'s own `aliases` config field, resolved from
+   * `config.aliases`. Threaded through incremental/watch-mode rebuilds
+   * (`rebuildFile` in `incremental.ts`) so codegraph-configured aliases
+   * apply identically to `codegraph watch` and a full build (#2242) — a
+   * full build merges this on top of tsconfig/jsconfig aliases via
+   * `mergeConfigAliases`; `rebuildFile` does the same using this field
+   * since it has no `PipelineContext`/`ctx.config` to read from directly.
+   */
+  aliases?: Record<string, unknown>;
   /** Persistent NativeDatabase connection for build writes (Phase 6.15). */
   nativeDb?: NativeDatabase;
   /**

--- a/tests/integration/issue-1967-watch-barrel-rename.test.ts
+++ b/tests/integration/issue-1967-watch-barrel-rename.test.ts
@@ -304,7 +304,7 @@ describe.each(ENGINES)(
              JOIN nodes n2 ON e.target_id = n2.id
              WHERE n1.kind = 'file' AND n1.file = 'barrel.ts'
              AND n2.kind = 'file' AND n2.file = 'utils/foo.ts'
-             AND e.kind IN ('imports', 'reexports')`,
+             AND e.kind = 'reexports'`,
           )
           .get();
         expect(row).toBeDefined();

--- a/tests/integration/issue-1967-watch-barrel-rename.test.ts
+++ b/tests/integration/issue-1967-watch-barrel-rename.test.ts
@@ -278,16 +278,6 @@ describe.each(ENGINES)(
     });
 
     it('the rename row still resolves to the real aliased file after the barrel is reparsed', () => {
-      // Deliberately scoped to the row itself, not the barrel's own `calls`/
-      // `imports` edges: incremental.ts's edge-building functions
-      // (buildImportEdges, buildImportedNamesMap, etc.) hardcode an *empty*
-      // PathAliases object for every import resolution — a separate,
-      // pre-existing limitation of the whole file (not introduced by this
-      // fix, and not scoped to reexports/renames) that also breaks the
-      // barrel's own alias-resolved edges when it's reparsed under watch.
-      // Filed as a follow-up (issue link in the PR description) rather than
-      // fixed here — it affects every edge kind under watch for alias-based
-      // projects, well beyond this fix's scope.
       expect(readReexportRenames(dbPath)).toEqual([
         {
           barrel_file: 'barrel.ts',
@@ -296,6 +286,31 @@ describe.each(ENGINES)(
           source_file: 'utils/foo.ts',
         },
       ]);
+    });
+
+    it("the barrel's own alias-resolved reexports edge also survives being reparsed under watch (#2242)", () => {
+      // incremental.ts's edge-building functions (buildImportEdges,
+      // buildImportedNamesMap, etc.) used to hardcode an *empty* PathAliases
+      // object for every import resolution — not just reexports/renames —
+      // so reparsing this alias-based barrel under watch would drop its own
+      // reexports edge to utils/foo.ts even though the rename row (above)
+      // was already fixed for #1967. Fixed for every edge kind by #2242.
+      const db = new Database(dbPath, { readonly: true });
+      try {
+        const row = db
+          .prepare(
+            `SELECT 1 FROM edges e
+             JOIN nodes n1 ON e.source_id = n1.id
+             JOIN nodes n2 ON e.target_id = n2.id
+             WHERE n1.kind = 'file' AND n1.file = 'barrel.ts'
+             AND n2.kind = 'file' AND n2.file = 'utils/foo.ts'
+             AND e.kind IN ('imports', 'reexports')`,
+          )
+          .get();
+        expect(row).toBeDefined();
+      } finally {
+        db.close();
+      }
     });
   },
 );

--- a/tests/integration/issue-2242-watch-alias-reverse-dep.test.ts
+++ b/tests/integration/issue-2242-watch-alias-reverse-dep.test.ts
@@ -29,6 +29,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { initSchema, openDb } from '../../src/db/index.js';
 import { rebuildFile } from '../../src/domain/graph/builder/incremental.js';
 import { buildGraph } from '../../src/domain/graph/builder.js';
+import { loadConfig } from '../../src/infrastructure/config.js';
 import type { EngineMode } from '../../src/types.js';
 import { createIncrementalStmts } from '../helpers/incremental-stmts.js';
 
@@ -63,7 +64,7 @@ function writeFixture(dir: string) {
   }
 }
 
-function hasFileEdge(dbPath: string, fromFile: string, toFile: string): boolean {
+function hasReexportsEdge(dbPath: string, fromFile: string, toFile: string): boolean {
   const db = new Database(dbPath, { readonly: true });
   try {
     const row = db
@@ -72,7 +73,7 @@ function hasFileEdge(dbPath: string, fromFile: string, toFile: string): boolean 
          JOIN nodes n1 ON e.source_id = n1.id
          JOIN nodes n2 ON e.target_id = n2.id
          WHERE n1.kind = 'file' AND n1.file = ? AND n2.kind = 'file' AND n2.file = ?
-         AND e.kind IN ('imports', 'reexports')`,
+         AND e.kind = 'reexports'`,
       )
       .get(fromFile, toFile);
     return row !== undefined;
@@ -97,7 +98,7 @@ describe.each(ENGINES)(
       dbPath = path.join(watchDir, '.codegraph', 'graph.db');
 
       // Sanity check: the full build resolved the alias-based reexport.
-      expect(hasFileEdge(dbPath, 'barrel.ts', 'utils/foo.ts')).toBe(true);
+      expect(hasReexportsEdge(dbPath, 'barrel.ts', 'utils/foo.ts')).toBe(true);
 
       // Touch the DEEPEST file — barrel.ts (which imports it via alias) is
       // a reverse dep and gets reparsed via rebuildReverseDepEdges.
@@ -115,7 +116,89 @@ describe.each(ENGINES)(
     });
 
     it("barrel.ts's alias-resolved reexports edge survives the reverse-dep cascade", () => {
-      expect(hasFileEdge(dbPath, 'barrel.ts', 'utils/foo.ts')).toBe(true);
+      expect(hasReexportsEdge(dbPath, 'barrel.ts', 'utils/foo.ts')).toBe(true);
+    });
+  },
+);
+
+/**
+ * Regression coverage for a Greptile finding on this same PR: `rebuildFile`
+ * resolved tsconfig/jsconfig aliases correctly but silently excluded
+ * aliases configured via `.codegraphrc.json`'s own `aliases` field — which
+ * `pipeline.ts`'s full-build `loadAliases` stage merges on top of
+ * tsconfig/jsconfig via `mergeConfigAliases`. Fixed by threading
+ * `config.aliases` through `EngineOpts.aliases` (set once in
+ * `setupWatcher`, mirroring the existing `pointsToMaxIterations` pattern)
+ * so `rebuildFile` applies the exact same merge.
+ *
+ * Fixture deliberately has NO tsconfig.json/jsconfig.json at all — the
+ * alias is defined ONLY via `.codegraphrc.json`, isolating this from the
+ * tsconfig/jsconfig path already covered above.
+ */
+const CODEGRAPHRC = JSON.stringify({ aliases: { '@utils/': './utils/' } });
+
+const CONFIG_ALIAS_FILES: Record<string, string> = {
+  '.codegraphrc.json': CODEGRAPHRC,
+  'utils/foo.ts': `
+export function realName(): string {
+  return 'real';
+}
+`,
+  'barrel.ts': `
+export { realName } from '@utils/foo';
+`,
+};
+
+function writeConfigAliasFixture(dir: string) {
+  for (const [rel, content] of Object.entries(CONFIG_ALIAS_FILES)) {
+    const abs = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, content);
+  }
+}
+
+describe.each(ENGINES)(
+  'codegraph watch preserves a .codegraphrc.json-configured alias edge (#2242 review) — initial build: %s',
+  (engine) => {
+    let watchDir: string;
+    let dbPath: string;
+
+    beforeAll(async () => {
+      watchDir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2242-config-alias-${engine}-`));
+      writeConfigAliasFixture(watchDir);
+
+      await buildGraph(watchDir, { incremental: false, skipRegistry: true, engine });
+      dbPath = path.join(watchDir, '.codegraph', 'graph.db');
+
+      // Sanity check: the full build resolved the .codegraphrc.json alias.
+      expect(hasReexportsEdge(dbPath, 'barrel.ts', 'utils/foo.ts')).toBe(true);
+
+      // Touch barrel.ts directly — exercises rebuildEdgesForTargetFile.
+      const barrelFile = path.join(watchDir, 'barrel.ts');
+      fs.appendFileSync(barrelFile, '\n// touch\n');
+
+      const db = openDb(dbPath);
+      initSchema(db);
+      // Mirrors setupWatcher's engineOpts construction (watcher.ts): the
+      // real config.aliases threaded through, not a hand-picked value.
+      const config = loadConfig(watchDir);
+      await rebuildFile(
+        db,
+        watchDir,
+        barrelFile,
+        createIncrementalStmts(db),
+        { engine, aliases: config.aliases },
+        null,
+      );
+      db.close();
+    }, 60_000);
+
+    afterAll(() => {
+      if (watchDir) fs.rmSync(watchDir, { recursive: true, force: true });
+    });
+
+    it("barrel.ts's .codegraphrc.json-alias-resolved reexports edge survives being reparsed under watch", () => {
+      expect(hasReexportsEdge(dbPath, 'barrel.ts', 'utils/foo.ts')).toBe(true);
     });
   },
 );

--- a/tests/integration/issue-2242-watch-alias-reverse-dep.test.ts
+++ b/tests/integration/issue-2242-watch-alias-reverse-dep.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Regression test for #2242: `codegraph watch`'s single-file rebuild path
+ * (`rebuildFile` in `domain/graph/builder/incremental.ts`) hardcoded an
+ * *empty* `PathAliases` object (`{ baseUrl: null, paths: {} }`) at every one
+ * of its import-resolution call sites, instead of loading the project's real
+ * tsconfig/jsconfig aliases — unlike the full-build pipeline, which threads
+ * `ctx.aliases` (loaded once via `loadPathAliases`) throughout.
+ *
+ * This test covers the *reverse-dep cascade* call site specifically
+ * (`rebuildReverseDepEdges`) — distinct from `rebuildEdgesForTargetFile`
+ * (the primary touched-file path, covered by the extended assertion in
+ * `issue-1967-watch-barrel-rename.test.ts`). When a file is touched under
+ * watch, every file that imports it (a "reverse dep") is also reparsed and
+ * its own edges rebuilt — if that reverse dep's own imports use a
+ * tsconfig/jsconfig alias, the hardcoded-empty-aliases bug dropped its
+ * `imports`/`reexports` edges too, not just renamed reexports.
+ *
+ * Fixture: `utils/foo.ts` exports `realName`; `barrel.ts` re-exports it via
+ * an alias-based specifier (`@utils/foo`, no rename); `consumer.ts` imports
+ * from `barrel.ts` and calls it. Touching `utils/foo.ts` under watch makes
+ * `barrel.ts` a reverse dep (it imports from `utils/foo.ts`) and exercises
+ * `rebuildReverseDepEdges`'s alias resolution.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { initSchema, openDb } from '../../src/db/index.js';
+import { rebuildFile } from '../../src/domain/graph/builder/incremental.js';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+import type { EngineMode } from '../../src/types.js';
+import { createIncrementalStmts } from '../helpers/incremental-stmts.js';
+
+const TSCONFIG = JSON.stringify({
+  compilerOptions: { baseUrl: '.', paths: { '@utils/*': ['utils/*'] } },
+});
+
+const FILES: Record<string, string> = {
+  'tsconfig.json': TSCONFIG,
+  'utils/foo.ts': `
+export function realName(): string {
+  return 'real';
+}
+`,
+  'barrel.ts': `
+export { realName } from '@utils/foo';
+`,
+  'consumer.ts': `
+import { realName } from './barrel.js';
+
+export function useIt(): string {
+  return realName();
+}
+`,
+};
+
+function writeFixture(dir: string) {
+  for (const [rel, content] of Object.entries(FILES)) {
+    const abs = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, content);
+  }
+}
+
+function hasFileEdge(dbPath: string, fromFile: string, toFile: string): boolean {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    const row = db
+      .prepare(
+        `SELECT 1 FROM edges e
+         JOIN nodes n1 ON e.source_id = n1.id
+         JOIN nodes n2 ON e.target_id = n2.id
+         WHERE n1.kind = 'file' AND n1.file = ? AND n2.kind = 'file' AND n2.file = ?
+         AND e.kind IN ('imports', 'reexports')`,
+      )
+      .get(fromFile, toFile);
+    return row !== undefined;
+  } finally {
+    db.close();
+  }
+}
+
+const ENGINES: EngineMode[] = ['wasm', 'native'];
+
+describe.each(ENGINES)(
+  'codegraph watch preserves an alias-based reverse-dep edge (#2242) — initial build: %s',
+  (engine) => {
+    let watchDir: string;
+    let dbPath: string;
+
+    beforeAll(async () => {
+      watchDir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2242-${engine}-`));
+      writeFixture(watchDir);
+
+      await buildGraph(watchDir, { incremental: false, skipRegistry: true, engine });
+      dbPath = path.join(watchDir, '.codegraph', 'graph.db');
+
+      // Sanity check: the full build resolved the alias-based reexport.
+      expect(hasFileEdge(dbPath, 'barrel.ts', 'utils/foo.ts')).toBe(true);
+
+      // Touch the DEEPEST file — barrel.ts (which imports it via alias) is
+      // a reverse dep and gets reparsed via rebuildReverseDepEdges.
+      const targetFile = path.join(watchDir, 'utils/foo.ts');
+      fs.appendFileSync(targetFile, '\n// touch\n');
+
+      const db = openDb(dbPath);
+      initSchema(db);
+      await rebuildFile(db, watchDir, targetFile, createIncrementalStmts(db), { engine }, null);
+      db.close();
+    }, 60_000);
+
+    afterAll(() => {
+      if (watchDir) fs.rmSync(watchDir, { recursive: true, force: true });
+    });
+
+    it("barrel.ts's alias-resolved reexports edge survives the reverse-dep cascade", () => {
+      expect(hasFileEdge(dbPath, 'barrel.ts', 'utils/foo.ts')).toBe(true);
+    });
+  },
+);


### PR DESCRIPTION
## Summary
- `incremental.ts`'s single-file rebuild path (`rebuildFile`, used by `codegraph watch`) hardcoded an empty `PathAliases` object (`{ baseUrl: null, paths: {} }`) at every import-resolution call site, instead of loading the project's real tsconfig/jsconfig aliases the way the full-build pipeline does via `loadPathAliases`.
- Any file whose imports use an alias (e.g. `@utils/*`) got incorrect or missing edges (`imports`, `reexports`, `calls` — not just renamed reexports, which #1967 already fixed narrowly) whenever it was reparsed under watch.
- Loads aliases once per `rebuildFile` invocation (mirroring the existing `knownFiles` pattern) and threads them through `rebuildEdgesForTargetFile`, `runReverseDepCascade`, `rebuildReverseDepEdges`, and `emitBarrelImportEdgesForReverseDeps`.
- Also fixed a stale comment in `issue-1967-watch-barrel-rename.test.ts` that documented this exact gap as an accepted "known limitation, filed as follow-up" — added the missing assertion there instead of leaving it undocumented as fixed.

## Test plan
- [x] New regression test (`issue-2242-watch-alias-reverse-dep.test.ts`) covering the reverse-dep cascade path, both engines — fails without the fix, passes with it
- [x] Extended assertion in `issue-1967-watch-barrel-rename.test.ts` covering the direct-rebuild path — fails without the fix, passes with it
- [x] Full test suite passes (4803 tests)
- [x] `node scripts/parity-compare.mjs` — 42/42 fixtures identical
- [x] `codegraph diff-impact origin/main -T` — blast radius limited to the 5 touched functions

Closes #2242