### PR TITLE
docs(readme): correct runtime dependency count from 3 to 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ No config files, no Docker, no JVM, no API keys, no accounts. Point your agent a
 | Architecture rules + CI gate | **Yes** | Partial (risk-gate, no boundary rules) | Partial (layer model, no CI gate) | — | — | — |
 | Security scanning (SAST / vuln detection) | Intentionally out of scope¹⁵ | — | **Yes** | — | — | Partial (opt-in taint, `--pdg` only) |
 | Zero config, `npm install` | **Yes** | — (pip) | **Yes** | **Yes** | No¹⁶ | **Yes** |
-| Runtime dependencies (direct packages)¹⁷ | **3** | 7 | **0**¹⁸ | 10 | 23¹⁹ | 36 |
+| Runtime dependencies (direct packages)¹⁷ | **4** | 7 | **0**¹⁸ | 10 | 23¹⁹ | 36 |
 | Graph export (GraphML / Neo4j / DOT) | **Yes** | **Yes**²⁰ | Partial²¹ | — | — | — |
 | Open source + commercial use | **Yes** (Apache-2.0) | **Yes** (MIT) | **Yes** (Apache-2.0/MIT) | **Yes** (MIT) | **Yes** (MIT) | Non-commercial²² |
 
@@ -742,12 +742,13 @@ Metrics are normalized per file for cross-version comparability. Times above are
 
 <a href="https://www.npmjs.com/package/@optave/codegraph"><img src="https://img.shields.io/npm/unpacked-size/@optave/codegraph?style=flat-square&label=unpacked%20size" alt="npm unpacked size" /></a>
 
-Only **3 runtime dependencies** — everything else is optional or a devDependency:
+Only **4 runtime dependencies** — everything else is optional or a devDependency:
 
 | Dependency | What it does | | |
 |---|---|---|---|
 | [better-sqlite3](https://github.com/WiseLibs/better-sqlite3) | SQLite driver (WASM engine; lazy-loaded, not used for native-engine reads) | ![GitHub stars](https://img.shields.io/github/stars/WiseLibs/better-sqlite3?style=flat-square&label=%E2%AD%90) | ![npm downloads](https://img.shields.io/npm/dw/better-sqlite3?style=flat-square&label=%F0%9F%93%A5%2Fwk) |
 | [commander](https://github.com/tj/commander.js) | CLI argument parsing | ![GitHub stars](https://img.shields.io/github/stars/tj/commander.js?style=flat-square&label=%E2%AD%90) | ![npm downloads](https://img.shields.io/npm/dw/commander?style=flat-square&label=%F0%9F%93%A5%2Fwk) |
+| [smol-toml](https://github.com/squirrelchat/smol-toml) | TOML parsing — reads `Cargo.toml` for Rust `crate::` target overrides and `pyproject.toml` for Python import roots | ![GitHub stars](https://img.shields.io/github/stars/squirrelchat/smol-toml?style=flat-square&label=%E2%AD%90) | ![npm downloads](https://img.shields.io/npm/dw/smol-toml?style=flat-square&label=%F0%9F%93%A5%2Fwk) |
 | [web-tree-sitter](https://github.com/tree-sitter/tree-sitter) | WASM tree-sitter bindings | ![GitHub stars](https://img.shields.io/github/stars/tree-sitter/tree-sitter?style=flat-square&label=%E2%AD%90) | ![npm downloads](https://img.shields.io/npm/dw/web-tree-sitter?style=flat-square&label=%F0%9F%93%A5%2Fwk) |
 
 Optional: `@huggingface/transformers` (semantic search), `@modelcontextprotocol/sdk` (MCP server) — lazy-loaded only when needed.


### PR DESCRIPTION
## Summary

The README claimed **3** runtime dependencies in two places. `package.json` declares **4**.

`smol-toml` was added in #2376 to parse `Cargo.toml` for `[[bin]]`/`[[example]]`/`[[test]]`/`[[bench]]` targets with an explicit `path = "..."` — without it, `findRustCrateRoot` misattributed those files and misresolved every `crate::`/`self::`/`super::` import in them (closing documented limitation #2217). It picked up a second consumer a day later in #2410, which parses `pyproject.toml` for Python import roots (`tool.pytest.ini_options.pythonpath`, `tool.setuptools.package-dir`, `tool.poetry.packages`).

Neither PR updated the README. This corrects both spots and lists the dependency alongside the other three.

Deliberately narrow: this PR only fixes our own count. It does not touch the metric definition, the footnotes, or any competitor's cell.

### Why the dependency was kept

Reviewed during this change rather than assumed:

- **No stdlib option.** Node has no built-in TOML parser at any supported version — verified on Node 24.18.1 (`util.parseTOML` is `undefined`, no builtin module matches).
- **Cannot be a devDependency.** The build is plain `tsc` with no bundler, so the import survives into `dist/` as a real module resolution.
- **It is the most popular option available**, not a fringe pick: 28.2M weekly downloads vs 15.0M (`toml`), 6.7M (`@iarna/toml`, no release since 2020), 380K (`@ltd/j-toml`, LGPL-3.0), 27K (`js-toml`, pulls in `xregexp` + `chevrotain`).
- **Zero transitive dependencies**, BSD-3-Clause, ~206 KB — adds one node to the install tree, not a subtree.
- **Contained blast radius.** Two call sites, both `try`/`catch` best-effort: malformed TOML yields no results rather than failing resolution. Replaceable without a migration if it ever goes stale.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Refactoring (`refactor:`)
- [x] Documentation (`docs:`)
- [ ] Tests (`test:`)
- [ ] Maintenance (`chore:`, `ci:`, `build:`)

## Testing checklist

- [ ] I ran `npm test` and all tests pass
- [ ] I ran `npm run lint` with no errors
- [ ] I added/updated tests for my changes (if applicable)

**Not run locally — flagging rather than silently skipping.** No `node_modules` in this worktree or the main checkout, and installing triggers a full WASM grammar rebuild via `prepare`. CI is the gate.

Verified by inspection instead:

- `tests/unit/docs-check-flags.test.ts` is the only test asserting on `README.md`; it scans for `--`-prefixed `codegraph check` flags. This diff adds no `--` tokens (only single-hyphen names like `smol-toml`), so it is unaffected.
- Biome lint is scoped to `src/` and `tests/` per `biome.json` — a README-only diff is out of scope.
- The edited comparison-table row still has 7 cells; the dependency table still has 4 columns.

## Breaking changes

N/A

## Related issues

Refs #2417 — no CI guard keeps these counts in sync with `package.json`, which is why this drifted within a day of the dependency landing.
