### PR TITLE
fix(gitignore): recurse .codegraph/* ignore into nested test-fixture dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,14 @@
 node_modules/
 # codegraph — graph DB is local build output; basics.md is committed guidance for agents.
-# Must be `.codegraph/*`, not `.codegraph/`: ignoring the directory stops git descending
-# into it, which silently voids the negation below.
-.codegraph/*
+# Must be `**/.codegraph/*`, not `.codegraph/*` or `.codegraph/`:
+#  - the `**/` prefix is required because a bare `.codegraph/*` has a slash in the
+#    middle, which anchors it to this .gitignore's own directory (the repo root) —
+#    it silently stops matching nested `.codegraph/` dirs, e.g. under
+#    tests/benchmarks/resolution/fixtures/**, letting build output like
+#    changes.journal or graph.db-wal/-shm leak through as untracked cruft.
+#  - ignoring the directory itself (`.codegraph/`) would stop git descending into
+#    it, which silently voids the negation below.
+**/.codegraph/*
 !.codegraph/basics.md
 dist/
 .tsbuildinfo


### PR DESCRIPTION
## Summary
- `.codegraph/*` in `.gitignore` has a slash in the middle, which per gitignore semantics anchors it to the repo root instead of matching at every depth. Nested `.codegraph/` dirs under e.g. `tests/benchmarks/resolution/fixtures/jelly-micro/*/` were never covered by this rule — only `graph.db` leaked through as ignored (via the separate, unanchored `*.db` pattern), while `changes.journal` and SQLite WAL/SHM sidecars (`graph.db-wal`, `graph.db-shm`) showed up as untracked cruft after running the resolution benchmark suite.
- Adds the `**/` prefix so the pattern recurses at any depth, matching the rule's original documented intent. The `!.codegraph/basics.md` negation is unaffected and stays anchored to the repo root — confirmed that's the only tracked `.codegraph/` path anywhere in the repo.

Fixes #2415.

## Test plan
- [x] `git check-ignore -v` confirms nested paths (`tests/benchmarks/resolution/fixtures/jelly-micro/*/.codegraph/changes.journal`, `.../graph.db-wal`, `.../graph.db-shm`, arbitrary nested files) are now ignored, while the root `.codegraph/basics.md` stays tracked and a hypothetical nested `basics.md` stays correctly ignored.
- [x] Ran `tests/benchmarks/resolution/jelly-micro.test.ts` (the exact repro from #2415) — 64 tests pass, creates 23 `.codegraph/` dirs directly inside tracked fixture paths, and `git status --porcelain` shows none of them as untracked.
- [x] Verified every file inside those 23 leaked directories individually with `git check-ignore` — all covered.
- [x] `npm run doctor` reports environment healthy; no unrelated test regressions observed in the runs above.

## Notes for reviewers
While tracing why `changes.journal` ends up inside the tracked fixture dirs in the first place (rather than just why it wasn't ignored), I found that `buildGraph`'s `dbPath` override relocates the database but the incremental-build journal always writes to `rootDir` regardless — that's the actual mechanism producing the stray `.codegraph/` dirs under `dbPath`-redirected test builds. It's out of scope for this fix (currently harmless due to the `#2414` empty-`file_hashes` guard) but I filed it separately as #2426 since it's a real latent coupling gap worth closing on its own.