### PR TITLE
fix(python): resolve module imports to files and aliased module calls (#2387)

### DIFF
--- a/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
@@ -1576,6 +1576,40 @@ fn collect_imported_names_for_file(
                     name: local,
                     file: String::new(),
                     imported: None,
+                    namespace: None,
+                });
+                continue;
+            }
+            // A binding that names the module itself targets the module file
+            // and has no declared symbol to trace through a barrel (#2387).
+            if imp
+                .namespace_bindings
+                .as_ref()
+                .is_some_and(|b| b.contains(&local))
+            {
+                imported_names.push(ImportedName {
+                    name: local,
+                    file: resolved_path.clone(),
+                    imported: None,
+                    namespace: Some(true),
+                });
+                continue;
+            }
+            // `from pkg import submod` binds a module too, but which reading
+            // applies depends on whether `pkg/submod.py` exists — a question
+            // only the resolver can answer (#2387).
+            if let Some(submodule) = crate::domain::graph::resolve::resolve_python_submodule(
+                abs_str,
+                &imp.source,
+                &original,
+                &import_ctx.root_dir,
+                Some(&import_ctx.known_files),
+            ) {
+                imported_names.push(ImportedName {
+                    name: local,
+                    file: submodule,
+                    imported: None,
+                    namespace: Some(true),
                 });
                 continue;
             }
@@ -1598,6 +1632,7 @@ fn collect_imported_names_for_file(
                 },
                 name: local,
                 file: target_file,
+                namespace: None,
             });
         }
     }

--- a/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
@@ -74,6 +74,12 @@ pub struct ImportedName {
     /// `name` — the renamed local alias only exists in the importing file,
     /// not in `file` itself (#1730).
     pub imported: Option<String>,
+    /// True when `name` is bound to the whole module `file` rather than to a
+    /// symbol inside it (Python's `import lib as L`, `from pkg import
+    /// submod`). A call written `L.f()` then means "f, as declared in `file`"
+    /// — see `resolve_call_targets`'s namespace branch (#2387). Mirrors the
+    /// `namespace` field of the TS `importedNames` FFI entry.
+    pub namespace: Option<bool>,
 }
 
 #[napi(object)]
@@ -896,6 +902,7 @@ struct PtsAliasCtx<'a> {
     rel_path: &'a str,
     imported_names: &'a HashMap<&'a str, &'a str>,
     imported_original_names: &'a HashMap<&'a str, &'a str>,
+    namespace_imports: &'a HashMap<&'a str, &'a str>,
     type_map: &'a HashMap<&'a str, (&'a str, f64)>,
 }
 
@@ -934,6 +941,7 @@ fn emit_pts_alias_edges<'a>(
             alias_ctx.caller_name,
             alias_ctx.imported_names,
             alias_ctx.imported_original_names,
+            alias_ctx.namespace_imports,
             &mut alias_confidence_override,
         );
         sort_targets_by_confidence(
@@ -1016,6 +1024,11 @@ struct FileContext<'a> {
     /// omitted. Consulted by `resolve_call_targets` so a call to the local
     /// alias resolves against the correct exported symbol (#1730).
     imported_original_names: HashMap<&'a str, &'a str>,
+    /// Local binding -> module file, for bindings that name a module rather
+    /// than a symbol (Python's `import lib as L`, `from pkg import submod`).
+    /// Lets `resolve_call_targets` read `L.f()` as "f, declared in that
+    /// module" instead of resolving it to nothing (#2387).
+    namespace_imports: HashMap<&'a str, &'a str>,
     type_map: HashMap<&'a str, (&'a str, f64)>,
     defs_with_ids: Vec<DefWithId<'a>>,
     pts_map: Option<HashMap<String, HashSet<String>>>,
@@ -1152,6 +1165,12 @@ fn build_file_context<'a>(
         .iter()
         .filter_map(|im| im.imported.as_deref().map(|orig| (im.name.as_str(), orig)))
         .collect();
+    let namespace_imports: HashMap<&str, &str> = file_input
+        .imported_names
+        .iter()
+        .filter(|im| im.namespace.unwrap_or(false))
+        .map(|im| (im.name.as_str(), im.file.as_str()))
+        .collect();
     let type_map = build_type_map(file_input);
     let file_nodes: Vec<&NodeInfo> = all_nodes.iter().filter(|n| n.file == rel_path).collect();
     let defs_with_ids: Vec<DefWithId> = file_input
@@ -1181,6 +1200,7 @@ fn build_file_context<'a>(
         file_node_id: file_input.file_node_id,
         imported_names,
         imported_original_names,
+        namespace_imports,
         type_map,
         defs_with_ids,
         pts_map,
@@ -1250,6 +1270,7 @@ fn emit_no_receiver_pts_edges<'a>(
                 rel_path: fc.rel_path,
                 imported_names: &fc.imported_names,
                 imported_original_names: &fc.imported_original_names,
+                namespace_imports: &fc.namespace_imports,
                 type_map: &fc.type_map,
             },
             seen_edges,
@@ -1297,6 +1318,7 @@ fn emit_receiver_pts_edges<'a>(
             rel_path: fc.rel_path,
             imported_names: &fc.imported_names,
             imported_original_names: &fc.imported_original_names,
+            namespace_imports: &fc.namespace_imports,
             type_map: &fc.type_map,
         },
         seen_edges,
@@ -1356,6 +1378,7 @@ fn process_file<'a>(
             caller_name,
             &fc.imported_names,
             &fc.imported_original_names,
+            &fc.namespace_imports,
             &mut confidence_override,
         );
         // #1771/#1784: value-ref references (object-literal property values,
@@ -1742,6 +1765,7 @@ fn resolve_call_targets<'a>(
     caller_name: &str,
     imported_names: &HashMap<&str, &str>,
     imported_original_names: &HashMap<&str, &str>,
+    namespace_imports: &HashMap<&str, &str>,
     confidence_override: &mut Option<f64>,
 ) -> Vec<&'a NodeInfo> {
     let targets = resolve_call_targets_core(
@@ -1753,6 +1777,7 @@ fn resolve_call_targets<'a>(
         caller_name,
         imported_names,
         imported_original_names,
+        namespace_imports,
         confidence_override,
     );
     if call.receiver.is_some() {
@@ -1801,6 +1826,7 @@ fn resolve_call_targets_core<'a>(
     caller_name: &str,
     imported_names: &HashMap<&str, &str>,
     imported_original_names: &HashMap<&str, &str>,
+    namespace_imports: &HashMap<&str, &str>,
     confidence_override: &mut Option<f64>,
 ) -> Vec<&'a NodeInfo> {
     // Flagged dynamic calls use synthetic names like "<dynamic:eval>". Short-circuit
@@ -1876,6 +1902,29 @@ fn resolve_call_targets_core<'a>(
                     .collect()
             })
             .unwrap_or_default();
+    }
+
+    // A call through a module namespace binding (`import lib as L; L.f()`,
+    // `from pkg import submod; submod.f()`) names a module, not a value, so
+    // the target is simply `call.name` as declared in that module's file.
+    // Resolved ahead of the general cascade because the cascade has nothing to
+    // work with here: `call.name` is not itself an imported binding, and the
+    // receiver has no type to look up — which is why every such call
+    // previously resolved to nothing and left the callee reported as dead
+    // (#2387).
+    //
+    // Scoped to the module's own file and authoritative: a miss means the
+    // module does not declare that name, not "keep looking". Falling through
+    // would let an unrelated same-named function elsewhere in the project
+    // claim the call. Mirrors resolveCallTargets in call-resolver.ts.
+    if let Some(receiver) = call.receiver.as_deref() {
+        if let Some(namespace_file) = namespace_imports.get(receiver) {
+            return ctx
+                .nodes_by_name_and_file
+                .get(&(call.name.as_str(), *namespace_file))
+                .map(|v| v.to_vec())
+                .unwrap_or_default();
+        }
     }
 
     // When the call site uses a renamed import binding (`import { X as Y }`),
@@ -4590,6 +4639,7 @@ mod call_edge_tests {
             name: "SR".to_string(),
             file: "sqlite-repository.js".to_string(),
             imported: Some("SqliteRepository".to_string()),
+            namespace: None,
         }];
 
         let edges = build_call_edges(vec![file], all_nodes, vec![], MAX_SOLVER_ITERATIONS, None);
@@ -4648,6 +4698,7 @@ mod call_edge_tests {
             name: "SqliteRepository".to_string(),
             file: "sqlite-repository.js".to_string(),
             imported: None,
+            namespace: None,
         }];
 
         let edges = build_call_edges(vec![file], all_nodes, vec![], MAX_SOLVER_ITERATIONS, None);
@@ -4705,6 +4756,7 @@ mod call_edge_tests {
             name: "SqliteRepository".to_string(),
             file: "sqlite-repository.js".to_string(),
             imported: None,
+            namespace: None,
         }];
 
         let edges = build_call_edges(vec![file], all_nodes, vec![], MAX_SOLVER_ITERATIONS, None);
@@ -4819,6 +4871,7 @@ mod call_edge_tests {
             name: "Calculator".to_string(),
             file: "utils.js".to_string(),
             imported: None,
+            namespace: None,
         }];
 
         let edges = build_call_edges(vec![file], all_nodes, vec![], MAX_SOLVER_ITERATIONS, None);
