### PR TITLE
fix(cha): exclude super-dispatch edges from CHA sibling expansion

### DIFF
--- a/src/domain/graph/builder/helpers.ts
+++ b/src/domain/graph/builder/helpers.ts
@@ -787,10 +787,10 @@ export function runChaPostPass(db: BetterSqlite3Database): number {
     debug('runChaPostPass: no constructor-call evidence — proceeding without RTA filter');
   }
 
-  // No technique exclusion here: this pass's own prior output is now tagged
-  // 'cha' (#1996), the same label as this/super-dispatch edges from a
-  // different pass — both are legitimate candidates for further BFS
-  // expansion (e.g. a this-dispatch edge resolved to an ancestor's method
+  // No technique exclusion for 'cha'/this-dispatch here: this pass's own
+  // prior output is now tagged 'cha' (#1996), the same label as this-dispatch
+  // edges from a different pass — both are legitimate candidates for further
+  // BFS expansion (e.g. a this-dispatch edge resolved to an ancestor's method
   // may still need expanding to sibling overrides). Re-examining a
   // previously-expanded edge as a candidate again is safe: the BFS below
   // already walks the full multi-level hierarchy in one pass, so any
@@ -799,6 +799,11 @@ export function runChaPostPass(db: BetterSqlite3Database): number {
   // incorrect edges result, only bounded redundant work on incremental
   // rebuilds that re-scan the whole candidate set (Gate A/B in the native
   // orchestrator's equivalent, `fetchChaCallToMethods`).
+  //
+  // 'super-dispatch' IS excluded: `super.method()` is a static, non-virtual
+  // call that always invokes the declaring ancestor's method directly and
+  // can never dispatch to a sibling subclass's override — unlike this/CHA
+  // edges, it must never be treated as an expansion candidate (issue #2243).
   const callToMethods = db
     .prepare(
       `SELECT e.source_id, src.name AS caller_name, src.file AS caller_file, tgt.name AS method_name
@@ -806,7 +811,8 @@ export function runChaPostPass(db: BetterSqlite3Database): number {
        JOIN nodes tgt ON e.target_id = tgt.id
        JOIN nodes src ON e.source_id = src.id
        WHERE e.kind = 'calls' AND tgt.kind = 'method'
-       AND INSTR(tgt.name, '.') > 0`,
+       AND INSTR(tgt.name, '.') > 0
+       AND (e.technique IS NULL OR e.technique != 'super-dispatch')`,
     )
     .all() as Array<{
     source_id: number;

--- a/src/domain/graph/builder/stages/native-orchestrator.ts
+++ b/src/domain/graph/builder/stages/native-orchestrator.ts
@@ -864,17 +864,22 @@ function fetchChaCallToMethods(
   changedFiles: string[] | null,
   scopeToChangedFiles: boolean,
 ): ChaCallRow[] {
-  // No technique exclusion here: this pass's own prior output is tagged
-  // 'cha' (#1996), the same label used by this/super-dispatch edges from a
-  // different pass (runPostNativeThisDispatch) — both are legitimate
-  // candidates for further BFS expansion. Re-examining a previously-expanded
-  // edge as a candidate again is safe: expandChaEdges's BFS already walks the
-  // full multi-level hierarchy in one pass, so re-processing an
-  // already-expanded edge just re-derives pairs already present in `seen`
-  // and is skipped there — no duplicate or incorrect edges, only bounded
-  // redundant work on the rare incremental rebuild where Gate A/B forces a
-  // full rescan. Mirrors the equivalent change in builder/helpers.ts's
-  // runChaPostPass (the WASM-path twin of this function).
+  // No technique exclusion for 'cha'/this-dispatch here: this pass's own
+  // prior output is tagged 'cha' (#1996), the same label used by
+  // this-dispatch edges from a different pass (runPostNativeThisDispatch) —
+  // both are legitimate candidates for further BFS expansion. Re-examining a
+  // previously-expanded edge as a candidate again is safe: expandChaEdges's
+  // BFS already walks the full multi-level hierarchy in one pass, so
+  // re-processing an already-expanded edge just re-derives pairs already
+  // present in `seen` and is skipped there — no duplicate or incorrect
+  // edges, only bounded redundant work on the rare incremental rebuild
+  // where Gate A/B forces a full rescan. Mirrors the equivalent change in
+  // builder/helpers.ts's runChaPostPass (the WASM-path twin of this function).
+  //
+  // 'super-dispatch' IS excluded: `super.method()` is a static, non-virtual
+  // call that always invokes the declaring ancestor's method directly and
+  // can never dispatch to a sibling subclass's override — unlike this/CHA
+  // edges, it must never be treated as an expansion candidate (issue #2243).
   if (scopeToChangedFiles && changedFiles && changedFiles.length > 0) {
     const CHUNK_SIZE = 500;
     const rows: ChaCallRow[] = [];
@@ -889,6 +894,7 @@ function fetchChaCallToMethods(
            JOIN nodes src ON e.source_id = src.id
            WHERE e.kind = 'calls' AND tgt.kind = 'method'
            AND INSTR(tgt.name, '.') > 0
+           AND (e.technique IS NULL OR e.technique != 'super-dispatch')
            AND src.file IN (${ph})`,
         )
         .all(...chunk) as ChaCallRow[];
@@ -904,6 +910,7 @@ function fetchChaCallToMethods(
       JOIN nodes src ON e.source_id = src.id
       WHERE e.kind = 'calls' AND tgt.kind = 'method'
       AND INSTR(tgt.name, '.') > 0
+      AND (e.technique IS NULL OR e.technique != 'super-dispatch')
     `)
     .all() as ChaCallRow[];
 }

--- a/tests/fixtures/cha-dispatch/Dispatcher.ts
+++ b/tests/fixtures/cha-dispatch/Dispatcher.ts
@@ -1,6 +1,7 @@
 import { ConcreteWorker } from './ConcreteWorker.js';
 import type { IWorker } from './IWorker.js';
 import { MockWorker } from './MockWorker.js';
+import { Tiger } from './Tiger.js';
 
 // Typed parameter — typeMap will record worker: IWorker (confidence 0.9).
 // CHA should expand worker.doWork() to all instantiated IWorker implementations.
@@ -12,5 +13,11 @@ export function run(): string {
   const w1 = new ConcreteWorker();
   const w2 = new MockWorker();
   // GhostWorker is never instantiated — RTA excludes it from CHA targets.
+  // Tiger IS instantiated (issue #2243) — gives the CHA expansion post-pass
+  // real RTA evidence for Lion's sibling subclass, so the "does NOT
+  // CHA-expand Lion.speak to sibling Tiger.speak" test actually exercises
+  // the super-dispatch guard instead of passing by RTA-filter accident.
+  const tiger = new Tiger();
+  tiger.speak();
   return dispatch(w1) + dispatch(w2);
 }

--- a/tests/fixtures/cha-dispatch/Dispatcher.ts
+++ b/tests/fixtures/cha-dispatch/Dispatcher.ts
@@ -17,7 +17,9 @@ export function run(): string {
   // real RTA evidence for Lion's sibling subclass, so the "does NOT
   // CHA-expand Lion.speak to sibling Tiger.speak" test actually exercises
   // the super-dispatch guard instead of passing by RTA-filter accident.
-  const tiger = new Tiger();
-  tiger.speak();
+  // Deliberately not called — an unrelated run -> Tiger.speak call edge
+  // would add noise unrelated to what this fixture is testing (Greptile
+  // review on PR #2403).
+  const _tiger = new Tiger();
   return dispatch(w1) + dispatch(w2);
 }


### PR DESCRIPTION
## Summary
- `super.method()` is a static, non-virtual call — it always invokes the declaring ancestor's method directly and can never dispatch to a sibling subclass. The CHA expansion post-pass (`runChaPostPass` in `helpers.ts`, mirrored by `fetchChaCallToMethods` in `native-orchestrator.ts`) treated a `'super-dispatch'`-tagged call edge as an eligible candidate for virtual dispatch expansion, same as a this-dispatch or typed-receiver edge.
- When the ancestor class had an instantiated sibling subclass overriding the same method, the post-pass fabricated an edge straight to that unrelated sibling's override (e.g. `Lion.speak -> Tiger.speak`, which `Lion` never calls).
- Excludes `technique = 'super-dispatch'` from both candidate queries. this/CHA-tagged edges remain eligible (they ARE polymorphic).
- Added an instantiation site for `Tiger` (Lion's sibling subclass) in the existing `cha-dispatch` fixture so the existing "does NOT CHA-expand Lion.speak to sibling Tiger.speak" test genuinely exercises this guard instead of passing by RTA-filter accident (per the issue's own finding).

## Test plan
- [x] Extended fixture + existing test fails without the fix (both engines), passes with it
- [x] Full test suite passes (4805 tests)
- [x] `node scripts/parity-compare.mjs` — 42/42 fixtures identical
- [x] `jelly-micro` classes recall floor holds
- [x] `codegraph diff-impact origin/main -T` — blast radius limited to the 2 touched functions + fixture

Closes #2243