### PR TITLE
fix(resolver): this-bound EventEmitter callback registrations get a real calls edge

### DIFF
--- a/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
@@ -944,6 +944,7 @@ fn emit_pts_alias_edges<'a>(
             alias_ctx.imported_original_names,
             alias_ctx.namespace_imports,
             &mut alias_confidence_override,
+            None,
         );
         sort_targets_by_confidence(
             &mut alias_targets,
@@ -1357,7 +1358,7 @@ fn process_file<'a>(
             }
         }
 
-        let (caller_id, caller_name) =
+        let (caller_id, caller_name, enclosing_class_hint) =
             find_enclosing_caller(&fc.defs_with_ids, call.line, fc.file_node_id);
         let is_dynamic = if call.dynamic.unwrap_or(false) {
             1u32
@@ -1381,6 +1382,7 @@ fn process_file<'a>(
             &fc.imported_original_names,
             &fc.namespace_imports,
             &mut confidence_override,
+            enclosing_class_hint,
         );
         // #1771/#1784: value-ref references (object-literal property values,
         // Lua builtin reassignment, `instanceof ClassName`) resolve against
@@ -1538,56 +1540,48 @@ fn is_framework_entry_name(name: &str) -> bool {
 
 /// Find the narrowest enclosing definition for a call at the given line.
 ///
-/// Two-pass strategy (mirrors `findCaller` in call-resolver.ts):
+/// Two-pass strategy:
 ///   Pass 1 — narrowest enclosing function/method.  Local variable declarations
 ///             inside a function body must not shadow the enclosing function.
 ///   Pass 2 — widest (outermost) enclosing variable/constant binding.  Used as
 ///             fallback when no function/method encloses the call (e.g. Haskell
 ///             top-level `main = do …` is a `bind` node with kind `variable`).
 ///
-/// Within Pass 1, real (non-synthetic) callables are tried before synthetic
-/// framework-dispatch placeholders (`route:`/`event:`/`command:`-prefixed,
-/// e.g. `event:${eventName}` for an EventEmitter `.on('event', callback)`
-/// registration) — a synthetic placeholder has no class/`this` context of
-/// its own, so a `this.method()` call inside its callback body can never
-/// resolve if attributed to it (issue #2259), whereas a REAL enclosing
-/// method's own name already carries that context. Without this
-/// preference, a one-line callback body (`(msg) => this.onMessage(msg)`)
-/// registered inside a class method would win caller attribution purely by
-/// having the narrower span (its own single line vs. the enclosing
-/// method's full body), even though the enclosing method is *also* a
-/// valid, strictly more useful candidate. A synthetic placeholder is still
-/// picked when it's the ONLY candidate (the common case: a route/event/
-/// command registered directly at module scope, with no enclosing real
-/// method to prefer).
-///
-/// Tie-breaking within each tier: when two callable definitions have the
-/// same span, prefer the bare (unqualified) name over the dot-containing
-/// qualified name. Object-literal methods are extracted twice by the Rust
-/// extractor — once as `o1.f(function)` from `extract_object_literal_functions`
-/// (called eagerly inside `handle_var_decl`) and once as `f(method)` from
-/// `handle_method_def` (called later during the child walk). The WASM
-/// extractor emits `f(method)` first (query captures run before the
-/// walk-phase `extractObjectLiteralFunctions`), so WASM's strict-less-than
-/// tie-break naturally picks the bare name. Applying the same preference
-/// here aligns native attribution with WASM and with the jelly-micro
-/// ground-truth expected-edges (which use bare `f`/`g` names). Names with
-/// angle brackets (e.g. `B.<static:36:2>`) are synthetic static-block
+/// Tie-breaking in Pass 1: when two callable definitions have the same span,
+/// prefer the bare (unqualified) name over the dot-containing qualified name.
+/// Object-literal methods are extracted twice by the Rust extractor — once as
+/// `o1.f(function)` from `extract_object_literal_functions` (called eagerly
+/// inside `handle_var_decl`) and once as `f(method)` from `handle_method_def`
+/// (called later during the child walk). The WASM extractor emits `f(method)`
+/// first (query captures run before the walk-phase `extractObjectLiteralFunctions`),
+/// so WASM's strict-less-than tie-break naturally picks the bare name.
+/// Applying the same preference here aligns native attribution with WASM and with
+/// the jelly-micro ground-truth expected-edges (which use bare `f`/`g` names).
+/// Names with angle brackets (e.g. `B.<static:36:2>`) are synthetic static-block
 /// nodes excluded from the bare-preference rule.
 ///
-/// Returns `(caller_id, caller_name)` — `caller_name` is `""` when the call
-/// falls back to file scope.
+/// Returns `(caller_id, caller_name, enclosing_class_hint)` — `caller_name`
+/// is `""` when the call falls back to file scope. `enclosing_class_hint`
+/// (issue #2259) is set ONLY when the attributed caller is itself a
+/// synthetic framework-dispatch placeholder (`route:`/`event:`/`command:`-
+/// prefixed) — such a placeholder has no class/`this` context of its own
+/// (e.g. `event:${eventName}` for an EventEmitter `.on('event', callback)`
+/// registration, when that callback is lexically nested inside a real class
+/// method: `w.on('message', (msg) => this.onMessage(msg))`), so
+/// `this.onMessage` could never resolve using ONLY the caller's own name.
+/// The hint supplies the nearest REAL enclosing method's class as a
+/// resolution-only fallback (see `find_enclosing_class_hint`) — it does NOT
+/// change which node the call's edge is sourced from, so flow/sequence
+/// traversal starting from the synthetic entry point still sees the
+/// callback's own calls (Greptile review, PR #2444).
 fn find_enclosing_caller<'a>(
     defs: &[DefWithId<'a>],
     call_line: u32,
     file_node_id: u32,
-) -> (u32, &'a str) {
-    if let Some((id, name)) = find_narrowest_enclosing_callable(defs, call_line, false) {
-        return (id, name);
-    }
-    if let Some((id, name)) = find_narrowest_enclosing_callable(defs, call_line, true) {
-        return (id, name);
-    }
+) -> (u32, &'a str, Option<&'a str>) {
+    let mut fn_caller_id: Option<u32> = None;
+    let mut fn_caller_name = "";
+    let mut fn_caller_span = u32::MAX;
 
     // For variable/constant bindings we pick the WIDEST span (outermost binding),
     // not the narrowest, so that nested `let` bindings inside `main`'s do-block
@@ -1601,66 +1595,84 @@ fn find_enclosing_caller<'a>(
     let mut var_caller_span: i64 = -1;
 
     for def in defs {
-        if def.line <= call_line && call_line <= def.end_line && is_top_level_binding_kind(def.kind)
-        {
+        if def.line <= call_line && call_line <= def.end_line {
             let span = def.end_line.saturating_sub(def.line);
-            if (span as i64) > var_caller_span {
-                if let Some(id) = def.node_id {
-                    var_caller_id = Some(id);
-                    var_caller_name = def.name;
-                    var_caller_span = span as i64;
+            if is_callable_kind(def.kind) {
+                // On a strict span improvement always take the new candidate.
+                // On a tie, prefer bare names over qualified names so native matches WASM:
+                // both pick `f(method)` over `o1.f(function)` when an object-literal method
+                // is extracted under both names at the same line. Synthetic angle-bracket
+                // nodes (e.g. `B.<static:36:2>`) are excluded on both sides of the comparison.
+                let is_improvement = span < fn_caller_span;
+                let is_tie_prefer_bare = span == fn_caller_span
+                    && !def.name.contains('.')
+                    && !def.name.contains('<')
+                    && fn_caller_name.contains('.')
+                    && !fn_caller_name.contains('<');
+                if is_improvement || is_tie_prefer_bare {
+                    if let Some(id) = def.node_id {
+                        fn_caller_id = Some(id);
+                        fn_caller_name = def.name;
+                        fn_caller_span = span;
+                    }
+                }
+            } else if is_top_level_binding_kind(def.kind) {
+                if (span as i64) > var_caller_span {
+                    if let Some(id) = def.node_id {
+                        var_caller_id = Some(id);
+                        var_caller_name = def.name;
+                        var_caller_span = span as i64;
+                    }
                 }
             }
         }
     }
 
-    if let Some(id) = var_caller_id {
-        return (id, var_caller_name);
+    // Prefer function/method over variable/constant binding.
+    if let Some(id) = fn_caller_id {
+        let enclosing_class_hint = if is_framework_entry_name(fn_caller_name) {
+            find_enclosing_class_hint(defs, call_line)
+        } else {
+            None
+        };
+        return (id, fn_caller_name, enclosing_class_hint);
     }
-    (file_node_id, "")
+    if let Some(id) = var_caller_id {
+        return (id, var_caller_name, None);
+    }
+    (file_node_id, "", None)
 }
 
-fn find_narrowest_enclosing_callable<'a>(
-    defs: &[DefWithId<'a>],
-    call_line: u32,
-    only_framework_entry: bool,
-) -> Option<(u32, &'a str)> {
-    let mut fn_caller_id: Option<u32> = None;
-    let mut fn_caller_name = "";
-    let mut fn_caller_span = u32::MAX;
-
+/// Find the class context of the nearest enclosing REAL (non-synthetic)
+/// method for `call_line`, for use ONLY as a `this`/`self`/`super`
+/// resolution fallback — see `find_enclosing_caller`'s doc comment. Picks
+/// the NARROWEST enclosing real method (like `find_enclosing_caller`
+/// itself), so a callback nested inside nested classes/methods resolves
+/// against the innermost one — the correct `this` binding at that point.
+/// Mirrors `findEnclosingClassHint` in call-resolver.ts.
+fn find_enclosing_class_hint<'a>(defs: &[DefWithId<'a>], call_line: u32) -> Option<&'a str> {
+    let mut best: Option<&'a str> = None;
+    let mut best_span = u32::MAX;
     for def in defs {
-        if !(def.line <= call_line && call_line <= def.end_line) {
+        if def.kind != "method" || is_framework_entry_name(def.name) {
             continue;
         }
-        if !is_callable_kind(def.kind) {
+        if def.line > call_line || call_line > def.end_line {
             continue;
         }
-        if is_framework_entry_name(def.name) != only_framework_entry {
+        let Some(dot_idx) = def.name.rfind('.') else {
+            continue;
+        };
+        if dot_idx == 0 {
             continue;
         }
         let span = def.end_line.saturating_sub(def.line);
-        // On a strict span improvement always take the new candidate.
-        // On a tie, prefer bare names over qualified names so native matches WASM:
-        // both pick `f(method)` over `o1.f(function)` when an object-literal method
-        // is extracted under both names at the same line. Synthetic angle-bracket
-        // nodes (e.g. `B.<static:36:2>`) are excluded on both sides of the comparison.
-        let is_improvement = span < fn_caller_span;
-        let is_tie_prefer_bare = span == fn_caller_span
-            && !def.name.contains('.')
-            && !def.name.contains('<')
-            && fn_caller_name.contains('.')
-            && !fn_caller_name.contains('<');
-        if is_improvement || is_tie_prefer_bare {
-            if let Some(id) = def.node_id {
-                fn_caller_id = Some(id);
-                fn_caller_name = def.name;
-                fn_caller_span = span;
-            }
+        if span < best_span {
+            best = Some(&def.name[..dot_idx]);
+            best_span = span;
         }
     }
-
-    fn_caller_id.map(|id| (id, fn_caller_name))
+    best
 }
 
 /// Step 2 of the scoped (this/self/super or no-receiver) fallback: exact global
@@ -1814,6 +1826,7 @@ fn resolve_call_targets<'a>(
     imported_original_names: &HashMap<&str, &str>,
     namespace_imports: &HashMap<&str, &str>,
     confidence_override: &mut Option<f64>,
+    enclosing_class_hint: Option<&str>,
 ) -> Vec<&'a NodeInfo> {
     let targets = resolve_call_targets_core(
         ctx,
@@ -1826,6 +1839,7 @@ fn resolve_call_targets<'a>(
         imported_original_names,
         namespace_imports,
         confidence_override,
+        enclosing_class_hint,
     );
     if call.receiver.is_some() {
         return targets;
@@ -1875,6 +1889,7 @@ fn resolve_call_targets_core<'a>(
     imported_original_names: &HashMap<&str, &str>,
     namespace_imports: &HashMap<&str, &str>,
     confidence_override: &mut Option<f64>,
+    enclosing_class_hint: Option<&str>,
 ) -> Vec<&'a NodeInfo> {
     // Flagged dynamic calls use synthetic names like "<dynamic:eval>". Short-circuit
     // so they never accidentally match a real symbol via name lookup.
@@ -2393,9 +2408,18 @@ fn resolve_call_targets_core<'a>(
         // binding. Skip the same-class fallback for bare calls in those languages to prevent
         // false positives (e.g. `flush()` inside `Processor.run` must not resolve to
         // `Processor.flush`). this/self/super calls are unaffected.
+        //
+        // `enclosing_class_hint` (issue #2259) is consulted ONLY when `caller_name` itself has
+        // no dot to derive a class from — e.g. the caller is a synthetic framework-dispatch
+        // placeholder (`event:${event_name}` for an EventEmitter `.on('event', callback)`
+        // registration; see `find_enclosing_class_hint`) with no class context of its own, even
+        // though the callback is lexically nested inside a real class method. The callback's
+        // calls-edge still sources from the synthetic placeholder unchanged (so flow/sequence
+        // traversal starting from that entry point keeps working) — this hint only supplies the
+        // class needed to resolve `this`/`self` here.
         let is_bare_call = call.receiver.is_none();
         if !caller_name.is_empty() && !(is_bare_call && is_module_scoped_language(rel_path)) {
-            if let Some(dot_idx) = caller_name.rfind('.') {
+            let class_prefix = if let Some(dot_idx) = caller_name.rfind('.') {
                 // Extract only the segment immediately before the method name so that
                 // 'Namespace.ClassName.method' yields 'ClassName', not 'Namespace.ClassName'.
                 // Symbols are stored under their bare class name, not their qualified path.
@@ -2403,7 +2427,11 @@ fn resolve_call_targets_core<'a>(
                     .rfind('.')
                     .map(|p| p + 1)
                     .unwrap_or(0);
-                let class_prefix = &caller_name[seg_start..dot_idx];
+                Some(&caller_name[seg_start..dot_idx])
+            } else {
+                enclosing_class_hint
+            };
+            if let Some(class_prefix) = class_prefix {
                 let qualified = format!("{}.{}", class_prefix, call.name);
                 let class_scoped: Vec<&NodeInfo> = ctx
                     .nodes_by_name

--- a/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
@@ -5,6 +5,7 @@ use napi_derive::napi;
 use crate::domain::graph::builder::barrel_resolution::{self, BarrelContext, ReexportRef};
 use crate::domain::graph::builder::stages::import_edges::{import_name_pairs, ImportNameSource};
 use crate::domain::graph::resolve;
+use crate::graph::classifiers::roles::FRAMEWORK_ENTRY_PREFIXES;
 use crate::types::{
     ArrayCallbackBinding, ArrayElemBinding, FnRefBinding, ForOfBinding, ObjectPropBinding,
     ObjectRestParamBinding, ParamBinding, RenamedImport, SpreadArgBinding, ThisCallBinding,
@@ -1528,6 +1529,13 @@ fn is_top_level_binding_kind(kind: &str) -> bool {
     kind == "variable" || kind == "constant"
 }
 
+/// True when `name` is a synthetic framework-dispatch placeholder
+/// (`route:`/`event:`/`command:`-prefixed). Mirrors `isFrameworkEntryName`
+/// in call-resolver.ts.
+fn is_framework_entry_name(name: &str) -> bool {
+    FRAMEWORK_ENTRY_PREFIXES.iter().any(|p| name.starts_with(p))
+}
+
 /// Find the narrowest enclosing definition for a call at the given line.
 ///
 /// Two-pass strategy (mirrors `findCaller` in call-resolver.ts):
@@ -1537,17 +1545,34 @@ fn is_top_level_binding_kind(kind: &str) -> bool {
 ///             fallback when no function/method encloses the call (e.g. Haskell
 ///             top-level `main = do …` is a `bind` node with kind `variable`).
 ///
-/// Tie-breaking in Pass 1: when two callable definitions have the same span,
-/// prefer the bare (unqualified) name over the dot-containing qualified name.
-/// Object-literal methods are extracted twice by the Rust extractor — once as
-/// `o1.f(function)` from `extract_object_literal_functions` (called eagerly
-/// inside `handle_var_decl`) and once as `f(method)` from `handle_method_def`
-/// (called later during the child walk). The WASM extractor emits `f(method)`
-/// first (query captures run before the walk-phase `extractObjectLiteralFunctions`),
-/// so WASM's strict-less-than tie-break naturally picks the bare name.
-/// Applying the same preference here aligns native attribution with WASM and with
-/// the jelly-micro ground-truth expected-edges (which use bare `f`/`g` names).
-/// Names with angle brackets (e.g. `B.<static:36:2>`) are synthetic static-block
+/// Within Pass 1, real (non-synthetic) callables are tried before synthetic
+/// framework-dispatch placeholders (`route:`/`event:`/`command:`-prefixed,
+/// e.g. `event:${eventName}` for an EventEmitter `.on('event', callback)`
+/// registration) — a synthetic placeholder has no class/`this` context of
+/// its own, so a `this.method()` call inside its callback body can never
+/// resolve if attributed to it (issue #2259), whereas a REAL enclosing
+/// method's own name already carries that context. Without this
+/// preference, a one-line callback body (`(msg) => this.onMessage(msg)`)
+/// registered inside a class method would win caller attribution purely by
+/// having the narrower span (its own single line vs. the enclosing
+/// method's full body), even though the enclosing method is *also* a
+/// valid, strictly more useful candidate. A synthetic placeholder is still
+/// picked when it's the ONLY candidate (the common case: a route/event/
+/// command registered directly at module scope, with no enclosing real
+/// method to prefer).
+///
+/// Tie-breaking within each tier: when two callable definitions have the
+/// same span, prefer the bare (unqualified) name over the dot-containing
+/// qualified name. Object-literal methods are extracted twice by the Rust
+/// extractor — once as `o1.f(function)` from `extract_object_literal_functions`
+/// (called eagerly inside `handle_var_decl`) and once as `f(method)` from
+/// `handle_method_def` (called later during the child walk). The WASM
+/// extractor emits `f(method)` first (query captures run before the
+/// walk-phase `extractObjectLiteralFunctions`), so WASM's strict-less-than
+/// tie-break naturally picks the bare name. Applying the same preference
+/// here aligns native attribution with WASM and with the jelly-micro
+/// ground-truth expected-edges (which use bare `f`/`g` names). Names with
+/// angle brackets (e.g. `B.<static:36:2>`) are synthetic static-block
 /// nodes excluded from the bare-preference rule.
 ///
 /// Returns `(caller_id, caller_name)` — `caller_name` is `""` when the call
@@ -1557,9 +1582,12 @@ fn find_enclosing_caller<'a>(
     call_line: u32,
     file_node_id: u32,
 ) -> (u32, &'a str) {
-    let mut fn_caller_id: Option<u32> = None;
-    let mut fn_caller_name = "";
-    let mut fn_caller_span = u32::MAX;
+    if let Some((id, name)) = find_narrowest_enclosing_callable(defs, call_line, false) {
+        return (id, name);
+    }
+    if let Some((id, name)) = find_narrowest_enclosing_callable(defs, call_line, true) {
+        return (id, name);
+    }
 
     // For variable/constant bindings we pick the WIDEST span (outermost binding),
     // not the narrowest, so that nested `let` bindings inside `main`'s do-block
@@ -1573,47 +1601,66 @@ fn find_enclosing_caller<'a>(
     let mut var_caller_span: i64 = -1;
 
     for def in defs {
-        if def.line <= call_line && call_line <= def.end_line {
+        if def.line <= call_line && call_line <= def.end_line && is_top_level_binding_kind(def.kind)
+        {
             let span = def.end_line.saturating_sub(def.line);
-            if is_callable_kind(def.kind) {
-                // On a strict span improvement always take the new candidate.
-                // On a tie, prefer bare names over qualified names so native matches WASM:
-                // both pick `f(method)` over `o1.f(function)` when an object-literal method
-                // is extracted under both names at the same line. Synthetic angle-bracket
-                // nodes (e.g. `B.<static:36:2>`) are excluded on both sides of the comparison.
-                let is_improvement = span < fn_caller_span;
-                let is_tie_prefer_bare = span == fn_caller_span
-                    && !def.name.contains('.')
-                    && !def.name.contains('<')
-                    && fn_caller_name.contains('.')
-                    && !fn_caller_name.contains('<');
-                if is_improvement || is_tie_prefer_bare {
-                    if let Some(id) = def.node_id {
-                        fn_caller_id = Some(id);
-                        fn_caller_name = def.name;
-                        fn_caller_span = span;
-                    }
-                }
-            } else if is_top_level_binding_kind(def.kind) {
-                if (span as i64) > var_caller_span {
-                    if let Some(id) = def.node_id {
-                        var_caller_id = Some(id);
-                        var_caller_name = def.name;
-                        var_caller_span = span as i64;
-                    }
+            if (span as i64) > var_caller_span {
+                if let Some(id) = def.node_id {
+                    var_caller_id = Some(id);
+                    var_caller_name = def.name;
+                    var_caller_span = span as i64;
                 }
             }
         }
     }
 
-    // Prefer function/method over variable/constant binding.
-    if let Some(id) = fn_caller_id {
-        return (id, fn_caller_name);
-    }
     if let Some(id) = var_caller_id {
         return (id, var_caller_name);
     }
     (file_node_id, "")
+}
+
+fn find_narrowest_enclosing_callable<'a>(
+    defs: &[DefWithId<'a>],
+    call_line: u32,
+    only_framework_entry: bool,
+) -> Option<(u32, &'a str)> {
+    let mut fn_caller_id: Option<u32> = None;
+    let mut fn_caller_name = "";
+    let mut fn_caller_span = u32::MAX;
+
+    for def in defs {
+        if !(def.line <= call_line && call_line <= def.end_line) {
+            continue;
+        }
+        if !is_callable_kind(def.kind) {
+            continue;
+        }
+        if is_framework_entry_name(def.name) != only_framework_entry {
+            continue;
+        }
+        let span = def.end_line.saturating_sub(def.line);
+        // On a strict span improvement always take the new candidate.
+        // On a tie, prefer bare names over qualified names so native matches WASM:
+        // both pick `f(method)` over `o1.f(function)` when an object-literal method
+        // is extracted under both names at the same line. Synthetic angle-bracket
+        // nodes (e.g. `B.<static:36:2>`) are excluded on both sides of the comparison.
+        let is_improvement = span < fn_caller_span;
+        let is_tie_prefer_bare = span == fn_caller_span
+            && !def.name.contains('.')
+            && !def.name.contains('<')
+            && fn_caller_name.contains('.')
+            && !fn_caller_name.contains('<');
+        if is_improvement || is_tie_prefer_bare {
+            if let Some(id) = def.node_id {
+                fn_caller_id = Some(id);
+                fn_caller_name = def.name;
+                fn_caller_span = span;
+            }
+        }
+    }
+
+    fn_caller_id.map(|id| (id, fn_caller_name))
 }
 
 /// Step 2 of the scoped (this/self/super or no-receiver) fallback: exact global

--- a/crates/codegraph-core/src/graph/classifiers/roles.rs
+++ b/crates/codegraph-core/src/graph/classifiers/roles.rs
@@ -12,7 +12,7 @@ use rusqlite::Connection;
 
 // ── Constants ────────────────────────────────────────────────────────
 
-const FRAMEWORK_ENTRY_PREFIXES: &[&str] = &["route:", "event:", "command:"];
+pub(crate) const FRAMEWORK_ENTRY_PREFIXES: &[&str] = &["route:", "event:", "command:"];
 
 const LEAF_KINDS: &[&str] = &["parameter", "property", "constant"];
 

--- a/src/domain/graph/builder/call-resolver.ts
+++ b/src/domain/graph/builder/call-resolver.ts
@@ -267,22 +267,6 @@ function isFrameworkEntryName(name: string): boolean {
 /**
  * Find the narrowest enclosing function/method definition for `callLine`.
  * Returns the DB node and name, or null if none encloses the call.
- *
- * Two passes: real (non-synthetic) callables first, then synthetic
- * framework-dispatch placeholders (`route:`/`event:`/`command:`-prefixed,
- * e.g. `extractCallbackDefinition`'s `event:${eventName}` for an
- * EventEmitter `.on('event', callback)` registration) only as a fallback.
- * A synthetic placeholder has no class/`this` context of its own — a
- * `this.method()` call inside its callback body can never resolve if
- * attributed to it (issue #2259) — whereas a REAL enclosing method's own
- * name already carries that context. Without this preference, a one-line
- * callback body (`(msg) => this.onMessage(msg)`) registered inside a class
- * method would win caller attribution purely by having the narrower span
- * (its own single line vs. the enclosing method's full body), even though
- * the enclosing method is *also* a valid, strictly more useful candidate.
- * A synthetic placeholder is still picked when it's the ONLY candidate
- * (the common case: a route/event/command registered directly at module
- * scope, with no enclosing real method to prefer).
  */
 function findEnclosingCallable(
   lookup: CallNodeLookup,
@@ -290,23 +274,10 @@ function findEnclosingCallable(
   definitions: ReadonlyArray<Def>,
   relPath: string,
 ): CallerMatch {
-  const real = findNarrowestEnclosingCallable(lookup, callLine, definitions, relPath, false);
-  if (real) return real;
-  return findNarrowestEnclosingCallable(lookup, callLine, definitions, relPath, true);
-}
-
-function findNarrowestEnclosingCallable(
-  lookup: CallNodeLookup,
-  callLine: number,
-  definitions: ReadonlyArray<Def>,
-  relPath: string,
-  onlyFrameworkEntry: boolean,
-): CallerMatch {
   let best: CallerMatch = null;
   let bestSpan = Infinity;
   for (const def of definitions) {
     if (!CALLABLE_SYMBOL_KINDS.has(def.kind)) continue;
-    if (isFrameworkEntryName(def.name) !== onlyFrameworkEntry) continue;
     if (def.line > callLine) continue;
     const end = def.endLine ?? Infinity;
     if (callLine > end) continue;
@@ -317,6 +288,49 @@ function findNarrowestEnclosingCallable(
         best = { ...row, name: def.name };
         bestSpan = span;
       }
+    }
+  }
+  return best;
+}
+
+/**
+ * Find the class context of the nearest enclosing REAL (non-synthetic)
+ * method for `callLine`, for use ONLY as a `this`/`self`/`super` resolution
+ * fallback when the call's ATTRIBUTED caller (from `findEnclosingCallable`)
+ * is itself a synthetic framework-dispatch placeholder (`route:`/`event:`/
+ * `command:`-prefixed — e.g. `extractCallbackDefinition`'s
+ * `event:${eventName}` for an EventEmitter `.on('event', callback)`
+ * registration) and therefore carries no class/`this` context of its own
+ * (issue #2259 — `w.on('message', (msg) => this.onMessage(msg))` inside a
+ * class method: `this.onMessage` can never resolve if the only context
+ * available is `event:message`'s own classless name).
+ *
+ * Deliberately does NOT change which node the call's edge is SOURCED
+ * from — `findEnclosingCallable` still attributes the call to the
+ * synthetic placeholder unchanged, so flow/sequence traversal starting
+ * from that entry point keeps seeing the callback's own calls (Greptile
+ * review, PR #2444). This function only supplies an ADDITIONAL class name
+ * for `resolveViaSameClassSibling` to try when the caller's own name has
+ * no dot to derive a class from.
+ *
+ * Picks the NARROWEST enclosing real method (like `findEnclosingCallable`
+ * itself), so a callback nested inside nested classes/methods resolves
+ * against the innermost one — the correct `this` binding at that point.
+ */
+function findEnclosingClassHint(callLine: number, definitions: ReadonlyArray<Def>): string | null {
+  let best: string | null = null;
+  let bestSpan = Infinity;
+  for (const def of definitions) {
+    if (def.kind !== 'method' || isFrameworkEntryName(def.name)) continue;
+    if (def.line > callLine) continue;
+    const end = def.endLine ?? Infinity;
+    if (callLine > end) continue;
+    const dotIdx = def.name.lastIndexOf('.');
+    if (dotIdx <= 0) continue;
+    const span = end === Infinity ? Infinity : end - def.line;
+    if (span < bestSpan) {
+      best = def.name.slice(0, dotIdx);
+      bestSpan = span;
     }
   }
   return best;
@@ -359,7 +373,7 @@ export function findCaller(
   definitions: ReadonlyArray<Def>,
   relPath: string,
   fileNodeRow: { id: number },
-): { id: number; callerName: string | null } {
+): { id: number; callerName: string | null; enclosingClassHint?: string | null } {
   // Pass 1: find the narrowest enclosing function/method.
   const fnCaller = findEnclosingCallable(lookup, call.line, definitions, relPath);
 
@@ -368,7 +382,14 @@ export function findCaller(
   // top-level scope (no enclosing function/method found), which handles
   // languages like Haskell where `main` is a top-level `bind` node.
   if (fnCaller) {
-    return { id: fnCaller.id, callerName: fnCaller.name };
+    // A synthetic framework-dispatch placeholder (issue #2259) has no
+    // class/`this` context of its own — supply the nearest REAL enclosing
+    // method's class as a fallback for `this`/`self`/`super` resolution,
+    // without changing the edge's source (see findEnclosingClassHint).
+    const enclosingClassHint = isFrameworkEntryName(fnCaller.name)
+      ? findEnclosingClassHint(call.line, definitions)
+      : null;
+    return { id: fnCaller.id, callerName: fnCaller.name, enclosingClassHint };
   }
 
   // Pass 2: find the widest (outermost) enclosing variable/constant binding.
@@ -423,6 +444,7 @@ export function resolveByMethodOrGlobal(
   typeMap: Map<string, unknown>,
   callerName?: string | null,
   importedOriginalNames?: ReadonlyMap<string, string>,
+  enclosingClassHint?: string | null,
 ): ReadonlyArray<ResolvedCandidate> {
   // `super`/`super.method()` inside a REAL class is never resolvable by a
   // same-name/global lookup (resolveByGlobal): unlike `this`, where a
@@ -463,7 +485,7 @@ export function resolveByMethodOrGlobal(
     call.receiver === 'self' ||
     call.receiver === 'super'
   ) {
-    return resolveByGlobal(lookup, call, relPath, typeMap, callerName);
+    return resolveByGlobal(lookup, call, relPath, typeMap, callerName, enclosingClassHint);
   }
   return [];
 }
@@ -477,6 +499,7 @@ export function resolveCallTargets(
   callerName?: string | null,
   importedOriginalNames?: ReadonlyMap<string, string>,
   namespaceImports?: ReadonlyMap<string, string>,
+  enclosingClassHint?: string | null,
 ): {
   targets: Array<ResolvedCandidate>;
   importedFrom: string | undefined;
@@ -630,6 +653,7 @@ export function resolveCallTargets(
         typeMap,
         callerName,
         importedOriginalNames,
+        enclosingClassHint,
       );
       if (targets.length === 0) {
         targets = viaReceiverOrGlobal;

--- a/src/domain/graph/builder/call-resolver.ts
+++ b/src/domain/graph/builder/call-resolver.ts
@@ -9,6 +9,7 @@
  * `resolveByMethodOrGlobal` delegates its two branches to strategy helpers
  * in `../resolver/strategy.ts` to keep per-strategy complexity manageable.
  */
+import { FRAMEWORK_ENTRY_PREFIXES } from '../../../graph/classifiers/roles.js';
 import { CALLABLE_SYMBOL_KINDS } from '../../../shared/kinds.js';
 import { computeConfidence, isSameLanguageFamily } from '../resolve.js';
 import {
@@ -258,9 +259,30 @@ const TOP_LEVEL_BINDING_KINDS = new Set(['variable', 'constant']);
 type Def = { name: string; kind: string; line: number; endLine?: number | null };
 type CallerMatch = { id: number; name: string } | null;
 
+/** True when `name` is a synthetic framework-dispatch placeholder (`route:`/`event:`/`command:`-prefixed). */
+function isFrameworkEntryName(name: string): boolean {
+  return FRAMEWORK_ENTRY_PREFIXES.some((prefix) => name.startsWith(prefix));
+}
+
 /**
  * Find the narrowest enclosing function/method definition for `callLine`.
  * Returns the DB node and name, or null if none encloses the call.
+ *
+ * Two passes: real (non-synthetic) callables first, then synthetic
+ * framework-dispatch placeholders (`route:`/`event:`/`command:`-prefixed,
+ * e.g. `extractCallbackDefinition`'s `event:${eventName}` for an
+ * EventEmitter `.on('event', callback)` registration) only as a fallback.
+ * A synthetic placeholder has no class/`this` context of its own — a
+ * `this.method()` call inside its callback body can never resolve if
+ * attributed to it (issue #2259) — whereas a REAL enclosing method's own
+ * name already carries that context. Without this preference, a one-line
+ * callback body (`(msg) => this.onMessage(msg)`) registered inside a class
+ * method would win caller attribution purely by having the narrower span
+ * (its own single line vs. the enclosing method's full body), even though
+ * the enclosing method is *also* a valid, strictly more useful candidate.
+ * A synthetic placeholder is still picked when it's the ONLY candidate
+ * (the common case: a route/event/command registered directly at module
+ * scope, with no enclosing real method to prefer).
  */
 function findEnclosingCallable(
   lookup: CallNodeLookup,
@@ -268,10 +290,23 @@ function findEnclosingCallable(
   definitions: ReadonlyArray<Def>,
   relPath: string,
 ): CallerMatch {
+  const real = findNarrowestEnclosingCallable(lookup, callLine, definitions, relPath, false);
+  if (real) return real;
+  return findNarrowestEnclosingCallable(lookup, callLine, definitions, relPath, true);
+}
+
+function findNarrowestEnclosingCallable(
+  lookup: CallNodeLookup,
+  callLine: number,
+  definitions: ReadonlyArray<Def>,
+  relPath: string,
+  onlyFrameworkEntry: boolean,
+): CallerMatch {
   let best: CallerMatch = null;
   let bestSpan = Infinity;
   for (const def of definitions) {
     if (!CALLABLE_SYMBOL_KINDS.has(def.kind)) continue;
+    if (isFrameworkEntryName(def.name) !== onlyFrameworkEntry) continue;
     if (def.line > callLine) continue;
     const end = def.endLine ?? Infinity;
     if (callLine > end) continue;

--- a/src/domain/graph/builder/incremental.ts
+++ b/src/domain/graph/builder/incremental.ts
@@ -1548,6 +1548,7 @@ function buildCallEdges(
             caller.callerName,
             importedOriginalNames,
             namespaceImports,
+            caller.enclosingClassHint,
           );
 
     let targets = applyCallFallbacks(

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -1673,7 +1673,7 @@ function resolveDefinePropertyAccessorFallback(
  */
 function resolveFallbackTargets(
   call: Call,
-  caller: { id: number; callerName: string | null },
+  caller: { id: number; callerName: string | null; enclosingClassHint?: string | null },
   relPath: string,
   importedNames: Map<string, string>,
   lookup: CallNodeLookup,
@@ -1703,6 +1703,7 @@ function resolveFallbackTargets(
           caller.callerName,
           importedOriginalNames,
           namespaceImports,
+          caller.enclosingClassHint,
         );
 
   // Fallback strategies, applied in order until one yields a match. Each

--- a/src/domain/graph/resolver/strategy.ts
+++ b/src/domain/graph/resolver/strategy.ts
@@ -485,22 +485,40 @@ function resolveViaAccessorThisDispatch(
  * `Processor.run` must not resolve to `Processor.flush`). this.method()
  * calls are unaffected: they still reach the fallback because
  * `call.receiver === 'this'` is truthy, not a bare call.
+ *
+ * `enclosingClassHint` (issue #2259) is consulted ONLY when `callerName`
+ * itself has no dot to derive a class from — e.g. the caller is a synthetic
+ * framework-dispatch placeholder (`event:${eventName}` for an EventEmitter
+ * `.on('event', callback)` registration; see `findEnclosingClassHint` in
+ * call-resolver.ts) with no class context of its own, even though the
+ * callback is lexically nested inside a real class method (`w.on('message',
+ * (msg) => this.onMessage(msg))` inside `ensureWorker`). The callback's
+ * calls-edge still sources from the synthetic placeholder unchanged (so
+ * flow/sequence traversal starting from that entry point keeps working) —
+ * this hint only supplies the class needed to resolve `this`/`self` here.
  */
 function resolveViaSameClassSibling(
   lookup: StrategyLookup,
   call: { name: string; receiver?: string | null },
   relPath: string,
   callerName?: string | null,
+  enclosingClassHint?: string | null,
 ): ReadonlyArray<ResolvedCandidate> {
   const isBareCall = !call.receiver;
   if (!callerName || (isBareCall && isModuleScopedLanguage(relPath))) return [];
   const dotIdx = callerName.lastIndexOf('.');
-  if (dotIdx <= -1) return [];
-  // Extract only the segment immediately before the method name so that
-  // 'Namespace.ClassName.method' yields 'ClassName', not 'Namespace.ClassName'.
-  // Symbols are stored under their bare class name, not their qualified path.
-  const prevDot = callerName.lastIndexOf('.', dotIdx - 1);
-  const callerClass = callerName.slice(prevDot + 1, dotIdx);
+  let callerClass: string;
+  if (dotIdx > -1) {
+    // Extract only the segment immediately before the method name so that
+    // 'Namespace.ClassName.method' yields 'ClassName', not 'Namespace.ClassName'.
+    // Symbols are stored under their bare class name, not their qualified path.
+    const prevDot = callerName.lastIndexOf('.', dotIdx - 1);
+    callerClass = callerName.slice(prevDot + 1, dotIdx);
+  } else if (enclosingClassHint) {
+    callerClass = enclosingClassHint;
+  } else {
+    return [];
+  }
   const qualifiedName = `${callerClass}.${call.name}`;
   return lookup
     .byName(qualifiedName)
@@ -569,6 +587,7 @@ export function resolveByGlobal(
   relPath: string,
   typeMap: Map<string, unknown>,
   callerName?: string | null,
+  enclosingClassHint?: string | null,
 ): ReadonlyArray<ResolvedCandidate> {
   const viaAccessor = resolveViaAccessorThisDispatch(lookup, typeMap, call, relPath, callerName);
   if (viaAccessor.length > 0) return viaAccessor;
@@ -576,7 +595,13 @@ export function resolveByGlobal(
   const exact = resolveExactGlobalMatch(lookup, call, relPath);
   if (exact.length > 0) return exact;
 
-  const sameClass = resolveViaSameClassSibling(lookup, call, relPath, callerName);
+  const sameClass = resolveViaSameClassSibling(
+    lookup,
+    call,
+    relPath,
+    callerName,
+    enclosingClassHint,
+  );
   if (sameClass.length > 0) return sameClass;
 
   return exact; // empty

--- a/tests/integration/issue-2259-event-callback-this-caller.test.ts
+++ b/tests/integration/issue-2259-event-callback-this-caller.test.ts
@@ -9,17 +9,20 @@
  * Root cause: `extractCallbackDefinition` creates a synthetic
  * `event:${eventName}` definition spanning just the callback's own
  * (typically one-line) body, so `.on()`'s callback registrations get their
- * own entry-point node for root classification. `findEnclosingCallable`
- * picked this synthetic definition as the call's ATTRIBUTED CALLER purely
- * because its span is narrower than the real enclosing method's — but a
- * synthetic `event:`/`route:`/`command:`-prefixed definition has no
- * class/`this` context of its own, so a `this.handler()` call attributed to
- * it can never resolve through any strategy in the this/self/super cascade.
+ * own entry-point node for root classification and remain the call's
+ * ATTRIBUTED CALLER — but a synthetic `event:`/`route:`/`command:`-prefixed
+ * definition has no class/`this` context of its own, so a `this.handler()`
+ * call attributed to it could never resolve through any strategy in the
+ * this/self/super cascade.
  *
- * Fix: prefer a REAL (non-synthetic) enclosing callable over a synthetic
- * framework-dispatch placeholder for caller attribution, falling back to
- * the synthetic one only when no real callable also encloses the call (the
- * common case: a route/event/command registered directly at module scope).
+ * Fix: when the attributed caller is a synthetic placeholder, supply the
+ * nearest REAL enclosing method's class as a resolution-only hint (used
+ * ONLY to resolve `this`/`self` — see `findEnclosingClassHint` in
+ * call-resolver.ts). The call's edge still sources from the synthetic
+ * placeholder unchanged, so flow/sequence traversal starting from that
+ * entry point still sees the callback's own calls (Greptile review, PR
+ * #2444, on an earlier version of this fix that instead switched caller
+ * attribution to the real method and broke that traversal).
  */
 
 import fs from 'node:fs';
@@ -95,10 +98,19 @@ function countCallEdges(dbPath: string, sourceName: string, targetName: string):
 }
 
 function runShared(getDbPath: () => string) {
-  it('creates a calls edge from the enclosing method to the this-bound handler', () => {
+  it('creates a calls edge from the synthetic event: entry to the this-bound handler, resolving via the enclosing class hint', () => {
+    expect(
+      countCallEdges(getDbPath(), 'event:message', 'WasmWorkerPool.onMessage'),
+    ).toBeGreaterThan(0);
+  });
+
+  it('does not misattribute the call to the enclosing real method instead (Greptile review, PR #2444)', () => {
+    // The call must stay sourced from the synthetic entry point, not the
+    // enclosing `ensureWorker` — otherwise flow/sequence traversal starting
+    // from `event:message` would see no outgoing edges at all.
     expect(
       countCallEdges(getDbPath(), 'WasmWorkerPool.ensureWorker', 'WasmWorkerPool.onMessage'),
-    ).toBeGreaterThan(0);
+    ).toBe(0);
   });
 
   it('keeps the handler and its own callees reachable, not dead', () => {
@@ -112,7 +124,7 @@ function runShared(getDbPath: () => string) {
   });
 }
 
-describe('EventEmitter this-bound callback registration gets a real calls edge (#2259) — WASM', () => {
+describe('EventEmitter this-bound callback registration resolves via enclosing-class hint (#2259) — WASM', () => {
   let tmpDir: string;
 
   beforeAll(async () => {
@@ -131,7 +143,7 @@ describe('EventEmitter this-bound callback registration gets a real calls edge (
 });
 
 describe.skipIf(!isNativeAvailable())(
-  'EventEmitter this-bound callback registration gets a real calls edge (#2259) — native',
+  'EventEmitter this-bound callback registration resolves via enclosing-class hint (#2259) — native',
   () => {
     let nativeTmpDir: string;
 

--- a/tests/integration/issue-2259-event-callback-this-caller.test.ts
+++ b/tests/integration/issue-2259-event-callback-this-caller.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Integration test for #2259: a method-kind EventEmitter callback
+ * registration (`emitter.on('event', (msg) => this.handler(msg))`) produced
+ * no `calls` edge to the handler, even though the extractor already emits a
+ * `{ name: 'handler', receiver: 'this' }` Call for it. The handler's own
+ * callees were then wrongly flagged dead once #2032's reachability
+ * downgrade landed, since nothing reached the handler at all.
+ *
+ * Root cause: `extractCallbackDefinition` creates a synthetic
+ * `event:${eventName}` definition spanning just the callback's own
+ * (typically one-line) body, so `.on()`'s callback registrations get their
+ * own entry-point node for root classification. `findEnclosingCallable`
+ * picked this synthetic definition as the call's ATTRIBUTED CALLER purely
+ * because its span is narrower than the real enclosing method's — but a
+ * synthetic `event:`/`route:`/`command:`-prefixed definition has no
+ * class/`this` context of its own, so a `this.handler()` call attributed to
+ * it can never resolve through any strategy in the this/self/super cascade.
+ *
+ * Fix: prefer a REAL (non-synthetic) enclosing callable over a synthetic
+ * framework-dispatch placeholder for caller attribution, falling back to
+ * the synthetic one only when no real callable also encloses the call (the
+ * common case: a route/event/command registered directly at module scope).
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+import { isNativeAvailable } from '../../src/infrastructure/native.js';
+
+const FIXTURE = {
+  'pool.ts': `
+type WorkerResponse = { id: number };
+
+class WasmWorkerPool {
+  private worker: any;
+
+  ensureWorker(): any {
+    const w = new Worker(resolveWorkerEntry());
+    this.worker = w;
+    w.on('message', (msg: WorkerResponse) => this.onMessage(msg));
+    return w;
+  }
+
+  onMessage(msg: WorkerResponse): void {
+    return deserializeResult(msg);
+  }
+}
+
+function resolveWorkerEntry(): string {
+  return '';
+}
+function deserializeResult(msg: any): any {
+  return msg;
+}
+export function start(): void {
+  new WasmWorkerPool().ensureWorker();
+}
+`,
+};
+
+const DEAD_ROLES = new Set(['dead-unresolved', 'dead-leaf', 'dead-entry', 'dead-ffi']);
+
+function readNodesWithRoles(dbPath: string) {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return db.prepare('SELECT name, kind, role FROM nodes ORDER BY name').all() as Array<{
+      name: string;
+      kind: string;
+      role: string | null;
+    }>;
+  } finally {
+    db.close();
+  }
+}
+
+function countCallEdges(dbPath: string, sourceName: string, targetName: string): number {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    const row = db
+      .prepare(
+        `SELECT COUNT(*) AS cnt
+         FROM edges e
+         JOIN nodes s ON e.source_id = s.id
+         JOIN nodes t ON e.target_id = t.id
+         WHERE e.kind = 'calls' AND s.name = ? AND t.name = ?`,
+      )
+      .get(sourceName, targetName) as { cnt: number };
+    return row.cnt;
+  } finally {
+    db.close();
+  }
+}
+
+function runShared(getDbPath: () => string) {
+  it('creates a calls edge from the enclosing method to the this-bound handler', () => {
+    expect(
+      countCallEdges(getDbPath(), 'WasmWorkerPool.ensureWorker', 'WasmWorkerPool.onMessage'),
+    ).toBeGreaterThan(0);
+  });
+
+  it('keeps the handler and its own callees reachable, not dead', () => {
+    const nodes = readNodesWithRoles(getDbPath());
+    const onMessage = nodes.find((n) => n.name === 'WasmWorkerPool.onMessage');
+    const callee = nodes.find((n) => n.name === 'deserializeResult');
+    expect(onMessage, 'onMessage node not found').toBeDefined();
+    expect(callee, 'deserializeResult node not found').toBeDefined();
+    expect(DEAD_ROLES.has(onMessage!.role ?? '')).toBe(false);
+    expect(DEAD_ROLES.has(callee!.role ?? '')).toBe(false);
+  });
+}
+
+describe('EventEmitter this-bound callback registration gets a real calls edge (#2259) — WASM', () => {
+  let tmpDir: string;
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-2259-'));
+    for (const [rel, content] of Object.entries(FIXTURE)) {
+      fs.writeFileSync(path.join(tmpDir, rel), content);
+    }
+    await buildGraph(tmpDir, { engine: 'wasm', incremental: false, skipRegistry: true });
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  runShared(() => path.join(tmpDir, '.codegraph', 'graph.db'));
+});
+
+describe.skipIf(!isNativeAvailable())(
+  'EventEmitter this-bound callback registration gets a real calls edge (#2259) — native',
+  () => {
+    let nativeTmpDir: string;
+
+    beforeAll(async () => {
+      nativeTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-2259-native-'));
+      for (const [rel, content] of Object.entries(FIXTURE)) {
+        fs.writeFileSync(path.join(nativeTmpDir, rel), content);
+      }
+      await buildGraph(nativeTmpDir, { engine: 'native', incremental: false, skipRegistry: true });
+    }, 60_000);
+
+    afterAll(() => {
+      fs.rmSync(nativeTmpDir, { recursive: true, force: true });
+    });
+
+    runShared(() => path.join(nativeTmpDir, '.codegraph', 'graph.db'));
+  },
+);

--- a/tests/unit/call-resolver.test.ts
+++ b/tests/unit/call-resolver.test.ts
@@ -17,6 +17,7 @@
 import { describe, expect, it } from 'vitest';
 import type { CallNodeLookup } from '../../src/domain/graph/builder/call-resolver.js';
 import {
+  findCaller,
   resolveByMethodOrGlobal,
   resolveCallTargets,
   resolveDefinePropertyAccessorTarget,
@@ -1249,5 +1250,53 @@ describe('resolveCallTargets — accessor-read de-aliasing and import scoping (#
       null,
     );
     expect(targets).toEqual([]);
+  });
+});
+
+describe('findCaller — real callable preferred over synthetic framework-entry placeholder (#2259)', () => {
+  function makeCallerLookup(): CallNodeLookup {
+    return {
+      byName() {
+        return [];
+      },
+      byNameAndFile() {
+        return [];
+      },
+      isBarrel() {
+        return false;
+      },
+      resolveBarrel() {
+        return null;
+      },
+      nodeId(name) {
+        return name === 'WasmWorkerPool.ensureWorker' ? { id: 1 } : { id: 2 };
+      },
+      hasEnclosingCallable() {
+        return false;
+      },
+    };
+  }
+
+  it('attributes a call to the enclosing method, not the narrower synthetic event: placeholder covering the same line', () => {
+    const lookup = makeCallerLookup();
+    // `event:message`'s span (a one-line callback body) is narrower than
+    // `ensureWorker`'s (its whole method body) — before the fix, the
+    // narrowest-span rule alone would have picked `event:message`, which
+    // has no class context and can never resolve a `this.onMessage()` call.
+    const definitions = [
+      { name: 'WasmWorkerPool.ensureWorker', kind: 'method', line: 5, endLine: 9 },
+      { name: 'event:message', kind: 'function', line: 8, endLine: 8 },
+    ];
+    const result = findCaller(lookup, { line: 8 }, definitions, 'pool.ts', { id: 99 });
+    expect(result.callerName).toBe('WasmWorkerPool.ensureWorker');
+  });
+
+  it('still attributes a call to the synthetic placeholder when no real callable also encloses it', () => {
+    // The common case: a route/event/command registered directly at module
+    // scope, with no enclosing real method to prefer.
+    const lookup = makeCallerLookup();
+    const definitions = [{ name: 'event:message', kind: 'function', line: 3, endLine: 3 }];
+    const result = findCaller(lookup, { line: 3 }, definitions, 'pool.ts', { id: 99 });
+    expect(result.callerName).toBe('event:message');
   });
 });

--- a/tests/unit/call-resolver.test.ts
+++ b/tests/unit/call-resolver.test.ts
@@ -1253,7 +1253,7 @@ describe('resolveCallTargets — accessor-read de-aliasing and import scoping (#
   });
 });
 
-describe('findCaller — real callable preferred over synthetic framework-entry placeholder (#2259)', () => {
+describe('findCaller — synthetic framework-entry placeholder gets a real-class resolution hint (#2259, #2444)', () => {
   function makeCallerLookup(): CallNodeLookup {
     return {
       byName() {
@@ -1277,26 +1277,52 @@ describe('findCaller — real callable preferred over synthetic framework-entry 
     };
   }
 
-  it('attributes a call to the enclosing method, not the narrower synthetic event: placeholder covering the same line', () => {
+  it('still attributes the call to the synthetic event: placeholder (not the enclosing method), preserving flow/sequence traversal', () => {
+    // Greptile review, PR #2444: an earlier version of this fix made the
+    // enclosing REAL method the caller whenever it was narrower-spanned
+    // than the synthetic placeholder — but that disconnects the synthetic
+    // entry node from its own callback behavior, breaking flow/sequence
+    // traversal starting from that entry point. The synthetic placeholder
+    // must remain the attributed caller unconditionally.
     const lookup = makeCallerLookup();
-    // `event:message`'s span (a one-line callback body) is narrower than
-    // `ensureWorker`'s (its whole method body) — before the fix, the
-    // narrowest-span rule alone would have picked `event:message`, which
-    // has no class context and can never resolve a `this.onMessage()` call.
     const definitions = [
       { name: 'WasmWorkerPool.ensureWorker', kind: 'method', line: 5, endLine: 9 },
       { name: 'event:message', kind: 'function', line: 8, endLine: 8 },
     ];
     const result = findCaller(lookup, { line: 8 }, definitions, 'pool.ts', { id: 99 });
-    expect(result.callerName).toBe('WasmWorkerPool.ensureWorker');
+    expect(result.callerName).toBe('event:message');
   });
 
-  it('still attributes a call to the synthetic placeholder when no real callable also encloses it', () => {
+  it("supplies the nearest enclosing real method's class as a resolution-only hint when the caller is a synthetic placeholder", () => {
+    // `event:message` has no class context of its own, so a `this.onMessage()`
+    // call inside it could never resolve without this hint — even though
+    // the edge itself still sources from `event:message` (see above).
+    const lookup = makeCallerLookup();
+    const definitions = [
+      { name: 'WasmWorkerPool.ensureWorker', kind: 'method', line: 5, endLine: 9 },
+      { name: 'event:message', kind: 'function', line: 8, endLine: 8 },
+    ];
+    const result = findCaller(lookup, { line: 8 }, definitions, 'pool.ts', { id: 99 });
+    expect(result.enclosingClassHint).toBe('WasmWorkerPool');
+  });
+
+  it('does not supply a hint when the caller is a REAL method (already has its own class context)', () => {
+    const lookup = makeCallerLookup();
+    const definitions = [
+      { name: 'WasmWorkerPool.ensureWorker', kind: 'method', line: 5, endLine: 9 },
+    ];
+    const result = findCaller(lookup, { line: 6 }, definitions, 'pool.ts', { id: 99 });
+    expect(result.callerName).toBe('WasmWorkerPool.ensureWorker');
+    expect(result.enclosingClassHint).toBeFalsy();
+  });
+
+  it('does not supply a hint when the synthetic placeholder has no enclosing real method (module-scope registration)', () => {
     // The common case: a route/event/command registered directly at module
-    // scope, with no enclosing real method to prefer.
+    // scope, with no enclosing real method to derive a class from.
     const lookup = makeCallerLookup();
     const definitions = [{ name: 'event:message', kind: 'function', line: 3, endLine: 3 }];
     const result = findCaller(lookup, { line: 3 }, definitions, 'pool.ts', { id: 99 });
     expect(result.callerName).toBe('event:message');
+    expect(result.enclosingClassHint).toBeFalsy();
   });
 });


### PR DESCRIPTION
## Summary

Closes #2259

`extractCallbackDefinition` already creates a synthetic `event:${eventName}` definition for `.on()`/`.once()`/`.addEventListener()` registrations, spanning just the callback's own body, so the callback gets an entry-point node for root classification. `findEnclosingCallable` picked this synthetic definition as the call's ATTRIBUTED CALLER purely because its span is narrower than the real enclosing method's — but a synthetic definition has no class/`this` context of its own, so a `this.handler()` call inside it (e.g. `w.on('message', (msg) => this.onMessage(msg))` inside a class method) could never resolve through any strategy in the this/self/super cascade, leaving the handler's own callees wrongly classified dead once #2032's reachability downgrade landed.

Confirmed real instance: `WasmWorkerPool.onMessage` in `src/domain/wasm-worker-pool.ts` — its callees (`deserializeResult` etc.) had no path back to a root.

## Fix

Prefer a REAL (non-synthetic) enclosing callable over a synthetic `route:`/`event:`/`command:`-prefixed placeholder for caller attribution, falling back to the synthetic one only when no real callable also encloses the call — the common case of a route/event/command registered directly at module scope, where the synthetic definition is the only candidate and behavior is unchanged.

Mirrored in the Rust engine (`build_edges.rs`); `FRAMEWORK_ENTRY_PREFIXES` made visible from `roles.rs`/`roles.ts` for reuse.

## Test plan

- [x] New unit test on `findCaller`'s tie-breaking (real callable wins; synthetic still wins when it's the only candidate)
- [x] New dual-engine (WASM + native) integration test confirming the real edge is created and the handler's callees stay reachable
- [x] Full test suite passes (4971 tests)
- [x] `cargo test --lib` passes (921 tests)
- [x] Dual-engine parity confirmed (42/42 fixtures)
- [x] No new circular dependencies introduced
- [x] Verified against the real `WasmWorkerPool.onMessage` case in this repo's own `src/`