@@ -6155,6 +6208,7 @@ mod call_edge_tests {
             name: "e4".to_string(),
             file: "other.js".to_string(),
             imported: None,
+            namespace: None,
         }];
         file.param_bindings = Some(vec![ParamBinding {
             callee: "f3".to_string(),

--- a/crates/codegraph-core/src/domain/graph/builder/stages/import_edges.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/import_edges.rs
@@ -699,6 +699,33 @@ fn emit_edges_for_import(
         return;
     }
     let resolved_path = ctx.get_resolved(abs_str, &imp.source);
+
+    // `from pkg import submod` depends on `pkg/submod.py`, not merely on
+    // `pkg/__init__.py` — emitting only the latter would report the package
+    // barrel as the dependency and leave the module that actually changed
+    // invisible to `deps`/`impact` (#2387). Mirrors emitEdgesForImport in
+    // stages/build-edges.ts.
+    for (_local, original, _type_only) in import_name_pairs(imp) {
+        let Some(submodule) = crate::domain::graph::resolve::resolve_python_submodule(
+            abs_str,
+            &imp.source,
+            &original,
+            &ctx.root_dir,
+            Some(&ctx.known_files),
+        ) else {
+            continue;
+        };
+        if let Some(&submodule_id) = file_node_ids.get(&submodule) {
+            edges.push(EdgeRow {
+                source_id: file_node_id,
+                target_id: submodule_id,
+                kind: "imports".to_string(),
+                confidence: 1.0,
+                dynamic: 0,
+            });
+        }
+    }
+
     let target_id = match file_node_ids.get(&resolved_path) {
         Some(&id) => id,
         None => return,

--- a/crates/codegraph-core/src/domain/graph/resolve.rs
+++ b/crates/codegraph-core/src/domain/graph/resolve.rs
@@ -552,6 +552,344 @@ fn relativize_to_root(candidate: &str, root_dir: &str) -> String {
     }
 }
 
+// ── Python module-path resolution ───────────────────────────────────
+// Mirrors resolve.ts's resolvePythonImportPath and its helpers (issue #2387).
+
+/// True if `file` is Python source. Both engines resolve Python imports by
+/// module path rather than by filesystem path, so this gates the whole Python
+/// branch of `resolve_import_path_inner`.
+fn is_python_file(file: &str) -> bool {
+    file.ends_with(".py") || file.ends_with(".pyi")
+}
+
+/// Import roots declared by `pyproject.toml`, as absolute directories.
+///
+/// Layout conventions cover most projects (see `python_package_root`), but a
+/// root that is neither the repo root nor derivable from `__init__.py`
+/// placement can only be known from configuration — `pythonpath = ["src",
+/// "scripts"]` being the case observed on `data-analytics-pipeline-svc`
+/// (#2387), where `scripts/` is importable but contains no package marker.
+///
+/// Best-effort: unreadable or malformed TOML contributes no roots rather than
+/// failing resolution, matching `parse_cargo_target_overrides`'s precedent.
+fn parse_pyproject_import_roots(root_dir: &str) -> Vec<String> {
+    let manifest = Path::new(root_dir).join("pyproject.toml");
+    let Ok(content) = std::fs::read_to_string(&manifest) else {
+        return Vec::new();
+    };
+    let Ok(parsed) = toml::from_str::<toml::Value>(&content) else {
+        return Vec::new();
+    };
+    let Some(tool) = parsed.get("tool") else {
+        return Vec::new();
+    };
+
+    let mut roots = Vec::new();
+    // `package-dir` maps an import prefix to a directory; only the directory
+    // half is an import root. An empty-string value means "the repo root",
+    // which is already probed unconditionally.
+    let mut add_root = |value: Option<&toml::Value>| {
+        if let Some(s) = value.and_then(|v| v.as_str()).filter(|s| !s.is_empty()) {
+            roots.push(
+                Path::new(root_dir)
+                    .join(s)
+                    .display()
+                    .to_string()
+                    .replace('\\', "/"),
+            );
+        }
+    };
+
+    // [tool.pytest.ini_options] pythonpath = ["src", "scripts"]
+    if let Some(entries) = tool
+        .get("pytest")
+        .and_then(|p| p.get("ini_options"))
+        .and_then(|o| o.get("pythonpath"))
+        .and_then(|v| v.as_array())
+    {
+        for entry in entries {
+            add_root(Some(entry));
+        }
+    }
+    // [tool.setuptools] package-dir = { "" = "src" }
+    if let Some(table) = tool
+        .get("setuptools")
+        .and_then(|s| s.get("package-dir"))
+        .and_then(|v| v.as_table())
+    {
+        for value in table.values() {
+            add_root(Some(value));
+        }
+    }
+    // [tool.setuptools.packages.find] where = ["src"]
+    if let Some(entries) = tool
+        .get("setuptools")
+        .and_then(|s| s.get("packages"))
+        .and_then(|p| p.get("find"))
+        .and_then(|f| f.get("where"))
+        .and_then(|v| v.as_array())
+    {
+        for entry in entries {
+            add_root(Some(entry));
+        }
+    }
+    // [tool.poetry] packages = [{ include = "pipeline", from = "src" }]
+    if let Some(entries) = tool
+        .get("poetry")
+        .and_then(|p| p.get("packages"))
+        .and_then(|v| v.as_array())
+    {
+        for entry in entries {
+            add_root(entry.get("from"));
+        }
+    }
+
+    roots
+}
+
+/// Cache: root_dir → configured import roots. Populated lazily on the first
+/// Python import resolved for a given root_dir, so non-Python projects never
+/// pay for the manifest read.
+fn python_configured_roots_cache() -> &'static Mutex<HashMap<String, Vec<String>>> {
+    static CACHE: OnceLock<Mutex<HashMap<String, Vec<String>>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Cache: file directory → its derived package root.
+fn python_package_root_cache() -> &'static Mutex<HashMap<String, String>> {
+    static CACHE: OnceLock<Mutex<HashMap<String, String>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Clear both Python import-root caches — called from the NAPI-exported
+/// `clear_python_import_roots_cache` (so a long-lived process picks up
+/// pyproject.toml edits and `__init__.py` additions/removals) and
+/// `resolve_imports`'s once-per-build reset, as well as directly from tests.
+pub fn clear_python_import_roots_cache() {
+    python_configured_roots_cache()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clear();
+    python_package_root_cache()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clear();
+}
+
+fn get_python_configured_roots(root_dir: &str) -> Vec<String> {
+    let mut cache = python_configured_roots_cache()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(existing) = cache.get(root_dir) {
+        return existing.clone();
+    }
+    let roots = parse_pyproject_import_roots(root_dir);
+    cache.insert(root_dir.to_string(), roots.clone());
+    roots
+}
+
+/// The directory an absolute Python import from `from_file` resolves against,
+/// derived from package layout: walk up from the file's own directory for as
+/// long as each level is a package (contains `__init__.py`), and stop at the
+/// first ancestor that is not.
+///
+/// That ancestor is the directory that would be on `sys.path` at runtime, so
+/// this handles the PyPA-endorsed "src layout" (`src/pipeline/…`, imported as
+/// `from pipeline…`) and a flat layout with the same rule and no
+/// configuration — the src-layout case being precisely what made
+/// `data-analytics-pipeline-svc` resolve zero imports (#2387).
+///
+/// Never walks above `root_dir`: a stray `__init__.py` at the repo root must
+/// not send resolution outside the project.
+fn python_package_root(
+    from_file: &str,
+    root_dir: &str,
+    known_files: Option<&HashSet<String>>,
+) -> String {
+    let start_dir = Path::new(from_file)
+        .parent()
+        .unwrap_or(Path::new(""))
+        .display()
+        .to_string()
+        .replace('\\', "/");
+    if let Some(hit) = python_package_root_cache()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(&start_dir)
+    {
+        return hit.clone();
+    }
+
+    let root_normalized = root_dir.replace('\\', "/");
+    let mut dir = start_dir.clone();
+    loop {
+        if dir == root_normalized {
+            break;
+        }
+        let init = Path::new(&dir)
+            .join("__init__.py")
+            .display()
+            .to_string()
+            .replace('\\', "/");
+        if !file_exists(&init, known_files, root_dir) {
+            break;
+        }
+        let Some(parent) = Path::new(&dir).parent() else {
+            break;
+        };
+        let parent_str = parent.display().to_string().replace('\\', "/");
+        if parent_str == dir {
+            break;
+        }
+        dir = parent_str;
+    }
+
+    python_package_root_cache()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert(start_dir, dir.clone());
+    dir
+}
+
+/// Candidate import roots for `from_file`, most specific first: the
+/// layout-derived package root, then the conventional `src/` directory, then
+/// the repo root, then anything `pyproject.toml` declares.
+fn python_import_roots(
+    from_file: &str,
+    root_dir: &str,
+    known_files: Option<&HashSet<String>>,
+) -> Vec<String> {
+    let mut roots = vec![
+        python_package_root(from_file, root_dir, known_files),
+        Path::new(root_dir)
+            .join("src")
+            .display()
+            .to_string()
+            .replace('\\', "/"),
+        root_dir.replace('\\', "/"),
+    ];
+    roots.extend(get_python_configured_roots(root_dir));
+    roots
+}
+
+/// Resolve dotted module `segments` beneath `base_dir` to the file that
+/// declares that module: `a/b/c.py`, then the package form
+/// `a/b/c/__init__.py`, then the stub `a/b/c.pyi`. Empty `segments` means the
+/// package itself (`from . import x`), which only ever resolves to its
+/// `__init__.py`.
+///
+/// Returns a root-relative path, or None when nothing matches — including
+/// when a candidate would land outside `root_dir`, which a relative import
+/// with more leading dots than there are package levels can otherwise do.
+fn resolve_python_module_under(
+    base_dir: &str,
+    segments: &[&str],
+    root_dir: &str,
+    known_files: Option<&HashSet<String>>,
+) -> Option<String> {
+    let mut target = PathBuf::from(base_dir);
+    for segment in segments {
+        target.push(segment);
+    }
+    let target_str = target.display().to_string().replace('\\', "/");
+
+    let candidates: Vec<String> = if segments.is_empty() {
+        vec![format!("{target_str}/__init__.py")]
+    } else {
+        vec![
+            format!("{target_str}.py"),
+            format!("{target_str}/__init__.py"),
+            format!("{target_str}.pyi"),
+        ]
+    };
+    for candidate in candidates {
+        if !file_exists(&candidate, known_files, root_dir) {
+            continue;
+        }
+        let rel = relativize_to_root(&candidate, root_dir);
+        if rel.starts_with("..") {
+            continue;
+        }
+        return Some(rel);
+    }
+    None
+}
+
+/// Resolve a Python `import a.b.c` / `from a.b import c` / `from .. import c`
+/// module path to the file that declares it (#2387).
+///
+/// Returns None for anything not found under a project import root — standard
+/// library and third-party modules included — so the caller falls through to
+/// the bare-specifier behaviour that treats them as external.
+fn resolve_python_import_path(
+    from_file: &str,
+    import_source: &str,
+    root_dir: &str,
+    known_files: Option<&HashSet<String>>,
+) -> Option<String> {
+    let dots = import_source.chars().take_while(|c| *c == '.').count();
+
+    if dots > 0 {
+        // Relative import: one dot is the current package, each extra dot
+        // climbs one level further up before the remaining segments are
+        // walked down.
+        let rest = &import_source[dots..];
+        let mut dir = Path::new(from_file)
+            .parent()
+            .unwrap_or(Path::new(""))
+            .to_path_buf();
+        for _ in 1..dots {
+            if !dir.pop() {
+                return None;
+            }
+        }
+        let dir_str = dir.display().to_string().replace('\\', "/");
+        let segments: Vec<&str> = if rest.is_empty() {
+            Vec::new()
+        } else {
+            rest.split('.').collect()
+        };
+        return resolve_python_module_under(&dir_str, &segments, root_dir, known_files);
+    }
+
+    let segments: Vec<&str> = import_source.split('.').collect();
+    if segments.iter().any(|s| s.is_empty()) {
+        return None;
+    }
+    for root in python_import_roots(from_file, root_dir, known_files) {
+        if let Some(resolved) = resolve_python_module_under(&root, &segments, root_dir, known_files)
+        {
+            return Some(resolved);
+        }
+    }
+    None
+}
+
+/// Resolve `from <source> import <name>` where `name` is itself a submodule
+/// rather than a symbol (`from pipeline.stages import extract`) — Python's two
+/// readings of that statement are indistinguishable without knowing which
+/// files exist, so this is decided here rather than in the extractor.
+///
+/// Returns the submodule's root-relative path, or None when `name` is an
+/// ordinary symbol declared inside the source module.
+pub fn resolve_python_submodule(
+    from_file: &str,
+    import_source: &str,
+    name: &str,
+    root_dir: &str,
+    known_files: Option<&HashSet<String>>,
+) -> Option<String> {
+    if !is_python_file(from_file) || name == "*" {
+        return None;
+    }
+    let combined = if import_source.ends_with('.') {
+        format!("{import_source}{name}")
+    } else {
+        format!("{import_source}.{name}")
+    };
+    resolve_python_import_path(from_file, &combined, root_dir, known_files)
+}
+
 // ── Rust `crate::`/`self::`/`super::` module-path resolution ────────
 // Mirrors resolve.ts's resolveRustUsePath and its helpers (issue #2007).
 
@@ -1044,6 +1382,18 @@ fn resolve_import_path_inner(
     known_files: Option<&HashSet<String>>,
     workspaces: Option<&HashMap<String, WorkspaceEntry>>,
 ) -> String {
+    // Python resolves by module path, not filesystem path, in both the
+    // absolute (`import a.b.c`) and relative (`from ..pkg import x`) forms —
+    // the latter shares JS's leading-dot spelling but means "climb the package
+    // tree", not "a path relative to this directory", so this must run before
+    // the generic relative branch below ever sees it (#2387).
+    if is_python_file(from_file) {
+        if let Some(resolved) =
+            resolve_python_import_path(from_file, import_source, root_dir, known_files)
+        {
+            return resolved;
+        }
+    }
     if !import_source.starts_with('.') {
         return resolve_non_relative_import(
             from_file,
@@ -1850,6 +2200,207 @@ mod tests {
         let normalized = normalize_known_files(input);
         assert!(normalized.contains("/project/main.rs"));
         assert!(normalized.contains("service.rs"));
+    }
+
+    // ── Python module-path resolution (#2387) ──────────────────────
+    //
+    // Each test uses a distinct root_dir so the process-wide package-root
+    // cache (keyed by directory) can never leak between tests running in
+    // parallel on separate threads.
+
+    fn python_src_layout_known_files(root: &str) -> HashSet<String> {
+        [
+            "src/pipeline/__init__.py",
+            "src/pipeline/util.py",
+            "src/pipeline/main.py",
+            "src/pipeline/stages/__init__.py",
+            "src/pipeline/stages/extract.py",
+            "src/pipeline/stages/load.py",
+            "scripts/tool.py",
+        ]
+        .iter()
+        .map(|f| format!("{root}/{f}"))
+        .collect()
+    }
+
+    #[test]
+    fn python_absolute_import_resolves_through_src_layout_package_root() {
+        // PyPA "src layout": package root is src/, imports written `pipeline…`.
+        let root = "/py-abs";
+        let known = python_src_layout_known_files(root);
+        let resolved = resolve_python_import_path(
+            &format!("{root}/src/pipeline/main.py"),
+            "pipeline.util",
+            root,
+            Some(&known),
+        );
+        assert_eq!(resolved, Some("src/pipeline/util.py".to_string()));
+    }
+
+    #[test]
+    fn python_absolute_import_resolves_nested_module() {
+        let root = "/py-nested";
+        let known = python_src_layout_known_files(root);
+        let resolved = resolve_python_import_path(
+            &format!("{root}/src/pipeline/main.py"),
+            "pipeline.stages.extract",
+            root,
+            Some(&known),
+        );
+        assert_eq!(resolved, Some("src/pipeline/stages/extract.py".to_string()));
+    }
+
+    #[test]
+    fn python_package_import_resolves_to_its_init_file() {
+        let root = "/py-pkg";
+        let known = python_src_layout_known_files(root);
+        let resolved = resolve_python_import_path(
+            &format!("{root}/src/pipeline/main.py"),
+            "pipeline.stages",
+            root,
+            Some(&known),
+        );
+        assert_eq!(
+            resolved,
+            Some("src/pipeline/stages/__init__.py".to_string())
+        );
+    }
+
+    #[test]
+    fn python_single_dot_relative_import_resolves_to_sibling_module() {
+        let root = "/py-rel1";
+        let known = python_src_layout_known_files(root);
+        let resolved = resolve_python_import_path(
+            &format!("{root}/src/pipeline/stages/load.py"),
+            ".extract",
+            root,
+            Some(&known),
+        );
+        assert_eq!(resolved, Some("src/pipeline/stages/extract.py".to_string()));
+    }
+
+    #[test]
+    fn python_double_dot_relative_import_resolves_to_parent_package() {
+        let root = "/py-rel2";
+        let known = python_src_layout_known_files(root);
+        let resolved = resolve_python_import_path(
+            &format!("{root}/src/pipeline/stages/load.py"),
+            "..util",
+            root,
+            Some(&known),
+        );
+        assert_eq!(resolved, Some("src/pipeline/util.py".to_string()));
+    }
+
+    #[test]
+    fn python_bare_dot_relative_import_resolves_to_current_package_init() {
+        let root = "/py-rel0";
+        let known = python_src_layout_known_files(root);
+        let resolved = resolve_python_import_path(
+            &format!("{root}/src/pipeline/stages/load.py"),
+            ".",
+            root,
+            Some(&known),
+        );
+        assert_eq!(
+            resolved,
+            Some("src/pipeline/stages/__init__.py".to_string())
+        );
+    }
+
+    #[test]
+    fn python_import_from_outside_the_package_tree_resolves_via_src_convention() {
+        let root = "/py-outside";
+        let known = python_src_layout_known_files(root);
+        let resolved = resolve_python_import_path(
+            &format!("{root}/scripts/tool.py"),
+            "pipeline.util",
+            root,
+            Some(&known),
+        );
+        assert_eq!(resolved, Some("src/pipeline/util.py".to_string()));
+    }
+
+    #[test]
+    fn python_stdlib_and_third_party_modules_stay_unresolved() {
+        // Must return None so the caller falls through to the bare-specifier
+        // behaviour that treats them as external, rather than inventing an
+        // edge to some coincidentally-named project file.
+        let root = "/py-external";
+        let known = python_src_layout_known_files(root);
+        let from = format!("{root}/src/pipeline/main.py");
+        assert_eq!(
+            resolve_python_import_path(&from, "os.path", root, Some(&known)),
+            None
+        );
+        assert_eq!(
+            resolve_python_import_path(&from, "numpy", root, Some(&known)),
+            None
+        );
+    }
+
+    #[test]
+    fn python_relative_import_never_escapes_the_repo_root() {
+        let root = "/py-escape";
+        let known = python_src_layout_known_files(root);
+        let resolved = resolve_python_import_path(
+            &format!("{root}/src/pipeline/stages/load.py"),
+            "...escape",
+            root,
+            Some(&known),
+        );
+        assert!(resolved.is_none_or(|p| !p.starts_with("..")));
+    }
+
+    #[test]
+    fn python_submodule_import_is_distinguished_from_a_symbol_import() {
+        // `from pipeline.stages import extract` — extract is a module.
+        // `from pipeline.util import shared_helper` — shared_helper is not.
+        let root = "/py-submodule";
+        let known = python_src_layout_known_files(root);
+        let from = format!("{root}/src/pipeline/main.py");
+        assert_eq!(
+            resolve_python_submodule(&from, "pipeline.stages", "extract", root, Some(&known)),
+            Some("src/pipeline/stages/extract.py".to_string())
+        );
+        assert_eq!(
+            resolve_python_submodule(&from, "pipeline.util", "shared_helper", root, Some(&known)),
+            None
+        );
+    }
+
+    #[test]
+    fn python_submodule_resolution_declines_wildcards_and_non_python_callers() {
+        let root = "/py-submodule-guard";
+        let known = python_src_layout_known_files(root);
+        assert_eq!(
+            resolve_python_submodule(
+                &format!("{root}/src/pipeline/main.py"),
+                "pipeline",
+                "*",
+                root,
+                Some(&known)
+            ),
+            None
+        );
+        assert_eq!(
+            resolve_python_submodule(
+                &format!("{root}/src/main.ts"),
+                "pipeline",
+                "stages",
+                root,
+                Some(&known)
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn is_python_file_recognizes_source_and_stub_extensions() {
+        assert!(is_python_file("app/main.py"));
+        assert!(is_python_file("app/types.pyi"));
+        assert!(!is_python_file("src/index.ts"));
+        assert!(!is_python_file("main.rs"));
     }
 
     #[test]

--- a/crates/codegraph-core/src/extractors/python.rs
+++ b/crates/codegraph-core/src/extractors/python.rs
@@ -173,27 +173,48 @@ fn handle_call(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     }
 }
 
+/// `import a.b`, `import a.b as ab`, `import a, b` — the module-binding form.
+///
+/// Each module in the statement becomes its own `Import`, whose `source` is
+/// the module path and whose single name is the local binding it introduces.
+/// That split matters twice over: `source` previously carried the *alias* for
+/// `import lib as L`, which can never resolve to a file, and a multi-module
+/// `import a, b` collapsed into one record naming only `a` as its source
+/// (#2387).
+///
+/// The binding names a module object rather than a symbol, so it is also
+/// recorded in `namespace_bindings` — that is what lets `L.strip_block()`
+/// resolve `strip_block` inside the module `L` refers to. For the unaliased
+/// dotted form the binding is recorded under its full dotted spelling (`a.b`),
+/// because that is the receiver text a call site writes (`a.b.func()`).
+///
+/// Mirrors `handlePyImport` in src/extractors/python.ts.
 fn handle_import_stmt(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
-    let mut names = Vec::new();
+    let line = start_line(node);
     for i in 0..node.child_count() {
         let Some(child) = node.child(i) else { continue };
-        if child.kind() != "dotted_name" && child.kind() != "aliased_import" {
-            continue;
-        }
-        let name = if child.kind() == "aliased_import" {
-            child
-                .child_by_field_name("alias")
-                .or_else(|| child.child_by_field_name("name"))
-                .map(|n| node_text(&n, source).to_string())
-        } else {
-            Some(node_text(&child, source).to_string())
+        let (module, local) = match child.kind() {
+            "dotted_name" => {
+                let text = node_text(&child, source).to_string();
+                (Some(text.clone()), Some(text))
+            }
+            "aliased_import" => {
+                let module = child
+                    .child_by_field_name("name")
+                    .map(|n| node_text(&n, source).to_string());
+                let local = child
+                    .child_by_field_name("alias")
+                    .map(|n| node_text(&n, source).to_string())
+                    .or_else(|| module.clone());
+                (module, local)
+            }
+            _ => continue,
         };
-        if let Some(name) = name {
-            names.push(name);
-        }
-    }
-    if !names.is_empty() {
-        let mut imp = Import::new(names[0].clone(), names, start_line(node));
+        let (Some(module), Some(local)) = (module, local) else {
+            continue;
+        };
+        let mut imp = Import::new(module, vec![local.clone()], line);
+        imp.namespace_bindings = Some(vec![local]);
         imp.python_import = Some(true);
         symbols.imports.push(imp);
     }
@@ -561,6 +582,69 @@ mod tests {
         assert_eq!(s.imports.len(), 1);
         assert_eq!(s.imports[0].source, "os.path");
         assert!(s.imports[0].names.contains(&"join".to_string()));
+    }
+
+    #[test]
+    fn plain_import_records_the_module_as_source_and_a_namespace_binding() {
+        // #2387: `source` must be the module, not the binding name — a binding
+        // name can never resolve to a file.
+        let s = parse_py("import lib\n");
+        assert_eq!(s.imports.len(), 1);
+        assert_eq!(s.imports[0].source, "lib");
+        assert_eq!(s.imports[0].names, vec!["lib".to_string()]);
+        assert_eq!(
+            s.imports[0].namespace_bindings,
+            Some(vec!["lib".to_string()])
+        );
+    }
+
+    #[test]
+    fn aliased_import_keeps_the_module_as_source_and_the_alias_as_the_binding() {
+        // #2387: this previously stored the alias ("L") as `source`, which is
+        // why `import lib as L` produced no imports edge and `L.f()` resolved
+        // to nothing.
+        let s = parse_py("import lib as L\n");
+        assert_eq!(s.imports.len(), 1);
+        assert_eq!(s.imports[0].source, "lib");
+        assert_eq!(s.imports[0].names, vec!["L".to_string()]);
+        assert_eq!(s.imports[0].namespace_bindings, Some(vec!["L".to_string()]));
+    }
+
+    #[test]
+    fn dotted_import_binds_under_its_full_dotted_spelling() {
+        // `import a.b.c` is written `a.b.c.func()` at the call site, so the
+        // binding is recorded under the dotted text a receiver would carry.
+        let s = parse_py("import a.b.c\n");
+        assert_eq!(s.imports.len(), 1);
+        assert_eq!(s.imports[0].source, "a.b.c");
+        assert_eq!(
+            s.imports[0].namespace_bindings,
+            Some(vec!["a.b.c".to_string()])
+        );
+    }
+
+    #[test]
+    fn multi_module_import_produces_one_record_per_module() {
+        // #2387: `import a, b` used to collapse into a single record whose
+        // source was "a", silently losing b entirely.
+        let s = parse_py("import alpha, beta as B\n");
+        assert_eq!(s.imports.len(), 2);
+        let sources: Vec<&str> = s.imports.iter().map(|i| i.source.as_str()).collect();
+        assert!(sources.contains(&"alpha"));
+        assert!(sources.contains(&"beta"));
+        let beta = s.imports.iter().find(|i| i.source == "beta").unwrap();
+        assert_eq!(beta.names, vec!["B".to_string()]);
+    }
+
+    #[test]
+    fn from_import_names_are_not_namespace_bindings() {
+        // `from mod import name` binds a symbol; whether `name` is actually a
+        // submodule is decided at resolution time, not here.
+        let s = parse_py("from lib import helper\n");
+        assert_eq!(s.imports.len(), 1);
+        assert_eq!(s.imports[0].source, "lib");
+        assert_eq!(s.imports[0].names, vec!["helper".to_string()]);
+        assert_eq!(s.imports[0].namespace_bindings, None);
     }
 
     #[test]

--- a/crates/codegraph-core/src/extractors/python.rs
+++ b/crates/codegraph-core/src/extractors/python.rs
@@ -220,9 +220,31 @@ fn handle_import_stmt(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     }
 }
 
+/// `from pkg import submod`, `from pkg import submod as alias`, `from pkg
+/// import a, b as c` — the symbol/submodule-binding form.
+///
+/// `names` must carry the *local* binding (the alias, when there is one) —
+/// call sites write `alias.f()`, not `submod.f()`, and every downstream
+/// consumer (`import_name_pairs`, the namespace/submodule maps in
+/// `collect_imported_names_for_file`/build_edges.rs) keys off the local name.
+/// Previously this took the `aliased_import`'s pre-alias `name` field
+/// unconditionally, so an aliased specifier's local binding was silently
+/// dropped: `from pkg import submod as alias` recorded `submod`, and a call
+/// through `alias` resolved to nothing in both engines (#2387).
+///
+/// The pre-alias name doesn't disappear — it's the name actually declared in
+/// `source` (whether that turns out to be a symbol in `pkg`'s file or, per
+/// `resolve_python_submodule`, a submodule `pkg/submod.py`), so it is
+/// recorded in `renamed_imports` exactly like a renamed JS specifier
+/// (`import { X as Y }`, #1730). `import_name_pairs` already recovers it from
+/// there for barrel tracing, submodule probing, and namespace-import mapping
+/// — mirrors `scan_import_names_depth`'s `import_specifier` handling in
+/// extractors/javascript.rs. Mirrors `handlePyImportFrom` in
+/// src/extractors/python.ts.
 fn handle_import_from_stmt(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     let mut source_str = String::new();
     let mut names = Vec::new();
+    let mut renamed_imports = Vec::new();
     for i in 0..node.child_count() {
         let Some(child) = node.child(i) else { continue };
         match child.kind() {
@@ -234,9 +256,21 @@ fn handle_import_from_stmt(node: &Node, source: &[u8], symbols: &mut FileSymbols
                 }
             }
             "aliased_import" => {
-                let n = child.child_by_field_name("name").or_else(|| child.child(0));
-                if let Some(n) = n {
-                    names.push(node_text(&n, source).to_string());
+                let source_name_node = child.child_by_field_name("name");
+                let alias_node = child.child_by_field_name("alias");
+                let local_node = alias_node.or(source_name_node).or_else(|| child.child(0));
+                if let Some(local_node) = local_node {
+                    names.push(node_text(&local_node, source).to_string());
+                    if let (Some(alias), Some(source_name)) = (alias_node, source_name_node) {
+                        let alias_text = node_text(&alias, source);
+                        let source_text = node_text(&source_name, source);
+                        if alias_text != source_text {
+                            renamed_imports.push(RenamedImport {
+                                local: alias_text.to_string(),
+                                imported: source_text.to_string(),
+                            });
+                        }
+                    }
                 }
             }
             "wildcard_import" => {
@@ -248,6 +282,9 @@ fn handle_import_from_stmt(node: &Node, source: &[u8], symbols: &mut FileSymbols
     if !source_str.is_empty() {
         let mut imp = Import::new(source_str, names, start_line(node));
         imp.python_import = Some(true);
+        if !renamed_imports.is_empty() {
+            imp.renamed_imports = Some(renamed_imports);
+        }
         symbols.imports.push(imp);
     }
 }
@@ -645,6 +682,46 @@ mod tests {
         assert_eq!(s.imports[0].source, "lib");
         assert_eq!(s.imports[0].names, vec!["helper".to_string()]);
         assert_eq!(s.imports[0].namespace_bindings, None);
+    }
+
+    /// Found in review of #2387: `from pkg import submod as alias` must
+    /// record the *local* binding (`alias`) in `names` — that's what call
+    /// sites reference (`alias.f()`) — plus the `{ local: alias, imported:
+    /// submod }` pair in `renamed_imports` so `import_name_pairs` can recover
+    /// the pre-alias name for barrel tracing and submodule probing
+    /// (`resolve_python_submodule` needs the real file/symbol name, not the
+    /// alias). Previously this took the `aliased_import`'s pre-alias `name`
+    /// field unconditionally, silently dropping the alias.
+    #[test]
+    fn aliased_from_import_records_local_alias_and_rename_pair() {
+        let s = parse_py("from pkg import submod as alias\n");
+        assert_eq!(s.imports.len(), 1);
+        assert_eq!(s.imports[0].source, "pkg");
+        assert_eq!(s.imports[0].names, vec!["alias".to_string()]);
+        let renamed = s.imports[0]
+            .renamed_imports
+            .as_ref()
+            .expect("renamed_imports should be populated for an aliased from-import");
+        assert_eq!(renamed.len(), 1);
+        assert_eq!(renamed[0].local, "alias");
+        assert_eq!(renamed[0].imported, "submod");
+    }
+
+    #[test]
+    fn aliased_from_import_multi_name_only_renames_the_aliased_specifier() {
+        // `from pkg import a, b as c` — the unaliased `a` must stay a plain
+        // name with no rename entry; only `b as c` contributes to
+        // `renamed_imports`.
+        let s = parse_py("from pkg import a, b as c\n");
+        assert_eq!(s.imports.len(), 1);
+        assert_eq!(s.imports[0].names, vec!["a".to_string(), "c".to_string()]);
+        let renamed = s.imports[0]
+            .renamed_imports
+            .as_ref()
+            .expect("renamed_imports should be populated when any specifier is aliased");
+        assert_eq!(renamed.len(), 1);
+        assert_eq!(renamed[0].local, "c");
+        assert_eq!(renamed[0].imported, "b");
     }
 
     #[test]

--- a/crates/codegraph-core/src/lib.rs
+++ b/crates/codegraph-core/src/lib.rs
@@ -150,6 +150,7 @@ pub fn resolve_imports(
     domain::graph::resolve::reset_workspace_resolved_paths();
     domain::graph::resolve::clear_exports_cache();
     domain::graph::resolve::clear_cargo_target_overrides_cache();
+    domain::graph::resolve::clear_python_import_roots_cache();
     domain::graph::resolve::resolve_imports_batch(
         &inputs,
         &root_dir,
@@ -169,6 +170,16 @@ pub fn resolve_imports(
 #[napi]
 pub fn clear_cargo_target_overrides_cache() {
     domain::graph::resolve::clear_cargo_target_overrides_cache();
+}
+
+/// Clear the native Python import-root caches (pyproject-declared roots and
+/// layout-derived package roots, issue #2387) — called from the JS-side
+/// `clearPythonImportRootsCache()` (`resolve.ts`) for the same reason as the
+/// Cargo one above: watch mode's `rebuildFile` goes through `resolve_import`,
+/// the single-import entry point, which does not self-clear per build.
+#[napi]
+pub fn clear_python_import_roots_cache() {
+    domain::graph::resolve::clear_python_import_roots_cache();
 }
 
 /// Compute proximity-based confidence for call resolution.

--- a/crates/codegraph-core/src/types.rs
+++ b/crates/codegraph-core/src/types.rs
@@ -183,6 +183,18 @@ pub struct Import {
     /// (#1813).
     #[napi(js_name = "typeOnlyNames")]
     pub type_only_names: Option<Vec<String>>,
+    /// Local binding names (subset of `names`) bound to the imported *module*
+    /// itself rather than to a symbol inside it — Python's `import lib as L`
+    /// and JavaScript's `import * as ns from 'lib'`.
+    ///
+    /// Call resolution needs the distinction: for a namespace binding, a call
+    /// written `L.strip_block()` means "the symbol `strip_block` declared in
+    /// the module `L` refers to", whereas for an ordinary symbol binding the
+    /// same shape means "a member of the value `L`". Sparsely populated,
+    /// mirroring `renamed_imports`/`type_only_names`. Mirrors TS
+    /// `Import.namespaceBindings` (#2387).
+    #[napi(js_name = "namespaceBindings")]
+    pub namespace_bindings: Option<Vec<String>>,
     // Language-specific flags
     #[napi(js_name = "pythonImport")]
     pub python_import: Option<bool>,
@@ -228,6 +240,7 @@ impl Import {
             wildcard_reexport: None,
             renamed_imports: None,
             type_only_names: None,
+            namespace_bindings: None,
             python_import: None,
             go_import: None,
             rust_use: None,

--- a/src/domain/graph/builder/call-resolver.ts
+++ b/src/domain/graph/builder/call-resolver.ts
@@ -441,6 +441,7 @@ export function resolveCallTargets(
   typeMap: Map<string, unknown>,
   callerName?: string | null,
   importedOriginalNames?: ReadonlyMap<string, string>,
+  namespaceImports?: ReadonlyMap<string, string>,
 ): {
   targets: Array<ResolvedCandidate>;
   importedFrom: string | undefined;
@@ -500,6 +501,25 @@ export function resolveCallTargets(
     }
     const targets = lookup.byName(qualified).filter((n) => n.accessorKind === call.accessorRead);
     return { targets: [...targets], importedFrom: undefined };
+  }
+
+  // A call through a module namespace binding (`import lib as L; L.f()`,
+  // `from pkg import submod; submod.f()`) names a module, not a value, so the
+  // target is simply `call.name` as declared in that module's file. Resolved
+  // ahead of the general cascade because the cascade has nothing to work with
+  // here: `call.name` is not itself an imported binding, and the receiver has
+  // no type to look up — which is why every such call previously resolved to
+  // nothing and left the callee reported as dead (#2387).
+  //
+  // Scoped to the module's own file and authoritative: a miss means the module
+  // does not declare that name, not "keep looking". Falling through would let
+  // an unrelated same-named function elsewhere in the project claim the call.
+  const namespaceFile = call.receiver ? namespaceImports?.get(call.receiver) : undefined;
+  if (namespaceFile) {
+    return {
+      targets: [...lookup.byNameAndFile(call.name, namespaceFile)],
+      importedFrom: undefined,
+    };
   }
 
   const importedFrom = importedNames.get(call.name);

--- a/src/domain/graph/builder/incremental.ts
+++ b/src/domain/graph/builder/incremental.ts
@@ -27,8 +27,10 @@ import type {
 import { parseFileIncremental } from '../../parser.js';
 import {
   clearCargoTargetOverridesCache,
+  clearPythonImportRootsCache,
   computeConfidence,
   resolveImportPath,
+  resolvePythonSubmodule,
 } from '../resolve.js';
 import {
   buildPointsToMapForFile,
@@ -362,7 +364,7 @@ function rebuildReverseDepEdges(
     skipBarrel ? null : db,
     knownFiles,
   );
-  const { importedNames, importedOriginalNames } = buildImportedNamesMap(
+  const { importedNames, importedOriginalNames, namespaceImports } = buildImportedNamesMap(
     symbols,
     rootDir,
     depRelPath,
@@ -379,6 +381,7 @@ function rebuildReverseDepEdges(
     importedNames,
     importedOriginalNames,
     maxIterations,
+    namespaceImports,
   );
   edgesAdded += buildClassHierarchyEdges(
     db,
@@ -901,9 +904,14 @@ function buildImportedNamesMap(
   aliases: PathAliases,
   db: BetterSqlite3Database,
   knownFiles: readonly string[],
-): { importedNames: Map<string, string>; importedOriginalNames: Map<string, string> } {
+): {
+  importedNames: Map<string, string>;
+  importedOriginalNames: Map<string, string>;
+  namespaceImports: Map<string, string>;
+} {
   const importedNames = new Map<string, string>();
   const importedOriginalNames = new Map<string, string>();
+  const namespaceImports = new Map<string, string>();
   for (const imp of symbols.imports) {
     const resolvedPath = resolveImportPath(
       path.join(rootDir, relPath),
@@ -912,7 +920,27 @@ function buildImportedNamesMap(
       aliases,
       knownFiles,
     );
+    const namespaceLocals = new Set(imp.namespaceBindings ?? []);
     for (const { local, original } of importNamePairs(imp)) {
+      // Module bindings target the module file itself — mirrors the full-build
+      // path in stages/build-edges.ts (#2387).
+      if (namespaceLocals.has(local)) {
+        importedNames.set(local, resolvedPath);
+        namespaceImports.set(local, resolvedPath);
+        continue;
+      }
+      const submodule = resolvePythonSubmodule(
+        path.join(rootDir, relPath),
+        imp.source,
+        original,
+        rootDir,
+        knownFiles,
+      );
+      if (submodule) {
+        importedNames.set(local, submodule);
+        namespaceImports.set(local, submodule);
+        continue;
+      }
       // Mirror full-build's `buildImportedNamesMap`: follow barrel re-exports so
       // `importedNames` maps to the *defining* file, not the barrel. This ensures
       // `computeConfidence` gets `importedFrom === targetFile` and returns 1.0
@@ -930,7 +958,7 @@ function buildImportedNamesMap(
       if (targetName !== local) importedOriginalNames.set(local, targetName);
     }
   }
-  return { importedNames, importedOriginalNames };
+  return { importedNames, importedOriginalNames, namespaceImports };
 }
 
 // ── Class hierarchy edges ───────────────────────────────────────────────
@@ -1472,6 +1500,9 @@ function buildCallEdges(
   // override applies to watch-mode rebuilds, not just full builds.
   // Undefined falls back to buildPointsToMapForFile's own default parameter.
   maxIterations?: number,
+  // #2387: local bindings that name a whole module (Python's `import x as y`),
+  // so `y.f()` resolves f inside that module rather than resolving to nothing.
+  namespaceImports?: ReadonlyMap<string, string>,
 ): number {
   const typeMap = buildIncrementalTypeMap(symbols);
   const seenCallEdges = new Set<string>();
@@ -1516,6 +1547,7 @@ function buildCallEdges(
             typeMap,
             caller.callerName,
             importedOriginalNames,
+            namespaceImports,
           );
 
     let targets = applyCallFallbacks(
@@ -1758,7 +1790,7 @@ function rebuildEdgesForTargetFile(
     db,
     knownFiles,
   );
-  const { importedNames, importedOriginalNames } = buildImportedNamesMap(
+  const { importedNames, importedOriginalNames, namespaceImports } = buildImportedNamesMap(
     symbols,
     rootDir,
     relPath,
@@ -1775,6 +1807,7 @@ function rebuildEdgesForTargetFile(
     importedNames,
     importedOriginalNames,
     maxIterations,
+    namespaceImports,
   );
   edgesAdded += buildClassHierarchyEdges(
     db,
@@ -2274,6 +2307,11 @@ export async function rebuildFile(
   // just Rust ones — means the very next Rust file to change (a near-certain
   // companion edit to any real Cargo.toml target change) re-scans fresh.
   clearCargoTargetOverridesCache();
+  // Same reasoning for Python (#2387): pyproject.toml isn't watched either,
+  // and the layout-derived package roots this also clears go stale as soon as
+  // an `__init__.py` is added or removed — which changes where every absolute
+  // import in that package tree resolves.
+  clearPythonImportRootsCache();
   // #2242: real tsconfig/jsconfig + codegraph-configured aliases, loaded
   // once per rebuild (mirrors knownFiles just above) and threaded through
   // every edge-building call below — a hardcoded empty PathAliases

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -38,7 +38,7 @@ import type {
   ThisCallBinding,
   TypeMapEntry,
 } from '../../../../types.js';
-import { computeConfidence } from '../../resolve.js';
+import { computeConfidence, resolvePythonSubmodule } from '../../resolve.js';
 import type { PointsToMap } from '../../resolver/points-to.js';
 import { buildPointsToMapForFile, resolveViaPointsTo } from '../../resolver/points-to.js';
 import type { ResolvedCandidate } from '../../resolver/strategy.js';
@@ -121,7 +121,7 @@ interface NativeFileEntry {
     params?: string[];
   }>;
   calls: Call[];
-  importedNames: Array<{ name: string; file: string; imported?: string }>;
+  importedNames: Array<{ name: string; file: string; imported?: string; namespace?: boolean }>;
   classes: ClassRelation[];
   typeMap: Array<{ name: string; typeName: string; confidence: number }>;
   /** Phase 8.3: function-reference bindings for pts analysis. */
@@ -271,6 +271,25 @@ function emitEdgesForImport(
   allEdgeRows: EdgeRowTuple[],
 ): void {
   const resolvedPath = getResolved(ctx, path.join(ctx.rootDir, relPath), imp.source);
+
+  // `from pkg import submod` depends on `pkg/submod.py`, not merely on
+  // `pkg/__init__.py` — emitting only the latter would report the package
+  // barrel as the dependency and leave the module that actually changed
+  // invisible to `deps`/`impact` (#2387).
+  for (const { original } of importNamePairs(imp)) {
+    const submodule = resolvePythonSubmodule(
+      path.join(ctx.rootDir, relPath),
+      imp.source,
+      original,
+      ctx.rootDir,
+      ctx.allFiles,
+    );
+    if (!submodule) continue;
+    const submoduleRow = getNodeIdStmt.get(submodule, 'file', submodule, 0);
+    if (submoduleRow)
+      allEdgeRows.push([fileNodeId, submoduleRow.id, 'imports', 1.0, 0, null, null]);
+  }
+
   const targetRow = getNodeIdStmt.get(resolvedPath, 'file', resolvedPath, 0);
   if (!targetRow) return;
 
@@ -1074,14 +1093,37 @@ function buildImportedNamesForNative(
   relPath: string,
   symbols: ExtractorOutput,
   rootDir: string,
-): Array<{ name: string; file: string; imported?: string }> {
-  const importedNames: Array<{ name: string; file: string; imported?: string }> = [];
+): Array<{ name: string; file: string; imported?: string; namespace?: boolean }> {
+  const importedNames: Array<{
+    name: string;
+    file: string;
+    imported?: string;
+    namespace?: boolean;
+  }> = [];
   // Process dynamic imports first (lower priority), then static imports
   // (higher priority). Rust HashMap::collect keeps the last entry per key,
   // so static imports win when both contribute the same name.
   const addImports = (imp: (typeof symbols.imports)[number]) => {
     const resolvedPath = getResolved(ctx, path.join(rootDir, relPath), imp.source);
+    const namespaceLocals = new Set(imp.namespaceBindings ?? []);
     for (const { local, original } of importNamePairs(imp)) {
+      // Module bindings target the module file itself and have no declared
+      // symbol to trace through a barrel — mirrors buildImportedNamesMap.
+      if (namespaceLocals.has(local)) {
+        importedNames.push({ name: local, file: resolvedPath, namespace: true });
+        continue;
+      }
+      const submodule = resolvePythonSubmodule(
+        path.join(rootDir, relPath),
+        imp.source,
+        original,
+        rootDir,
+        ctx.allFiles,
+      );
+      if (submodule) {
+        importedNames.push({ name: local, file: submodule, namespace: true });
+        continue;
+      }
       let targetFile = resolvedPath;
       let targetName = original;
       if (isBarrelFile(ctx, resolvedPath)) {
@@ -1205,7 +1247,7 @@ function buildCallEdgesJS(
     const fileNodeRow = getNodeIdStmt.get(relPath, 'file', relPath, 0);
     if (!fileNodeRow) continue;
 
-    const { importedNames, importedOriginalNames } = buildImportedNamesMap(
+    const { importedNames, importedOriginalNames, namespaceImports } = buildImportedNamesMap(
       ctx,
       relPath,
       symbols,
@@ -1273,6 +1315,7 @@ function buildCallEdgesJS(
       chaCtx,
       importArtifactNames,
       importedOriginalNames,
+      namespaceImports,
     );
     buildClassHierarchyEdges(
       lookup,
@@ -1296,25 +1339,57 @@ function buildCallEdgesJS(
  * Barrel tracing and downstream target-file symbol lookups must search using
  * that declared name — neither the renamed local alias nor the barrel's
  * external rename exists in the file being imported from.
+ *
+ * Also reports the subset of those bindings that name a whole module rather
+ * than a symbol (`namespaceImports`, e.g. Python's `import lib as L`), which
+ * call resolution needs in order to read `L.strip_block()` as "strip_block, in
+ * the module L refers to" (#2387).
  */
 function buildImportedNamesMap(
   ctx: PipelineContext,
   relPath: string,
   symbols: ExtractorOutput,
   rootDir: string,
-): { importedNames: Map<string, string>; importedOriginalNames: Map<string, string> } {
+): {
+  importedNames: Map<string, string>;
+  importedOriginalNames: Map<string, string>;
+  namespaceImports: Map<string, string>;
+} {
   const importedNames = new Map<string, string>();
   const importedOriginalNames = new Map<string, string>();
+  const namespaceImports = new Map<string, string>();
   // Phase 8.4: trace through barrel files so that symbol names map to their
   // actual definition file, not the re-exporting barrel. Mirrors the tracing
   // already done in buildImportedNamesForNative (the native path), and
   // shares its implementation with buildImportArtifactNames's CJS require
   // path via traceBarrelTarget (#2071).
   const addImportNames = (imp: (typeof symbols.imports)[number], resolvedPath: string) => {
+    const namespaceLocals = new Set(imp.namespaceBindings ?? []);
     for (const { local, original } of importNamePairs(imp)) {
+      // A namespace binding names the module itself, so it has no declared
+      // symbol to trace through a barrel — the module file *is* the target.
+      if (namespaceLocals.has(local)) {
+        importedNames.set(local, resolvedPath);
+        namespaceImports.set(local, resolvedPath);
+        continue;
+      }
       const { file, name } = traceBarrelTarget(ctx, resolvedPath, original);
       importedNames.set(local, file);
       if (name !== local) importedOriginalNames.set(local, name);
+      // `from pkg import submod` binds a module too, but which reading applies
+      // depends on whether `pkg/submod.py` exists — a question only the
+      // resolver can answer (#2387).
+      const submodule = resolvePythonSubmodule(
+        path.join(rootDir, relPath),
+        imp.source,
+        original,
+        rootDir,
+        ctx.allFiles,
+      );
+      if (submodule) {
+        importedNames.set(local, submodule);
+        namespaceImports.set(local, submodule);
+      }
     }
   };
   // Process dynamic imports first (lower priority), then static imports
@@ -1331,7 +1406,7 @@ function buildImportedNamesMap(
     const resolvedPath = getResolved(ctx, path.join(rootDir, relPath), imp.source);
     addImportNames(imp, resolvedPath);
   }
-  return { importedNames, importedOriginalNames };
+  return { importedNames, importedOriginalNames, namespaceImports };
 }
 
 /**
@@ -1485,6 +1560,7 @@ function resolveFallbackTargets(
   definePropertyReceivers: Map<string, string> | undefined,
   invokedPropertyNames: ReadonlySet<string>,
   importedOriginalNames?: ReadonlyMap<string, string>,
+  namespaceImports?: ReadonlyMap<string, string>,
 ): {
   targets: ReadonlyArray<ResolvedCandidate>;
   importedFrom: string | null | undefined;
@@ -1505,6 +1581,7 @@ function resolveFallbackTargets(
           typeMap as Map<string, unknown>,
           caller.callerName,
           importedOriginalNames,
+          namespaceImports,
         );
 
   // Fallback strategies, applied in order until one yields a match. Each
@@ -1951,6 +2028,7 @@ function buildFileCallEdges(
   chaCtx?: ChaContext,
   importArtifactNames?: ReadonlyMap<string, BarrelExportResolution>,
   importedOriginalNames?: ReadonlyMap<string, string>,
+  namespaceImports?: ReadonlyMap<string, string>,
 ): void {
   // Tracks edges that were inserted by the pts fallback (edgeKey → allEdgeRows index).
   // Kept separate from seenCallEdges so that a subsequent direct-call edge for the same
@@ -1990,6 +2068,7 @@ function buildFileCallEdges(
       symbols.definePropertyReceivers,
       invokedPropertyNames,
       importedOriginalNames,
+      namespaceImports,
     );
 
     // Step 2: Emit direct-call edges (upgrades any pending pts edge in-place).

--- a/src/domain/graph/resolve.ts
+++ b/src/domain/graph/resolve.ts
@@ -768,6 +768,265 @@ function resolveRustUsePath(
   return resolved ? normalizePath(path.relative(rootDir, resolved)) : null;
 }
 
+// ── Python module-path resolution (#2387) ───────────────────────────────
+
+/**
+ * True if `file` is Python source. Both engines resolve Python imports by
+ * module path rather than by filesystem path, so this gates the whole
+ * Python branch of `resolveImportPathJS`.
+ */
+function isPythonFile(file: string): boolean {
+  return file.endsWith('.py') || file.endsWith('.pyi');
+}
+
+/**
+ * File-existence probe with the same semantics as the native resolver's
+ * `file_exists`: consult `knownFiles` when the caller supplied one (accepting
+ * either the absolute or the root-relative convention), and fall back to a
+ * real filesystem check when it did not. Keeping the two engines on identical
+ * semantics matters here — a probe that answered differently would make the
+ * native and WASM graphs disagree about which imports resolve.
+ */
+function pythonCandidateExists(
+  candidate: string,
+  knownFiles: Set<string> | null,
+  rootDir: string,
+): boolean {
+  if (knownFiles) return knownFilesHasFile(knownFiles, candidate, rootDir);
+  return fs.existsSync(candidate);
+}
+
+/**
+ * Extra import roots declared by `pyproject.toml`, as absolute directories.
+ *
+ * Layout conventions cover most projects (see `pythonPackageRoot`), but a
+ * root that is neither the repo root nor derivable from `__init__.py`
+ * placement can only be known from configuration — `pythonpath = ["src",
+ * "scripts"]` being the case observed on `data-analytics-pipeline-svc`
+ * (#2387), where `scripts/` is importable but contains no package marker.
+ *
+ * Best-effort: unreadable or malformed TOML contributes no roots rather than
+ * failing resolution, matching `parseCargoTargetOverrides`'s precedent.
+ */
+function parsePyprojectImportRoots(rootDir: string): string[] {
+  const manifest = path.join(rootDir, 'pyproject.toml');
+  let parsed: unknown;
+  try {
+    parsed = parseToml(fs.readFileSync(manifest, 'utf8'));
+  } catch (e) {
+    debug(`parsePyprojectImportRoots: cannot read ${manifest}: ${toErrorMessage(e)}`);
+    return [];
+  }
+  if (typeof parsed !== 'object' || parsed === null) return [];
+  const tool = (parsed as Record<string, any>).tool;
+  if (typeof tool !== 'object' || tool === null) return [];
+
+  const roots: string[] = [];
+  const addRoot = (value: unknown): void => {
+    // `package-dir` maps an import prefix to a directory; only the directory
+    // half is an import root. An empty-string value means "the repo root",
+    // which is already probed unconditionally.
+    if (typeof value === 'string' && value.length > 0) roots.push(path.join(rootDir, value));
+  };
+
+  // [tool.pytest.ini_options] pythonpath = ["src", "scripts"]
+  const pythonpath = tool.pytest?.ini_options?.pythonpath;
+  if (Array.isArray(pythonpath)) for (const entry of pythonpath) addRoot(entry);
+
+  // [tool.setuptools] package-dir = { "" = "src" }
+  const packageDir = tool.setuptools?.['package-dir'];
+  if (typeof packageDir === 'object' && packageDir !== null) {
+    for (const value of Object.values(packageDir)) addRoot(value);
+  }
+
+  // [tool.setuptools.packages.find] where = ["src"]
+  const where = tool.setuptools?.packages?.find?.where;
+  if (Array.isArray(where)) for (const entry of where) addRoot(entry);
+
+  // [tool.poetry] packages = [{ include = "pipeline", from = "src" }]
+  const poetryPackages = tool.poetry?.packages;
+  if (Array.isArray(poetryPackages)) {
+    for (const entry of poetryPackages) addRoot((entry as Record<string, unknown> | null)?.from);
+  }
+
+  return roots;
+}
+
+/**
+ * Cache: rootDir → configured import roots. Populated lazily on the first
+ * Python import resolved for a given rootDir, so non-Python projects never
+ * pay for the manifest read.
+ */
+const _pythonConfiguredRootsCache: Map<string, string[]> = new Map();
+
+function getPythonConfiguredRoots(rootDir: string): string[] {
+  let roots = _pythonConfiguredRootsCache.get(rootDir);
+  if (!roots) {
+    roots = parsePyprojectImportRoots(rootDir);
+    _pythonConfiguredRootsCache.set(rootDir, roots);
+  }
+  return roots;
+}
+
+/**
+ * Clear the pyproject import-root cache, in both this (TypeScript) resolver
+ * and the native one — a long-lived process (`codegraph watch`, the MCP
+ * server) can outlive edits to pyproject.toml itself. Mirrors
+ * `clearCargoTargetOverridesCache`; also exported directly for testing.
+ */
+export function clearPythonImportRootsCache(): void {
+  _pythonConfiguredRootsCache.clear();
+  _pythonPackageRootCache.clear();
+  loadNative()?.clearPythonImportRootsCache?.();
+}
+
+/** Cache: file directory → its derived package root. */
+const _pythonPackageRootCache: Map<string, string> = new Map();
+
+/**
+ * The directory an absolute Python import from `fromFile` resolves against,
+ * derived from package layout: walk up from the file's own directory for as
+ * long as each level is a package (contains `__init__.py`), and stop at the
+ * first ancestor that is not.
+ *
+ * That ancestor is the directory that would be on `sys.path` at runtime, so
+ * this handles the PyPA-endorsed "src layout" (`src/pipeline/…`, imported as
+ * `from pipeline…`) and a flat layout with the same rule and no
+ * configuration — the src-layout case being precisely what made
+ * `data-analytics-pipeline-svc` resolve zero imports (#2387).
+ *
+ * Never walks above `rootDir`: a stray `__init__.py` at the repo root must
+ * not send resolution outside the project.
+ */
+function pythonPackageRoot(
+  fromFile: string,
+  rootDir: string,
+  knownFiles: Set<string> | null,
+): string {
+  const startDir = path.dirname(fromFile);
+  const cached = _pythonPackageRootCache.get(startDir);
+  if (cached !== undefined) return cached;
+
+  let dir = startDir;
+  for (;;) {
+    if (dir === rootDir) break;
+    if (!pythonCandidateExists(path.join(dir, '__init__.py'), knownFiles, rootDir)) break;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  _pythonPackageRootCache.set(startDir, dir);
+  return dir;
+}
+
+/**
+ * Candidate import roots for `fromFile`, most specific first: the layout-derived
+ * package root, then the conventional `src/` directory, then the repo root,
+ * then anything `pyproject.toml` declares.
+ */
+function pythonImportRoots(
+  fromFile: string,
+  rootDir: string,
+  knownFiles: Set<string> | null,
+): string[] {
+  const roots = [pythonPackageRoot(fromFile, rootDir, knownFiles), path.join(rootDir, 'src')];
+  roots.push(rootDir, ...getPythonConfiguredRoots(rootDir));
+  return roots;
+}
+
+/**
+ * Resolve dotted module `segments` beneath `baseDir` to the file that declares
+ * that module: `a/b/c.py`, then the package form `a/b/c/__init__.py`, then the
+ * stub `a/b/c.pyi`. Empty `segments` means the package itself (`from . import
+ * x`), which only ever resolves to its `__init__.py`.
+ *
+ * Returns a root-relative path, or null when nothing matches — including when
+ * a candidate would land outside `rootDir`, which a relative import with more
+ * leading dots than there are package levels can otherwise do.
+ */
+function resolvePythonModuleUnder(
+  baseDir: string,
+  segments: string[],
+  rootDir: string,
+  knownFiles: Set<string> | null,
+): string | null {
+  const target = segments.length > 0 ? path.join(baseDir, ...segments) : baseDir;
+  const candidates =
+    segments.length > 0
+      ? [`${target}.py`, path.join(target, '__init__.py'), `${target}.pyi`]
+      : [path.join(target, '__init__.py')];
+  for (const candidate of candidates) {
+    if (!pythonCandidateExists(candidate, knownFiles, rootDir)) continue;
+    const rel = normalizePath(path.relative(rootDir, candidate));
+    if (rel.startsWith('..')) continue;
+    return rel;
+  }
+  return null;
+}
+
+/**
+ * Resolve a Python `import a.b.c` / `from a.b import c` / `from .. import c`
+ * module path to the file that declares it (#2387).
+ *
+ * Returns null for anything not found under a project import root — standard
+ * library and third-party modules included — so the caller falls through to
+ * the bare-specifier behaviour that treats them as external.
+ */
+function resolvePythonImportPath(
+  fromFile: string,
+  importSource: string,
+  rootDir: string,
+  knownFiles: Set<string> | null,
+): string | null {
+  let dots = 0;
+  while (dots < importSource.length && importSource[dots] === '.') dots++;
+
+  if (dots > 0) {
+    // Relative import: one dot is the current package, each extra dot climbs
+    // one level further up before the remaining segments are walked down.
+    const rest = importSource.slice(dots);
+    let dir = path.dirname(fromFile);
+    for (let i = 1; i < dots; i++) {
+      const parent = path.dirname(dir);
+      if (parent === dir) return null;
+      dir = parent;
+    }
+    const segments = rest.length > 0 ? rest.split('.') : [];
+    return resolvePythonModuleUnder(dir, segments, rootDir, knownFiles);
+  }
+
+  const segments = importSource.split('.');
+  if (segments.some((s) => s.length === 0)) return null;
+  for (const root of pythonImportRoots(fromFile, rootDir, knownFiles)) {
+    const resolved = resolvePythonModuleUnder(root, segments, rootDir, knownFiles);
+    if (resolved) return resolved;
+  }
+  return null;
+}
+
+/**
+ * Resolve `from <source> import <name>` where `name` is itself a submodule
+ * rather than a symbol (`from pipeline.stages import extract`) — Python's two
+ * readings of that statement are indistinguishable without knowing which
+ * files exist, so this is decided here rather than in the extractor.
+ *
+ * Returns the submodule's root-relative path, or null when `name` is an
+ * ordinary symbol declared inside the source module.
+ */
+export function resolvePythonSubmodule(
+  fromFile: string,
+  importSource: string,
+  name: string,
+  rootDir: string,
+  knownFiles?: readonly string[] | null,
+): string | null {
+  if (!isPythonFile(fromFile) || name === '*') return null;
+  const combined = importSource.endsWith('.')
+    ? `${importSource}${name}`
+    : `${importSource}.${name}`;
+  return resolvePythonImportPath(fromFile, combined, rootDir, toKnownFilesSet(knownFiles));
+}
+
 /** Cache: knownFiles array identity → Set, so repeated resolutions against
  * the same project file list (e.g. every Rust `use` statement in a build)
  * don't each rebuild the Set from scratch. */
@@ -790,6 +1049,20 @@ function resolveImportPathJS(
   aliases: PathAliases | null,
   knownFiles?: readonly string[] | null,
 ): string {
+  // Python resolves by module path, not filesystem path, in both the absolute
+  // (`import a.b.c`) and relative (`from ..pkg import x`) forms — the latter
+  // shares JS's leading-dot spelling but means "climb the package tree", not
+  // "a path relative to this directory", so this must run before the generic
+  // relative branch below ever sees it (#2387).
+  if (isPythonFile(fromFile)) {
+    const pyResolved = resolvePythonImportPath(
+      fromFile,
+      importSource,
+      rootDir,
+      toKnownFilesSet(knownFiles),
+    );
+    if (pyResolved) return pyResolved;
+  }
   if (!importSource.startsWith('.') && aliases) {
     const aliasResolved = resolveViaAlias(importSource, aliases, rootDir);
     if (aliasResolved) return normalizePath(path.relative(rootDir, aliasResolved));

--- a/src/extractors/python.ts
+++ b/src/extractors/python.ts
@@ -179,25 +179,45 @@ function handlePyCall(node: TreeSitterNode, ctx: ExtractorOutput): void {
   }
 }
 
+/**
+ * `import a.b`, `import a.b as ab`, `import a, b` — the module-binding form.
+ *
+ * Each module in the statement becomes its own `Import`, whose `source` is the
+ * module path and whose single name is the local binding it introduces. That
+ * split matters twice over: `source` previously carried the *alias* for
+ * `import lib as L`, which can never resolve to a file, and a multi-module
+ * `import a, b` collapsed into one record that named only `a` as its source
+ * (#2387).
+ *
+ * The binding names a module object rather than a symbol, so it is also
+ * recorded in `namespaceBindings` — that is what lets `L.strip_block()` resolve
+ * `strip_block` inside the module `L` refers to. For the unaliased dotted form
+ * the binding is recorded under its full dotted spelling (`a.b`), because that
+ * is the receiver text a call site writes (`a.b.func()`).
+ */
 function handlePyImport(node: TreeSitterNode, ctx: ExtractorOutput): void {
-  const names: string[] = [];
+  const line = node.startPosition.row + 1;
   for (let i = 0; i < node.childCount; i++) {
     const child = node.child(i);
-    if (child && (child.type === 'dotted_name' || child.type === 'aliased_import')) {
-      const name =
-        child.type === 'aliased_import'
-          ? (child.childForFieldName('alias') || child.childForFieldName('name'))?.text
-          : child.text;
-      if (name) names.push(name);
+    if (!child) continue;
+    let source: string | undefined;
+    let local: string | undefined;
+    if (child.type === 'dotted_name') {
+      source = child.text;
+      local = child.text;
+    } else if (child.type === 'aliased_import') {
+      source = child.childForFieldName('name')?.text;
+      local = child.childForFieldName('alias')?.text ?? source;
     }
-  }
-  if (names.length > 0)
+    if (!source || !local) continue;
     ctx.imports.push({
-      source: names[0] ?? '',
-      names,
-      line: node.startPosition.row + 1,
+      source,
+      names: [local],
+      namespaceBindings: [local],
+      line,
       pythonImport: true,
     });
+  }
 }
 
 function handlePyExpressionStmt(node: TreeSitterNode, ctx: ExtractorOutput): void {

--- a/src/extractors/python.ts
+++ b/src/extractors/python.ts
@@ -237,9 +237,31 @@ function handlePyExpressionStmt(node: TreeSitterNode, ctx: ExtractorOutput): voi
   }
 }
 
+/**
+ * `from pkg import submod`, `from pkg import submod as alias`, `from pkg
+ * import a, b as c` — the symbol/submodule-binding form.
+ *
+ * `names` must carry the *local* binding (the alias, when there is one) —
+ * call sites write `alias.f()`, not `submod.f()`, and every downstream
+ * consumer (`importNamePairs`, the namespace/submodule maps in
+ * `buildImportedNamesMap`/`buildImportedNamesForNative`) keys off the local
+ * name. Previously this took the `aliased_import`'s pre-alias `name` field
+ * unconditionally, so an aliased specifier's local binding was silently
+ * dropped: `from pkg import submod as alias` recorded `submod`, and a call
+ * through `alias` resolved to nothing in both engines (#2387).
+ *
+ * The pre-alias name doesn't disappear — it's the name actually declared in
+ * `source` (whether that turns out to be a symbol in `pkg`'s file or, per
+ * `resolvePythonSubmodule`, a submodule `pkg/submod.py`), so it is recorded
+ * in `renamedImports` exactly like a renamed JS specifier (`import { X as Y
+ * }`, #1730). `importNamePairs` already recovers it from there for barrel
+ * tracing, submodule probing, and namespace-import mapping — mirrors
+ * `extractImportNames`'s `import_specifier` handling in extractors/javascript.ts.
+ */
 function handlePyImportFrom(node: TreeSitterNode, ctx: ExtractorOutput): void {
   let source = '';
   const names: string[] = [];
+  const renamedImports: Array<{ local: string; imported: string }> = [];
   for (let i = 0; i < node.childCount; i++) {
     const child = node.child(i);
     if (!child) continue;
@@ -248,13 +270,26 @@ function handlePyImportFrom(node: TreeSitterNode, ctx: ExtractorOutput): void {
       else names.push(child.text);
     }
     if (child.type === 'aliased_import') {
-      const n = child.childForFieldName('name') || child.child(0);
-      if (n) names.push(n.text);
+      const sourceNameNode = child.childForFieldName('name');
+      const aliasNode = child.childForFieldName('alias');
+      const localNode = aliasNode ?? sourceNameNode ?? child.child(0);
+      if (localNode) {
+        names.push(localNode.text);
+        if (aliasNode && sourceNameNode && aliasNode.text !== sourceNameNode.text) {
+          renamedImports.push({ local: aliasNode.text, imported: sourceNameNode.text });
+        }
+      }
     }
     if (child.type === 'wildcard_import') names.push('*');
   }
   if (source)
-    ctx.imports.push({ source, names, line: node.startPosition.row + 1, pythonImport: true });
+    ctx.imports.push({
+      source,
+      names,
+      line: node.startPosition.row + 1,
+      pythonImport: true,
+      ...(renamedImports.length > 0 ? { renamedImports } : {}),
+    });
 }
 
 // ── Python-specific helpers ─────────────────────────────────────────────────

--- a/src/types.ts
+++ b/src/types.ts
@@ -668,6 +668,20 @@ export interface Import {
    * with a symbol-level `imports-type` edge (#1813).
    */
   typeOnlyNames?: string[];
+  /**
+   * Local binding names (subset of `names`) bound to the imported *module*
+   * itself rather than to a symbol inside it — Python's `import lib as L` and
+   * JavaScript's `import * as ns from 'lib'`.
+   *
+   * Call resolution needs the distinction: for a namespace binding, a call
+   * written `L.strip_block()` means "the symbol `strip_block` declared in the
+   * module `L` refers to", whereas for an ordinary symbol binding the same
+   * shape means "a member of the value `L`". Resolving the two identically
+   * would either miss every aliased module call (#2387) or invent edges to
+   * unrelated same-named top-level functions. Sparsely populated, mirroring
+   * `renamedImports`/`typeOnlyNames`.
+   */
+  namespaceBindings?: string[];
   // Language-specific flags (mutually exclusive at runtime)
   pythonImport?: boolean;
   goImport?: boolean;
@@ -2531,6 +2545,12 @@ export interface NativeAddon {
    * export, so callers must feature-detect via `?.()`.
    */
   clearCargoTargetOverridesCache?(): void;
+  /**
+   * Clear the native Python import-root cache (pyproject-declared roots and
+   * layout-derived package roots, #2387) — optional for the same reason as
+   * `clearCargoTargetOverridesCache`: older published addons predate it.
+   */
+  clearPythonImportRootsCache?(): void;
   computeConfidence(callerFile: string, targetFile: string, importedFrom: string | null): number;
   detectCycles(edges: Array<{ source: string; target: string }>): string[][];
   bfsTraversal(

--- a/tests/integration/issue-2387-python-imports.test.ts
+++ b/tests/integration/issue-2387-python-imports.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Regression test for #2387: Python produced no `imports` edges at all, and
+ * an aliased module call (`import lib as L` … `L.strip_block()`) resolved to
+ * nothing, leaving the callee reported as dead code.
+ *
+ * Two distinct defects sat behind that:
+ *
+ *  1. `resolveImportPathJS`/`resolve_import_path_inner` had no Python branch.
+ *     A dotted module path (`pipeline.util`) is not a filesystem path, so it
+ *     fell through to the bare-specifier fallback and was echoed back
+ *     unchanged, matching no file node — hence zero `imports` edges, and
+ *     `deps`/`impact`/`map` blind on every Python repo. Python's *relative*
+ *     imports share JS's leading-dot spelling but mean "climb the package
+ *     tree", so they were mis-resolved by the generic relative branch too.
+ *
+ *  2. The Python extractor put the *alias* in `Import.source` for
+ *     `import lib as L` — an alias can never resolve to a file — and a
+ *     multi-module `import a, b` collapsed into a single record naming only
+ *     `a`. Module bindings are now recorded in `namespaceBindings`, which is
+ *     what lets `L.strip_block()` be read as "strip_block, as declared in the
+ *     module L refers to".
+ *
+ * The fixture uses the PyPA-endorsed "src layout" (package root `src/`,
+ * imports written `from pipeline…`) because that is the layout on the Optave
+ * Python services where this was found, and the one a repo-root-relative
+ * resolver gets wrong even after dotted paths are handled at all.
+ *
+ * Two same-named `shared_helper` functions would not disambiguate anything
+ * here — instead the assertions pin each edge to a specific target *file*, so
+ * a resolver that fell back to a global same-name lookup could not pass.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+import type { EngineMode } from '../../src/types.js';
+
+const FILES: Record<string, string> = {
+  'pyproject.toml': `
+[project]
+name = "pipeline"
+
+[tool.setuptools.package-dir]
+"" = "src"
+`,
+  'src/pipeline/__init__.py': '',
+  'src/pipeline/stages/__init__.py': '',
+  'src/pipeline/util.py': `
+def shared_helper():
+    return 1
+`,
+  'src/pipeline/stages/extract.py': `
+def run_extract(data):
+    return data
+`,
+  'src/pipeline/stages/load.py': `
+from .extract import run_extract
+from ..util import shared_helper
+
+def run_load(data):
+    shared_helper()
+    return run_extract(data)
+`,
+  'src/pipeline/main.py': `
+import pipeline.util as U
+from pipeline.stages import extract
+from pipeline.stages.load import run_load
+
+def main():
+    U.shared_helper()
+    extract.run_extract([])
+    return run_load([])
+`,
+};
+
+function writeFixture(dir: string) {
+  for (const [rel, content] of Object.entries(FILES)) {
+    const abs = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, content);
+  }
+}
+
+interface EdgeRow {
+  src: string;
+  src_file: string;
+  tgt: string;
+  tgt_file: string;
+}
+
+function readEdges(dbPath: string, kind: string): EdgeRow[] {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return db
+      .prepare(
+        `SELECT n1.name AS src, n1.file AS src_file, n2.name AS tgt, n2.file AS tgt_file
+         FROM edges e
+         JOIN nodes n1 ON e.source_id = n1.id
+         JOIN nodes n2 ON e.target_id = n2.id
+         WHERE e.kind = ?
+         ORDER BY n1.file, n1.name, n2.file, n2.name`,
+      )
+      .all(kind) as EdgeRow[];
+  } finally {
+    db.close();
+  }
+}
+
+const hasEdge = (edges: EdgeRow[], srcFile: string, tgtFile: string): boolean =>
+  edges.some((e) => e.src_file === srcFile && e.tgt_file === tgtFile);
+
+const hasCall = (edges: EdgeRow[], src: string, tgt: string, tgtFile: string): boolean =>
+  edges.some((e) => e.src === src && e.tgt === tgt && e.tgt_file === tgtFile);
+
+const ENGINES: EngineMode[] = ['wasm', 'native'];
+
+describe.each(ENGINES)('Python import resolution (#2387) — engine: %s', (engine) => {
+  let dir: string;
+  let dbPath: string;
+  let importEdges: EdgeRow[];
+  let callEdges: EdgeRow[];
+
+  beforeAll(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2387-${engine}-`));
+    writeFixture(dir);
+    await buildGraph(dir, { incremental: false, skipRegistry: true, engine });
+    dbPath = path.join(dir, '.codegraph', 'graph.db');
+    importEdges = readEdges(dbPath, 'imports');
+    callEdges = readEdges(dbPath, 'calls');
+  });
+
+  afterAll(() => {
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('emits imports edges for Python at all', () => {
+    expect(importEdges.length).toBeGreaterThan(0);
+  });
+
+  it('resolves an absolute dotted import through the src-layout package root', () => {
+    // `import pipeline.util as U` from src/pipeline/main.py
+    expect(hasEdge(importEdges, 'src/pipeline/main.py', 'src/pipeline/util.py')).toBe(true);
+  });
+
+  it('resolves single- and double-dot relative imports', () => {
+    // `from .extract import run_extract` and `from ..util import shared_helper`
+    expect(
+      hasEdge(importEdges, 'src/pipeline/stages/load.py', 'src/pipeline/stages/extract.py'),
+    ).toBe(true);
+    expect(hasEdge(importEdges, 'src/pipeline/stages/load.py', 'src/pipeline/util.py')).toBe(true);
+  });
+
+  it('points `from pkg import submod` at the submodule, not only at the package __init__', () => {
+    // `from pipeline.stages import extract` — depending on stages/__init__.py
+    // alone would leave the module that actually changed invisible to
+    // deps/impact.
+    expect(hasEdge(importEdges, 'src/pipeline/main.py', 'src/pipeline/stages/extract.py')).toBe(
+      true,
+    );
+  });
+
+  it('resolves a call through an aliased module binding (import x as y; y.f())', () => {
+    // The headline defect: U.shared_helper() previously produced no edge and
+    // left shared_helper classified dead.
+    expect(hasCall(callEdges, 'main', 'shared_helper', 'src/pipeline/util.py')).toBe(true);
+  });
+
+  it('resolves a call through a submodule binding (from pkg import submod; submod.f())', () => {
+    expect(hasCall(callEdges, 'main', 'run_extract', 'src/pipeline/stages/extract.py')).toBe(true);
+  });
+
+  it('still resolves the plain `from mod import name` form', () => {
+    expect(hasCall(callEdges, 'main', 'run_load', 'src/pipeline/stages/load.py')).toBe(true);
+    expect(hasCall(callEdges, 'run_load', 'shared_helper', 'src/pipeline/util.py')).toBe(true);
+    expect(hasCall(callEdges, 'run_load', 'run_extract', 'src/pipeline/stages/extract.py')).toBe(
+      true,
+    );
+  });
+
+  it('does not invent import edges for stdlib or third-party modules', () => {
+    // Nothing in the fixture imports os/numpy; every imports edge must land on
+    // a real project file, never on an echoed bare specifier.
+    const projectFiles = new Set(Object.keys(FILES).filter((f) => f.endsWith('.py')));
+    for (const edge of importEdges) {
+      expect(projectFiles.has(edge.tgt_file)).toBe(true);
+    }
+  });
+});

--- a/tests/integration/issue-2387-python-imports.test.ts
+++ b/tests/integration/issue-2387-python-imports.test.ts
@@ -28,6 +28,15 @@
  * Two same-named `shared_helper` functions would not disambiguate anything
  * here — instead the assertions pin each edge to a specific target *file*, so
  * a resolver that fell back to a global same-name lookup could not pass.
+ *
+ * A third defect surfaced in review of this fix: `from pkg import submod as
+ * alias` recorded the *pre-alias* name (`submod`) as the local binding, so
+ * `alias.f()` had no local name to key `namespaceImports` off of and resolved
+ * to nothing — the alias analogue of defect 2 above, but for the `from …
+ * import` form rather than `import … as …`. `tr.run_transform([])` below
+ * exercises exactly that: `run_transform` is declared nowhere else, so a
+ * resolver that dropped the alias would leave this call unresolved rather
+ * than accidentally matching something else.
  */
 
 import fs from 'node:fs';
@@ -56,6 +65,10 @@ def shared_helper():
 def run_extract(data):
     return data
 `,
+  'src/pipeline/stages/transform.py': `
+def run_transform(data):
+    return data
+`,
   'src/pipeline/stages/load.py': `
 from .extract import run_extract
 from ..util import shared_helper
@@ -67,11 +80,13 @@ def run_load(data):
   'src/pipeline/main.py': `
 import pipeline.util as U
 from pipeline.stages import extract
+from pipeline.stages import transform as tr
 from pipeline.stages.load import run_load
 
 def main():
     U.shared_helper()
     extract.run_extract([])
+    tr.run_transform([])
     return run_load([])
 `,
 };
@@ -162,6 +177,14 @@ describe.each(ENGINES)('Python import resolution (#2387) — engine: %s', (engin
     );
   });
 
+  it('points an aliased `from pkg import submod as alias` at the submodule too', () => {
+    // `from pipeline.stages import transform as tr` — the alias must not
+    // prevent the submodule-vs-package-symbol distinction from applying.
+    expect(hasEdge(importEdges, 'src/pipeline/main.py', 'src/pipeline/stages/transform.py')).toBe(
+      true,
+    );
+  });
+
   it('resolves a call through an aliased module binding (import x as y; y.f())', () => {
     // The headline defect: U.shared_helper() previously produced no edge and
     // left shared_helper classified dead.
@@ -170,6 +193,16 @@ describe.each(ENGINES)('Python import resolution (#2387) — engine: %s', (engin
 
   it('resolves a call through a submodule binding (from pkg import submod; submod.f())', () => {
     expect(hasCall(callEdges, 'main', 'run_extract', 'src/pipeline/stages/extract.py')).toBe(true);
+  });
+
+  it('resolves a call through an aliased submodule binding (from pkg import submod as alias; alias.f())', () => {
+    // `from pipeline.stages import transform as tr; tr.run_transform([])` —
+    // the extractor previously recorded the pre-alias name `transform` as
+    // the local binding, so `tr` had no entry in namespaceImports and this
+    // call resolved to nothing (found in review of #2387).
+    expect(hasCall(callEdges, 'main', 'run_transform', 'src/pipeline/stages/transform.py')).toBe(
+      true,
+    );
   });
 
   it('still resolves the plain `from mod import name` form', () => {

--- a/tests/parsers/unified.test.ts
+++ b/tests/parsers/unified.test.ts
@@ -105,6 +105,30 @@ describe('Unified parser API', () => {
         expect.objectContaining({ name: 'greet', kind: 'function' }),
       );
     });
+
+    it('records the local alias, not the pre-alias name, for an aliased Python from-import (#2387)', async () => {
+      // Found in review of #2387: `from pkg import submod as alias` recorded
+      // only `submod` (the pre-alias name declared in `pkg`) as the local
+      // binding, so `alias.f()` had no local name to key namespace/submodule
+      // resolution off of and resolved to nothing in both engines.
+      const symbols = await parseFileAuto('test.py', 'from pkg import submod as alias\n', {
+        engine: 'wasm',
+      });
+      expect(symbols).not.toBeNull();
+      expect(symbols.imports).toHaveLength(1);
+      expect(symbols.imports[0].source).toBe('pkg');
+      expect(symbols.imports[0].names).toEqual(['alias']);
+      expect(symbols.imports[0].renamedImports).toEqual([{ local: 'alias', imported: 'submod' }]);
+    });
+
+    it('only records a rename pair for the aliased specifier in a multi-name from-import', async () => {
+      const symbols = await parseFileAuto('test.py', 'from pkg import a, b as c\n', {
+        engine: 'wasm',
+      });
+      expect(symbols).not.toBeNull();
+      expect(symbols.imports[0].names).toEqual(['a', 'c']);
+      expect(symbols.imports[0].renamedImports).toEqual([{ local: 'c', imported: 'b' }]);
+    });
   });
 
   describe('parseFilesAuto', () => {

--- a/tests/unit/resolve.test.ts
+++ b/tests/unit/resolve.test.ts
@@ -12,6 +12,7 @@ import {
   clearCargoTargetOverridesCache,
   clearExportsCache,
   clearJsToTsCache,
+  clearPythonImportRootsCache,
   clearWorkspaceCache,
   computeConfidence,
   computeConfidenceJS,
@@ -21,6 +22,7 @@ import {
   parseBareSpecifier,
   resolveImportPathJS,
   resolveImportsBatch,
+  resolvePythonSubmodule,
   resolveViaExports,
   resolveViaWorkspace,
   setWorkspaces,
@@ -1170,5 +1172,175 @@ path = "custom/location/tool.rs"
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('resolveImportPathJS - Python module paths (#2387)', () => {
+  // PyPA "src layout": the package root is `src/`, but imports are written
+  // `from pipeline…` — the exact shape that resolved zero imports on
+  // data-analytics-pipeline-svc.
+  let pyDir: string;
+  const knownFiles = [
+    'src/pipeline/__init__.py',
+    'src/pipeline/util.py',
+    'src/pipeline/main.py',
+    'src/pipeline/stages/__init__.py',
+    'src/pipeline/stages/extract.py',
+    'src/pipeline/stages/load.py',
+    'scripts/tool.py',
+    'flat.py',
+  ];
+
+  beforeAll(() => {
+    pyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-resolve-py-'));
+    for (const rel of knownFiles) {
+      fs.mkdirSync(path.join(pyDir, path.dirname(rel)), { recursive: true });
+      fs.writeFileSync(path.join(pyDir, rel), '');
+    }
+    clearPythonImportRootsCache();
+  });
+
+  afterAll(() => {
+    if (pyDir) fs.rmSync(pyDir, { recursive: true, force: true });
+    clearPythonImportRootsCache();
+  });
+
+  const resolveFrom = (relFrom: string, source: string): string =>
+    resolveImportPathJS(path.join(pyDir, relFrom), source, pyDir, null, knownFiles);
+
+  it('resolves an absolute dotted import against the layout-derived package root (src layout)', () => {
+    expect(resolveFrom('src/pipeline/main.py', 'pipeline.util')).toBe('src/pipeline/util.py');
+  });
+
+  it('resolves a dotted import to a nested module', () => {
+    expect(resolveFrom('src/pipeline/main.py', 'pipeline.stages.extract')).toBe(
+      'src/pipeline/stages/extract.py',
+    );
+  });
+
+  it('resolves a package import to its __init__.py', () => {
+    expect(resolveFrom('src/pipeline/main.py', 'pipeline.stages')).toBe(
+      'src/pipeline/stages/__init__.py',
+    );
+  });
+
+  it('resolves a single-dot relative import to a sibling module', () => {
+    expect(resolveFrom('src/pipeline/stages/load.py', '.extract')).toBe(
+      'src/pipeline/stages/extract.py',
+    );
+  });
+
+  it('resolves a double-dot relative import to the parent package', () => {
+    expect(resolveFrom('src/pipeline/stages/load.py', '..util')).toBe('src/pipeline/util.py');
+  });
+
+  it('resolves a bare-dot relative import to the current package __init__.py', () => {
+    expect(resolveFrom('src/pipeline/stages/load.py', '.')).toBe('src/pipeline/stages/__init__.py');
+  });
+
+  it('resolves an import from a file outside the package tree via the src/ convention', () => {
+    expect(resolveFrom('scripts/tool.py', 'pipeline.util')).toBe('src/pipeline/util.py');
+  });
+
+  it('resolves a flat-layout import against the repo root', () => {
+    expect(resolveFrom('flat.py', 'flat')).toBe('flat.py');
+  });
+
+  it('leaves a stdlib/third-party module unresolved so it is treated as external', () => {
+    // Falls through to the bare-specifier fallback, which echoes the specifier.
+    expect(resolveFrom('src/pipeline/main.py', 'os.path')).toBe('os.path');
+    expect(resolveFrom('src/pipeline/main.py', 'numpy')).toBe('numpy');
+  });
+
+  it('does not escape the repo root when a relative import climbs past the package', () => {
+    // `...` from src/pipeline/stages/ would land above pyDir — must not resolve.
+    const result = resolveFrom('src/pipeline/stages/load.py', '...escape');
+    expect(result.startsWith('..')).toBe(false);
+  });
+
+  it('honours a pyproject.toml pythonpath entry that no layout convention implies', () => {
+    const cfgDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-resolve-pycfg-'));
+    try {
+      const cfgFiles = ['lib/vendored/helper.py', 'app/run.py'];
+      for (const rel of cfgFiles) {
+        fs.mkdirSync(path.join(cfgDir, path.dirname(rel)), { recursive: true });
+        fs.writeFileSync(path.join(cfgDir, rel), '');
+      }
+      fs.writeFileSync(
+        path.join(cfgDir, 'pyproject.toml'),
+        '[tool.pytest.ini_options]\npythonpath = ["lib"]\n',
+      );
+      clearPythonImportRootsCache();
+
+      const result = resolveImportPathJS(
+        path.join(cfgDir, 'app/run.py'),
+        'vendored.helper',
+        cfgDir,
+        null,
+        cfgFiles,
+      );
+      expect(result).toBe('lib/vendored/helper.py');
+    } finally {
+      fs.rmSync(cfgDir, { recursive: true, force: true });
+      clearPythonImportRootsCache();
+    }
+  });
+});
+
+describe('resolvePythonSubmodule (#2387)', () => {
+  let subDir: string;
+  const knownFiles = [
+    'pkg/__init__.py',
+    'pkg/stages/__init__.py',
+    'pkg/stages/extract.py',
+    'pkg/util.py',
+    'pkg/main.py',
+  ];
+
+  beforeAll(() => {
+    subDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-resolve-pysub-'));
+    for (const rel of knownFiles) {
+      fs.mkdirSync(path.join(subDir, path.dirname(rel)), { recursive: true });
+      fs.writeFileSync(path.join(subDir, rel), '');
+    }
+    clearPythonImportRootsCache();
+  });
+
+  afterAll(() => {
+    if (subDir) fs.rmSync(subDir, { recursive: true, force: true });
+    clearPythonImportRootsCache();
+  });
+
+  it('resolves `from pkg.stages import extract` to the submodule file', () => {
+    expect(
+      resolvePythonSubmodule(
+        path.join(subDir, 'pkg/main.py'),
+        'pkg.stages',
+        'extract',
+        subDir,
+        knownFiles,
+      ),
+    ).toBe('pkg/stages/extract.py');
+  });
+
+  it('returns null when the imported name is an ordinary symbol, not a submodule', () => {
+    expect(
+      resolvePythonSubmodule(
+        path.join(subDir, 'pkg/main.py'),
+        'pkg.util',
+        'shared_helper',
+        subDir,
+        knownFiles,
+      ),
+    ).toBeNull();
+  });
+
+  it('returns null for a wildcard import and for non-Python callers', () => {
+    expect(
+      resolvePythonSubmodule(path.join(subDir, 'pkg/main.py'), 'pkg', '*', subDir, knownFiles),
+    ).toBeNull();
+    expect(
+      resolvePythonSubmodule(path.join(subDir, 'main.ts'), 'pkg', 'stages', subDir, knownFiles),
+    ).toBeNull();
   });
 });


### PR DESCRIPTION
Closes #2387.

## The problem

Python emitted **zero `imports` edges**, so `deps`, `impact` and `map` were blind on every Python repo, and `import lib as L` + `L.f()` resolved to nothing — leaving the callee reported as dead code. Four actively-developed Optave Python services are affected.

Two distinct defects, both reproduced on the minimal fixture from the issue before any change:

1. **Neither resolver had a Python branch.** A dotted module path (`pipeline.util`) is not a filesystem path, so it fell through to the bare-specifier fallback and was echoed back unchanged, matching no file node. Python's *relative* imports share JS's leading-dot spelling but mean "climb the package tree", so `from ..util import x` was mis-resolved by the generic relative branch as well.

2. **The extractor put the alias in `Import.source`.** For `import lib as L`, `source` was `L` — an alias can never resolve to a file. A multi-module `import a, b` also collapsed into a single record naming only `a`, silently losing `b`.

## The approach

**Import roots are derived from package layout**, not assumed to be the repo root: walk up from the importing file while each level is a package (contains `__init__.py`), and stop at the first ancestor that is not. That ancestor is what would be on `sys.path` at runtime, so the PyPA-endorsed "src layout" (`src/pipeline/…`, imported as `from pipeline…`) and a flat layout resolve under one rule with no configuration. The src-layout case is exactly what made `data-analytics-pipeline-svc` resolve nothing.

Roots that no convention implies are read from `pyproject.toml` — `[tool.pytest.ini_options] pythonpath`, `[tool.setuptools] package-dir`, `[tool.setuptools.packages.find] where`, and poetry's `packages[].from`. That covers the `pythonpath = ["src", "scripts"]` case observed on the same repo, where `scripts/` is importable but has no package marker.

**Module bindings are modelled explicitly.** A new `Import.namespaceBindings` field records local names bound to a *module* rather than a symbol. Call resolution reads it to interpret `L.strip_block()` as "`strip_block`, as declared in the module `L` refers to" — scoped to that module's file and authoritative, so a miss can't be claimed by an unrelated same-named function elsewhere. The field is defined generally (JavaScript's `import * as ns` is the same concept) but only Python populates it here.

**`from pkg import submod` is resolved as a submodule** when `pkg/submod.py` exists — Python's two readings of that statement are indistinguishable without knowing which files exist, so the resolver decides rather than the extractor. It both binds a namespace (so `submod.f()` resolves) and emits an `imports` edge to the submodule, so `deps`/`impact` name the module that actually changed instead of only the package barrel.

Import-root caches are cleared per rebuild alongside the Cargo one, since `pyproject.toml` isn't a watched extension and layout-derived roots go stale the moment an `__init__.py` is added or removed.

## Engine parity

Mirrored in `crates/codegraph-core/` (extractor, resolver, edge emission, call resolution, NAPI cache-clear export). Native and WASM were compared directly on five fixtures — Python minimal, Python src-layout, and three JS controls — and produce **identical edge sets**.

Worth knowing for future parity work: `--engine wasm` does *not* exercise the JS resolver when the native addon is present, because `resolveImportPath` prefers native regardless of the flag. The JS path has to be tested with the addon unavailable.

## Verification

- 4833 TS tests pass, 886 Rust tests pass, lint and typecheck clean.
- New coverage: 14 resolver unit tests (`tests/unit/resolve.test.ts`), 12 Rust resolver/extractor unit tests, and an 8-assertion integration test run against **both engines** (`tests/integration/issue-2387-python-imports.test.ts`) on a src-layout fixture. Assertions pin each edge to a specific target *file*, so a resolver falling back to a global same-name lookup cannot pass.
- Stdlib and third-party modules deliberately stay unresolved and are treated as external; a test asserts every emitted `imports` edge lands on a real project file.

## Found in passing, not fixed here

- #2407 — the WASM path skips the #2032 reachability downgrade that native applies. **Not caused by this work**: both role classifiers are untouched by this diff, and it reproduces on plain same-file JavaScript with no Python involved. Python previously had too few resolved call edges for the reachability path to be reached at all, which is why it stayed invisible.