### PR TITLE
fix(extractors): var shadows at the function boundary; loop heads kill the fallback value

### DIFF
--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -4241,6 +4241,13 @@ fn handle_instanceof_value_ref(node: &Node, source: &[u8], calls: &mut Vec<Call>
 /// doesn't get mistaken for a reference to the outer fallback variable being
 /// checked (issue #2257, Greptile review).
 ///
+/// `for_in_statement` is deliberately ABSENT (Greptile review, PR #2432): a
+/// `for (… of right)` head that binds `name` must not prune the whole loop,
+/// because `right` is evaluated in the ENCLOSING scope and can hold a genuine
+/// read (`for (const x of fn())`). `block_contains_identifier_excluding`
+/// handles that shape directly instead — scanning `right` while skipping the
+/// body.
+///
 /// Mirrors `SCOPE_NODE_TYPES` in `src/extractors/javascript.ts`.
 const SCOPE_NODE_TYPES: &[&str] = &[
     "statement_block",
@@ -4252,21 +4259,80 @@ const SCOPE_NODE_TYPES: &[&str] = &[
     "method_definition",
     "catch_clause",
     "for_statement",
-    "for_in_statement",
     "switch_body",
 ];
 
+/// Node types that open a new FUNCTION scope — the boundary at which a `var`
+/// declaration is scoped, and therefore the level at which a `var` shadow of
+/// `name` has to be detected (see `function_scope_declares_var`).
+///
+/// Mirrors `FUNCTION_SCOPE_NODE_TYPES` in `src/extractors/javascript.ts`.
+const FUNCTION_SCOPE_NODE_TYPES: &[&str] = &[
+    "function_declaration",
+    "function_expression",
+    "generator_function_declaration",
+    "generator_function",
+    "arrow_function",
+    "method_definition",
+];
+
+/// True when `node`'s subtree declares `var name` anywhere within the SAME
+/// function scope — i.e. without crossing into a nested function, which opens
+/// its own independent `var` scope and is checked separately when the
+/// recursive scan reaches it.
+///
+/// `var` is function-scoped, not block-scoped, so a `var name` buried in any
+/// nested block/loop/switch of a function body still shadows an outer `name`
+/// for that ENTIRE function — `function inner() { if (x) { var fn = 1; } fn(); }`
+/// reads `inner`'s own hoisted `fn`, not the outer fallback variable, so the
+/// whole function must be pruned from the liveness scan (Greptile review, PR
+/// #2432). Detecting this only at the block that physically contains the
+/// `var` would miss the read that sits outside that block.
+///
+/// Depth-bounded like every other recursive walk in this file
+/// (`MAX_WALK_DEPTH`).
+///
+/// Mirrors `functionScopeDeclaresVar` in `src/extractors/javascript.ts`.
+fn function_scope_declares_var(node: &Node, name: &str, source: &[u8], depth: usize) -> bool {
+    if depth >= MAX_WALK_DEPTH {
+        return false;
+    }
+    if node.kind() == "variable_declaration" && declaration_declares_name(node, name, source) {
+        return true;
+    }
+    for i in 0..node.child_count() {
+        let Some(child) = node.child(i) else {
+            continue;
+        };
+        // A nested function opens its own `var` scope — its declarations
+        // don't shadow anything out here.
+        if FUNCTION_SCOPE_NODE_TYPES.contains(&child.kind()) {
+            continue;
+        }
+        if function_scope_declares_var(&child, name, source, depth + 1) {
+            return true;
+        }
+    }
+    false
+}
+
 /// True when `node` (one of `SCOPE_NODE_TYPES`) declares its OWN binding
 /// named `name` at this scope's own level — a function/method parameter or
-/// own name, a catch clause's exception binding, a for-loop's own loop
-/// variable, or a `let`/`const` declared directly inside this block (not a
-/// deeper nested block, which gets its own independent shadow check when
-/// the recursive scan reaches it). Deliberately NOT `var` (Greptile review,
-/// PR #2432): `var` is function-scoped, so a `var` anywhere below this node
-/// is always the SAME binding as an outer `var` of the same name, never a
-/// distinct shadow — treating it as one would wrongly prune a genuine read
-/// elsewhere in this subtree for a redeclaration that isn't actually a
-/// different variable.
+/// own name, a `var` hoisted anywhere inside a function body, a catch
+/// clause's exception binding, a for-loop's own `let`/`const` loop variable,
+/// or a `let`/`const` declared directly inside this block (not a deeper
+/// nested block, which gets its own independent shadow check when the
+/// recursive scan reaches it).
+///
+/// The BLOCK-level cases deliberately exclude `variable_declaration` (`var`)
+/// (Greptile review, PR #2432): `var` is function-scoped, so a `var` anywhere
+/// below such a node is always the SAME binding as an outer `var` of the same
+/// name, never a distinct shadow — treating it as one would wrongly prune a
+/// genuine read elsewhere in that subtree for a redeclaration that isn't
+/// actually a different variable.
+///
+/// `var` shadowing is therefore decided at the FUNCTION boundary instead, via
+/// `function_scope_declares_var` — the scope a `var` actually belongs to.
 ///
 /// Mirrors `introducesShadowedBinding` in `src/extractors/javascript.ts`.
 fn introduces_shadowed_binding(node: &Node, name: &str, source: &[u8]) -> bool {
@@ -4282,17 +4348,19 @@ fn introduces_shadowed_binding(node: &Node, name: &str, source: &[u8]) -> bool {
                     return true;
                 }
             }
-            match node.child_by_field_name("parameters") {
-                Some(params) => {
-                    for i in 0..params.child_count() {
-                        if let Some(param) = params.child(i) {
-                            if pattern_binds_name(&param, name, source, 0) {
-                                return true;
-                            }
+            if let Some(params) = node.child_by_field_name("parameters") {
+                for i in 0..params.child_count() {
+                    if let Some(param) = params.child(i) {
+                        if pattern_binds_name(&param, name, source, 0) {
+                            return true;
                         }
                     }
-                    false
                 }
+            }
+            // A `var` anywhere in this function's body is scoped to THIS
+            // function.
+            match node.child_by_field_name("body") {
+                Some(body) => function_scope_declares_var(&body, name, source, 0),
                 None => false,
             }
         }
@@ -4300,44 +4368,30 @@ fn introduces_shadowed_binding(node: &Node, name: &str, source: &[u8]) -> bool {
             Some(param) => pattern_binds_name(&param, name, source, 0),
             None => false,
         },
-        // A C-style for-loop's init clause (`for (let/const x = ...; ...)`)
-        // wraps its declaration in a `lexical_declaration` child node.
-        // `var`, deliberately EXCLUDED (Greptile review, PR #2432): it's
-        // function-scoped, not scoped to this loop, so a `var` init here is
-        // the SAME binding as the outer variable, never a distinct shadow —
-        // treating it as one would wrongly prune a genuine read anywhere in
-        // this loop's body.
+        // A C-style for-loop's init clause wraps its declaration in a
+        // `lexical_declaration` child, and a for-head `let`/`const fn` is a
+        // genuinely new binding scoped to the loop whose own initializer lives
+        // in that same loop scope (`for (let fn = fn; …)` is a TDZ error), so
+        // pruning the whole loop is correct.
         //
-        // A for-in/for-of loop's DECLARING form (`for (let/const x of/in
-        // y)`), by contrast, does NOT wrap its loop variable in a
-        // `lexical_declaration` node at all — `kind` (the let/const/var
-        // keyword) and `left` (the bare identifier/pattern) are separate
-        // direct fields instead (discovered while verifying the `var`
-        // exclusion above — Greptile review, PR #2432 — this specific check
-        // had never actually matched a for-in/for-of declaring form's real
-        // AST shape). A `let`/`const` loop variable genuinely IS a new
-        // binding scoped to just this loop (unlike `var`, whose bare `left`
-        // here is the SAME function-scoped binding as an outer `var` and is
-        // therefore excluded, matching the var-never-shadows principle
-        // above).
-        "for_statement" | "for_in_statement" => {
+        // `var` is deliberately EXCLUDED: it's function-scoped, so a `var`
+        // init here is the SAME binding as the outer variable, never a
+        // distinct shadow (matching the reasoning applied to
+        // `statement_block` and `switch_body`). It's handled as a KILL in
+        // `block_contains_identifier_excluding` instead — which still scans
+        // the initializer, so `for (var fn = fn; …)` keeps its genuine read
+        // (Greptile review, PR #2432).
+        //
+        // A for-in/for-of head is NOT handled here at all — see
+        // `SCOPE_NODE_TYPES` and the for-in branch of
+        // `block_contains_identifier_excluding`: its `right` is evaluated in
+        // the ENCLOSING scope, so pruning the whole node would lose a real
+        // read.
+        "for_statement" => {
             for i in 0..node.child_count() {
                 if let Some(child) = node.child(i) {
                     if child.kind() == "lexical_declaration"
                         && declaration_declares_name(&child, name, source)
-                    {
-                        return true;
-                    }
-                }
-            }
-            if node.kind() == "for_in_statement" {
-                let kind = node
-                    .child_by_field_name("kind")
-                    .map(|k| node_text(&k, source));
-                let left = node.child_by_field_name("left");
-                if let (Some(kind), Some(left)) = (kind, left) {
-                    if (kind == "let" || kind == "const")
-                        && pattern_binds_name(&left, name, source, 0)
                     {
                         return true;
                     }
@@ -4389,19 +4443,15 @@ fn introduces_shadowed_binding(node: &Node, name: &str, source: &[u8]) -> bool {
         // independent block scope instead, already handled when the
         // recursive scan reaches that nested `statement_block`.
         //
-        // Deliberately EXCLUDES `variable_declaration` (`var`), unlike the
-        // `statement_block` case above (Greptile review, PR #2432): `var`
-        // is function-scoped, not block-scoped, so a `var fn` in one case
-        // is never a genuinely NEW binding — it's the SAME outer `fn` (or,
-        // if the outer `fn` is `let`/`const`, redeclaring it is a
-        // SyntaxError, so a valid parse can't reach this with a real shadow
-        // anyway). Treating it as a shadow here would skip the ENTIRE
-        // switch — including a genuine read in a DIFFERENT, unrelated
-        // case — for a redeclaration that isn't actually a distinct
-        // binding. (The `statement_block` case above doesn't have this
-        // problem: each `{}` is checked independently, so a `var` in one
-        // sibling block never affects a different sibling's shadow check
-        // the way one shared switch scope does here.)
+        // Like the `statement_block` case above, deliberately EXCLUDES
+        // `variable_declaration` (`var`) — it's function-scoped, so a `var
+        // fn` in one case is never a genuinely NEW binding, just the SAME
+        // outer `fn` (and if the outer `fn` is `let`/`const`, redeclaring it
+        // is a SyntaxError, so a valid parse can't reach this with a real
+        // shadow anyway). Treating it as a shadow here would skip the ENTIRE
+        // switch — including a genuine read in a DIFFERENT, unrelated case —
+        // for a redeclaration that isn't a distinct binding at all (Greptile
+        // review, PR #2432).
         "switch_body" => {
             for i in 0..node.child_count() {
                 let Some(switch_case) = node.child(i) else {
@@ -4797,37 +4847,33 @@ fn block_contains_identifier_excluding(
             }
         }
     }
-    // A `for (fn of values) {}` / `for (fn in obj) {}` loop with NO
-    // declaration keyword reassigns an EXISTING binding on every iteration —
-    // a WRITE, like assignment_expression's left side, not a read of the
-    // value `fn` held before the loop started (Greptile review, PR #2432).
-    // A declaring form (`for (let fn of values)`) is already excluded from
-    // reaching here: it shadows `name` entirely via
-    // introduces_shadowed_binding above when `left` binds `name`, or is
-    // simply unrelated otherwise — either way `pattern_binds_name` (which
-    // only recognizes bare identifiers/destructuring patterns, not
-    // declaration nodes) returns false for it, so this branch only fires
-    // for the bare-target form.
+    // A `for (… of right)` / `for (… in right)` head that BINDS `name` kills
+    // the value `name` held before the loop: `right` is evaluated first, then
+    // `name` is assigned on every iteration, so nothing in the body can be
+    // reading the pre-loop value (Greptile review, PR #2432). So scan `right`
+    // — which is evaluated in the ENCLOSING scope and can hold a genuine read
+    // (`for (const x of fn())`) — plus any default hidden in the `left`
+    // pattern, and never the body.
+    //
+    // This covers ALL binding forms uniformly, whichever kills the value:
+    // - bare (`for (fn of values)`) — reassigns the existing binding;
+    // - `var` (`for (var fn of values)`) — the SAME function-scoped binding;
+    // - `let`/`const` (`for (let fn of values)`) — a new per-iteration binding
+    //   that shadows the outer one inside the body.
+    //
+    // Note the grammar gives a declaring for-in/of head a `kind` FIELD
+    // (`var`/`let`/`const`) with `left` holding the pattern directly — there
+    // is no `variable_declaration` child to detect, which is why this must be
+    // handled here rather than in `introduces_shadowed_binding`.
     if node.kind() == "for_in_statement" {
         if let Some(left) = node.child_by_field_name("left") {
             if pattern_binds_name(&left, name, source, 0) {
                 if scan_pattern_defaults_for_reference(&left, name, exclude_id, source, depth + 1) {
                     return true;
                 }
-                if let Some(right) = node.child_by_field_name("right") {
-                    if block_contains_identifier_excluding(
+                return match node.child_by_field_name("right") {
+                    Some(right) => block_contains_identifier_excluding(
                         &right,
-                        name,
-                        exclude_id,
-                        source,
-                        depth + 1,
-                    ) {
-                        return true;
-                    }
-                }
-                return match node.child_by_field_name("body") {
-                    Some(body) => block_contains_identifier_excluding(
-                        &body,
                         name,
                         exclude_id,
                         source,
@@ -4835,6 +4881,29 @@ fn block_contains_identifier_excluding(
                     ),
                     None => false,
                 };
+            }
+        }
+    }
+    // A classic `for (var fn = …; cond; update) body` head likewise kills the
+    // value before `cond`/`update`/`body` ever run, so only the declaration's
+    // own initializer can still hold a genuine read (`for (var fn = fn; …)`).
+    // The `let`/`const` form never reaches here — `introduces_shadowed_binding`
+    // prunes the whole loop for it (Greptile review, PR #2432).
+    if node.kind() == "for_statement" {
+        for i in 0..node.child_count() {
+            let Some(child) = node.child(i) else {
+                continue;
+            };
+            if child.kind() == "variable_declaration"
+                && declaration_declares_name(&child, name, source)
+            {
+                return block_contains_identifier_excluding(
+                    &child,
+                    name,
+                    exclude_id,
+                    source,
+                    depth + 1,
+                );
             }
         }
     }
@@ -8245,15 +8314,37 @@ mod tests {
         }));
     }
 
-    // Same principle for a C-style for-loop: a `var` in the loop's own init
-    // clause is the SAME function-scoped binding, so a read in the loop's
-    // test/update clause must still count.
+    // A C-style for-loop whose own init clause rebinds the name via `var` is
+    // the SAME function-scoped binding — and that is precisely why it KILLS
+    // the fallback value rather than reading it: `var fn = 0` runs before the
+    // test/update clauses, so `fn < 10` and `fn++` only ever see the number.
+    // Verified at runtime: `typeof fn` inside that loop is always `number`,
+    // and the fallback function is never invoked. Crediting liveness here
+    // would fabricate an edge for a value that is assigned and immediately
+    // overwritten without ever being consumed.
+    //
+    // A loop that does NOT rebind the name is unaffected — see the next test.
     #[test]
-    fn still_credits_liveness_from_a_for_loop_read_when_the_loop_redeclares_the_name_via_var() {
+    fn does_not_credit_liveness_from_a_for_loop_whose_own_var_init_overwrote_the_value() {
         let s = parse_js(
             "function outer() {\n\
                var fn = options.custom || fetchLatestVersion;\n\
                for (var fn = 0; fn < 10; fn++) {}\n\
+             }",
+        );
+        assert!(!s.calls.iter().any(|c| {
+            c.dynamic_kind.as_deref() == Some("value-ref") && c.name == "fetchLatestVersion"
+        }));
+    }
+
+    // The guard for that last sentence: a loop counter with a DIFFERENT name
+    // must not suppress a real read in the loop body.
+    #[test]
+    fn credits_liveness_from_a_loop_body_read_when_the_loop_counter_is_a_different_name() {
+        let s = parse_js(
+            "function outer() {\n\
+               var fn = options.custom || fetchLatestVersion;\n\
+               for (var i = 0; i < 10; i++) { fn(); }\n\
              }",
         );
         assert!(s.calls.iter().any(|c| {
@@ -8274,6 +8365,52 @@ mod tests {
              }",
         );
         assert!(!s.calls.iter().any(|c| {
+            c.dynamic_kind.as_deref() == Some("value-ref") && c.name == "fetchLatestVersion"
+        }));
+    }
+
+    // The flip side of the var-is-function-scoped model: because `var` hoists
+    // to the FUNCTION scope, a nested function declaring `var fn` at ANY depth
+    // in its body shadows the outer `fn` for that whole function — including a
+    // read sitting outside the block that physically contains the `var`.
+    #[test]
+    fn does_not_credit_liveness_from_a_nested_function_that_hoists_its_own_var_deeper_down() {
+        let s = parse_js(
+            "function outer() {\n\
+               var fn = options.custom || fetchLatestVersion;\n\
+               function inner(flag) {\n\
+                 if (flag) { var fn = 1; }\n\
+                 return fn();\n\
+               }\n\
+             }",
+        );
+        assert!(!s.calls.iter().any(|c| {
+            c.dynamic_kind.as_deref() == Some("value-ref") && c.name == "fetchLatestVersion"
+        }));
+    }
+
+    // A for-in/of head that binds the name kills the pre-loop value, so the
+    // BODY can never be reading it — even for a bare (non-declaring) target.
+    #[test]
+    fn does_not_credit_liveness_from_a_for_of_body_read_of_a_bare_loop_target() {
+        let s = parse_js(
+            "let fn = options.custom || fetchLatestVersion;\n\
+             for (fn of values) { fn(); }",
+        );
+        assert!(!s.calls.iter().any(|c| {
+            c.dynamic_kind.as_deref() == Some("value-ref") && c.name == "fetchLatestVersion"
+        }));
+    }
+
+    // …but `right` IS evaluated in the enclosing scope, so a genuine read
+    // there must still count.
+    #[test]
+    fn credits_liveness_from_a_for_of_right_hand_side_read_in_the_enclosing_scope() {
+        let s = parse_js(
+            "const fn = options.custom || fetchLatestVersion;\n\
+             for (const item of fn()) { use(item); }",
+        );
+        assert!(s.calls.iter().any(|c| {
             c.dynamic_kind.as_deref() == Some("value-ref") && c.name == "fetchLatestVersion"
         }));
     }

--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -4885,26 +4885,67 @@ fn block_contains_identifier_excluding(
         }
     }
     // A classic `for (var fn = …; cond; update) body` head likewise kills the
-    // value before `cond`/`update`/`body` ever run, so only the declaration's
-    // own initializer can still hold a genuine read (`for (var fn = fn; …)`).
-    // The `let`/`const` form never reaches here — `introduces_shadowed_binding`
-    // prunes the whole loop for it (Greptile review, PR #2432).
+    // value before `cond`/`update`/`body` ever run. The `let`/`const` form never
+    // reaches here — `introduces_shadowed_binding` prunes the whole loop for it
+    // (Greptile review, PR #2432).
+    //
+    // Only an INITIALIZER actually overwrites the value, and only the
+    // declarators up to and including it can still be reading the old one
+    // (Greptile review, PR #2440):
+    //
+    // - `for (var fn; cond; update) body` — a bare redeclaration assigns
+    //   nothing, so it is NOT a kill and the whole loop still has to be scanned;
+    // - `for (var a = fn(), fn = 0; …)` — `a`'s initializer runs BEFORE the
+    //   kill, so its read is genuine;
+    // - `for (var fn = fn; …)` — the killing declarator's own initializer reads
+    //   the pre-loop value;
+    // - `for (var fn = 0, a = fn(); …)` — `a`'s initializer runs AFTER the kill,
+    //   so it reads the new value and must not count.
     if node.kind() == "for_statement" {
         for i in 0..node.child_count() {
-            let Some(child) = node.child(i) else {
+            let Some(decl) = node.child(i) else {
                 continue;
             };
-            if child.kind() == "variable_declaration"
-                && declaration_declares_name(&child, name, source)
-            {
-                return block_contains_identifier_excluding(
-                    &child,
-                    name,
-                    exclude_id,
-                    source,
-                    depth + 1,
-                );
+            if decl.kind() != "variable_declaration" {
+                continue;
             }
+            let mut kill_index: Option<usize> = None;
+            for j in 0..decl.child_count() {
+                let Some(declarator) = decl.child(j) else {
+                    continue;
+                };
+                if declarator.kind() != "variable_declarator" {
+                    continue;
+                }
+                let Some(decl_name) = declarator.child_by_field_name("name") else {
+                    continue;
+                };
+                if pattern_binds_name(&decl_name, name, source, 0)
+                    && declarator.child_by_field_name("value").is_some()
+                {
+                    kill_index = Some(j);
+                    break;
+                }
+            }
+            // No initialized declarator for `name` — nothing is overwritten
+            // here, so fall through to the ordinary whole-loop scan below.
+            let Some(kill_index) = kill_index else {
+                continue;
+            };
+            for j in 0..=kill_index {
+                if let Some(child) = decl.child(j) {
+                    if block_contains_identifier_excluding(
+                        &child,
+                        name,
+                        exclude_id,
+                        source,
+                        depth + 1,
+                    ) {
+                        return true;
+                    }
+                }
+            }
+            return false;
         }
     }
     for i in 0..node.child_count() {
@@ -8333,6 +8374,65 @@ mod tests {
              }",
         );
         assert!(!s.calls.iter().any(|c| {
+            c.dynamic_kind.as_deref() == Some("value-ref") && c.name == "fetchLatestVersion"
+        }));
+    }
+
+    // Greptile review, PR #2440: only an INITIALIZER overwrites the value. A
+    // bare `var fn;` redeclaration in the loop head assigns nothing, so it is
+    // not a kill and the body's read is genuine.
+    #[test]
+    fn credits_liveness_from_a_for_loop_body_read_when_the_head_does_not_initialize() {
+        let s = parse_js(
+            "function outer() {\n\
+               var fn = options.custom || fetchLatestVersion;\n\
+               for (var fn; cond; update) { fn(); }\n\
+             }",
+        );
+        assert!(s.calls.iter().any(|c| {
+            c.dynamic_kind.as_deref() == Some("value-ref") && c.name == "fetchLatestVersion"
+        }));
+    }
+
+    // A sibling declarator BEFORE the killing one runs before the overwrite, so
+    // its read is genuine.
+    #[test]
+    fn credits_liveness_from_a_for_head_sibling_initializer_before_the_kill() {
+        let s = parse_js(
+            "function outer() {\n\
+               var fn = options.custom || fetchLatestVersion;\n\
+               for (var a = fn(), fn = 0; fn < 3; fn++) {}\n\
+             }",
+        );
+        assert!(s.calls.iter().any(|c| {
+            c.dynamic_kind.as_deref() == Some("value-ref") && c.name == "fetchLatestVersion"
+        }));
+    }
+
+    // …but a sibling declarator AFTER the killing one reads the NEW value.
+    #[test]
+    fn does_not_credit_liveness_from_a_for_head_sibling_initializer_after_the_kill() {
+        let s = parse_js(
+            "function outer() {\n\
+               var fn = options.custom || fetchLatestVersion;\n\
+               for (var fn = 0, a = fn(); fn < 3; fn++) {}\n\
+             }",
+        );
+        assert!(!s.calls.iter().any(|c| {
+            c.dynamic_kind.as_deref() == Some("value-ref") && c.name == "fetchLatestVersion"
+        }));
+    }
+
+    // The killing declarator's own initializer still reads the pre-loop value.
+    #[test]
+    fn credits_liveness_from_a_for_head_initializer_that_reads_what_it_overwrites() {
+        let s = parse_js(
+            "function outer() {\n\
+               var fn = options.custom || fetchLatestVersion;\n\
+               for (var fn = fn; cond; update) {}\n\
+             }",
+        );
+        assert!(s.calls.iter().any(|c| {
             c.dynamic_kind.as_deref() == Some("value-ref") && c.name == "fetchLatestVersion"
         }));
     }

--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -5055,17 +5055,36 @@ fn block_contains_identifier_excluding(
     // (`var`/`let`/`const`) with `left` holding the pattern directly — there
     // is no `variable_declaration` child to detect, which is why this must be
     // handled here rather than in `introduces_shadowed_binding`.
+    //
+    // A `let`/`const` target's own pattern DEFAULTS are the one place where
+    // `scan_pattern_defaults_for_reference` must NOT run (Greptile review, PR
+    // #2440): `let`/`const` creates a brand-new per-iteration binding for
+    // `name`, so a default inside THIS SAME pattern that mentions `name`
+    // (`for (let [fn = fn] of values)`) resolves to that new binding — in the
+    // temporal dead zone until its own position initializes it — never to the
+    // enclosing fallback. `var`/bare targets reuse the SAME pre-existing
+    // binding (no new scope), so a default reading `name` there is still a
+    // genuine read of its current, soon-to-be-overwritten value.
     if node.kind() == "for_in_statement" {
         if let Some(left) = node.child_by_field_name("left") {
             if pattern_binds_name(&left, name, source, 0) {
-                if scan_pattern_defaults_for_reference(
-                    &left,
-                    name,
-                    exclude_id,
-                    source,
-                    depth + 1,
-                    require_call_site,
-                ) {
+                let is_lexical = node
+                    .child_by_field_name("kind")
+                    .map(|k| {
+                        let kind_text = node_text(&k, source);
+                        kind_text == "let" || kind_text == "const"
+                    })
+                    .unwrap_or(false);
+                if !is_lexical
+                    && scan_pattern_defaults_for_reference(
+                        &left,
+                        name,
+                        exclude_id,
+                        source,
+                        depth + 1,
+                        require_call_site,
+                    )
+                {
                     return true;
                 }
                 return match node.child_by_field_name("right") {
@@ -8806,6 +8825,44 @@ mod tests {
              }",
         );
         assert!(!s.calls.iter().any(|c| {
+            c.dynamic_kind.as_deref() == Some("value-ref") && c.name == "fetchLatestVersion"
+        }));
+    }
+
+    // Greptile review, PR #2440: a `let`/`const` for-of target creates a
+    // BRAND-NEW per-iteration binding for `name` — a default hidden inside
+    // that SAME destructuring pattern which mentions `name` resolves to that
+    // new binding (in the temporal dead zone until its own position
+    // initializes it), never to the enclosing fallback. Verified at runtime:
+    // `let [fn = fn] = [undefined]` throws "Cannot access 'fn' before
+    // initialization" — it never reads the outer `fn`.
+    #[test]
+    fn does_not_credit_liveness_from_a_lexical_destructuring_default_that_self_references_the_loop_target(
+    ) {
+        let s = parse_js(
+            "function outer() {\n\
+               var fn = options.custom || fetchLatestVersion;\n\
+               for (const [fn = fn] of values) { fn(); }\n\
+             }",
+        );
+        assert!(!s.calls.iter().any(|c| {
+            c.dynamic_kind.as_deref() == Some("value-ref") && c.name == "fetchLatestVersion"
+        }));
+    }
+
+    // …but a `var` target reuses the SAME pre-existing binding (no new
+    // scope), so the identical shape still reads the current,
+    // soon-to-be-overwritten value — this must stay credited.
+    #[test]
+    fn still_credits_liveness_from_a_var_destructuring_default_that_self_references_the_loop_target(
+    ) {
+        let s = parse_js(
+            "function outer() {\n\
+               var fn = options.custom || fetchLatestVersion;\n\
+               for (var [fn = fn] of values) {}\n\
+             }",
+        );
+        assert!(s.calls.iter().any(|c| {
             c.dynamic_kind.as_deref() == Some("value-ref") && c.name == "fetchLatestVersion"
         }));
     }

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -4750,16 +4750,50 @@ function blockContainsIdentifierExcluding(
     }
   }
   // A classic `for (var fn = …; cond; update) body` head likewise kills the
-  // value before `cond`/`update`/`body` ever run, so only the declaration's
-  // own initializer can still hold a genuine read (`for (var fn = fn; …)`).
-  // The `let`/`const` form never reaches here — `introducesShadowedBinding`
-  // prunes the whole loop for it (Greptile review, PR #2432).
+  // value before `cond`/`update`/`body` ever run. The `let`/`const` form never
+  // reaches here — `introducesShadowedBinding` prunes the whole loop for it
+  // (Greptile review, PR #2432).
+  //
+  // Only an INITIALIZER actually overwrites the value, and only the
+  // declarators up to and including it can still be reading the old one
+  // (Greptile review, PR #2440):
+  //
+  // - `for (var fn; cond; update) body` — a bare redeclaration assigns
+  //   nothing, so it is NOT a kill and the whole loop still has to be scanned;
+  // - `for (var a = fn(), fn = 0; …)` — `a`'s initializer runs BEFORE the
+  //   kill, so its read is genuine;
+  // - `for (var fn = fn; …)` — the killing declarator's own initializer reads
+  //   the pre-loop value;
+  // - `for (var fn = 0, a = fn(); …)` — `a`'s initializer runs AFTER the kill,
+  //   so it reads the new value and must not count.
   if (node.type === 'for_statement') {
     for (let i = 0; i < node.childCount; i++) {
-      const child = node.child(i);
-      if (child?.type === 'variable_declaration' && declarationDeclaresName(child, name)) {
-        return blockContainsIdentifierExcluding(child, name, excludeId, depth + 1);
+      const decl = node.child(i);
+      if (decl?.type !== 'variable_declaration') continue;
+      let killIndex = -1;
+      for (let j = 0; j < decl.childCount; j++) {
+        const declarator = decl.child(j);
+        if (declarator?.type !== 'variable_declarator') continue;
+        const declName = declarator.childForFieldName('name');
+        if (
+          declName &&
+          patternBindsName(declName, name) &&
+          declarator.childForFieldName('value')
+        ) {
+          killIndex = j;
+          break;
+        }
       }
+      // No initialized declarator for `name` — nothing is overwritten here, so
+      // fall through to the ordinary whole-loop scan below.
+      if (killIndex === -1) continue;
+      for (let j = 0; j <= killIndex; j++) {
+        const child = decl.child(j);
+        if (child && blockContainsIdentifierExcluding(child, name, excludeId, depth + 1)) {
+          return true;
+        }
+      }
+      return false;
     }
   }
   for (let i = 0; i < node.childCount; i++) {

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -4253,6 +4253,12 @@ function collectInstanceofValueRefCall(binaryNode: TreeSitterNode, calls: Call[]
  * recurses into them, so a same-named binding declared in a NESTED scope
  * doesn't get mistaken for a reference to the outer fallback variable being
  * checked (issue #2257, Greptile review).
+ *
+ * `for_in_statement` is deliberately ABSENT (Greptile review, PR #2432): a
+ * `for (… of right)` head that binds `name` must not prune the whole loop,
+ * because `right` is evaluated in the ENCLOSING scope and can hold a genuine
+ * read (`for (const x of fn())`). `blockContainsIdentifierExcluding` handles
+ * that shape directly instead — scanning `right` while skipping the body.
  */
 const SCOPE_NODE_TYPES: ReadonlySet<string> = new Set([
   'statement_block',
@@ -4264,22 +4270,72 @@ const SCOPE_NODE_TYPES: ReadonlySet<string> = new Set([
   'method_definition',
   'catch_clause',
   'for_statement',
-  'for_in_statement',
   'switch_body',
 ]);
 
 /**
+ * Node types that open a new FUNCTION scope — the boundary at which a `var`
+ * declaration is scoped, and therefore the level at which a `var` shadow of
+ * `name` has to be detected (see `functionScopeDeclaresVar`).
+ */
+const FUNCTION_SCOPE_NODE_TYPES: ReadonlySet<string> = new Set([
+  'function_declaration',
+  'function_expression',
+  'generator_function_declaration',
+  'generator_function',
+  'arrow_function',
+  'method_definition',
+]);
+
+/**
+ * True when `node`'s subtree declares `var name` anywhere within the SAME
+ * function scope — i.e. without crossing into a nested function, which opens
+ * its own independent `var` scope and is checked separately when the
+ * recursive scan reaches it.
+ *
+ * `var` is function-scoped, not block-scoped, so a `var name` buried in any
+ * nested block/loop/switch of a function body still shadows an outer `name`
+ * for that ENTIRE function — `function inner() { if (x) { var fn = 1; } fn(); }`
+ * reads `inner`'s own hoisted `fn`, not the outer fallback variable, so the
+ * whole function must be pruned from the liveness scan (Greptile review, PR
+ * #2432). Detecting this only at the block that physically contains the
+ * `var` would miss the read that sits outside that block.
+ *
+ * Depth-bounded like every other recursive walk in this file
+ * (`MAX_WALK_DEPTH`).
+ */
+function functionScopeDeclaresVar(node: TreeSitterNode, name: string, depth = 0): boolean {
+  if (depth >= MAX_WALK_DEPTH) return false;
+  if (node.type === 'variable_declaration' && declarationDeclaresName(node, name)) return true;
+  for (let i = 0; i < node.childCount; i++) {
+    const child = node.child(i);
+    if (!child) continue;
+    // A nested function opens its own `var` scope — its declarations don't
+    // shadow anything out here.
+    if (FUNCTION_SCOPE_NODE_TYPES.has(child.type)) continue;
+    if (functionScopeDeclaresVar(child, name, depth + 1)) return true;
+  }
+  return false;
+}
+
+/**
  * True when `node` (one of `SCOPE_NODE_TYPES`) declares its OWN binding
  * named `name` at this scope's own level — a function/method parameter or
- * own name, a catch clause's exception binding, a for-loop's own loop
- * variable, or a `let`/`const` declared directly inside this block (not a
- * deeper nested block, which gets its own independent shadow check when the
- * recursive scan reaches it). Deliberately NOT `var` (Greptile review, PR
- * #2432): `var` is function-scoped, so a `var` anywhere below this node is
- * always the SAME binding as an outer `var` of the same name, never a
- * distinct shadow — treating it as one would wrongly prune a genuine read
- * elsewhere in this subtree for a redeclaration that isn't actually a
- * different variable.
+ * own name, a `var` hoisted anywhere inside a function body, a catch
+ * clause's exception binding, a for-loop's own `let`/`const` loop variable,
+ * or a `let`/`const` declared directly inside this block (not a deeper
+ * nested block, which gets its own independent shadow check when the
+ * recursive scan reaches it).
+ *
+ * The BLOCK-level cases deliberately exclude `variable_declaration` (`var`)
+ * (Greptile review, PR #2432): `var` is function-scoped, so a `var` anywhere
+ * below such a node is always the SAME binding as an outer `var` of the same
+ * name, never a distinct shadow — treating it as one would wrongly prune a
+ * genuine read elsewhere in that subtree for a redeclaration that isn't
+ * actually a different variable.
+ *
+ * `var` shadowing is therefore decided at the FUNCTION boundary instead, via
+ * `functionScopeDeclaresVar` — the scope a `var` actually belongs to.
  */
 function introducesShadowedBinding(node: TreeSitterNode, name: string): boolean {
   switch (node.type) {
@@ -4291,48 +4347,42 @@ function introducesShadowedBinding(node: TreeSitterNode, name: string): boolean 
     case 'method_definition': {
       if (node.childForFieldName('name')?.text === name) return true;
       const params = node.childForFieldName('parameters');
-      if (!params) return false;
-      for (let i = 0; i < params.childCount; i++) {
-        const param = params.child(i);
-        if (param && patternBindsName(param, name)) return true;
+      if (params) {
+        for (let i = 0; i < params.childCount; i++) {
+          const param = params.child(i);
+          if (param && patternBindsName(param, name)) return true;
+        }
       }
-      return false;
+      // A `var` anywhere in this function's body is scoped to THIS function.
+      const body = node.childForFieldName('body');
+      return body ? functionScopeDeclaresVar(body, name) : false;
     }
     case 'catch_clause': {
       const param = node.childForFieldName('parameter');
       return param ? patternBindsName(param, name) : false;
     }
-    case 'for_statement':
-    case 'for_in_statement': {
-      // A C-style for-loop's init clause (`for (let/const x = ...; ...)`)
-      // wraps its declaration in a `lexical_declaration` child node. `var`,
-      // deliberately EXCLUDED (Greptile review, PR #2432): it's
-      // function-scoped, not scoped to this loop, so a `var` init here is
-      // the SAME binding as the outer variable, never a distinct shadow —
-      // treating it as one would wrongly prune a genuine read anywhere in
-      // this loop's body (matches the same reasoning already applied to
-      // `switch_body`, below, and to the `statement_block` case).
+    case 'for_statement': {
+      // A C-style for-loop's init clause wraps its declaration in a
+      // `lexical_declaration` child, and a for-head `let`/`const fn` is a
+      // genuinely new binding scoped to the loop whose own initializer lives
+      // in that same loop scope (`for (let fn = fn; …)` is a TDZ error), so
+      // pruning the whole loop is correct.
+      //
+      // `var` is deliberately EXCLUDED: it's function-scoped, so a `var` init
+      // here is the SAME binding as the outer variable, never a distinct
+      // shadow (matching the reasoning applied to `statement_block` and
+      // `switch_body`). It's handled as a KILL in
+      // `blockContainsIdentifierExcluding` instead — which still scans the
+      // initializer, so `for (var fn = fn; …)` keeps its genuine read
+      // (Greptile review, PR #2432).
+      //
+      // A for-in/for-of head is NOT handled here at all — see
+      // `SCOPE_NODE_TYPES` and the for-in branch of
+      // `blockContainsIdentifierExcluding`: its `right` is evaluated in the
+      // ENCLOSING scope, so pruning the whole node would lose a real read.
       for (let i = 0; i < node.childCount; i++) {
         const child = node.child(i);
-        if (child && child.type === 'lexical_declaration' && declarationDeclaresName(child, name)) {
-          return true;
-        }
-      }
-      // A for-in/for-of loop's DECLARING form (`for (let/const x of/in
-      // y)`), by contrast, does NOT wrap its loop variable in a
-      // `lexical_declaration` node at all — `kind` (the let/const/var
-      // keyword) and `left` (the bare identifier/pattern) are separate
-      // direct fields instead (discovered while verifying the `var`
-      // exclusion above — Greptile review, PR #2432 — this specific check
-      // had never actually matched a for-in/for-of declaring form's real
-      // AST shape). A `let`/`const` loop variable genuinely IS a new
-      // binding scoped to just this loop (unlike `var`, whose bare `left`
-      // here is the SAME function-scoped binding as an outer `var` and is
-      // therefore excluded, matching the var-never-shadows principle above).
-      if (node.type === 'for_in_statement') {
-        const kind = node.childForFieldName('kind')?.text;
-        const left = node.childForFieldName('left');
-        if ((kind === 'let' || kind === 'const') && left && patternBindsName(left, name)) {
+        if (child?.type === 'lexical_declaration' && declarationDeclaresName(child, name)) {
           return true;
         }
       }
@@ -4376,18 +4426,15 @@ function introducesShadowedBinding(node: TreeSitterNode, name: string): boolean 
       // scope instead, already handled when the recursive scan reaches that
       // nested `statement_block`.
       //
-      // Deliberately EXCLUDES `variable_declaration` (`var`), unlike the
-      // `statement_block` case above (Greptile review, PR #2432): `var` is
-      // function-scoped, not block-scoped, so a `var fn` in one case is
-      // never a genuinely NEW binding — it's the SAME outer `fn` (or, if the
-      // outer `fn` is `let`/`const`, redeclaring it is a SyntaxError, so a
-      // valid parse can't reach this with a real shadow anyway). Treating it
-      // as a shadow here would skip the ENTIRE switch — including a
-      // genuine read in a DIFFERENT, unrelated case — for a redeclaration
-      // that isn't actually a distinct binding. (The `statement_block` case
-      // above doesn't have this problem: each `{}` is checked independently,
-      // so a `var` in one sibling block never affects a different sibling's
-      // shadow check the way one shared switch scope does here.)
+      // Like the `statement_block` case above, deliberately EXCLUDES
+      // `variable_declaration` (`var`) — it's function-scoped, so a `var fn`
+      // in one case is never a genuinely NEW binding, just the SAME outer
+      // `fn` (and if the outer `fn` is `let`/`const`, redeclaring it is a
+      // SyntaxError, so a valid parse can't reach this with a real shadow
+      // anyway). Treating it as a shadow here would skip the ENTIRE switch —
+      // including a genuine read in a DIFFERENT, unrelated case — for a
+      // redeclaration that isn't a distinct binding at all (Greptile review,
+      // PR #2432).
       for (let i = 0; i < node.childCount; i++) {
         const switchCase = node.child(i);
         if (!switchCase) continue;
@@ -4676,24 +4723,43 @@ function blockContainsIdentifierExcluding(
       return right ? blockContainsIdentifierExcluding(right, name, excludeId, depth + 1) : false;
     }
   }
-  // A `for (fn of values) {}` / `for (fn in obj) {}` loop with NO
-  // declaration keyword reassigns an EXISTING binding on every iteration —
-  // a WRITE, like assignment_expression's left side, not a read of the
-  // value `fn` held before the loop started (Greptile review, PR #2432). A
-  // declaring form (`for (let fn of values)`) is already excluded from
-  // reaching here: it shadows `name` entirely via introducesShadowedBinding
-  // above when `left` binds `name`, or is simply unrelated otherwise —
-  // either way `patternBindsName` (which only recognizes bare
-  // identifiers/destructuring patterns, not declaration nodes) returns
-  // false for it, so this branch only fires for the bare-target form.
+  // A `for (… of right)` / `for (… in right)` head that BINDS `name` kills
+  // the value `name` held before the loop: `right` is evaluated first, then
+  // `name` is assigned on every iteration, so nothing in the body can be
+  // reading the pre-loop value (Greptile review, PR #2432). So scan `right`
+  // — which is evaluated in the ENCLOSING scope and can hold a genuine read
+  // (`for (const x of fn())`) — plus any default hidden in the `left`
+  // pattern, and never the body.
+  //
+  // This covers ALL binding forms uniformly, whichever kills the value:
+  // - bare (`for (fn of values)`) — reassigns the existing binding;
+  // - `var` (`for (var fn of values)`) — the SAME function-scoped binding;
+  // - `let`/`const` (`for (let fn of values)`) — a new per-iteration binding
+  //   that shadows the outer one inside the body.
+  //
+  // Note the grammar gives a declaring for-in/of head a `kind` FIELD
+  // (`var`/`let`/`const`) with `left` holding the pattern directly — there is
+  // no `variable_declaration` child to detect, which is why this must be
+  // handled here rather than in `introducesShadowedBinding`.
   if (node.type === 'for_in_statement') {
     const left = node.childForFieldName('left');
     if (left && patternBindsName(left, name)) {
       if (scanPatternDefaultsForReference(left, name, excludeId, depth + 1)) return true;
       const right = node.childForFieldName('right');
-      const body = node.childForFieldName('body');
-      if (right && blockContainsIdentifierExcluding(right, name, excludeId, depth + 1)) return true;
-      return body ? blockContainsIdentifierExcluding(body, name, excludeId, depth + 1) : false;
+      return right ? blockContainsIdentifierExcluding(right, name, excludeId, depth + 1) : false;
+    }
+  }
+  // A classic `for (var fn = …; cond; update) body` head likewise kills the
+  // value before `cond`/`update`/`body` ever run, so only the declaration's
+  // own initializer can still hold a genuine read (`for (var fn = fn; …)`).
+  // The `let`/`const` form never reaches here — `introducesShadowedBinding`
+  // prunes the whole loop for it (Greptile review, PR #2432).
+  if (node.type === 'for_statement') {
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i);
+      if (child?.type === 'variable_declaration' && declarationDeclaresName(child, name)) {
+        return blockContainsIdentifierExcluding(child, name, excludeId, depth + 1);
+      }
     }
   }
   for (let i = 0; i < node.childCount; i++) {

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -4917,10 +4917,25 @@ function blockContainsIdentifierExcluding(
   // (`var`/`let`/`const`) with `left` holding the pattern directly — there is
   // no `variable_declaration` child to detect, which is why this must be
   // handled here rather than in `introducesShadowedBinding`.
+  //
+  // A `let`/`const` target's own pattern DEFAULTS are the one place where
+  // `scanPatternDefaultsForReference` must NOT run (Greptile review, PR
+  // #2440): `let`/`const` creates a brand-new per-iteration binding for
+  // `name`, so a default inside THIS SAME pattern that mentions `name`
+  // (`for (let [fn = fn] of values)`) resolves to that new binding — in the
+  // temporal dead zone until its own position initializes it — never to the
+  // enclosing fallback. `var`/bare targets reuse the SAME pre-existing
+  // binding (no new scope), so a default reading `name` there is still a
+  // genuine read of its current, soon-to-be-overwritten value.
   if (node.type === 'for_in_statement') {
     const left = node.childForFieldName('left');
     if (left && patternBindsName(left, name)) {
-      if (scanPatternDefaultsForReference(left, name, excludeId, depth + 1, requireCallSite)) {
+      const kindText = node.childForFieldName('kind')?.text;
+      const isLexical = kindText === 'let' || kindText === 'const';
+      if (
+        !isLexical &&
+        scanPatternDefaultsForReference(left, name, excludeId, depth + 1, requireCallSite)
+      ) {
         return true;
       }
       const right = node.childForFieldName('right');

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -4775,11 +4775,7 @@ function blockContainsIdentifierExcluding(
         const declarator = decl.child(j);
         if (declarator?.type !== 'variable_declarator') continue;
         const declName = declarator.childForFieldName('name');
-        if (
-          declName &&
-          patternBindsName(declName, name) &&
-          declarator.childForFieldName('value')
-        ) {
+        if (declName && patternBindsName(declName, name) && declarator.childForFieldName('value')) {
           killIndex = j;
           break;
         }

--- a/tests/benchmarks/regression-guard.test.ts
+++ b/tests/benchmarks/regression-guard.test.ts
@@ -243,8 +243,30 @@ const SKIP_VERSIONS = new Set(['3.8.0']);
  * NOTE: WASM *timing* noise no longer needs per-version entries here — it is
  * handled structurally by WASM_TIMING_THRESHOLD (see above); native keeps the
  * strict thresholds and is the canary for real algorithmic regressions.
+ *
+ * v3.16.0 was released 2026-07-20 and no stable release has landed since.
+ * The same growth/runner-variance drift documented for 3.15.0 above (#2081)
+ * has recurred against this baseline on both metrics — tracked in #2412
+ * (Full build) and #2436 (both metrics). Evidence this is drift/noise, not a
+ * PR-introduced regression:
+ * - #2412: a docs-only PR touching only two Markdown files hit
+ *   `Full build: 4844 → 6063 (+25%)`; a second docs-only PR (#2382) hit the
+ *   identical failure and was merged anyway.
+ * - #2436: the same PR's gate failed three times on the same commit across
+ *   two different metrics (`Full build` +26%, then `1-file rebuild` +103% on
+ *   a re-run of the identical commit). Local benchmarking (6 runs/tree,
+ *   interleaved to control for thermal drift) showed the PR under test was
+ *   the *fastest* of PR/base/main on both metrics — CI's own numbers agreed,
+ *   with the base branch already reading +23%/+26% before any of the PR's
+ *   commits existed. The environment, not the code, accounts for the
+ *   swing: local `dev` measured faster than the recorded 3.16.0 baseline,
+ *   while CI measured 26-103% slower.
+ * Exemption clears itself: prune both entries once the next stable release
+ * folds current repo size and runner conditions into a fresh baseline (same
+ * pattern as the 3.12.0/3.13.0 prune at 3.15.0, and the 3.15.0 prune at
+ * 3.16.0, documented above).
  */
-const KNOWN_REGRESSIONS = new Set<string>([]);
+const KNOWN_REGRESSIONS = new Set<string>(['3.16.0:Full build', '3.16.0:1-file rebuild']);
 
 /**
  * Maximum minor-version gap allowed for comparison. When the nearest

--- a/tests/integration/issue-2257-logical-or-ternary-value-ref.test.ts
+++ b/tests/integration/issue-2257-logical-or-ternary-value-ref.test.ts
@@ -46,6 +46,46 @@ function unrelatedShadower() { return 99; }
 
 function siblingUsed(x) { return x + 4; }
 
+function readAroundNestedVar(x) { return x + 5; }
+function hoistedInNestedFn(x) { return x + 6; }
+function loopOwnBinding(x) { return x + 7; }
+function loopBareTarget(x) { return x + 8; }
+
+// \`var\` is FUNCTION-scoped, so the nested block's \`var varScoped\` is the SAME
+// binding as the outer one — the \`varScoped()\` read before it genuinely
+// consumes the fallback, and must not be pruned as a nested-scope shadow.
+export function nestedVarBlock(opts) {
+  var varScoped = opts.z || readAroundNestedVar;
+  {
+    varScoped();
+    var varScoped = somethingElse;
+  }
+}
+
+// The inner function hoists its OWN \`var hoisted\` (from a deeper block), so
+// \`hoisted()\` there reads that binding, never the outer fallback.
+export function nestedFnHoistsVar(opts) {
+  var hoisted = opts.z || hoistedInNestedFn;
+  function inner(flag) {
+    if (flag) { var hoisted = 1; }
+    return hoisted();
+  }
+  return inner;
+}
+
+// A for-in/of head that BINDS the name kills the pre-loop value: the body's
+// read is of the loop's own per-iteration binding, not the fallback.
+export function loopDeclaringOwnBinding(opts, values) {
+  const loopVar = opts.z || loopOwnBinding;
+  for (let loopVar of values) { loopVar(); }
+}
+
+// Same for a bare (non-declaring) target — it reassigns before the body runs.
+export function loopBareAssignTarget(opts, values) {
+  let bare = opts.z || loopBareTarget;
+  for (bare of values) { bare(); }
+}
+
 export function run(opts, cond) {
   const fetchFn = opts.custom || reachedViaFallback;
   const neverUsedAgain = opts.other || deadViaUnusedFallback;
@@ -130,6 +170,30 @@ function runShared(getDbPath: () => string) {
 
   it('creates a value-ref edge when the variable is used by a sibling declarator in the same statement', () => {
     expect(countCallEdgesTo(getDbPath(), 'siblingUsed')).toBeGreaterThan(0);
+  });
+
+  // Greptile review, PR #2432: `var` is function-scoped, so a nested block's
+  // `var` redeclaration is the SAME binding — it must not prune the block and
+  // discard a genuine read of the fallback.
+  it('still credits liveness from a read in a block that also redeclares the name via var', () => {
+    expect(countCallEdgesTo(getDbPath(), 'readAroundNestedVar')).toBeGreaterThan(0);
+  });
+
+  // The flip side of the same `var` model: a nested function that hoists its
+  // own `var` of that name — from ANY depth in its body — shadows the outer
+  // variable for the whole function, so a read there is not evidence.
+  it('does not credit liveness from a nested function that hoists its own var', () => {
+    expect(countCallEdgesTo(getDbPath(), 'hoistedInNestedFn')).toBe(0);
+  });
+
+  // A for-of head binding the name kills the pre-loop value, whether it
+  // declares a new binding or reassigns the existing one.
+  it('does not credit liveness from a for-of loop that declares its own binding', () => {
+    expect(countCallEdgesTo(getDbPath(), 'loopOwnBinding')).toBe(0);
+  });
+
+  it('does not credit liveness from a for-of body read of a bare loop target', () => {
+    expect(countCallEdgesTo(getDbPath(), 'loopBareTarget')).toBe(0);
   });
 }
 

--- a/tests/parsers/javascript.test.ts
+++ b/tests/parsers/javascript.test.ts
@@ -2464,6 +2464,61 @@ function runDemo(reporter: Reporter, users: string[]): void {
       ).toBe(false);
     });
 
+    // Greptile review, PR #2440: only an INITIALIZER overwrites the value. A
+    // bare `var fn;` redeclaration in the loop head assigns nothing, so it is
+    // not a kill and the body's read is genuine.
+    it('credits liveness from a for-loop body read when the head redeclares the name without initializing it', () => {
+      const symbols = parseJS(`
+        function outer() {
+          var fn = options.custom || fetchLatestVersion;
+          for (var fn; cond; update) { fn(); }
+        }
+      `);
+      expect(
+        symbols.calls.some((c) => c.dynamicKind === 'value-ref' && c.name === 'fetchLatestVersion'),
+      ).toBe(true);
+    });
+
+    // A sibling declarator BEFORE the killing one runs before the overwrite,
+    // so its read is genuine.
+    it('credits liveness from a for-head sibling initializer that runs before the kill', () => {
+      const symbols = parseJS(`
+        function outer() {
+          var fn = options.custom || fetchLatestVersion;
+          for (var a = fn(), fn = 0; fn < 3; fn++) {}
+        }
+      `);
+      expect(
+        symbols.calls.some((c) => c.dynamicKind === 'value-ref' && c.name === 'fetchLatestVersion'),
+      ).toBe(true);
+    });
+
+    // …but a sibling declarator AFTER the killing one reads the NEW value.
+    it('does not credit liveness from a for-head sibling initializer that runs after the kill', () => {
+      const symbols = parseJS(`
+        function outer() {
+          var fn = options.custom || fetchLatestVersion;
+          for (var fn = 0, a = fn(); fn < 3; fn++) {}
+        }
+      `);
+      expect(
+        symbols.calls.some((c) => c.dynamicKind === 'value-ref' && c.name === 'fetchLatestVersion'),
+      ).toBe(false);
+    });
+
+    // The killing declarator's own initializer still reads the pre-loop value.
+    it('credits liveness from a for-head initializer that reads the value it overwrites', () => {
+      const symbols = parseJS(`
+        function outer() {
+          var fn = options.custom || fetchLatestVersion;
+          for (var fn = fn; cond; update) {}
+        }
+      `);
+      expect(
+        symbols.calls.some((c) => c.dynamicKind === 'value-ref' && c.name === 'fetchLatestVersion'),
+      ).toBe(true);
+    });
+
     // …and the guard for that last sentence: a loop counter with a DIFFERENT
     // name must not suppress a real read in the loop body.
     it('credits liveness from a loop body read when the loop counter is a different name', () => {

--- a/tests/parsers/javascript.test.ts
+++ b/tests/parsers/javascript.test.ts
@@ -2565,6 +2565,40 @@ function runDemo(reporter: Reporter, users: string[]): void {
         symbols.calls.some((c) => c.dynamicKind === 'value-ref' && c.name === 'fetchLatestVersion'),
       ).toBe(false);
     });
+
+    // Greptile review, PR #2440: a `let`/`const` for-of target creates a
+    // BRAND-NEW per-iteration binding for `name` — a default hidden inside
+    // that SAME destructuring pattern which mentions `name` resolves to that
+    // new binding (in the temporal dead zone until its own position
+    // initializes it), never to the enclosing fallback. Verified at runtime:
+    // `let [fn = fn] = [undefined]` throws "Cannot access 'fn' before
+    // initialization" — it never reads the outer `fn`.
+    it('does not credit liveness from a lexical destructuring default that self-references the loop target', () => {
+      const symbols = parseJS(`
+        function outer() {
+          var fn = options.custom || fetchLatestVersion;
+          for (const [fn = fn] of values) { fn(); }
+        }
+      `);
+      expect(
+        symbols.calls.some((c) => c.dynamicKind === 'value-ref' && c.name === 'fetchLatestVersion'),
+      ).toBe(false);
+    });
+
+    // …but a `var` target reuses the SAME pre-existing binding (no new
+    // scope), so the identical shape still reads the current,
+    // soon-to-be-overwritten value — this must stay credited.
+    it('still credits liveness from a var destructuring default that self-references the loop target', () => {
+      const symbols = parseJS(`
+        function outer() {
+          var fn = options.custom || fetchLatestVersion;
+          for (var [fn = fn] of values) {}
+        }
+      `);
+      expect(
+        symbols.calls.some((c) => c.dynamicKind === 'value-ref' && c.name === 'fetchLatestVersion'),
+      ).toBe(true);
+    });
   });
 
   describe('computed/bracket-access dispatch-table invocation evidence (#2260)', () => {

--- a/tests/parsers/javascript.test.ts
+++ b/tests/parsers/javascript.test.ts
@@ -2314,6 +2314,65 @@ function runDemo(reporter: Reporter, users: string[]): void {
       ).toBe(true);
     });
 
+    // The flip side of the var-is-function-scoped model: because `var` hoists
+    // to the FUNCTION
+    // scope, a nested function declaring `var fn` at ANY depth in its body
+    // shadows the outer `fn` for that whole function — including a read that
+    // sits outside the block physically containing the `var`.
+    it('does not credit liveness from a nested function that hoists its own var deeper down', () => {
+      const symbols = parseJS(`
+        function outer() {
+          var fn = options.custom || fetchLatestVersion;
+          function inner(flag) {
+            if (flag) { var fn = 1; }
+            return fn();
+          }
+        }
+      `);
+      expect(
+        symbols.calls.some((c) => c.dynamicKind === 'value-ref' && c.name === 'fetchLatestVersion'),
+      ).toBe(false);
+    });
+
+    // Greptile review, PR #2432: a `for (let fn of …)` head declares its own
+    // per-iteration binding, so the body's read is of that binding. The
+    // grammar exposes the declaration as a `kind` FIELD rather than a
+    // `variable_declaration` child, which is why this needs handling on the
+    // for-in/of node itself.
+    it('does not credit liveness from a for-of loop that declares its own binding', () => {
+      const symbols = parseJS(`
+        const fn = options.custom || fetchLatestVersion;
+        for (let fn of values) { fn(); }
+      `);
+      expect(
+        symbols.calls.some((c) => c.dynamicKind === 'value-ref' && c.name === 'fetchLatestVersion'),
+      ).toBe(false);
+    });
+
+    // A for-in/of head that binds the name kills the pre-loop value, so the
+    // BODY can never be reading it — only `right` still can.
+    it('does not credit liveness from a for-of body read of a bare loop target', () => {
+      const symbols = parseJS(`
+        let fn = options.custom || fetchLatestVersion;
+        for (fn of values) { fn(); }
+      `);
+      expect(
+        symbols.calls.some((c) => c.dynamicKind === 'value-ref' && c.name === 'fetchLatestVersion'),
+      ).toBe(false);
+    });
+
+    // …but `right` IS evaluated in the enclosing scope, so a genuine read
+    // there must still count.
+    it('credits liveness from a for-of right-hand side read in the enclosing scope', () => {
+      const symbols = parseJS(`
+        const fn = options.custom || fetchLatestVersion;
+        for (const item of fn()) { use(item); }
+      `);
+      expect(
+        symbols.calls.some((c) => c.dynamicKind === 'value-ref' && c.name === 'fetchLatestVersion'),
+      ).toBe(true);
+    });
+
     // Greptile review, PR #2432: `for (fn of values) {}` / `for (fn in obj)
     // {}` with NO declaration keyword reassigns fn on every iteration — a
     // WRITE, not a read of the value it held before the loop started.
@@ -2382,14 +2441,36 @@ function runDemo(reporter: Reporter, users: string[]): void {
       ).toBe(true);
     });
 
-    // Same principle for a C-style for-loop: a `var` in the loop's own init
-    // clause is the SAME function-scoped binding, so a read in the loop's
-    // test/update clause must still count.
-    it('still credits liveness from a for-loop read when the loop redeclares the name via var', () => {
+    // A C-style for-loop whose own init clause rebinds the name via `var` is
+    // the SAME function-scoped binding — and that is precisely why it KILLS
+    // the fallback value rather than reading it: `var fn = 0` runs before the
+    // test/update clauses, so `fn < 10` and `fn++` only ever see the number.
+    // Verified at runtime: `typeof fn` inside that loop is always `number`,
+    // and the fallback function is never invoked. Crediting liveness here
+    // would fabricate an edge for a value that is assigned and immediately
+    // overwritten without ever being consumed.
+    //
+    // A loop that does NOT rebind the name is unaffected — `for (var i = 0;
+    // i < 10; i++) { fn(); }` still credits the body's genuine read.
+    it('does not credit liveness from a for-loop whose own var init overwrote the value', () => {
       const symbols = parseJS(`
         function outer() {
           var fn = options.custom || fetchLatestVersion;
           for (var fn = 0; fn < 10; fn++) {}
+        }
+      `);
+      expect(
+        symbols.calls.some((c) => c.dynamicKind === 'value-ref' && c.name === 'fetchLatestVersion'),
+      ).toBe(false);
+    });
+
+    // …and the guard for that last sentence: a loop counter with a DIFFERENT
+    // name must not suppress a real read in the loop body.
+    it('credits liveness from a loop body read when the loop counter is a different name', () => {
+      const symbols = parseJS(`
+        function outer() {
+          var fn = options.custom || fetchLatestVersion;
+          for (var i = 0; i < 10; i++) { fn(); }
         }
       `);
       expect(


### PR DESCRIPTION
Follow-on to #2432 (merged). Greptile's final round-12 finding on that PR was fixed
for the *block* case, but the same root cause survives in three other shapes. All
three are one defect: **`var` scoping was being decided at the wrong level.**

Verified empirically against the merged `main` (`ff0b6de5`), both engines.

## What's still wrong on main

| Shape | Correct | On `main` |
|---|---|---|
| `function inner(f) { if (f) { var fn = 1; } return fn(); }` | no edge | **edge** ❌ |
| `for (var fn = 0; fn < 10; fn++) {}` | no edge | **edge** ❌ |
| `for (fn of values) { fn(); }` | no edge | **edge** ❌ |

Each fabricates a value-ref `calls` edge, which keeps a fallback function and its
transitive callees out of `roles --role dead` when they are genuinely unreachable —
the same severity class as the shadowing false positives #2432 fixed.

### 1. `var` was never re-anchored at the function boundary

#2432 correctly stopped treating a block-level `var` as a shadow (`var` is
function-scoped, so a nested `var fn` is the *same* binding — pruning the block
discarded genuine reads). But nothing took over at the level where `var` actually
binds. So a nested function hoisting its own `var fn` from any depth in its body was
no longer detected at all, and a read of *that* binding got credited to the outer
fallback.

Adds `functionScopeDeclaresVar`: scans a function body for a `var` of that name
without crossing into nested functions, which open their own `var` scope. Depth-bounded
by `MAX_WALK_DEPTH` like every other walk in the file.

### 2. `for (var fn = 0; …)` — a regression from the round-12 fix

Dropping `variable_declaration` from the for-head shadow check left nothing in its
place. Being the same function-scoped binding is precisely what makes that init a
**kill**: `var fn = 0` runs before the test and update clauses, so `fn < 10` and
`fn++` only ever see the number.

Confirmed at runtime, not just by reading the AST:

```js
var fn = options.custom || fetchLatestVersion;
for (var fn = 0; fn < 3; fn++) { /* typeof fn === 'number', every iteration */ }
// fetchLatestVersion invoked 0 times
```

`main` currently asserts the opposite in
`still_credits_liveness_from_a_for_loop_read_when_the_loop_redeclares_the_name_via_var`
(and its TS twin). That test encodes a false positive as expected behaviour, so this PR
flips it and renames it, with the reasoning recorded inline. Its stated premise
("the same function-scoped binding") is right; the conclusion drawn from it isn't.

### 3. `for (fn of values) { fn(); }` — body read after the head reassigns

Loop heads that bind the name are now handled as a **kill** rather than a scope: only
the head's own initializer (`for (var fn = fn; …)`) or a for-in/of `right` — evaluated
in the *enclosing* scope — can still hold a genuine read. This also makes the for-in/of
path uniform across bare, `var`, `let` and `const` targets, and keeps
`for (const x of fn())` working, which a whole-node prune would have dropped.

## Not fixed here

A loop whose counter has a *different* name is deliberately unaffected —
`for (var i = 0; i < 10; i++) { fn(); }` still credits the body read (covered by a new
regression test).

The general write-kill case (`fn = other; fn();`) is **not** addressed: it needs ordered
reaching-definition analysis rather than the current "mentioned at or after this
statement" scan. Tracked in #2438.

## Verification

- 4994 JS tests pass (0 failures); 936 Rust tests pass (0 failures)
- `npm run lint` and `cargo fmt --check` clean
- Both engines produce **identical** graphs on the integration fixture; native addon
  built from source rather than the published prebuilt, so the Rust path was genuinely
  exercised
- New coverage in `tests/parsers/javascript.test.ts`, the Rust unit tests, and the
  dual-engine integration fixture

Refs #2257, #2432