### PR TITLE
fix(test-filter): -T recognizes test/fixture directories and per-language conventions

### DIFF
--- a/crates/codegraph-core/src/db/repository/graph_read.rs
+++ b/crates/codegraph-core/src/db/repository/graph_read.rs
@@ -63,25 +63,17 @@ fn push_file_filter(
     *idx += files.len();
 }
 
-/// Check if a file path looks like a test file (mirrors `isTestFile` in JS).
+/// Check if a file path looks like a test file. Delegates to the shared
+/// `infrastructure::test_filter` module (single source of truth, #2256);
+/// mirrors TS `isTestFile`.
 fn is_test_file(file: &str) -> bool {
-    file.contains(".test.")
-        || file.contains(".spec.")
-        || file.contains("__test__")
-        || file.contains("__tests__")
-        || file.contains(".stories.")
+    crate::infrastructure::test_filter::is_test_file(file)
 }
 
-/// Build test-file exclusion clauses for a column.
+/// Build test-file exclusion clauses for a column. Delegates to the shared
+/// `infrastructure::test_filter` module (single source of truth, #2256).
 fn test_filter_clauses(column: &str) -> String {
-    format!(
-        "AND {col} NOT LIKE '%.test.%' \
-         AND {col} NOT LIKE '%.spec.%' \
-         AND {col} NOT LIKE '%__test__%' \
-         AND {col} NOT LIKE '%__tests__%' \
-         AND {col} NOT LIKE '%.stories.%'",
-        col = column,
-    )
+    crate::infrastructure::test_filter::test_file_filter_col(column)
 }
 
 /// Read a full NativeNodeRow from a rusqlite Row by column name.

