### PR TITLE
fix(watch): don't purge a file from the graph when its rebuild fails (#2435)

### DIFF
--- a/src/domain/graph/builder/incremental.ts
+++ b/src/domain/graph/builder/incremental.ts
@@ -2235,6 +2235,32 @@ async function applyChaDispatchPostPass(
 
 /**
  * Parse a single file and update the database incrementally.
+ *
+ * The destructive purge of the file's existing graph data runs only once a
+ * full replacement is in hand — after the file has been read AND parsed
+ * successfully (#2435). Purging first (as this did before) turned any
+ * transient read failure into permanent data loss: every bail-out path
+ * returned without re-inserting anything, leaving the file with zero nodes
+ * and zero edges while its `file_hashes` row survived still matching the
+ * on-disk content, so the next `codegraph build --incremental` classified the
+ * file as unchanged and skipped it. The file stayed missing from the graph
+ * until someone ran `--no-incremental`. Transient read failures are routine
+ * under `codegraph watch`: many editors save via write-to-temp-then-rename,
+ * and some briefly change permissions, so the watcher can easily fire while
+ * the path is momentarily unreadable.
+ *
+ * Ordering — not a transaction — is what provides the atomicity here: this
+ * function is async (it awaits the parse and the reverse-dep cascade) and
+ * better-sqlite3 transactions cannot span an await.
+ *
+ * This mirrors the discipline the reverse-dep cascade in this same file
+ * already follows: `parseReverseDeps` deletes a dep's outgoing edges only
+ * after that dep has parsed successfully. The full-build path likewise never
+ * purges a file it failed to *read* — change detection reads every candidate's
+ * content up front and silently drops the unreadable ones from the changed set
+ * (`stages/detect-changes.ts`), so they are never classified as changed. Note
+ * that it does purge before parsing, so it does not share this function's
+ * protection against a failed *parse* — tracked separately in #2441.
  */
 export async function rebuildFile(
   db: BetterSqlite3Database,
@@ -2254,31 +2280,42 @@ export async function rebuildFile(
   // Find reverse-deps BEFORE purging (edges still reference the old nodes)
   const reverseDeps = findReverseDeps(db, relPath);
 
-  // Purge ancillary tables (incl. embeddings), edges, and nodes in one pass.
-  // Embeddings must be purged before nodes — better-sqlite3 enforces foreign
-  // keys by default, and `embeddings.node_id` references `nodes.id`. Issue #1176.
-  // `purgeHashes: false` preserves file_hashes for the next incremental build.
-  purgeFileData(db, relPath, { purgeHashes: false });
-
   if (!fs.existsSync(filePath)) {
     if (cache) (cache as { remove(p: string): void }).remove(filePath);
+    // Purge ancillary tables (incl. embeddings), edges, and nodes in one pass.
+    // Embeddings must be purged before nodes — better-sqlite3 enforces foreign
+    // keys by default, and `embeddings.node_id` references `nodes.id`. Issue #1176.
     // The file no longer exists, so it has no edges to keep in sync with a
-    // hash — delete it immediately (mirrors the full-build removed-file path
-    // in insertNodes.ts, which is likewise unconditional).
-    stmts.deleteFileHash.run(relPath);
+    // hash — `purgeHashes` defaults to true here, unlike the replacement purge
+    // below (mirrors the full-build removed-file path in insertNodes.ts, which
+    // is likewise unconditional).
+    purgeFileData(db, relPath);
     return buildDeletionResult(relPath, oldNodes, edgesBefore, oldSymbols, diffSymbols);
   }
 
+  // Read and parse before touching the graph (#2435) — both of these can fail
+  // on a file that is still perfectly present and valid in the DB, and there
+  // is nothing better to replace it with than what is already there.
   let code: string;
   try {
     code = readFileSafe(filePath);
   } catch (err) {
-    warn(`Cannot read ${relPath}: ${(err as Error).message}`);
+    warn(`Cannot read ${relPath}: ${(err as Error).message} — graph left unchanged`);
     return null;
   }
 
   const symbols = await parseFileIncremental(cache, filePath, code, engineOpts);
-  if (!symbols) return null;
+  if (!symbols) {
+    debug(`rebuildFile: no symbols extracted for ${relPath} — graph left unchanged`);
+    return null;
+  }
+
+  // A full replacement now exists, so swapping it in is safe. Purge ancillary
+  // tables (incl. embeddings), edges, and nodes in one pass. Embeddings must be
+  // purged before nodes — better-sqlite3 enforces foreign keys by default, and
+  // `embeddings.node_id` references `nodes.id`. Issue #1176. `purgeHashes:
+  // false` preserves file_hashes for the next incremental build.
+  purgeFileData(db, relPath, { purgeHashes: false });
 
   insertFileNodes(stmts, relPath, symbols);
 
@@ -2286,7 +2323,14 @@ export async function rebuildFile(
   const newSymbols: unknown[] = diffSymbols ? stmts.listSymbols.all(relPath) : [];
 
   const fileNodeRow = stmts.getNodeId.get(relPath, 'file', relPath, 0);
-  if (!fileNodeRow)
+  if (!fileNodeRow) {
+    // Unreachable in practice (`insertFileNodes` just inserted this exact row),
+    // but the purge above has already run, so bailing out here leaves the file
+    // with nodes and no edges. Drop its `file_hashes` row so the next
+    // `codegraph build --incremental` is forced to reprocess the file instead
+    // of trusting a hash that no longer describes the graph (#2435) — every
+    // other bail-out path returns before the purge and needs no such repair.
+    stmts.deleteFileHash.run(relPath);
     return {
       file: relPath,
       nodesAdded: newNodes,
@@ -2294,6 +2338,7 @@ export async function rebuildFile(
       edgesAdded: 0,
       edgesBefore,
     };
+  }
 
   // #2216: computed once per rebuild (this file's own node row is already
   // inserted above, so it's included) and threaded through every

--- a/tests/integration/issue-2435-watch-failed-rebuild-data-loss.test.ts
+++ b/tests/integration/issue-2435-watch-failed-rebuild-data-loss.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Regression test for #2435: a failed watch rebuild must not purge the file
+ * from the graph.
+ *
+ * Root cause: `rebuildFile` (`domain/graph/builder/incremental.ts`, the
+ * function `codegraph watch` calls per changed file) purged the file's nodes,
+ * edges and ancillary rows *before* reading and parsing it — so every bail-out
+ * path returned without re-inserting anything, leaving the file with zero
+ * nodes and zero edges. Its `file_hashes` row was deliberately preserved
+ * (`purgeHashes: false`) and still matched the on-disk content, so the next
+ * `codegraph build --incremental` classified the file as unchanged and skipped
+ * it: the file stayed missing from the graph until someone ran
+ * `--no-incremental`.
+ *
+ * That made a routine, transient failure permanent. Editors save via
+ * write-to-temp-then-rename and some briefly change permissions, so the
+ * watcher can easily fire while the path is momentarily unreadable.
+ *
+ * The fix reads and parses first, purging only once a full replacement is in
+ * hand. Each test below therefore drives `rebuildFile` through one bail-out
+ * path and asserts the file's whole contribution to the graph survives — its
+ * symbols AND the `calls` edge it owns into another file — then runs an
+ * incremental build to confirm the state is genuinely durable and not merely
+ * awaiting a rebuild that will never be triggered.
+ *
+ * The fixture file is deliberately left byte-identical on disk across the
+ * failed rebuild. That is the case the surviving hash makes permanent: with
+ * the content unchanged, change detection fast-skips the file forever. (Had
+ * the content changed, the hash mismatch would eventually self-heal it.)
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { initSchema, openDb } from '../../src/db/index.js';
+import { rebuildFile } from '../../src/domain/graph/builder/incremental.js';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+import { createIncrementalStmts } from '../helpers/incremental-stmts.js';
+
+// ── Fixture ───────────────────────────────────────────────────────────────
+
+/**
+ * `caller.js` imports and calls `target()` from `target.js` — the JS analogue
+ * of the issue's `run.py`/`lib.py` repro. `caller.js` is the file whose
+ * rebuild fails; `target.js` supplies the cross-file `calls` edge that a purge
+ * of `caller.js` silently takes with it.
+ */
+function writeProject(dir: string, { callsTarget = true }: { callsTarget?: boolean } = {}) {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'target.js'), 'export function target() { return 1; }\n');
+  fs.writeFileSync(
+    path.join(dir, 'caller.js'),
+    callsTarget
+      ? "import { target } from './target.js';\nexport function run() { return target(); }\n"
+      : 'export function run() { return 0; }\n',
+  );
+}
+
+// ── DB read helpers ───────────────────────────────────────────────────────
+
+function withDb<T>(dbPath: string, fn: (db: Database.Database) => T): T {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return fn(db);
+  } finally {
+    db.close();
+  }
+}
+
+/** Non-file symbol names declared in `file`. */
+function readSymbolNames(dbPath: string, file: string): string[] {
+  return withDb(dbPath, (db) =>
+    (
+      db
+        .prepare("SELECT name FROM nodes WHERE file = ? AND kind != 'file' ORDER BY name")
+        .all(file) as Array<{ name: string }>
+    ).map((r) => r.name),
+  );
+}
+
+/** `"<sourceFile>:<sourceName>"` for every `calls` edge into `targetName` in `targetFile`. */
+function readIncomingCalls(dbPath: string, targetFile: string, targetName: string): string[] {
+  return withDb(dbPath, (db) =>
+    (
+      db
+        .prepare(
+          `SELECT n_src.file AS file, n_src.name AS name FROM edges e
+           JOIN nodes n_src ON e.source_id = n_src.id
+           JOIN nodes n_tgt ON e.target_id = n_tgt.id
+           WHERE e.kind = 'calls' AND n_tgt.file = ? AND n_tgt.name = ?
+           ORDER BY n_src.file, n_src.name`,
+        )
+        .all(targetFile, targetName) as Array<{ file: string; name: string }>
+    ).map((r) => `${r.file}:${r.name}`),
+  );
+}
+
+function hasFileHashRow(dbPath: string, file: string): boolean {
+  return withDb(
+    dbPath,
+    (db) => db.prepare('SELECT 1 FROM file_hashes WHERE file = ?').get(file) !== undefined,
+  );
+}
+
+/** Run one watch-mode rebuild of `relFile` exactly as `processPendingFiles` does. */
+async function watchRebuild(
+  dbPath: string,
+  rootDir: string,
+  relFile: string,
+  cache: unknown = null,
+): Promise<unknown> {
+  const db = openDb(dbPath);
+  try {
+    initSchema(db);
+    return await rebuildFile(
+      db,
+      rootDir,
+      path.join(rootDir, relFile),
+      createIncrementalStmts(db),
+      { engine: 'wasm' },
+      cache,
+    );
+  } finally {
+    db.close();
+  }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe('Issue #2435: a failed watch rebuild leaves the graph intact', () => {
+  let tmpDir: string;
+  let dbPath: string;
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-2435-'));
+    writeProject(tmpDir);
+    // engine: 'wasm' pins parsing to the JS path for determinism; `rebuildFile`
+    // itself is JS-only either way (`codegraph watch` has no native rebuild).
+    await buildGraph(tmpDir, { incremental: false, skipRegistry: true, engine: 'wasm' });
+    dbPath = path.join(tmpDir, '.codegraph', 'graph.db');
+
+    // Baseline: the state a failed rebuild must not destroy.
+    expect(readSymbolNames(dbPath, 'caller.js')).toContain('run');
+    expect(readIncomingCalls(dbPath, 'target.js', 'target')).toEqual(['caller.js:run']);
+    expect(hasFileHashRow(dbPath, 'caller.js')).toBe(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /** Assert caller.js's full contribution to the graph is present. */
+  function expectGraphIntact() {
+    expect(readSymbolNames(dbPath, 'caller.js')).toContain('run');
+    expect(readIncomingCalls(dbPath, 'target.js', 'target')).toEqual(['caller.js:run']);
+  }
+
+  it('keeps the file in the graph when it cannot be read, and an incremental build agrees', async () => {
+    const callerAbs = path.join(tmpDir, 'caller.js');
+    // Fail only this one read (EACCES — what the issue's `chmod 000` repro
+    // produces; readFileSafe retries transient codes, then throws), passing
+    // every other read through so the rest of the rebuild behaves normally.
+    const actualReadFileSync = fs.readFileSync;
+    vi.spyOn(fs, 'readFileSync').mockImplementation(((
+      p: Parameters<typeof fs.readFileSync>[0],
+      opts: Parameters<typeof fs.readFileSync>[1],
+    ) => {
+      if (p === callerAbs) {
+        throw Object.assign(new Error('permission denied'), { code: 'EACCES' });
+      }
+      return actualReadFileSync(p, opts);
+    }) as typeof fs.readFileSync);
+
+    // The rebuild reports failure by returning null — the watcher skips the
+    // file (no journal entry, no change event) and moves on.
+    expect(await watchRebuild(dbPath, tmpDir, 'caller.js')).toBeNull();
+
+    vi.restoreAllMocks();
+    expectGraphIntact();
+
+    // The surviving hash row is only correct if the graph data it describes
+    // survived too: an incremental build fast-skips this unchanged file, so
+    // whatever state the failed rebuild left is the state that persists.
+    expect(hasFileHashRow(dbPath, 'caller.js')).toBe(true);
+    await buildGraph(tmpDir, { incremental: true, skipRegistry: true, engine: 'wasm' });
+    expectGraphIntact();
+  });
+
+  it('keeps the file in the graph when it cannot be parsed, and an incremental build agrees', async () => {
+    // A cache whose parseFile yields nothing drives `parseFileIncremental` to
+    // return null — the second bail-out path, reached after a successful read.
+    const emptyCache = { parseFile: () => null, remove: () => {} };
+
+    expect(await watchRebuild(dbPath, tmpDir, 'caller.js', emptyCache)).toBeNull();
+
+    expectGraphIntact();
+    expect(hasFileHashRow(dbPath, 'caller.js')).toBe(true);
+    await buildGraph(tmpDir, { incremental: true, skipRegistry: true, engine: 'wasm' });
+    expectGraphIntact();
+  });
+
+  it('still purges stale data on a successful rebuild', async () => {
+    // The counterpart risk of deferring the purge: it must still happen when a
+    // replacement does arrive. Drop the call and rebuild for real.
+    writeProject(tmpDir, { callsTarget: false });
+
+    const result = await watchRebuild(dbPath, tmpDir, 'caller.js');
+
+    expect(result).not.toBeNull();
+    expect(readSymbolNames(dbPath, 'caller.js')).toContain('run');
+    expect(readIncomingCalls(dbPath, 'target.js', 'target')).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #2435.

## The bug

`rebuildFile` (`src/domain/graph/builder/incremental.ts` — the function `codegraph watch` calls per changed file) purged the file's nodes, edges and ancillary rows **before** reading and parsing it. Every bail-out path then returned having deleted the file's whole contribution and re-inserted nothing:

- `readFileSafe` throws → `warn(...)`, `return null`
- `parseFileIncremental` returns null → `return null`

Its `file_hashes` row was deliberately preserved (`purgeHashes: false`) and still matched the on-disk content, so the next `codegraph build --incremental` classified the file as **unchanged** and skipped it. The file stayed missing from the graph until someone ran `--no-incremental`.

That turned a routine, transient failure into permanent data loss. Editors save via write-to-temp-then-rename and some briefly change permissions, so the watcher can easily fire while a path is momentarily unreadable. The loss covers everything the file contributed — symbols, imports, call edges, complexity rows — not just entrypoints.

## The fix

Read and parse first; purge only once a full replacement is in hand.

**Ordering, not a transaction, provides the atomicity.** `rebuildFile` is async — it awaits the parse and the reverse-dep cascade — and better-sqlite3 transactions cannot span an `await`, so the issue's "wrap it in one transaction" option isn't available here. Lazy purging is also the discipline the reverse-dep cascade in this same file already follows: `parseReverseDeps` deletes a dep's outgoing edges only after that dep parses successfully. This change makes the primary file consistent with its own cascade.

Two smaller pieces:

- The one bail-out that still returns after the purge — a file node that can't be looked up immediately after being inserted, unreachable in practice — now drops the `file_hashes` row, so the next incremental build reprocesses the file rather than trusting a hash that no longer describes the graph.
- The removed-file branch now purges hashes via `purgeFileData`'s default instead of a separate `deleteFileHash` call. Behaviour is unchanged (the existing "removes the file_hashes row when the file is deleted" test in `issue-1731-hash-edge-coupling.test.ts` still passes).

## Tests

New `tests/integration/issue-2435-watch-failed-rebuild-data-loss.test.ts` drives `rebuildFile` through each bail-out path and asserts the file's whole contribution survives — its symbols **and** the cross-file `calls` edge it owns — then runs an incremental build to confirm the state is genuinely durable and not merely awaiting a rebuild that will never be triggered.

- **read failure** — `fs.readFileSync` is made to throw `EACCES` for that one path only (the issue's `chmod 000` repro), everything else passing through
- **parse failure** — a cache whose `parseFile` yields nothing, driving `parseFileIncremental` to return null
- **purge still works** — the counterpart risk of deferring the purge: after a real edit that drops the call, a successful rebuild must still remove the stale edge

The fixture is deliberately left byte-identical on disk across the failed rebuild — that is the case the surviving hash makes permanent, since change detection then fast-skips the file forever.

Verified both data-loss tests fail on `main` (`expected [] to include 'run'`) and pass with the fix; the third guard passes either way.

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` (biome, 955 files) — clean
- **Full suite: 5022 passed, 0 failed**, with the native addon built from current `crates/` source (`napi build --release`) so both engines are genuinely exercised. `rebuildFile` itself is JS-only — `codegraph watch` has no native rebuild path — and the new tests pin `engine: 'wasm'`.

## Out of scope, filed separately

**#2441** — the same failure mode on the `codegraph build --incremental` (scoped) path, which this PR does **not** address. That path purges during change detection *before* `parseFiles`, and `commitFileHashes` writes a hash for every file in `ctx.filesToParse` without checking whether it produced symbols — so a changed file whose parse yields nothing is purged and then marked up to date. Read failures are already safe there (unreadable files never enter the changed set), which is why #2435 was watch-only for reads. Established by code reading, not a runtime repro.