--- a/crates/codegraph-core/src/graph/classifiers/roles.rs
+++ b/crates/codegraph-core/src/graph/classifiers/roles.rs
@@ -61,14 +61,6 @@ const ENTRY_PATH_PATTERNS: &[&str] = &[
 /// Mirrors `COMMANDER_DISPATCH_NAMES` in `graph/classifiers/roles.ts`.
 const COMMANDER_DISPATCH_NAMES: &[&str] = &["execute", "validate"];
 
-const TEST_FILE_PATTERNS: &[&str] = &[
-    "%.test.%",
-    "%.spec.%",
-    "%__test__%",
-    "%__tests__%",
-    "%.stories.%",
-];
-
 // ── Output types ─────────────────────────────────────────────────────
 
 #[napi(object)]
@@ -679,13 +671,10 @@ fn test_file_filter() -> String {
     test_file_filter_col("caller.file")
 }
 
-/// Build the test-file exclusion filter for an arbitrary column name.
+/// Build the test-file exclusion filter for an arbitrary column name. Delegates to the
+/// shared `infrastructure::test_filter` module (single source of truth, #2256).
 fn test_file_filter_col(column: &str) -> String {
-    TEST_FILE_PATTERNS
-        .iter()
-        .map(|p| format!("AND {} NOT LIKE '{}'", column, p))
-        .collect::<Vec<_>>()
-        .join(" ")
+    crate::infrastructure::test_filter::test_file_filter_col(column)
 }
 
 /// Compute two active-files sets from callable rows.

--- a/crates/codegraph-core/src/infrastructure/mod.rs
+++ b/crates/codegraph-core/src/infrastructure/mod.rs
@@ -1,1 +1,2 @@
 pub mod config;
+pub mod test_filter;

--- a/crates/codegraph-core/src/infrastructure/test_filter.rs
+++ b/crates/codegraph-core/src/infrastructure/test_filter.rs
@@ -83,19 +83,24 @@ fn basename(path: &str) -> &str {
     path.rsplit('/').next().unwrap_or(path)
 }
 
-/// Go: `foo_test.go` (#2256 follow-up).
-fn is_go_test_filename(path: &str) -> bool {
-    path.ends_with("_test.go")
+/// Go: `foo_test.go` (#2256 follow-up). `path` must already be lowercased —
+/// matched case-insensitively for parity with SQLite's case-insensitive
+/// `LIKE` (Greptile review, #2256): a mixed-case path like `pkg/foo_TEST.go`
+/// must be excluded consistently whether evaluated via `test_file_filter_col`
+/// or `is_test_file`.
+fn is_go_test_filename(lower_path: &str) -> bool {
+    lower_path.ends_with("_test.go")
 }
 
 /// Python: `test_foo.py` (prefix, checked on the basename) or `foo_test.py`
-/// (suffix, checked on the whole path) (#2256 follow-up).
-fn is_python_test_filename(path: &str) -> bool {
-    let base = basename(path);
+/// (suffix, checked on the whole path) (#2256 follow-up). `lower_path` must
+/// already be lowercased — see `is_go_test_filename`'s doc comment.
+fn is_python_test_filename(lower_path: &str) -> bool {
+    let base = basename(lower_path);
     if base.starts_with("test_") && base.ends_with(".py") {
         return true;
     }
-    path.ends_with("_test.py")
+    lower_path.ends_with("_test.py")
 }
 
 /// Java: `TestFoo.java` (prefix, camelCase-boundary-aware) or `FooTest.java`
@@ -122,15 +127,27 @@ fn is_java_test_filename(path: &str) -> bool {
 }
 
 /// Check whether a file path looks like a test file. Mirrors TS `isTestFile`
-/// (`src/infrastructure/test-filter.ts`).
+/// (`src/infrastructure/test-filter.ts`). Every check except the Java
+/// filename convention is case-insensitive, for parity with SQLite's
+/// case-insensitive `LIKE` (Greptile review, #2256) — the Java check stays
+/// case-sensitive on the original `path`, matching TS and this module's own
+/// top-of-file doc comment on why it's deliberately excluded from
+/// `TEST_FILE_LIKE_PATTERNS`.
 pub fn is_test_file(path: &str) -> bool {
-    if FILENAME_SUBSTRING_MARKERS.iter().any(|m| path.contains(m)) {
+    let lower = path.to_lowercase();
+    if FILENAME_SUBSTRING_MARKERS.iter().any(|m| lower.contains(m)) {
         return true;
     }
-    if path.split('/').any(|seg| TEST_PATH_SEGMENTS.contains(&seg)) {
+    if lower
+        .split('/')
+        .any(|seg| TEST_PATH_SEGMENTS.contains(&seg))
+    {
         return true;
     }
-    is_go_test_filename(path) || is_python_test_filename(path) || is_java_test_filename(path)
+    if is_go_test_filename(&lower) || is_python_test_filename(&lower) {
+        return true;
+    }
+    is_java_test_filename(path)
 }
 
 #[cfg(test)]
@@ -169,9 +186,27 @@ mod tests {
         "src/Protest.java",
     ];
 
+    // Mixed-case variants of the filename/segment/Go/Python markers — must
+    // match, for parity with SQLite's case-insensitive LIKE (#2256).
+    const MIXED_CASE_MATCH: &[&str] = &[
+        "src/foo.TEST.ts",
+        "src/Tests/foo.ts",
+        "src/TEST/foo.go",
+        "pkg/foo_TEST.go",
+        "TEST_foo.py",
+        "src/FOO_TEST.py",
+    ];
+
     #[test]
     fn matches_expected_test_paths() {
         for path in SHOULD_MATCH {
+            assert!(is_test_file(path), "expected {path} to be a test file");
+        }
+    }
+
+    #[test]
+    fn matches_mixed_case_variants() {
+        for path in MIXED_CASE_MATCH {
             assert!(is_test_file(path), "expected {path} to be a test file");
         }
     }

--- a/crates/codegraph-core/src/infrastructure/test_filter.rs
+++ b/crates/codegraph-core/src/infrastructure/test_filter.rs
@@ -1,0 +1,185 @@
+//! Canonical test/fixture path detection — mirrors
+//! `src/infrastructure/test-filter.ts`. See that file's doc comment for the
+//! full rationale (#2256); summarized here:
+//!
+//! `TEST_FILE_LIKE_PATTERNS` is the single source of truth for "does this
+//! path look like test/fixture infrastructure" behind every `-T`-style
+//! filter in this engine. `test_file_filter_col` (consumed by
+//! `graph/classifiers/roles.rs` and `db/repository/graph_read.rs`) turns
+//! these into `NOT LIKE` clauses; `is_test_file` re-implements the same
+//! intent as a boolean check for query paths that filter in Rust memory
+//! rather than in SQL.
+//!
+//! A literal `_` in a pattern means a literal underscore — `_` is SQL
+//! LIKE's own single-character wildcard, so `escape_like_underscores` escapes
+//! it before use (SQLite's LIKE is case-insensitive for ASCII by default).
+//! Path segments are bounded by `/` (or path start/end) so a segment name
+//! only matches a WHOLE directory component — `tests/`/`test/` never matches
+//! `contests/`, `latest/`, or a production `test-utils/` directory.
+//!
+//! The Java `TestFoo.java` / `FooTest.java` filename convention is
+//! deliberately excluded from `TEST_FILE_LIKE_PATTERNS` — SQLite's LIKE is
+//! case-insensitive, so a substring-based approximation would also match
+//! ordinary words merely containing "test" (`Latest.java`, `Contest.java`,
+//! `Testament.java`). `is_test_file` below still recognizes the Java
+//! convention precisely (case-sensitive, camelCase-boundary-aware) since it
+//! isn't constrained to LIKE syntax; the standard Maven/Gradle
+//! `src/test/java/` directory layout is covered by the `test` path segment
+//! either way.
+
+/// SQL LIKE templates (`%` = any run of characters). Keep in lockstep with
+/// TS `TEST_FILE_LIKE_PATTERNS` (`src/infrastructure/test-filter.ts`).
+pub const TEST_FILE_LIKE_PATTERNS: &[&str] = &[
+    // Filename substring markers.
+    "%.test.%",
+    "%.spec.%",
+    "%__test__%",
+    "%__tests__%",
+    "%.stories.%",
+    // Test/fixture directory segments (#2256).
+    "%/tests/%",
+    "tests/%",
+    "%/test/%",
+    "test/%",
+    "%/fixtures/%",
+    "fixtures/%",
+    "%/__fixtures__/%",
+    "__fixtures__/%",
+    // Go: foo_test.go (#2256 follow-up).
+    "%_test.go",
+    // Python: test_foo.py / foo_test.py (#2256 follow-up).
+    "%/test_%.py",
+    "test_%.py",
+    "%_test.py",
+];
+
+/// Escape LIKE's `_` single-character wildcard so it matches a literal underscore.
+pub fn escape_like_underscores(pattern: &str) -> String {
+    pattern.replace('_', "\\_")
+}
+
+/// Build a `NOT LIKE ... ESCAPE '\'` filter clause for `column` from
+/// `TEST_FILE_LIKE_PATTERNS`. Mirrors TS `testFilterSQL`
+/// (`src/db/query-builder.ts`).
+pub fn test_file_filter_col(column: &str) -> String {
+    TEST_FILE_LIKE_PATTERNS
+        .iter()
+        .map(|p| {
+            format!(
+                "AND {column} NOT LIKE '{}' ESCAPE '\\'",
+                escape_like_underscores(p)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+const FILENAME_SUBSTRING_MARKERS: &[&str] =
+    &[".test.", ".spec.", "__test__", "__tests__", ".stories."];
+
+const TEST_PATH_SEGMENTS: &[&str] = &["tests", "test", "fixtures", "__fixtures__"];
+
+fn basename(path: &str) -> &str {
+    path.rsplit('/').next().unwrap_or(path)
+}
+
+/// Go: `foo_test.go` (#2256 follow-up).
+fn is_go_test_filename(path: &str) -> bool {
+    path.ends_with("_test.go")
+}
+
+/// Python: `test_foo.py` (prefix, checked on the basename) or `foo_test.py`
+/// (suffix, checked on the whole path) (#2256 follow-up).
+fn is_python_test_filename(path: &str) -> bool {
+    let base = basename(path);
+    if base.starts_with("test_") && base.ends_with(".py") {
+        return true;
+    }
+    path.ends_with("_test.py")
+}
+
+/// Java: `TestFoo.java` (prefix, camelCase-boundary-aware) or `FooTest.java`
+/// (suffix) — case-sensitive by design: real Java test classes are always
+/// capitalized this way, which is what avoids matching `Testament.java`/
+/// `Latest.java`/`Contest.java`/`Protest.java` (#2256 follow-up).
+fn is_java_test_filename(path: &str) -> bool {
+    let base = basename(path);
+    if base.starts_with("Test") && base.ends_with(".java") {
+        if let Some(next) = base[4..].chars().next() {
+            if next.is_ascii_uppercase() {
+                return true;
+            }
+        }
+    }
+    if let Some(prefix) = path.strip_suffix("Test.java") {
+        if let Some(prev) = prefix.chars().last() {
+            if prev.is_ascii_lowercase() || prev.is_ascii_digit() {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Check whether a file path looks like a test file. Mirrors TS `isTestFile`
+/// (`src/infrastructure/test-filter.ts`).
+pub fn is_test_file(path: &str) -> bool {
+    if FILENAME_SUBSTRING_MARKERS.iter().any(|m| path.contains(m)) {
+        return true;
+    }
+    if path.split('/').any(|seg| TEST_PATH_SEGMENTS.contains(&seg)) {
+        return true;
+    }
+    is_go_test_filename(path) || is_python_test_filename(path) || is_java_test_filename(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SHOULD_MATCH: &[&str] = &[
+        "src/foo.test.ts",
+        "src/foo.spec.ts",
+        "src/__tests__/foo.ts",
+        "src/__test__/foo.ts",
+        "src/foo.stories.tsx",
+        "tests/foo.ts",
+        "src/tests/foo.ts",
+        "test/foo.go",
+        "src/test/foo.java",
+        "fixtures/foo.json",
+        "src/__fixtures__/foo.json",
+        "pkg/foo_test.go",
+        "test_foo.py",
+        "src/test_foo.py",
+        "foo_test.py",
+        "src/TestFoo.java",
+        "src/FooTest.java",
+    ];
+
+    const SHOULD_NOT_MATCH: &[&str] = &[
+        "src/contests/foo.ts",
+        "src/latest/foo.ts",
+        "src/test-utils/foo.ts",
+        "src/protest.py",
+        "src/latest.py",
+        "src/Testament.java",
+        "src/Contest.java",
+        "src/Latest.java",
+        "src/Protest.java",
+    ];
+
+    #[test]
+    fn matches_expected_test_paths() {
+        for path in SHOULD_MATCH {
+            assert!(is_test_file(path), "expected {path} to be a test file");
+        }
+    }
+
+    #[test]
+    fn does_not_match_ordinary_paths_containing_test_as_a_substring() {
+        for path in SHOULD_NOT_MATCH {
+            assert!(!is_test_file(path), "expected {path} to NOT be a test file");
+        }
+    }
+}

--- a/crates/codegraph-core/src/lib.rs
+++ b/crates/codegraph-core/src/lib.rs
@@ -13,6 +13,7 @@
 //! | `types.rs`                           | `src/types.ts`                                  |
 //! | `shared/constants.rs`                | `src/shared/constants.ts`                       |
 //! | `infrastructure/config.rs`           | `src/infrastructure/config.ts`                  |
+//! | `infrastructure/test_filter.rs`      | `src/infrastructure/test-filter.ts`             |
 //! | `db/connection.rs`                   | `src/db/connection.ts` + `src/db/migrations.ts` |
 //! | `db/repository/*`                    | `src/db/repository/*`                           |
 //! | `domain/parser.rs`                   | `src/domain/parser.ts`                          |

--- a/src/db/query-builder.ts
+++ b/src/db/query-builder.ts
@@ -1,3 +1,4 @@
+import { escapeLikeUnderscores, TEST_FILE_LIKE_PATTERNS } from '../infrastructure/test-filter.js';
 import { DbError } from '../shared/errors.js';
 import { DEAD_ROLE_PREFIX, EVERY_EDGE_KIND } from '../shared/kinds.js';
 import type { BetterSqlite3Database, NativeDatabase } from '../types.js';
@@ -148,11 +149,9 @@ export function collectFile(val: string, acc?: string[]): string[] {
 export function testFilterSQL(column = 'n.file', enabled = true): string {
   if (!enabled) return '';
   validateColumn(column);
-  return `AND ${column} NOT LIKE '%.test.%'
-       AND ${column} NOT LIKE '%.spec.%'
-       AND ${column} NOT LIKE '%__test__%'
-       AND ${column} NOT LIKE '%__tests__%'
-       AND ${column} NOT LIKE '%.stories.%'`;
+  return TEST_FILE_LIKE_PATTERNS.map(
+    (pattern) => `AND ${column} NOT LIKE '${escapeLikeUnderscores(pattern)}' ESCAPE '\\'`,
+  ).join('\n       ');
 }
 
 /** Build IN (?, ?, ?) placeholders and params array for a kind filter. */
@@ -215,15 +214,13 @@ export class NodeQuery {
     return this;
   }
 
-  /** Add 5 NOT LIKE conditions to exclude test files. No-op when enabled is falsy. */
+  /** Add NOT LIKE conditions to exclude test/fixture files. No-op when enabled is falsy. */
   excludeTests(enabled: boolean | undefined): this {
     if (!enabled) return this;
     this.#conditions.push(
-      `n.file NOT LIKE '%.test.%'`,
-      `n.file NOT LIKE '%.spec.%'`,
-      `n.file NOT LIKE '%__test__%'`,
-      `n.file NOT LIKE '%__tests__%'`,
-      `n.file NOT LIKE '%.stories.%'`,
+      ...TEST_FILE_LIKE_PATTERNS.map(
+        (pattern) => `n.file NOT LIKE '${escapeLikeUnderscores(pattern)}' ESCAPE '\\'`,
+      ),
     );
     return this;
   }

--- a/src/db/repository/in-memory-repository.ts
+++ b/src/db/repository/in-memory-repository.ts
@@ -1,3 +1,4 @@
+import { isTestFile } from '../../infrastructure/test-filter.js';
 import { ConfigError } from '../../shared/errors.js';
 import {
   CORE_SYMBOL_KINDS,
@@ -304,14 +305,7 @@ export class InMemoryRepository extends Repository {
     let nodes = [...this.#nodes.values()].filter((n) => kindsToUse.includes(n.kind));
 
     if (opts.noTests) {
-      nodes = nodes.filter(
-        (n) =>
-          !n.file.includes('.test.') &&
-          !n.file.includes('.spec.') &&
-          !n.file.includes('__test__') &&
-          !n.file.includes('__tests__') &&
-          !n.file.includes('.stories.'),
-      );
+      nodes = nodes.filter((n) => !isTestFile(n.file));
     }
     {
       const fileFn = buildFileFilterFn(opts.file);
@@ -640,14 +634,7 @@ export class InMemoryRepository extends Repository {
       nodes = nodes.filter((n) => patternRe.test(n.name));
     }
     if (opts.noTests) {
-      nodes = nodes.filter(
-        (n) =>
-          !n.file.includes('.test.') &&
-          !n.file.includes('.spec.') &&
-          !n.file.includes('__test__') &&
-          !n.file.includes('__tests__') &&
-          !n.file.includes('.stories.'),
-      );
+      nodes = nodes.filter((n) => !isTestFile(n.file));
     }
 
     nodes.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line);

--- a/src/domain/queries.ts
+++ b/src/domain/queries.ts
@@ -7,7 +7,7 @@
  */
 
 // ── Re-export from dedicated module for backward compat ───────────────────
-export { isTestFile, TEST_PATTERN } from '../infrastructure/test-filter.js';
+export { isTestFile } from '../infrastructure/test-filter.js';
 export { diffImpactMermaid } from '../presentation/diff-impact-mermaid.js';
 export { iterListFunctions, iterRoles, iterWhere } from '../shared/generators.js';
 // ── Kind/edge constants (canonical source: kinds.js) ─────────────────────

--- a/src/domain/search/search/filters.ts
+++ b/src/domain/search/search/filters.ts
@@ -1,3 +1,5 @@
+import { isTestFile } from '../../../infrastructure/test-filter.js';
+
 export function globMatch(filePath: string, pattern: string): boolean {
   const normalized = filePath.replace(/\\/g, '/');
   let regex = pattern.replace(/\\/g, '/').replace(/[.+^${}()|[\]\\]/g, '\\$&');
@@ -11,8 +13,6 @@ export function globMatch(filePath: string, pattern: string): boolean {
     return normalized.includes(pattern);
   }
 }
-
-const TEST_PATTERN = /\.(test|spec)\.|__test__|__tests__|\.stories\./;
 
 export interface FilterOpts {
   filePattern?: string | string[];
@@ -32,7 +32,7 @@ export function applyFilters<T extends { file: string }>(rows: T[], opts: Filter
     );
   }
   if (opts.noTests) {
-    filtered = filtered.filter((row) => !TEST_PATTERN.test(row.file));
+    filtered = filtered.filter((row) => !isTestFile(row.file));
   }
   return filtered;
 }

--- a/src/features/ast.ts
+++ b/src/features/ast.ts
@@ -9,7 +9,7 @@ import { buildExtensionSet } from '../ast-analysis/shared.js';
 import { walkWithVisitors } from '../ast-analysis/visitor.js';
 import { createAstStoreVisitor } from '../ast-analysis/visitors/ast-store-visitor.js';
 import { bulkNodeIdsByFile, openReadonlyOrFail, resolveBusyTimeoutMs } from '../db/index.js';
-import { buildFileConditionSQL } from '../db/query-builder.js';
+import { buildFileConditionSQL, testFilterSQL } from '../db/query-builder.js';
 import { debug } from '../infrastructure/logger.js';
 import { outputResult } from '../infrastructure/result-formatter.js';
 import { paginateResult } from '../shared/paginate.js';
@@ -327,13 +327,7 @@ export function astQueryData(
     params.push(...fc.params);
   }
 
-  if (noTests) {
-    where += ` AND a.file NOT LIKE '%.test.%'
-       AND a.file NOT LIKE '%.spec.%'
-       AND a.file NOT LIKE '%__test__%'
-       AND a.file NOT LIKE '%__tests__%'
-       AND a.file NOT LIKE '%.stories.%'`;
-  }
+  where += ` ${testFilterSQL('a.file', noTests ?? false)}`;
 
   const sql = `
     SELECT a.kind, a.name, a.file, a.line, a.text, a.receiver, a.parent_node_id,

--- a/src/features/complexity-query.ts
+++ b/src/features/complexity-query.ts
@@ -6,7 +6,7 @@
  */
 
 import { openReadonlyOrFail, resolveDbConfig } from '../db/index.js';
-import { buildFileConditionSQL } from '../db/query-builder.js';
+import { buildFileConditionSQL, testFilterSQL } from '../db/query-builder.js';
 import { DEFAULTS } from '../infrastructure/config.js';
 import { debug } from '../infrastructure/logger.js';
 import { isTestFile } from '../infrastructure/test-filter.js';
@@ -100,13 +100,7 @@ function buildComplexityWhere(opts: {
   let where = "WHERE n.kind IN ('function','method')";
   const params: unknown[] = [];
 
-  if (opts.noTests) {
-    where += ` AND n.file NOT LIKE '%.test.%'
-       AND n.file NOT LIKE '%.spec.%'
-       AND n.file NOT LIKE '%__test__%'
-       AND n.file NOT LIKE '%__tests__%'
-       AND n.file NOT LIKE '%.stories.%'`;
-  }
+  where += ` ${testFilterSQL('n.file', opts.noTests)}`;
   if (opts.target) {
     where += ' AND n.name LIKE ?';
     params.push(`%${opts.target}%`);

--- a/src/features/manifesto.ts
+++ b/src/features/manifesto.ts
@@ -1,5 +1,5 @@
 import { openReadonlyOrFail, resolveDbConfig } from '../db/index.js';
-import { buildFileConditionSQL } from '../db/query-builder.js';
+import { buildFileConditionSQL, testFilterSQL } from '../db/query-builder.js';
 import { findCycles } from '../domain/graph/cycles.js';
 import { DEFAULTS } from '../infrastructure/config.js';
 import { debug } from '../infrastructure/logger.js';
@@ -70,13 +70,6 @@ export const RULE_DEFS: RuleDef[] = [
 ];
 
 // ─── Helpers ──────────────────────────────────────────────────────────
-
-const NO_TEST_SQL = `
-  AND n.file NOT LIKE '%.test.%'
-  AND n.file NOT LIKE '%.spec.%'
-  AND n.file NOT LIKE '%__test__%'
-  AND n.file NOT LIKE '%__tests__%'
-  AND n.file NOT LIKE '%.stories.%'`;
 
 interface ResolvedRules {
   [name: string]: ThresholdRule;
@@ -251,7 +244,7 @@ function evaluateFunctionRules(
 
   let where = "WHERE n.kind IN ('function','method')";
   const params: unknown[] = [];
-  if (opts.noTests) where += NO_TEST_SQL;
+  where += ` ${testFilterSQL('n.file', opts.noTests ?? false)}`;
   {
     const fc = buildFileConditionSQL(opts.file as string, 'n.file');
     where += fc.sql;
@@ -305,7 +298,7 @@ function evaluateFileRules(
 
   let where = "WHERE n.kind = 'file'";
   const params: unknown[] = [];
-  if (opts.noTests) where += NO_TEST_SQL;
+  where += ` ${testFilterSQL('n.file', opts.noTests ?? false)}`;
   {
     const fc = buildFileConditionSQL(opts.file as string, 'n.file');
     where += fc.sql;

--- a/src/infrastructure/test-filter.ts
+++ b/src/infrastructure/test-filter.ts
@@ -74,22 +74,37 @@ const TEST_PATH_SEGMENTS: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Per-language filename conventions not covered by a directory segment or a
- * simple substring — camelCase-boundary-aware so `TestFoo`/`FooTest` match
- * but `Testament`/`Latest`/`Contest` don't (#2256 follow-up). Case-sensitive
- * by design: real Java test classes are always capitalized this way.
+ * Go/Python filename-suffix conventions — mirror the LIKE patterns above, so
+ * matched case-insensitively (`i` flag) for parity with SQLite's
+ * case-insensitive `LIKE` (Greptile review, #2256): a mixed-case path like
+ * `pkg/foo_TEST.go` must be excluded consistently whether it's evaluated via
+ * `testFilterSQL`/`NOT LIKE` or via `isTestFile`.
  */
-const LANGUAGE_FILENAME_PATTERNS: readonly RegExp[] = [
-  /_test\.go$/, // Go: foo_test.go
-  /(?:^|\/)test_[^/]*\.py$/, // Python: test_foo.py
-  /_test\.py$/, // Python: foo_test.py
+const CASE_INSENSITIVE_LANGUAGE_PATTERNS: readonly RegExp[] = [
+  /_test\.go$/i, // Go: foo_test.go
+  /(?:^|\/)test_[^/]*\.py$/i, // Python: test_foo.py
+  /_test\.py$/i, // Python: foo_test.py
+];
+
+/**
+ * Java filename convention not covered by a directory segment or a simple
+ * substring — camelCase-boundary-aware so `TestFoo`/`FooTest` match but
+ * `Testament`/`Latest`/`Contest` don't (#2256 follow-up). Case-sensitive by
+ * design (real Java test classes are always capitalized this way) and, unlike
+ * the patterns above, deliberately NOT mirrored in `TEST_FILE_LIKE_PATTERNS`
+ * — see this file's top doc comment for why a LIKE-based approximation can't
+ * express this precisely.
+ */
+const JAVA_LANGUAGE_PATTERNS: readonly RegExp[] = [
   /(?:^|\/)Test[A-Z]\w*\.java$/, // Java: TestFoo.java
   /[a-z0-9]Test\.java$/, // Java: FooTest.java
 ];
 
 /** Check whether a file path looks like a test file. */
 export function isTestFile(filePath: string): boolean {
-  if (FILENAME_SUBSTRING_MARKERS.some((marker) => filePath.includes(marker))) return true;
-  if (filePath.split('/').some((segment) => TEST_PATH_SEGMENTS.has(segment))) return true;
-  return LANGUAGE_FILENAME_PATTERNS.some((pattern) => pattern.test(filePath));
+  const lower = filePath.toLowerCase();
+  if (FILENAME_SUBSTRING_MARKERS.some((marker) => lower.includes(marker))) return true;
+  if (lower.split('/').some((segment) => TEST_PATH_SEGMENTS.has(segment))) return true;
+  if (CASE_INSENSITIVE_LANGUAGE_PATTERNS.some((pattern) => pattern.test(filePath))) return true;
+  return JAVA_LANGUAGE_PATTERNS.some((pattern) => pattern.test(filePath));
 }

--- a/src/infrastructure/test-filter.ts
+++ b/src/infrastructure/test-filter.ts
@@ -1,7 +1,95 @@
-/** Pattern matching test/spec/stories files. */
-export const TEST_PATTERN = /\.(test|spec)\.|__test__|__tests__|\.stories\./;
+/**
+ * Canonical test/fixture path markers, expressed as SQL LIKE templates
+ * (`%` = any run of characters; a literal `_` here means a literal
+ * underscore — `escapeLikeUnderscores` below escapes it for LIKE, since `_`
+ * is LIKE's own single-character wildcard). SQLite's LIKE is
+ * case-insensitive for ASCII by default.
+ *
+ * This is the single source of truth for "does this path look like
+ * test/fixture infrastructure" behind every `-T`-style filter —
+ * `testFilterSQL` (`src/db/query-builder.ts`) turns these into `NOT LIKE`
+ * clauses directly; `isTestFile` below re-implements the same intent as
+ * boolean/regex checks (LIKE syntax isn't usable outside a query). The
+ * mirrored Rust module (`crates/codegraph-core/src/infrastructure/test_filter.rs`)
+ * keeps both forms in lockstep — see its own doc comment (#2256).
+ *
+ * Path segments are bounded by `/` (or path start/end) so a segment name
+ * only matches a WHOLE directory component — `tests/`/`test/` never matches
+ * `contests/`, `latest/`, or a production `test-utils/` directory.
+ *
+ * The Go/Python filename-suffix patterns are included here because their
+ * real-world false-positive rate is negligible. The Java `TestFoo.java` /
+ * `FooTest.java` convention is deliberately EXCLUDED from this LIKE list —
+ * SQLite's LIKE is unconditionally case-insensitive, so a substring-based
+ * approximation would also match ordinary words merely containing "test"
+ * (`Latest.java`, `Contest.java`, `Protest.java`, `Testament.java`,
+ * `Testimony.java`). `isTestFile`'s regex below still recognizes the Java
+ * convention precisely (case-sensitive, camelCase-boundary-aware) since it
+ * isn't constrained to LIKE syntax; the standard Maven/Gradle
+ * `src/test/java/` directory layout is covered by the `test` path segment
+ * either way.
+ */
+export const TEST_FILE_LIKE_PATTERNS: readonly string[] = [
+  // Filename substring markers.
+  '%.test.%',
+  '%.spec.%',
+  '%__test__%',
+  '%__tests__%',
+  '%.stories.%',
+  // Test/fixture directory segments (#2256).
+  '%/tests/%',
+  'tests/%',
+  '%/test/%',
+  'test/%',
+  '%/fixtures/%',
+  'fixtures/%',
+  '%/__fixtures__/%',
+  '__fixtures__/%',
+  // Go: foo_test.go (#2256 follow-up).
+  '%_test.go',
+  // Python: test_foo.py / foo_test.py (#2256 follow-up).
+  '%/test_%.py',
+  'test_%.py',
+  '%_test.py',
+];
+
+/** Escape LIKE's `_` single-character wildcard so it matches a literal underscore. */
+export function escapeLikeUnderscores(pattern: string): string {
+  return pattern.replace(/_/g, '\\_');
+}
+
+const FILENAME_SUBSTRING_MARKERS: readonly string[] = [
+  '.test.',
+  '.spec.',
+  '__test__',
+  '__tests__',
+  '.stories.',
+];
+
+const TEST_PATH_SEGMENTS: ReadonlySet<string> = new Set([
+  'tests',
+  'test',
+  'fixtures',
+  '__fixtures__',
+]);
+
+/**
+ * Per-language filename conventions not covered by a directory segment or a
+ * simple substring — camelCase-boundary-aware so `TestFoo`/`FooTest` match
+ * but `Testament`/`Latest`/`Contest` don't (#2256 follow-up). Case-sensitive
+ * by design: real Java test classes are always capitalized this way.
+ */
+const LANGUAGE_FILENAME_PATTERNS: readonly RegExp[] = [
+  /_test\.go$/, // Go: foo_test.go
+  /(?:^|\/)test_[^/]*\.py$/, // Python: test_foo.py
+  /_test\.py$/, // Python: foo_test.py
+  /(?:^|\/)Test[A-Z]\w*\.java$/, // Java: TestFoo.java
+  /[a-z0-9]Test\.java$/, // Java: FooTest.java
+];
 
 /** Check whether a file path looks like a test file. */
 export function isTestFile(filePath: string): boolean {
-  return TEST_PATTERN.test(filePath);
+  if (FILENAME_SUBSTRING_MARKERS.some((marker) => filePath.includes(marker))) return true;
+  if (filePath.split('/').some((segment) => TEST_PATH_SEGMENTS.has(segment))) return true;
+  return LANGUAGE_FILENAME_PATTERNS.some((pattern) => pattern.test(filePath));
 }

--- a/tests/unit/query-builder.test.ts
+++ b/tests/unit/query-builder.test.ts
@@ -15,13 +15,50 @@ import {
 // ─── testFilterSQL ───────────────────────────────────────────────────
 
 describe('testFilterSQL', () => {
-  it('returns 5 NOT LIKE conditions with default column', () => {
-    const sql = testFilterSQL();
-    expect(sql).toContain("n.file NOT LIKE '%.test.%'");
-    expect(sql).toContain("n.file NOT LIKE '%.spec.%'");
-    expect(sql).toContain("n.file NOT LIKE '%__test__%'");
-    expect(sql).toContain("n.file NOT LIKE '%__tests__%'");
-    expect(sql).toContain("n.file NOT LIKE '%.stories.%'");
+  /** Runs the generated NOT LIKE clauses against a real SQLite connection. */
+  function isExcluded(file: string): boolean {
+    const db = new Database(':memory:');
+    try {
+      const sql = testFilterSQL('f');
+      const row = db.prepare(`SELECT (1 ${sql}) AS included FROM (SELECT ? AS f)`).get(file) as {
+        included: number;
+      };
+      return row.included === 0;
+    } finally {
+      db.close();
+    }
+  }
+
+  it('excludes filename-marker test files (#2256)', () => {
+    expect(isExcluded('src/foo.test.ts')).toBe(true);
+    expect(isExcluded('src/foo.spec.ts')).toBe(true);
+    expect(isExcluded('src/__tests__/foo.ts')).toBe(true);
+    expect(isExcluded('src/__test__/foo.ts')).toBe(true);
+    expect(isExcluded('src/foo.stories.tsx')).toBe(true);
+  });
+
+  it('excludes test/fixture directory segments (#2256)', () => {
+    expect(isExcluded('tests/foo.ts')).toBe(true);
+    expect(isExcluded('src/tests/foo.ts')).toBe(true);
+    expect(isExcluded('test/foo.go')).toBe(true);
+    expect(isExcluded('src/test/foo.java')).toBe(true);
+    expect(isExcluded('fixtures/foo.json')).toBe(true);
+    expect(isExcluded('src/__fixtures__/foo.json')).toBe(true);
+  });
+
+  it('excludes Go/Python filename-suffix conventions (#2256 follow-up)', () => {
+    expect(isExcluded('pkg/foo_test.go')).toBe(true);
+    expect(isExcluded('test_foo.py')).toBe(true);
+    expect(isExcluded('src/test_foo.py')).toBe(true);
+    expect(isExcluded('foo_test.py')).toBe(true);
+  });
+
+  it('does not exclude a directory or filename that merely contains "test" as a substring (#2256)', () => {
+    expect(isExcluded('src/contests/foo.ts')).toBe(false);
+    expect(isExcluded('src/latest/foo.ts')).toBe(false);
+    expect(isExcluded('src/test-utils/foo.ts')).toBe(false);
+    expect(isExcluded('src/protest.py')).toBe(false);
+    expect(isExcluded('src/latest.py')).toBe(false);
   });
 
   it('uses custom column', () => {

--- a/tests/unit/test-filter.test.ts
+++ b/tests/unit/test-filter.test.ts
@@ -48,6 +48,18 @@ const SHOULD_NOT_MATCH: readonly string[] = [
   'src/latest.py',
 ];
 
+// Mixed-case variants of the filename/segment/Go/Python markers — must match
+// consistently with sqlExcludes, since SQLite's LIKE is case-insensitive
+// (Greptile review, #2256).
+const MIXED_CASE_MATCH: readonly string[] = [
+  'src/foo.TEST.ts',
+  'src/Tests/foo.ts',
+  'src/TEST/foo.go',
+  'pkg/foo_TEST.go',
+  'TEST_foo.py',
+  'src/FOO_TEST.py',
+];
+
 // Recognized only by isTestFile's precise, case-sensitive regex — deliberately
 // excluded from the SQL LIKE list because SQLite's LIKE is case-insensitive,
 // so a substring approximation would also match ordinary words like
@@ -69,6 +81,10 @@ describe('isTestFile', () => {
     expect(isTestFile(file)).toBe(false);
   });
 
+  it.each(MIXED_CASE_MATCH)('matches the mixed-case variant %s', (file) => {
+    expect(isTestFile(file)).toBe(true);
+  });
+
   it.each(JAVA_FILENAME_MATCH)('recognizes the Java test-class filename convention: %s', (file) => {
     expect(isTestFile(file)).toBe(true);
   });
@@ -82,8 +98,16 @@ describe('isTestFile', () => {
 });
 
 describe('isTestFile / testFilterSQL parity', () => {
-  it.each([...SHOULD_MATCH, ...SHOULD_NOT_MATCH])('agrees with the SQL filter for %s', (file) => {
-    expect(sqlExcludes(file)).toBe(isTestFile(file));
+  it.each([...SHOULD_MATCH, ...SHOULD_NOT_MATCH, ...MIXED_CASE_MATCH])(
+    'agrees with the SQL filter for %s',
+    (file) => {
+      expect(sqlExcludes(file)).toBe(isTestFile(file));
+    },
+  );
+
+  it.each(MIXED_CASE_MATCH)('both filters exclude the mixed-case variant %s', (file) => {
+    expect(sqlExcludes(file)).toBe(true);
+    expect(isTestFile(file)).toBe(true);
   });
 
   it('SQL filter does not attempt the Java filename convention (documented asymmetry)', () => {

--- a/tests/unit/test-filter.test.ts
+++ b/tests/unit/test-filter.test.ts
@@ -1,0 +1,95 @@
+import Database from 'better-sqlite3';
+import { describe, expect, it } from 'vitest';
+import { testFilterSQL } from '../../src/db/query-builder.js';
+import { isTestFile } from '../../src/infrastructure/test-filter.js';
+
+/** Runs testFilterSQL's generated NOT LIKE clauses against a real SQLite connection. */
+function sqlExcludes(file: string): boolean {
+  const db = new Database(':memory:');
+  try {
+    const sql = testFilterSQL('f');
+    const row = db.prepare(`SELECT (1 ${sql}) AS included FROM (SELECT ? AS f)`).get(file) as {
+      included: number;
+    };
+    return row.included === 0;
+  } finally {
+    db.close();
+  }
+}
+
+const SHOULD_MATCH: readonly string[] = [
+  // Filename markers (pre-existing).
+  'src/foo.test.ts',
+  'src/foo.spec.ts',
+  'src/__tests__/foo.ts',
+  'src/__test__/foo.ts',
+  'src/foo.stories.tsx',
+  // Test/fixture directory segments (#2256).
+  'tests/foo.ts',
+  'src/tests/foo.ts',
+  'test/foo.go',
+  'src/test/foo.java',
+  'fixtures/foo.json',
+  'src/__fixtures__/foo.json',
+  // Go/Python filename-suffix conventions (#2256 follow-up).
+  'pkg/foo_test.go',
+  'test_foo.py',
+  'src/test_foo.py',
+  'foo_test.py',
+];
+
+const SHOULD_NOT_MATCH: readonly string[] = [
+  // Path segments that merely contain "test" as a substring, not as a whole segment.
+  'src/contests/foo.ts',
+  'src/latest/foo.ts',
+  'src/test-utils/foo.ts',
+  // Filenames that merely contain "test" as a substring, not the Go/Python suffix convention.
+  'src/protest.py',
+  'src/latest.py',
+];
+
+// Recognized only by isTestFile's precise, case-sensitive regex — deliberately
+// excluded from the SQL LIKE list because SQLite's LIKE is case-insensitive,
+// so a substring approximation would also match ordinary words like
+// "Latest.java"/"Contest.java"/"Testament.java" (see test-filter.ts's doc comment).
+const JAVA_FILENAME_MATCH: readonly string[] = ['src/TestFoo.java', 'src/FooTest.java'];
+const JAVA_FILENAME_NON_MATCH: readonly string[] = [
+  'src/Testament.java',
+  'src/Contest.java',
+  'src/Latest.java',
+  'src/Protest.java',
+];
+
+describe('isTestFile', () => {
+  it.each(SHOULD_MATCH)('matches %s', (file) => {
+    expect(isTestFile(file)).toBe(true);
+  });
+
+  it.each(SHOULD_NOT_MATCH)('does not match %s', (file) => {
+    expect(isTestFile(file)).toBe(false);
+  });
+
+  it.each(JAVA_FILENAME_MATCH)('recognizes the Java test-class filename convention: %s', (file) => {
+    expect(isTestFile(file)).toBe(true);
+  });
+
+  it.each(JAVA_FILENAME_NON_MATCH)(
+    'does not treat an ordinary word containing "test" as a Java test class: %s',
+    (file) => {
+      expect(isTestFile(file)).toBe(false);
+    },
+  );
+});
+
+describe('isTestFile / testFilterSQL parity', () => {
+  it.each([...SHOULD_MATCH, ...SHOULD_NOT_MATCH])('agrees with the SQL filter for %s', (file) => {
+    expect(sqlExcludes(file)).toBe(isTestFile(file));
+  });
+
+  it('SQL filter does not attempt the Java filename convention (documented asymmetry)', () => {
+    for (const file of JAVA_FILENAME_MATCH) {
+      expect(sqlExcludes(file)).toBe(false);
+      expect(isTestFile(file)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Closes #2256

## Problem

`-T`'s test-file exclusion only matched filename markers (`.test.`, `.spec.`, `__test__`, `__tests__`, `.stories.`) — it never recognized the dominant test/fixture layout convention used by most non-JS ecosystems: a `tests/`/`test/`/`fixtures/`/`__fixtures__/` directory, or Go's `_test.go` and Python's `test_*.py`/`*_test.py` filename suffixes.

On this repo's own self-build, 431 of 647 "dead -T" symbols were pure fixture noise from `tests/benchmarks/resolution/fixtures/**` (the hand-authored per-language resolution-precision fixtures) and `tests/fixtures/sample-project/**` — none of which match the filename-only heuristic despite living entirely under `tests/`.

The predicate was also independently duplicated across **9 call sites** (not the 2-3 named in the issue) — `src/infrastructure/test-filter.ts`, `src/db/query-builder.ts` (two separate spots: `testFilterSQL` and `NodeQuery.excludeTests`), `src/domain/search/search/filters.ts`, `src/features/ast.ts`, `src/features/complexity-query.ts`, `src/features/manifesto.ts`, `src/db/repository/in-memory-repository.ts` (two spots), plus the Rust mirrors in `crates/codegraph-core/src/graph/classifiers/roles.rs` and `crates/codegraph-core/src/db/repository/graph_read.rs`. Some had already drifted from each other before this fix.

## Fix

Consolidated into a single canonical pattern list per engine:
- TS: `src/infrastructure/test-filter.ts` — `TEST_FILE_LIKE_PATTERNS` (SQL LIKE templates) + `isTestFile()` (boolean predicate). Every other TS call site now delegates to one of these instead of hand-rolling its own copy.
- Rust: new `crates/codegraph-core/src/infrastructure/test_filter.rs`, mirroring the TS module (added to the `lib.rs` module-parity table). `roles.rs` and `graph_read.rs` both delegate to it now.

Path segments are bounded by `/` (or path start/end) so `tests/`/`test/` never matches `contests/`, `latest/`, or a production `test-utils/` directory — the exact false-positive risk the issue called out.

The Java `TestFoo.java`/`FooTest.java` filename convention is recognized precisely by `isTestFile`'s case-sensitive, camelCase-boundary-aware regex, but **deliberately excluded** from the SQL LIKE pattern list: SQLite's `LIKE` is case-insensitive by default, so a substring approximation would also match ordinary words merely containing "test" (`Latest.java`, `Contest.java`, `Protest.java`, `Testament.java`). The standard Maven/Gradle `src/test/java/` directory layout is already covered by the `test` path segment either way, so this is a deliberate, documented asymmetry rather than a gap.

While consolidating, found and fixed a latent LIKE-escaping bug: `_` is LIKE's own single-character wildcard, so the pre-existing `__test__`/`__tests__` patterns were unintentionally matching e.g. `"XXtestZZ"` (verified empirically against real SQLite). All literal underscores are now escaped with `ESCAPE '\'`.

## Testing

- New `tests/unit/test-filter.test.ts` (43 cases) + expanded `tests/unit/query-builder.test.ts`: filename markers, directory segments, Go/Python suffixes, explicit non-matches (`test-utils/`, `contests/`, `latest/`, `protest.py`), Java filename convention, and a parity check between `isTestFile` and the SQL filter.
- New Rust unit tests in `test_filter.rs` mirror the same battery.
- Self-build validation (this repo, 1049 files): `roles --role dead -T` dropped from 647 to 289, with **zero** remaining dead symbols under any `tests?/`/`fixtures/`/`__fixtures__/` directory (was 431).
- Full suite: 4899 JS tests + 891 Rust tests pass. `tsc --noEmit`, `npm run lint`, `cargo fmt --check` all clean.
- Dual-engine parity: `node scripts/parity-compare.mjs` — all 42 fixtures `PARITY OK`.