### PR TITLE
fix(resolver): computed dispatch-table access gets invocation evidence

### DIFF
--- a/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
@@ -2243,6 +2243,7 @@ fn build_and_insert_call_edges(
             array_callback_bindings: non_empty(&symbols.array_callback_bindings),
             object_rest_param_bindings: non_empty(&symbols.object_rest_param_bindings),
             object_prop_bindings: non_empty(&symbols.object_prop_bindings),
+            computed_dispatch_table_evidence: non_empty(&symbols.computed_dispatch_table_evidence),
         });
     }
 

--- a/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
@@ -150,6 +150,12 @@ pub struct FileEdgeInput {
     /// Phase 8.3f: object-property bindings.
     #[napi(js_name = "objectPropBindings")]
     pub object_prop_bindings: Option<Vec<ObjectPropBinding>>,
+    /// Table names (issue #2260) with confirmed LOCAL computed-invocation
+    /// evidence: `const handler = TABLE[computedExpr]; ...; handler(...)`.
+    /// Mirrors `ExtractorOutput.computedDispatchTableEvidence` in
+    /// `src/types.ts` — see its doc comment for the full rationale.
+    #[napi(js_name = "computedDispatchTableEvidence")]
+    pub computed_dispatch_table_evidence: Option<Vec<String>>,
 }
 
 #[napi(object)]
@@ -194,6 +200,14 @@ struct EdgeContext<'a> {
     /// liveness rationale. Owned (not borrowed) since the extra evidence
     /// comes from outside `files`' own lifetime.
     invoked_property_names: HashSet<String>,
+    /// Table names (issue #2260) with confirmed LOCAL computed-invocation
+    /// evidence across every file in this build pass — the alternate
+    /// liveness pathway for a computed/bracket-access dispatch table
+    /// (`const handler = TABLE[computedExpr]; ...; handler(...)`), where a
+    /// computed key can't name a specific property statically the way
+    /// `TABLE.key(...)` can, so evidence is credited to the whole table
+    /// rather than per-key. See `collect_computed_dispatch_table_evidence`.
+    computed_dispatch_table_evidence: HashSet<String>,
     /// CHA + RTA typed-dispatch context (#1949): interface/class name →
     /// concrete classes that implement or extend it, built once per build
     /// pass from every file's `classes` (`extends`/`implements`). Used by
@@ -261,6 +275,7 @@ impl<'a> EdgeContext<'a> {
                 files,
                 extra_invoked_property_names,
             ),
+            computed_dispatch_table_evidence: collect_computed_dispatch_table_evidence(files),
             cha_implementors: cha.implementors,
             cha_implementors_by_file: cha.implementors_by_file,
             cha_parents: cha.parents,
@@ -632,17 +647,50 @@ fn emit_cha_dispatch_edges(
 /// statistic even on the incremental path, for classification-threshold
 /// consistency). Mirrors `collectInvokedPropertyNames` in
 /// `src/domain/graph/builder/call-resolver.ts`.
+///
+/// Excludes `dynamic_kind: "value-ref"` calls (issue #2260): those carry a
+/// `receiver` of their own now (the dispatch-table's name, set by
+/// `handle_object_literal_pair_value_ref` — used for the computed-access
+/// liveness pathway, see `computed_dispatch_table_evidence`), but a
+/// value-ref call is itself a bare VALUE reference, never a real
+/// invocation — crediting its `name` (the referenced function's own
+/// identifier) here would pollute this set with a name that was never
+/// actually invoked via member-call syntax.
 fn collect_invoked_property_names(files: &[FileEdgeInput], extra: &[String]) -> HashSet<String> {
     let mut names = HashSet::new();
     for file in files {
         for call in &file.calls {
-            if call.receiver.is_some() {
+            if call.receiver.is_some() && call.dynamic_kind.as_deref() != Some("value-ref") {
                 names.insert(call.name.clone());
             }
         }
     }
     for name in extra {
         names.insert(name.clone());
+    }
+    names
+}
+
+/// Aggregate table names (issue #2260) with confirmed LOCAL computed-
+/// invocation evidence across every file in this build pass — mirrors
+/// `computedDispatchTableEvidence`'s aggregation in
+/// `src/domain/graph/builder/stages/build-edges.ts`. Each file's own list
+/// is populated by `handle_computed_dispatch_table_evidence` in
+/// `extractors/javascript.rs` (native-parsed) or by
+/// `collectComputedDispatchTableEvidence` in `extractors/javascript.ts`
+/// (WASM-parsed, threaded through `FileEdgeInput` via NAPI). No persisted-
+/// table union (unlike `collect_invoked_property_names`'s `extra` param) —
+/// the table+consumer for this idiom are typically same-file, so this
+/// narrower, in-memory-only scope is accepted for now; a cross-file case
+/// missed on a scoped incremental build recovers on the next full build.
+fn collect_computed_dispatch_table_evidence(files: &[FileEdgeInput]) -> HashSet<String> {
+    let mut names = HashSet::new();
+    for file in files {
+        if let Some(evidence) = &file.computed_dispatch_table_evidence {
+            for name in evidence {
+                names.insert(name.clone());
+            }
+        }
     }
     names
 }
@@ -1406,8 +1454,20 @@ fn process_file<'a>(
             // actually invoked somewhere (`x.key_expr(...)`) — merely being
             // wired into an object literal is not liveness. instanceof/Lua
             // value-refs never set key_expr, so they are unaffected.
+            //
+            // #2260: OR, the property's own dispatch table (`call.receiver`
+            // — the table's variable name, set by
+            // handle_object_literal_pair_value_ref) has confirmed COMPUTED-
+            // access invocation evidence (`const handler =
+            // TABLE[computedExpr]; ...; handler(...)`) — a computed key
+            // can't name this specific property statically, so that
+            // evidence is credited to the whole table rather than per-key.
             if let Some(key_expr) = call.key_expr.as_deref() {
-                if !ctx.invoked_property_names.contains(key_expr) {
+                let has_computed_evidence = call
+                    .receiver
+                    .as_deref()
+                    .is_some_and(|r| ctx.computed_dispatch_table_evidence.contains(r));
+                if !ctx.invoked_property_names.contains(key_expr) && !has_computed_evidence {
                     targets.clear();
                 }
             }
@@ -4507,6 +4567,7 @@ mod call_edge_tests {
             array_callback_bindings: None,
             object_rest_param_bindings: None,
             object_prop_bindings: None,
+            computed_dispatch_table_evidence: None,
         }
     }
 

--- a/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
@@ -672,6 +672,20 @@ fn collect_invoked_property_names(files: &[FileEdgeInput], extra: &[String]) -> 
 }
 
 /// Aggregate table names (issue #2260) with confirmed LOCAL computed-
+/// Scope key for #2260's computed-dispatch-table evidence set:
+/// `${file}::${tableName}`. A bare table name would let two unrelated files
+/// that each declare a same-named table (e.g. `HANDLERS`) share liveness —
+/// one file's confirmed computed-invocation evidence would wrongly credit
+/// the other file's same-named-but-unrelated table (Greptile review, PR
+/// #2445) — so every lookup/insert into that set must go through this key,
+/// mirroring this same struct's `cha_implementors_by_file`/
+/// `cha_parents_by_file` cross-file disambiguation convention (#2237) and
+/// the TypeScript-side `computedDispatchTableEvidenceKey` in
+/// `stages/build-edges.ts`.
+fn computed_dispatch_table_evidence_key(file: &str, table_name: &str) -> String {
+    format!("{file}::{table_name}")
+}
+
 /// invocation evidence across every file in this build pass — mirrors
 /// `computedDispatchTableEvidence`'s aggregation in
 /// `src/domain/graph/builder/stages/build-edges.ts`. Each file's own list
@@ -688,7 +702,7 @@ fn collect_computed_dispatch_table_evidence(files: &[FileEdgeInput]) -> HashSet<
     for file in files {
         if let Some(evidence) = &file.computed_dispatch_table_evidence {
             for name in evidence {
-                names.insert(name.clone());
+                names.insert(computed_dispatch_table_evidence_key(&file.file, name));
             }
         }
     }
@@ -1463,10 +1477,10 @@ fn process_file<'a>(
             // can't name this specific property statically, so that
             // evidence is credited to the whole table rather than per-key.
             if let Some(key_expr) = call.key_expr.as_deref() {
-                let has_computed_evidence = call
-                    .receiver
-                    .as_deref()
-                    .is_some_and(|r| ctx.computed_dispatch_table_evidence.contains(r));
+                let has_computed_evidence = call.receiver.as_deref().is_some_and(|r| {
+                    ctx.computed_dispatch_table_evidence
+                        .contains(&computed_dispatch_table_evidence_key(fc.rel_path, r))
+                });
                 if !ctx.invoked_property_names.contains(key_expr) && !has_computed_evidence {
                     targets.clear();
                 }

--- a/crates/codegraph-core/src/domain/graph/builder/stages/import_edges.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/import_edges.rs
@@ -295,6 +295,16 @@ pub fn persist_reexport_renames(
 /// has a durable, whole-graph view to query instead of only the file it is
 /// currently rebuilding — see #2087 for the false-negative this closes.
 ///
+/// Excludes `dynamic_kind: "value-ref"` calls (issue #2260), mirroring
+/// `collect_invoked_property_names`'s own exclusion in `build_edges.rs` — a
+/// value-ref call's `receiver` names its own dispatch table, not a genuine
+/// member-call-syntax invocation, so counting it here would let a
+/// value-ref's own persisted evidence satisfy its own liveness gate on a
+/// later build pass. This function has its own inline scan (rather than
+/// calling `collect_invoked_property_names`) because it iterates one file's
+/// calls at a time for per-file delete+reinsert, so the exclusion is
+/// duplicated here rather than shared — keep both in sync.
+///
 /// Deletes and re-inserts per file so a file whose invoked names changed (or
 /// were removed entirely) never leaves stale rows behind for it.
 pub fn persist_invoked_property_names(
@@ -320,7 +330,10 @@ pub fn persist_invoked_property_names(
                 .map_err(|e| e.to_string())?;
             let mut seen: HashSet<&str> = HashSet::new();
             for call in &file.calls {
-                if call.receiver.is_some() && seen.insert(call.name.as_str()) {
+                if call.receiver.is_some()
+                    && call.dynamic_kind.as_deref() != Some("value-ref")
+                    && seen.insert(call.name.as_str())
+                {
                     insert_stmt
                         .execute(rusqlite::params![file.file, call.name])
                         .map_err(|e| e.to_string())?;
@@ -975,6 +988,7 @@ mod tests {
             array_callback_bindings: vec![],
             object_rest_param_bindings: vec![],
             object_prop_bindings: vec![],
+            computed_dispatch_table_evidence: vec![],
         }
     }
 

--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -2497,6 +2497,13 @@ fn handle_var_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
         // #2257: logical-or/nullish-coalescing/ternary default assigned to a
         // named variable, e.g. `const fetchFn = options._fetchLatest || fetchLatestVersion`.
         handle_logical_or_ternary_value_ref(&declarator, source, &mut symbols.calls);
+        // #2260: computed dispatch-table access assigned to a named variable,
+        // e.g. `const handler = TABLE[node.type]; ...; handler(...)`.
+        handle_computed_dispatch_table_evidence(
+            &declarator,
+            source,
+            &mut symbols.computed_dispatch_table_evidence,
+        );
 
         let name_n = declarator.child_by_field_name("name");
         let value_n = declarator.child_by_field_name("value");
@@ -4138,7 +4145,52 @@ fn extract_callback_reference_calls(
 /// the key, since that's the name a dispatch consumer would actually call
 /// (`table.resolve(...)`), not the function's own declared name.
 ///
+/// Node kinds `find_enclosing_table_name` passes through on its way up to a
+/// `variable_declarator`. Mirrors `TABLE_NAME_PASSTHROUGH_TYPES` in
+/// `src/extractors/javascript.ts`.
+const TABLE_NAME_PASSTHROUGH_KINDS: &[&str] = &[
+    "object",
+    "parenthesized_expression",
+    "as_expression",
+    "satisfies_expression",
+    "non_null_expression",
+];
+
+/// Walk up from a dispatch-table object-literal's `pair`/shorthand-property
+/// node to find the name of the variable it's assigned to (e.g.
+/// `GROOVY_NODE_HANDLERS` for `const GROOVY_NODE_HANDLERS = { ... }`) — used
+/// to key the computed-access liveness pathway (issue #2260) on the TABLE's
+/// own name, set as the value-ref Call's `receiver`. Bounded to a small
+/// number of hops through common TS wrapper shapes so a deeply-nested or
+/// non-declarator-assigned object literal simply yields no table name.
+/// Mirrors `findEnclosingTableName` in `src/extractors/javascript.ts`.
+fn find_enclosing_table_name(node: &Node, source: &[u8]) -> Option<String> {
+    let mut current = node.parent();
+    let mut hops = 0;
+    while let Some(cur) = current {
+        if hops >= 6 {
+            return None;
+        }
+        if cur.kind() == "variable_declarator" {
+            let name_n = cur.child_by_field_name("name")?;
+            return if name_n.kind() == "identifier" {
+                Some(node_text(&name_n, source).to_string())
+            } else {
+                None
+            };
+        }
+        if !TABLE_NAME_PASSTHROUGH_KINDS.contains(&cur.kind()) {
+            return None;
+        }
+        current = cur.parent();
+        hops += 1;
+    }
+    None
+}
+
 /// Mirrors `collectObjectLiteralValueRefCall` in `src/extractors/javascript.ts`.
+/// `receiver` (issue #2260) carries the TABLE's own variable name, when
+/// resolvable — see `find_enclosing_table_name`.
 fn handle_object_literal_pair_value_ref(node: &Node, source: &[u8], calls: &mut Vec<Call>) {
     let Some(value_n) = node.child_by_field_name("value") else {
         return;
@@ -4159,6 +4211,7 @@ fn handle_object_literal_pair_value_ref(node: &Node, source: &[u8], calls: &mut 
         dynamic: Some(true),
         dynamic_kind: Some("value-ref".to_string()),
         key_expr,
+        receiver: find_enclosing_table_name(node, source),
         ..Default::default()
     });
 }
@@ -4186,6 +4239,7 @@ fn handle_object_literal_shorthand_value_ref(node: &Node, source: &[u8], calls: 
         dynamic: Some(true),
         dynamic_kind: Some("value-ref".to_string()),
         key_expr: Some(text.to_string()),
+        receiver: find_enclosing_table_name(node, source),
         ..Default::default()
     });
 }
@@ -4580,6 +4634,7 @@ fn scan_pattern_defaults_for_reference(
     exclude_id: usize,
     source: &[u8],
     depth: usize,
+    require_call_site: bool,
 ) -> bool {
     if depth >= MAX_WALK_DEPTH {
         return false;
@@ -4588,9 +4643,14 @@ fn scan_pattern_defaults_for_reference(
         "identifier" => false,
         "assignment_pattern" | "object_assignment_pattern" => {
             match pattern_node.child_by_field_name("right") {
-                Some(right) => {
-                    block_contains_identifier_excluding(&right, name, exclude_id, source, depth + 1)
-                }
+                Some(right) => block_contains_identifier_excluding(
+                    &right,
+                    name,
+                    exclude_id,
+                    source,
+                    depth + 1,
+                    require_call_site,
+                ),
                 None => false,
             }
         }
@@ -4604,6 +4664,7 @@ fn scan_pattern_defaults_for_reference(
                             exclude_id,
                             source,
                             depth + 1,
+                            require_call_site,
                         )
                     {
                         return true;
@@ -4626,6 +4687,7 @@ fn scan_pattern_defaults_for_reference(
                                 exclude_id,
                                 source,
                                 depth + 1,
+                                require_call_site,
                             ) {
                                 return true;
                             }
@@ -4638,6 +4700,7 @@ fn scan_pattern_defaults_for_reference(
                             exclude_id,
                             source,
                             depth + 1,
+                            require_call_site,
                         ) {
                             return true;
                         }
@@ -4656,6 +4719,7 @@ fn scan_pattern_defaults_for_reference(
                         exclude_id,
                         source,
                         depth + 1,
+                        require_call_site,
                     ) {
                         return true;
                     }
@@ -4702,6 +4766,23 @@ fn scan_pattern_defaults_for_reference(
 /// writing, so it's deliberately left to the generic scan below (its
 /// `left` is scanned like any other reference).
 ///
+/// True when `node` is the `function` field of its parent `call_expression`
+/// — i.e. `node` names the callee being CALLED, not merely referenced.
+/// Used by `block_contains_identifier_excluding`'s `require_call_site` mode
+/// (issue #2260) to require call-shape evidence specifically, matching
+/// #1895's own "invoked... via member-call syntax" precision (a bare
+/// reference — e.g. `console.log(handler)` — is not invocation evidence).
+/// Mirrors `isCallCallee` in `src/extractors/javascript.ts`.
+fn is_call_callee(node: &Node) -> bool {
+    let Some(parent) = node.parent() else {
+        return false;
+    };
+    parent.kind() == "call_expression"
+        && parent
+            .child_by_field_name("function")
+            .is_some_and(|f| f.id() == node.id())
+}
+
 /// Mirrors `blockContainsIdentifierExcluding` in `src/extractors/javascript.ts`.
 fn block_contains_identifier_excluding(
     node: &Node,
@@ -4709,6 +4790,7 @@ fn block_contains_identifier_excluding(
     exclude_id: usize,
     source: &[u8],
     depth: usize,
+    require_call_site: bool,
 ) -> bool {
     if depth >= MAX_WALK_DEPTH {
         return false;
@@ -4717,7 +4799,9 @@ fn block_contains_identifier_excluding(
         return false;
     }
     if node.kind() == "identifier" && node_text(node, source) == name {
-        return true;
+        if !require_call_site || is_call_callee(node) {
+            return true;
+        }
     }
     if SCOPE_NODE_TYPES.contains(&node.kind()) && introduces_shadowed_binding(node, name, source) {
         return false;
@@ -4755,8 +4839,14 @@ fn block_contains_identifier_excluding(
                         continue;
                     }
                 }
-                if block_contains_identifier_excluding(&child, name, exclude_id, source, depth + 1)
-                {
+                if block_contains_identifier_excluding(
+                    &child,
+                    name,
+                    exclude_id,
+                    source,
+                    depth + 1,
+                    require_call_site,
+                ) {
                     return true;
                 }
             }
@@ -4767,21 +4857,40 @@ fn block_contains_identifier_excluding(
         let decl_name = node.child_by_field_name("name");
         let value = node.child_by_field_name("value");
         if let Some(decl_name) = &decl_name {
-            if scan_pattern_defaults_for_reference(decl_name, name, exclude_id, source, depth + 1) {
+            if scan_pattern_defaults_for_reference(
+                decl_name,
+                name,
+                exclude_id,
+                source,
+                depth + 1,
+                require_call_site,
+            ) {
                 return true;
             }
         }
         return match value {
-            Some(value) => {
-                block_contains_identifier_excluding(&value, name, exclude_id, source, depth + 1)
-            }
+            Some(value) => block_contains_identifier_excluding(
+                &value,
+                name,
+                exclude_id,
+                source,
+                depth + 1,
+                require_call_site,
+            ),
             None => false,
         };
     }
     if node.kind() == "assignment_expression" {
         if let Some(left) = node.child_by_field_name("left") {
             if pattern_binds_name(&left, name, source, 0) {
-                if scan_pattern_defaults_for_reference(&left, name, exclude_id, source, depth + 1) {
+                if scan_pattern_defaults_for_reference(
+                    &left,
+                    name,
+                    exclude_id,
+                    source,
+                    depth + 1,
+                    require_call_site,
+                ) {
                     return true;
                 }
                 return match node.child_by_field_name("right") {
@@ -4791,6 +4900,7 @@ fn block_contains_identifier_excluding(
                         exclude_id,
                         source,
                         depth + 1,
+                        require_call_site,
                     ),
                     None => false,
                 };
@@ -4811,7 +4921,14 @@ fn block_contains_identifier_excluding(
     if node.kind() == "for_in_statement" {
         if let Some(left) = node.child_by_field_name("left") {
             if pattern_binds_name(&left, name, source, 0) {
-                if scan_pattern_defaults_for_reference(&left, name, exclude_id, source, depth + 1) {
+                if scan_pattern_defaults_for_reference(
+                    &left,
+                    name,
+                    exclude_id,
+                    source,
+                    depth + 1,
+                    require_call_site,
+                ) {
                     return true;
                 }
                 if let Some(right) = node.child_by_field_name("right") {
@@ -4821,6 +4938,7 @@ fn block_contains_identifier_excluding(
                         exclude_id,
                         source,
                         depth + 1,
+                        require_call_site,
                     ) {
                         return true;
                     }
@@ -4832,6 +4950,7 @@ fn block_contains_identifier_excluding(
                         exclude_id,
                         source,
                         depth + 1,
+                        require_call_site,
                     ),
                     None => false,
                 };
@@ -4840,7 +4959,14 @@ fn block_contains_identifier_excluding(
     }
     for i in 0..node.child_count() {
         if let Some(child) = node.child(i) {
-            if block_contains_identifier_excluding(&child, name, exclude_id, source, depth + 1) {
+            if block_contains_identifier_excluding(
+                &child,
+                name,
+                exclude_id,
+                source,
+                depth + 1,
+                require_call_site,
+            ) {
                 return true;
             }
         }
@@ -4868,11 +4994,19 @@ fn block_contains_identifier_excluding(
 /// same-named binding declared inside a nested function/block never gets
 /// mistaken for a use of the outer variable.
 ///
+/// `require_call_site` (issue #2260): when true, a matching identifier
+/// only counts if it's the callee of a `call_expression` (see
+/// `is_call_callee`) — used by `handle_computed_dispatch_table_evidence`
+/// to require genuine invocation evidence (`handler(...)`), not just any
+/// reference (`console.log(handler)`), matching #1895's own "invoked...
+/// via member-call syntax" precision.
+///
 /// Mirrors `hasLaterReferenceInEnclosingBlock` in `src/extractors/javascript.ts`.
 fn has_later_reference_in_enclosing_block(
     declarator_node: &Node,
     name: &str,
     source: &[u8],
+    require_call_site: bool,
 ) -> bool {
     let mut block = declarator_node.parent();
     while let Some(n) = block {
@@ -4913,7 +5047,14 @@ fn has_later_reference_in_enclosing_block(
                     continue;
                 }
             }
-            if block_contains_identifier_excluding(&child, name, declarator_node.id(), source, 0) {
+            if block_contains_identifier_excluding(
+                &child,
+                name,
+                declarator_node.id(),
+                source,
+                0,
+                require_call_site,
+            ) {
                 return true;
             }
         }
@@ -4983,7 +5124,7 @@ fn handle_logical_or_ternary_value_ref(declarator: &Node, source: &[u8], calls: 
         return;
     }
     let name_text = node_text(&name_n, source);
-    if !has_later_reference_in_enclosing_block(declarator, name_text, source) {
+    if !has_later_reference_in_enclosing_block(declarator, name_text, source, false) {
         return;
     }
 
@@ -4996,6 +5137,71 @@ fn handle_logical_or_ternary_value_ref(declarator: &Node, source: &[u8], calls: 
             ..Default::default()
         });
     }
+}
+
+/// Collect computed/bracket-access dispatch-table invocation evidence (issue
+/// #2260) — extends the #1771/#1895 dot-property value-ref mechanism to the
+/// `const handler = TABLE[computedExpr]; ...; handler(...)` idiom (a
+/// `node.type`-keyed AST-dispatch table is the canonical example:
+/// `src/extractors/groovy.ts`'s `GROOVY_NODE_HANDLERS`). A computed key
+/// can't name a specific property statically the way `TABLE.key(...)` can,
+/// so — unlike #1895, which checks each property's own key individually —
+/// this credits invocation evidence for the WHOLE table once any computed
+/// access into it is confirmed to be genuinely invoked.
+///
+/// Fires only when:
+///  - the declarator's value is DIRECTLY a `subscript_expression` (matching
+///    this file's "restrict to the simplest syntactic shape" precedent,
+///    #1771/#1784 — a wrapped/parenthesized form is left unresolved);
+///  - its `object` is a bare identifier (the table's own name) — a
+///    computed/dynamic object expression has no static name to credit;
+///  - its `index` is NOT a string/template-string literal — a literal key
+///    (`TABLE['resolve']`) already resolves through the existing
+///    computed-literal call-extraction path and needs no new mechanism;
+///  - the declared name is a plain identifier (no destructuring) that is
+///    later found as the CALLEE of a call expression in its own enclosing
+///    block (`has_later_reference_in_enclosing_block` with
+///    `require_call_site`) — the same local, position-scoped liveness
+///    check #2257 established, reused here for the intermediate variable
+///    specifically because a generic local name (`handler`) collides
+///    across unrelated files/functions far more often than a
+///    dispatch-table's own constant name does.
+///
+/// Mirrors `collectComputedDispatchTableEvidence` in `src/extractors/javascript.ts`.
+fn handle_computed_dispatch_table_evidence(
+    declarator: &Node,
+    source: &[u8],
+    evidence: &mut Vec<String>,
+) {
+    let Some(name_n) = declarator.child_by_field_name("name") else {
+        return;
+    };
+    if name_n.kind() != "identifier" {
+        return;
+    }
+    let Some(value_n) = declarator.child_by_field_name("value") else {
+        return;
+    };
+    if value_n.kind() != "subscript_expression" {
+        return;
+    }
+    let Some(object_n) = value_n.child_by_field_name("object") else {
+        return;
+    };
+    if object_n.kind() != "identifier" || JS_BUILTIN_GLOBALS.contains(&node_text(&object_n, source))
+    {
+        return;
+    }
+    if let Some(index_n) = value_n.child_by_field_name("index") {
+        if index_n.kind() == "string" || index_n.kind() == "template_string" {
+            return;
+        }
+    }
+    let name_text = node_text(&name_n, source);
+    if !has_later_reference_in_enclosing_block(declarator, name_text, source, true) {
+        return;
+    }
+    evidence.push(node_text(&object_n, source).to_string());
 }
 
 /// Extract definitions from destructured object bindings: `const { handleToken,
@@ -8276,6 +8482,112 @@ mod tests {
         assert!(!s.calls.iter().any(|c| {
             c.dynamic_kind.as_deref() == Some("value-ref") && c.name == "fetchLatestVersion"
         }));
+    }
+
+    // This mechanism's Call extraction is UNCONDITIONAL (like #1771/#1895 —
+    // every bare-identifier object-literal property value always produces a
+    // value-ref Call, regardless of liveness); only the RESOLVER (build_edges.rs)
+    // later gates whether that Call becomes a real edge, consulting
+    // invoked_property_names/computed_dispatch_table_evidence at that point —
+    // NOT here. So the correct thing to assert at the extractor level is
+    // computed_dispatch_table_evidence's own contents, not the calls array.
+
+    // The confirmed real-world case: an AST-node-type-keyed dispatch table
+    // (src/extractors/groovy.rs's GROOVY_NODE_HANDLERS), consumed via a
+    // computed lookup stored in an intermediate variable, then called.
+    #[test]
+    fn records_the_table_name_when_the_intermediate_variable_is_later_called() {
+        let s = parse_js(
+            "const NODE_HANDLERS = {\n\
+               interface_definition: handleInterfaceDecl,\n\
+             };\n\
+             function walkNode(node, ctx) {\n\
+               const handler = NODE_HANDLERS[node.type];\n\
+               if (handler) handler(node, ctx);\n\
+             }",
+        );
+        assert_eq!(s.computed_dispatch_table_evidence, vec!["NODE_HANDLERS"]);
+    }
+
+    #[test]
+    fn does_not_record_the_table_name_when_the_intermediate_variable_is_only_referenced_never_called(
+    ) {
+        let s = parse_js(
+            "const NODE_HANDLERS = {\n\
+               interface_definition: handleInterfaceDecl,\n\
+             };\n\
+             function walkNode(node, ctx) {\n\
+               const handler = NODE_HANDLERS[node.type];\n\
+               console.log(handler);\n\
+             }",
+        );
+        assert!(s.computed_dispatch_table_evidence.is_empty());
+    }
+
+    #[test]
+    fn does_not_fire_for_a_string_literal_key() {
+        let s = parse_js(
+            "const NODE_HANDLERS = {\n\
+               interface_definition: handleInterfaceDecl,\n\
+             };\n\
+             function walkNode() {\n\
+               const handler = NODE_HANDLERS['interface_definition'];\n\
+               handler();\n\
+             }",
+        );
+        assert!(s.computed_dispatch_table_evidence.is_empty());
+    }
+
+    #[test]
+    fn does_not_record_the_table_name_when_the_call_is_inside_a_shadowing_nested_scope() {
+        let s = parse_js(
+            "const NODE_HANDLERS = {\n\
+               interface_definition: handleInterfaceDecl,\n\
+             };\n\
+             function walkNode(node, ctx) {\n\
+               const handler = NODE_HANDLERS[node.type];\n\
+               {\n\
+                 let handler = unrelatedFn;\n\
+                 handler();\n\
+               }\n\
+             }",
+        );
+        assert!(s.computed_dispatch_table_evidence.is_empty());
+    }
+
+    #[test]
+    fn only_records_the_specific_table_that_has_its_own_computed_invocation_evidence() {
+        let s = parse_js(
+            "const HANDLERS_A = {\n\
+               interface_definition: handleA,\n\
+             };\n\
+             const HANDLERS_B = {\n\
+               interface_definition: handleB,\n\
+             };\n\
+             function walkNode(node, ctx) {\n\
+               const handler = HANDLERS_A[node.type];\n\
+               handler();\n\
+             }",
+        );
+        assert_eq!(s.computed_dispatch_table_evidence, vec!["HANDLERS_A"]);
+    }
+
+    #[test]
+    fn does_not_overflow_the_stack_on_a_pathologically_deep_enclosing_block_2260() {
+        let depth = 300;
+        let nested = format!(
+            "{}handler();\n{}",
+            "if (true) {\n".repeat(depth),
+            "}\n".repeat(depth)
+        );
+        let source = format!(
+            "const NODE_HANDLERS = {{ interface_definition: handleInterfaceDecl }};\n\
+             function walkNode(node) {{\n\
+               const handler = NODE_HANDLERS[node.type];\n\
+               {nested}\n\
+             }}"
+        );
+        let _ = parse_js(&source);
     }
 
     // #1895: key_expr capture — the property key, distinct from the

--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -4156,6 +4156,37 @@ const TABLE_NAME_PASSTHROUGH_KINDS: &[&str] = &[
     "non_null_expression",
 ];
 
+/// Walk outward from `node` through EVERY enclosing scope-introducing
+/// ancestor — not just function scopes — returning the start line of the
+/// nearest one that directly declares/shadows `name` itself
+/// (`introduces_shadowed_binding`, the same hardened shadow-detection #2257
+/// built out, already handles function-likes, `catch`, `for`/`for-in`,
+/// `statement_block`, and `switch_body`). `None` when no enclosing scope
+/// redeclares it, i.e. it comes from module scope.
+///
+/// Shared by both sides of issue #2260's computed-dispatch-table
+/// disambiguation (Greptile review, PR #2445, rounds 2 and 3): a file-scoped
+/// evidence key alone let two different FUNCTIONS in one file, each
+/// declaring their own same-named local table, share one entry; scoping by
+/// enclosing FUNCTION alone (round 2's fix) still let two sibling BLOCKS
+/// inside the SAME function do the same (e.g. an `if`/`else` each declaring
+/// their own same-named table). Walking every scope level, not just
+/// function boundaries, and identifying the match by its own line — not a
+/// human-readable qualifier, since a bare block has no name — disambiguates
+/// any two distinct lexical bindings of the same name anywhere in the file,
+/// regardless of nesting shape. Mirrors `findDeclaringScopeLine` in
+/// `src/extractors/javascript.ts`.
+fn find_declaring_scope_line(node: &Node, name: &str, source: &[u8]) -> Option<u32> {
+    let mut current = node.parent();
+    while let Some(cur) = current {
+        if introduces_shadowed_binding(&cur, name, source) {
+            return Some(cur.start_position().row as u32);
+        }
+        current = cur.parent();
+    }
+    None
+}
+
 /// Walk up from a dispatch-table object-literal's `pair`/shorthand-property
 /// node to find the name of the variable it's assigned to (e.g.
 /// `GROOVY_NODE_HANDLERS` for `const GROOVY_NODE_HANDLERS = { ... }`) — used
@@ -4164,18 +4195,12 @@ const TABLE_NAME_PASSTHROUGH_KINDS: &[&str] = &[
 /// number of hops through common TS wrapper shapes so a deeply-nested or
 /// non-declarator-assigned object literal simply yields no table name.
 ///
-/// When the table's own declaration is function-scoped (not module-level),
-/// the returned name carries a `#${qualifier}` suffix naming that enclosing
-/// function (`find_enclosing_function_qualifier`, the same
-/// `VAR_DECL_FN_SCOPE_TYPES` walk `extract_object_literal_functions` already
-/// uses for qualified definitions, #2033) — `#` can never appear in a real
-/// identifier, so this can't collide with an actual table name, and a
-/// module-scope table (the common case) is returned bare, unchanged from
-/// before this suffix existed. Disambiguates two different functions in the
-/// same file that each declare their own same-named local dispatch table
-/// (Greptile review, PR #2445): without it, both bindings would produce the
-/// identical `receiver` string and share one evidence-set entry, wrongly
-/// crediting each other's computed-invocation evidence. Mirrors
+/// When the table's own declaration is scoped inside any block (not
+/// module-level), the returned name carries a `#${line}` suffix identifying
+/// that declaring scope (`find_declaring_scope_line`) — `#` can never
+/// appear in a real identifier, so this can't collide with an actual table
+/// name, and a module-scope table (the common case) is returned bare,
+/// unchanged from before this suffix existed. Mirrors
 /// `findEnclosingTableName` in `src/extractors/javascript.ts`.
 fn find_enclosing_table_name(node: &Node, source: &[u8]) -> Option<String> {
     let mut current = node.parent();
@@ -4190,8 +4215,8 @@ fn find_enclosing_table_name(node: &Node, source: &[u8]) -> Option<String> {
                 return None;
             }
             let name = node_text(&name_n, source);
-            return Some(match find_enclosing_function_qualifier(&cur, source) {
-                Some(qualifier) => format!("{name}#{qualifier}"),
+            return Some(match find_declaring_scope_line(&cur, name, source) {
+                Some(scope_line) => format!("{name}#{scope_line}"),
                 None => name.to_string(),
             });
         }
@@ -5155,43 +5180,6 @@ fn handle_logical_or_ternary_value_ref(declarator: &Node, source: &[u8], calls: 
     }
 }
 
-/// Walk outward from a `TABLE[computedExpr]` reference through every
-/// enclosing function scope, returning the qualifier name
-/// (`qualifier_for_function_scope_node`) of the nearest one that locally
-/// declares `table_name` itself (via `introduces_shadowed_binding`, the
-/// same hardened shadow-detection #2257 built out) — i.e. the table is a
-/// function-local binding, not a module-level one. `None` when no enclosing
-/// function locally redeclares it (the common case: a module-level table
-/// referenced from inside a function), matching the bare, unsuffixed name
-/// `find_enclosing_table_name` produces for that same module-level
-/// declaration on the value-ref side.
-///
-/// Without this, two different functions each declaring their own
-/// same-named local table (Greptile review, PR #2445) would both reduce to
-/// the identical bare `table_name` and share one evidence-set entry — this
-/// makes the consumer side agree with `find_enclosing_table_name`'s
-/// declaration-side scoping so the two can only match when they really are
-/// the same lexical binding. Mirrors `findConsumerTableScopeQualifier` in
-/// `src/extractors/javascript.ts`.
-fn find_consumer_table_scope_qualifier(
-    node: &Node,
-    table_name: &str,
-    source: &[u8],
-) -> Option<String> {
-    let mut current = node.parent();
-    while let Some(cur) = current {
-        if VAR_DECL_FN_SCOPE_TYPES.contains(&cur.kind()) {
-            if let Some(body) = cur.child_by_field_name("body") {
-                if introduces_shadowed_binding(&body, table_name, source) {
-                    return qualifier_for_function_scope_node(&cur, source);
-                }
-            }
-        }
-        current = cur.parent();
-    }
-    None
-}
-
 /// Collect computed/bracket-access dispatch-table invocation evidence (issue
 /// #2260) — extends the #1771/#1895 dot-property value-ref mechanism to the
 /// `const handler = TABLE[computedExpr]; ...; handler(...)` idiom (a
@@ -5256,8 +5244,8 @@ fn handle_computed_dispatch_table_evidence(
     }
     let table_name = node_text(&object_n, source);
     evidence.push(
-        match find_consumer_table_scope_qualifier(declarator, table_name, source) {
-            Some(qualifier) => format!("{table_name}#{qualifier}"),
+        match find_declaring_scope_line(declarator, table_name, source) {
+            Some(scope_line) => format!("{table_name}#{scope_line}"),
             None => table_name.to_string(),
         },
     );

--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -4163,7 +4163,20 @@ const TABLE_NAME_PASSTHROUGH_KINDS: &[&str] = &[
 /// own name, set as the value-ref Call's `receiver`. Bounded to a small
 /// number of hops through common TS wrapper shapes so a deeply-nested or
 /// non-declarator-assigned object literal simply yields no table name.
-/// Mirrors `findEnclosingTableName` in `src/extractors/javascript.ts`.
+///
+/// When the table's own declaration is function-scoped (not module-level),
+/// the returned name carries a `#${qualifier}` suffix naming that enclosing
+/// function (`find_enclosing_function_qualifier`, the same
+/// `VAR_DECL_FN_SCOPE_TYPES` walk `extract_object_literal_functions` already
+/// uses for qualified definitions, #2033) — `#` can never appear in a real
+/// identifier, so this can't collide with an actual table name, and a
+/// module-scope table (the common case) is returned bare, unchanged from
+/// before this suffix existed. Disambiguates two different functions in the
+/// same file that each declare their own same-named local dispatch table
+/// (Greptile review, PR #2445): without it, both bindings would produce the
+/// identical `receiver` string and share one evidence-set entry, wrongly
+/// crediting each other's computed-invocation evidence. Mirrors
+/// `findEnclosingTableName` in `src/extractors/javascript.ts`.
 fn find_enclosing_table_name(node: &Node, source: &[u8]) -> Option<String> {
     let mut current = node.parent();
     let mut hops = 0;
@@ -4173,11 +4186,14 @@ fn find_enclosing_table_name(node: &Node, source: &[u8]) -> Option<String> {
         }
         if cur.kind() == "variable_declarator" {
             let name_n = cur.child_by_field_name("name")?;
-            return if name_n.kind() == "identifier" {
-                Some(node_text(&name_n, source).to_string())
-            } else {
-                None
-            };
+            if name_n.kind() != "identifier" {
+                return None;
+            }
+            let name = node_text(&name_n, source);
+            return Some(match find_enclosing_function_qualifier(&cur, source) {
+                Some(qualifier) => format!("{name}#{qualifier}"),
+                None => name.to_string(),
+            });
         }
         if !TABLE_NAME_PASSTHROUGH_KINDS.contains(&cur.kind()) {
             return None;
@@ -5139,6 +5155,43 @@ fn handle_logical_or_ternary_value_ref(declarator: &Node, source: &[u8], calls: 
     }
 }
 
+/// Walk outward from a `TABLE[computedExpr]` reference through every
+/// enclosing function scope, returning the qualifier name
+/// (`qualifier_for_function_scope_node`) of the nearest one that locally
+/// declares `table_name` itself (via `introduces_shadowed_binding`, the
+/// same hardened shadow-detection #2257 built out) — i.e. the table is a
+/// function-local binding, not a module-level one. `None` when no enclosing
+/// function locally redeclares it (the common case: a module-level table
+/// referenced from inside a function), matching the bare, unsuffixed name
+/// `find_enclosing_table_name` produces for that same module-level
+/// declaration on the value-ref side.
+///
+/// Without this, two different functions each declaring their own
+/// same-named local table (Greptile review, PR #2445) would both reduce to
+/// the identical bare `table_name` and share one evidence-set entry — this
+/// makes the consumer side agree with `find_enclosing_table_name`'s
+/// declaration-side scoping so the two can only match when they really are
+/// the same lexical binding. Mirrors `findConsumerTableScopeQualifier` in
+/// `src/extractors/javascript.ts`.
+fn find_consumer_table_scope_qualifier(
+    node: &Node,
+    table_name: &str,
+    source: &[u8],
+) -> Option<String> {
+    let mut current = node.parent();
+    while let Some(cur) = current {
+        if VAR_DECL_FN_SCOPE_TYPES.contains(&cur.kind()) {
+            if let Some(body) = cur.child_by_field_name("body") {
+                if introduces_shadowed_binding(&body, table_name, source) {
+                    return qualifier_for_function_scope_node(&cur, source);
+                }
+            }
+        }
+        current = cur.parent();
+    }
+    None
+}
+
 /// Collect computed/bracket-access dispatch-table invocation evidence (issue
 /// #2260) — extends the #1771/#1895 dot-property value-ref mechanism to the
 /// `const handler = TABLE[computedExpr]; ...; handler(...)` idiom (a
@@ -5201,7 +5254,13 @@ fn handle_computed_dispatch_table_evidence(
     if !has_later_reference_in_enclosing_block(declarator, name_text, source, true) {
         return;
     }
-    evidence.push(node_text(&object_n, source).to_string());
+    let table_name = node_text(&object_n, source);
+    evidence.push(
+        match find_consumer_table_scope_qualifier(declarator, table_name, source) {
+            Some(qualifier) => format!("{table_name}#{qualifier}"),
+            None => table_name.to_string(),
+        },
+    );
 }
 
 /// Extract definitions from destructured object bindings: `const { handleToken,

--- a/crates/codegraph-core/src/types.rs
+++ b/crates/codegraph-core/src/types.rs
@@ -570,6 +570,12 @@ pub struct FileSymbols {
     /// Phase 8.3f: object-property bindings from `const obj = { fn }`.
     #[napi(js_name = "objectPropBindings")]
     pub object_prop_bindings: Vec<ObjectPropBinding>,
+    /// Table names (issue #2260) with confirmed LOCAL computed-invocation
+    /// evidence: `const handler = TABLE[computedExpr]; ...; handler(...)`.
+    /// Mirrors `ExtractorOutput.computedDispatchTableEvidence` in
+    /// `src/types.ts`.
+    #[napi(js_name = "computedDispatchTableEvidence")]
+    pub computed_dispatch_table_evidence: Vec<String>,
 }
 
 impl FileSymbols {
@@ -596,6 +602,7 @@ impl FileSymbols {
             array_callback_bindings: Vec::new(),
             object_rest_param_bindings: Vec::new(),
             object_prop_bindings: Vec::new(),
+            computed_dispatch_table_evidence: Vec::new(),
         }
     }
 }

--- a/src/domain/graph/builder/call-resolver.ts
+++ b/src/domain/graph/builder/call-resolver.ts
@@ -79,14 +79,22 @@ export { isModuleScopedLanguage };
  * fan-in/out is a separate case, deliberately kept as a whole-graph
  * statistic even on the incremental path, for classification-threshold
  * consistency).
+ *
+ * Excludes `dynamicKind: 'value-ref'` calls (issue #2260): those carry a
+ * `receiver` of their own now (the dispatch-table's name, set by
+ * `collectObjectLiteralValueRefCall` — used for the computed-access liveness
+ * pathway, see `computedDispatchTableEvidence`), but a value-ref Call is
+ * itself a bare VALUE reference, never a real invocation — crediting its
+ * `name` (the referenced function's own identifier) here would pollute this
+ * set with a name that was never actually invoked via member-call syntax.
  */
 export function collectInvokedPropertyNames(
-  callsList: Iterable<Iterable<{ name: string; receiver?: string }>>,
+  callsList: Iterable<Iterable<{ name: string; receiver?: string; dynamicKind?: string | null }>>,
 ): Set<string> {
   const names = new Set<string>();
   for (const calls of callsList) {
     for (const call of calls) {
-      if (call.receiver) names.add(call.name);
+      if (call.receiver && call.dynamicKind !== 'value-ref') names.add(call.name);
     }
   }
   return names;

--- a/src/domain/graph/builder/incremental.ts
+++ b/src/domain/graph/builder/incremental.ts
@@ -1526,6 +1526,12 @@ function buildCallEdges(
     relPath,
     ownInvokedPropertyNames,
   );
+  // #2260: same-file-only scope (unlike invokedPropertyNames above, which
+  // additionally reads a persisted table) — the table+consumer for this
+  // idiom are typically same-file (an internal AST-dispatch table, not an
+  // exported API); a cross-file case missed on a scoped rebuild recovers on
+  // the next full build. See the fuller trade-off note in stages/build-edges.ts.
+  const computedDispatchTableEvidence = new Set(symbols.computedDispatchTableEvidence ?? []);
   let edgesAdded = 0;
 
   for (const call of symbols.calls) {
@@ -1572,7 +1578,14 @@ function buildCallEdges(
       // #1895: object-literal-property value-refs additionally require
       // independent evidence the property is actually invoked somewhere —
       // mirrors the same check in resolveFallbackTargets (stages/build-edges.ts).
-      if (call.keyExpr && !invokedPropertyNames.has(call.keyExpr)) {
+      // #2260: OR the property's own dispatch table has confirmed computed-
+      // access invocation evidence — see resolveFallbackTargets's fuller
+      // comment on this alternate pathway.
+      if (
+        call.keyExpr &&
+        !invokedPropertyNames.has(call.keyExpr) &&
+        !(call.receiver && computedDispatchTableEvidence.has(call.receiver))
+      ) {
         targets = [];
       }
     }

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -1342,6 +1342,19 @@ function persistReturnTypes(ctx: PipelineContext): void {
 
 // ── Call edges (JS fallback) ────────────────────────────────────────────
 
+/**
+ * Scope key for #2260's computed-dispatch-table evidence set:
+ * `${file}::${tableName}`. A bare table name would let two unrelated files
+ * that each declare a same-named table (e.g. `HANDLERS`) share liveness —
+ * one file's confirmed computed-invocation evidence would wrongly credit
+ * the other file's same-named-but-unrelated table (Greptile review, PR
+ * #2445) — so every lookup/insert into that set must go through this key,
+ * mirroring the `callee::restName` scoping convention (#1358).
+ */
+function computedDispatchTableEvidenceKey(relPath: string, tableName: string): string {
+  return `${relPath}::${tableName}`;
+}
+
 function buildCallEdgesJS(
   ctx: PipelineContext,
   getNodeIdStmt: NodeIdStmt,
@@ -1378,10 +1391,17 @@ function buildCallEdgesJS(
   // cross-file case missed on a scoped rebuild recovers on the next full
   // build, matching this codebase's other documented incremental scoping
   // trade-offs (see collectInvokedPropertyNames's own doc comment).
+  //
+  // Keyed on `${file}::${tableName}`, not the bare table name — mirrors the
+  // `callee::restName` scoping convention (#1358) for the same reason: two
+  // unrelated files can each declare a same-named table (e.g. `HANDLERS`),
+  // and a bare-name Set would let one file's computed-invocation evidence
+  // credit the other file's same-named-but-unrelated table (Greptile review,
+  // PR #2445).
   const computedDispatchTableEvidence = new Set<string>();
-  for (const symbols of fileSymbols.values()) {
+  for (const [relPath, symbols] of fileSymbols) {
     for (const name of symbols.computedDispatchTableEvidence ?? []) {
-      computedDispatchTableEvidence.add(name);
+      computedDispatchTableEvidence.add(computedDispatchTableEvidenceKey(relPath, name));
     }
   }
 
@@ -1799,7 +1819,10 @@ function resolveFallbackTargets(
     if (
       call.keyExpr &&
       !invokedPropertyNames.has(call.keyExpr) &&
-      !(call.receiver && computedDispatchTableEvidence.has(call.receiver))
+      !(
+        call.receiver &&
+        computedDispatchTableEvidence.has(computedDispatchTableEvidenceKey(relPath, call.receiver))
+      )
     ) {
       targets = [];
     }

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -134,6 +134,8 @@ interface NativeFileEntry {
   arrayCallbackBindings?: ArrayCallbackBinding[];
   objectRestParamBindings?: ObjectRestParamBinding[];
   objectPropBindings?: ObjectPropBinding[];
+  /** Issue #2260: table names with confirmed computed-access invocation evidence. */
+  computedDispatchTableEvidence?: string[];
 }
 
 /** Shape returned by native buildCallEdges. */
@@ -846,6 +848,9 @@ function buildNativeFileEntry(
       ? symbols.objectRestParamBindings
       : undefined,
     objectPropBindings: symbols.objectPropBindings?.length ? symbols.objectPropBindings : undefined,
+    computedDispatchTableEvidence: symbols.computedDispatchTableEvidence?.length
+      ? [...symbols.computedDispatchTableEvidence]
+      : undefined,
   };
 }
 
@@ -1363,6 +1368,23 @@ function buildCallEdgesJS(
     invokedPropertyNames.add(row.name);
   }
 
+  // #2260: table names with confirmed computed-access invocation evidence
+  // (`const handler = TABLE[computedExpr]; ...; handler(...)`) — an
+  // in-memory-only aggregation across this build's files, unlike
+  // invokedPropertyNames above, which additionally reads a persisted table
+  // to stay correct on a scoped incremental build. The table+consumer here
+  // are typically same-file (an internal AST-dispatch table, not an
+  // exported API), so this narrower scope is accepted for now; a
+  // cross-file case missed on a scoped rebuild recovers on the next full
+  // build, matching this codebase's other documented incremental scoping
+  // trade-offs (see collectInvokedPropertyNames's own doc comment).
+  const computedDispatchTableEvidence = new Set<string>();
+  for (const symbols of fileSymbols.values()) {
+    for (const name of symbols.computedDispatchTableEvidence ?? []) {
+      computedDispatchTableEvidence.add(name);
+    }
+  }
+
   for (const [relPath, symbols] of fileSymbols) {
     if (barrelOnlyFiles.has(relPath)) continue;
     const fileNodeRow = getNodeIdStmt.get(relPath, 'file', relPath, 0);
@@ -1432,6 +1454,7 @@ function buildCallEdgesJS(
       allEdgeRows,
       typeMap,
       invokedPropertyNames,
+      computedDispatchTableEvidence,
       ptsMap,
       chaCtx,
       importArtifactNames,
@@ -1680,6 +1703,7 @@ function resolveFallbackTargets(
   typeMap: Map<string, TypeMapEntry | string>,
   definePropertyReceivers: Map<string, string> | undefined,
   invokedPropertyNames: ReadonlySet<string>,
+  computedDispatchTableEvidence: ReadonlySet<string>,
   importedOriginalNames?: ReadonlyMap<string, string>,
   namespaceImports?: ReadonlyMap<string, string>,
 ): {
@@ -1765,7 +1789,18 @@ function resolveFallbackTargets(
     // somewhere (`x.keyExpr(...)`) — merely being wired into an object
     // literal is not liveness. instanceof/Lua value-refs never set keyExpr,
     // so they are unaffected by this stricter check.
-    if (call.keyExpr && !invokedPropertyNames.has(call.keyExpr)) {
+    //
+    // #2260: OR, the property's own dispatch table (`call.receiver` — the
+    // table's variable name, set by collectObjectLiteralValueRefCall)
+    // has confirmed COMPUTED-access invocation evidence
+    // (`const handler = TABLE[computedExpr]; ...; handler(...)`) — a
+    // computed key can't name this specific property statically, so that
+    // evidence is credited to the whole table rather than per-key.
+    if (
+      call.keyExpr &&
+      !invokedPropertyNames.has(call.keyExpr) &&
+      !(call.receiver && computedDispatchTableEvidence.has(call.receiver))
+    ) {
       targets = [];
     }
   }
@@ -2146,6 +2181,7 @@ function buildFileCallEdges(
   allEdgeRows: EdgeRowTuple[],
   typeMap: Map<string, TypeMapEntry | string>,
   invokedPropertyNames: ReadonlySet<string>,
+  computedDispatchTableEvidence: ReadonlySet<string>,
   ptsMap?: PointsToMap | null,
   chaCtx?: ChaContext,
   importArtifactNames?: ReadonlyMap<string, BarrelExportResolution>,
@@ -2189,6 +2225,7 @@ function buildFileCallEdges(
       typeMap,
       symbols.definePropertyReceivers,
       invokedPropertyNames,
+      computedDispatchTableEvidence,
       importedOriginalNames,
       namespaceImports,
     );

--- a/src/domain/wasm-worker-entry.ts
+++ b/src/domain/wasm-worker-entry.ts
@@ -725,6 +725,9 @@ function serializeExtractorOutput(
     ...(symbols.cjsRequireBindings?.length
       ? { cjsRequireBindings: symbols.cjsRequireBindings }
       : {}),
+    ...(symbols.computedDispatchTableEvidence?.length
+      ? { computedDispatchTableEvidence: symbols.computedDispatchTableEvidence }
+      : {}),
   };
 }
 

--- a/src/domain/wasm-worker-pool.ts
+++ b/src/domain/wasm-worker-pool.ts
@@ -127,6 +127,8 @@ function deserializeBindingFields(ser: SerializedExtractorOutput, out: Extractor
   if (ser.newExpressions?.length) out.newExpressions = ser.newExpressions;
   if (ser.callAssignments?.length) out.callAssignments = ser.callAssignments;
   if (ser.cjsRequireBindings?.length) out.cjsRequireBindings = ser.cjsRequireBindings;
+  if (ser.computedDispatchTableEvidence?.length)
+    out.computedDispatchTableEvidence = ser.computedDispatchTableEvidence;
 }
 
 /** Deserialize the Map-typed fields that require entry-by-entry reconstruction. */

--- a/src/domain/wasm-worker-protocol.ts
+++ b/src/domain/wasm-worker-protocol.ts
@@ -81,6 +81,8 @@ export interface SerializedExtractorOutput {
   dataflowVertices?: import('../types.js').DataflowVertex[];
   /** CJS require bindings — see ExtractorOutput.cjsRequireBindings (#1661). */
   cjsRequireBindings?: Array<{ names: string[]; source: string }>;
+  /** Issue #2260 — see ExtractorOutput.computedDispatchTableEvidence. */
+  computedDispatchTableEvidence?: readonly string[];
 }
 
 export interface WorkerParseResponseOk {

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -508,6 +508,7 @@ function extractSymbolsQuery(tree: TreeSitterTree, query: TreeSitterQuery): Extr
   // walk below so bare property reads can be recognized regardless of
   // whether the accessing code appears before or after the class declaration.
   const localAccessors = collectLocalAccessors(tree.rootNode);
+  const computedDispatchTableEvidence: string[] = [];
   runCollectorWalk(tree.rootNode, {
     definitions,
     typeMap,
@@ -517,6 +518,7 @@ function extractSymbolsQuery(tree: TreeSitterTree, query: TreeSitterQuery): Extr
     newExpressions,
     definePropertyReceivers,
     valueRefCalls: calls,
+    computedDispatchTableEvidence,
     localAccessors,
     imports,
     calls,
@@ -558,6 +560,7 @@ function extractSymbolsQuery(tree: TreeSitterTree, query: TreeSitterQuery): Extr
     newExpressions,
     ...(definePropertyReceivers.size > 0 ? { definePropertyReceivers } : {}),
     ...(cjsRequireBindings.length > 0 ? { cjsRequireBindings } : {}),
+    ...(computedDispatchTableEvidence.length > 0 ? { computedDispatchTableEvidence } : {}),
   };
 }
 
@@ -1412,6 +1415,7 @@ function extractSymbolsWalk(tree: TreeSitterTree): ExtractorOutput {
   // #1893: same-file get/set accessor registry — see the query-path call site
   // of collectLocalAccessors for why this must be computed up front.
   const localAccessors = collectLocalAccessors(tree.rootNode);
+  const computedDispatchTableEvidence: string[] = [];
   runCollectorWalk(tree.rootNode, {
     definitions: ctx.definitions,
     typeMap: ctx.typeMap!,
@@ -1421,11 +1425,15 @@ function extractSymbolsWalk(tree: TreeSitterTree): ExtractorOutput {
     newExpressions,
     definePropertyReceivers,
     valueRefCalls: ctx.calls,
+    computedDispatchTableEvidence,
     localAccessors,
     funcPropDefs: ctx.definitions,
   });
   ctx.newExpressions = newExpressions;
   if (definePropertyReceivers.size > 0) ctx.definePropertyReceivers = definePropertyReceivers;
+  if (computedDispatchTableEvidence.length > 0) {
+    ctx.computedDispatchTableEvidence = computedDispatchTableEvidence;
+  }
   return ctx;
 }
 
@@ -4181,6 +4189,43 @@ function collectObjectPropBindings(node: TreeSitterNode, bindings: ObjectPropBin
   }
 }
 
+/** Node types `findEnclosingTableName` passes through on its way up to a `variable_declarator`. */
+const TABLE_NAME_PASSTHROUGH_TYPES: ReadonlySet<string> = new Set([
+  'object',
+  'parenthesized_expression',
+  'as_expression',
+  'satisfies_expression',
+  'non_null_expression',
+]);
+
+/**
+ * Walk up from a dispatch-table object-literal's `pair`/shorthand-property
+ * node to find the name of the variable it's assigned to (e.g.
+ * `GROOVY_NODE_HANDLERS` for `const GROOVY_NODE_HANDLERS = { ... }`) — used
+ * to key the computed-access liveness pathway (issue #2260) on the TABLE's
+ * own name, set as the value-ref Call's `receiver`. Bounded to a small
+ * number of hops through common TS wrapper shapes (`as`/`satisfies`
+ * expressions, parenthesization, non-null assertion) so a deeply-nested or
+ * non-declarator-assigned object literal (e.g. passed directly as a call
+ * argument) simply yields no table name — the computed-access pathway then
+ * requires the dot/#1895 evidence instead, matching this file's "prefer no
+ * edge over a wrong one" precedent.
+ */
+function findEnclosingTableName(node: TreeSitterNode): string | undefined {
+  let current: TreeSitterNode | null = node.parent;
+  let hops = 0;
+  while (current && hops < 6) {
+    if (current.type === 'variable_declarator') {
+      const nameNode = current.childForFieldName('name');
+      return nameNode?.type === 'identifier' ? nameNode.text : undefined;
+    }
+    if (!TABLE_NAME_PASSTHROUGH_TYPES.has(current.type)) return undefined;
+    current = current.parent;
+    hops++;
+  }
+  return undefined;
+}
+
 /**
  * Collect a dynamic value-ref `Call` for an object-literal `pair` node whose
  * value is a bare identifier — e.g. `{ resolve: someFunction }`, the
@@ -4201,6 +4246,12 @@ function collectObjectPropBindings(node: TreeSitterNode, bindings: ObjectPropBin
  * downstream "is this property ever invoked" liveness check (#1895) needs the
  * key, since that's the name a dispatch consumer would actually call
  * (`table.resolve(...)`), not the function's own declared name.
+ *
+ * `receiver` (issue #2260) carries the TABLE's own variable name, when
+ * resolvable — the computed-access liveness pathway
+ * (`computedDispatchTableEvidence`) is keyed on this, since a computed key
+ * (`TABLE[node.type]`) can't name a specific property statically the way a
+ * dot access can.
  */
 function collectObjectLiteralValueRefCall(pairNode: TreeSitterNode, calls: Call[]): void {
   const valueNode = pairNode.childForFieldName('value');
@@ -4213,6 +4264,7 @@ function collectObjectLiteralValueRefCall(pairNode: TreeSitterNode, calls: Call[
     dynamic: true,
     dynamicKind: 'value-ref',
     keyExpr,
+    receiver: findEnclosingTableName(pairNode),
   });
 }
 
@@ -4527,6 +4579,7 @@ function scanPatternDefaultsForReference(
   name: string,
   excludeId: number,
   depth: number,
+  requireCallSite = false,
 ): boolean {
   if (depth >= MAX_WALK_DEPTH) return false;
   switch (patternNode.type) {
@@ -4535,7 +4588,9 @@ function scanPatternDefaultsForReference(
     case 'assignment_pattern':
     case 'object_assignment_pattern': {
       const right = patternNode.childForFieldName('right');
-      return right ? blockContainsIdentifierExcluding(right, name, excludeId, depth + 1) : false;
+      return right
+        ? blockContainsIdentifierExcluding(right, name, excludeId, depth + 1, requireCallSite)
+        : false;
     }
     case 'rest_pattern': {
       for (let i = 0; i < patternNode.childCount; i++) {
@@ -4543,7 +4598,7 @@ function scanPatternDefaultsForReference(
         if (
           child &&
           child.type !== '...' &&
-          scanPatternDefaultsForReference(child, name, excludeId, depth + 1)
+          scanPatternDefaultsForReference(child, name, excludeId, depth + 1, requireCallSite)
         ) {
           return true;
         }
@@ -4556,11 +4611,16 @@ function scanPatternDefaultsForReference(
         if (!child) continue;
         if (child.type === 'pair_pattern') {
           const value = child.childForFieldName('value');
-          if (value && scanPatternDefaultsForReference(value, name, excludeId, depth + 1)) {
+          if (
+            value &&
+            scanPatternDefaultsForReference(value, name, excludeId, depth + 1, requireCallSite)
+          ) {
             return true;
           }
         } else if (child.type === 'rest_pattern' || child.type === 'object_assignment_pattern') {
-          if (scanPatternDefaultsForReference(child, name, excludeId, depth + 1)) return true;
+          if (scanPatternDefaultsForReference(child, name, excludeId, depth + 1, requireCallSite)) {
+            return true;
+          }
         }
         // shorthand_property_identifier_pattern has no default to scan.
       }
@@ -4569,7 +4629,10 @@ function scanPatternDefaultsForReference(
     case 'array_pattern': {
       for (let i = 0; i < patternNode.childCount; i++) {
         const child = patternNode.child(i);
-        if (child && scanPatternDefaultsForReference(child, name, excludeId, depth + 1)) {
+        if (
+          child &&
+          scanPatternDefaultsForReference(child, name, excludeId, depth + 1, requireCallSite)
+        ) {
           return true;
         }
       }
@@ -4615,15 +4678,35 @@ function scanPatternDefaultsForReference(
  * deliberately left to the generic scan below (its `left` is scanned like
  * any other reference).
  */
+/**
+ * True when `node` is the `function` field of its parent `call_expression`
+ * — i.e. `node` names the callee being CALLED, not merely referenced.
+ * Used by `blockContainsIdentifierExcluding`'s `requireCallSite` mode
+ * (issue #2260) to require call-shape evidence specifically, matching
+ * #1895's own "invoked... via member-call syntax" precision (a bare
+ * reference — e.g. `console.log(handler)` — is not invocation evidence).
+ */
+function isCallCallee(node: TreeSitterNode): boolean {
+  const parent = node.parent;
+  return (
+    !!parent &&
+    parent.type === 'call_expression' &&
+    parent.childForFieldName('function')?.id === node.id
+  );
+}
+
 function blockContainsIdentifierExcluding(
   node: TreeSitterNode,
   name: string,
   excludeId: number,
   depth = 0,
+  requireCallSite = false,
 ): boolean {
   if (depth >= MAX_WALK_DEPTH) return false;
   if (node.id === excludeId) return false;
-  if (node.type === 'identifier' && node.text === name) return true;
+  if (node.type === 'identifier' && node.text === name) {
+    if (!requireCallSite || isCallCallee(node)) return true;
+  }
   if (SCOPE_NODE_TYPES.has(node.type) && introducesShadowedBinding(node, name)) return false;
   // A declaration statement with MULTIPLE sibling declarators
   // (`var result = fn(), fn = custom || fallback;`) — if the excluded
@@ -4655,7 +4738,9 @@ function blockContainsIdentifierExcluding(
             continue;
           }
         }
-        if (blockContainsIdentifierExcluding(child, name, excludeId, depth + 1)) return true;
+        if (blockContainsIdentifierExcluding(child, name, excludeId, depth + 1, requireCallSite)) {
+          return true;
+        }
       }
       return false;
     }
@@ -4663,17 +4748,26 @@ function blockContainsIdentifierExcluding(
   if (node.type === 'variable_declarator') {
     const declName = node.childForFieldName('name');
     const value = node.childForFieldName('value');
-    if (declName && scanPatternDefaultsForReference(declName, name, excludeId, depth + 1)) {
+    if (
+      declName &&
+      scanPatternDefaultsForReference(declName, name, excludeId, depth + 1, requireCallSite)
+    ) {
       return true;
     }
-    return value ? blockContainsIdentifierExcluding(value, name, excludeId, depth + 1) : false;
+    return value
+      ? blockContainsIdentifierExcluding(value, name, excludeId, depth + 1, requireCallSite)
+      : false;
   }
   if (node.type === 'assignment_expression') {
     const left = node.childForFieldName('left');
     const right = node.childForFieldName('right');
     if (left && patternBindsName(left, name)) {
-      if (scanPatternDefaultsForReference(left, name, excludeId, depth + 1)) return true;
-      return right ? blockContainsIdentifierExcluding(right, name, excludeId, depth + 1) : false;
+      if (scanPatternDefaultsForReference(left, name, excludeId, depth + 1, requireCallSite)) {
+        return true;
+      }
+      return right
+        ? blockContainsIdentifierExcluding(right, name, excludeId, depth + 1, requireCallSite)
+        : false;
     }
   }
   // A `for (fn of values) {}` / `for (fn in obj) {}` loop with NO
@@ -4689,16 +4783,30 @@ function blockContainsIdentifierExcluding(
   if (node.type === 'for_in_statement') {
     const left = node.childForFieldName('left');
     if (left && patternBindsName(left, name)) {
-      if (scanPatternDefaultsForReference(left, name, excludeId, depth + 1)) return true;
+      if (scanPatternDefaultsForReference(left, name, excludeId, depth + 1, requireCallSite)) {
+        return true;
+      }
       const right = node.childForFieldName('right');
       const body = node.childForFieldName('body');
-      if (right && blockContainsIdentifierExcluding(right, name, excludeId, depth + 1)) return true;
-      return body ? blockContainsIdentifierExcluding(body, name, excludeId, depth + 1) : false;
+      if (
+        right &&
+        blockContainsIdentifierExcluding(right, name, excludeId, depth + 1, requireCallSite)
+      ) {
+        return true;
+      }
+      return body
+        ? blockContainsIdentifierExcluding(body, name, excludeId, depth + 1, requireCallSite)
+        : false;
     }
   }
   for (let i = 0; i < node.childCount; i++) {
     const child = node.child(i);
-    if (child && blockContainsIdentifierExcluding(child, name, excludeId, depth + 1)) return true;
+    if (
+      child &&
+      blockContainsIdentifierExcluding(child, name, excludeId, depth + 1, requireCallSite)
+    ) {
+      return true;
+    }
   }
   return false;
 }
@@ -4734,8 +4842,19 @@ function blockContainsIdentifierExcluding(
  * since a sibling declarator earlier in the same statement legitimately reads
  * a later one (`const a = x(), b = y || fallback;` — `a`'s initializer runs
  * first but that's a same-statement forward reference, not a hoisting hazard).
+ *
+ * `requireCallSite` (issue #2260): when true, a matching identifier only
+ * counts if it's the callee of a `call_expression` (see `isCallCallee`) —
+ * used by `collectComputedDispatchTableEvidence` to require genuine
+ * invocation evidence (`handler(...)`), not just any reference
+ * (`console.log(handler)`), matching #1895's own "invoked... via
+ * member-call syntax" precision.
  */
-function hasLaterReferenceInEnclosingBlock(declaratorNode: TreeSitterNode, name: string): boolean {
+function hasLaterReferenceInEnclosingBlock(
+  declaratorNode: TreeSitterNode,
+  name: string,
+  requireCallSite = false,
+): boolean {
   let block: TreeSitterNode | null = declaratorNode.parent;
   while (block && block.type !== 'statement_block' && block.type !== 'program') {
     block = block.parent;
@@ -4765,7 +4884,9 @@ function hasLaterReferenceInEnclosingBlock(declaratorNode: TreeSitterNode, name:
         continue;
       }
     }
-    if (blockContainsIdentifierExcluding(child, name, declaratorNode.id)) return true;
+    if (blockContainsIdentifierExcluding(child, name, declaratorNode.id, 0, requireCallSite)) {
+      return true;
+    }
   }
   return false;
 }
@@ -4823,6 +4944,52 @@ function collectLogicalOrTernaryValueRefCall(declaratorNode: TreeSitterNode, cal
       dynamicKind: 'value-ref',
     });
   }
+}
+
+/**
+ * Collect computed/bracket-access dispatch-table invocation evidence (issue
+ * #2260) — extends the #1771/#1895 dot-property value-ref mechanism to the
+ * `const handler = TABLE[computedExpr]; ...; handler(...)` idiom (a
+ * `node.type`-keyed AST-dispatch table is the canonical example:
+ * `src/extractors/groovy.ts`'s `GROOVY_NODE_HANDLERS`). A computed key
+ * can't name a specific property statically the way `TABLE.key(...)` can,
+ * so — unlike #1895, which checks each property's own key individually —
+ * this credits invocation evidence for the WHOLE table once any computed
+ * access into it is confirmed to be genuinely invoked.
+ *
+ * Fires only when:
+ *  - the declarator's value is DIRECTLY a `subscript_expression` (matching
+ *    this file's "restrict to the simplest syntactic shape" precedent,
+ *    #1771/#1784 — a wrapped/parenthesized form is left unresolved);
+ *  - its `object` is a bare identifier (the table's own name) — a
+ *    computed/dynamic object expression has no static name to credit;
+ *  - its `index` is NOT a string/template-string literal — a literal key
+ *    (`TABLE['resolve']`) already resolves through the existing
+ *    computed-literal call-extraction path and needs no new mechanism;
+ *  - the declared name is a plain identifier (no destructuring) that is
+ *    later found as the CALLEE of a call expression in its own enclosing
+ *    block (`hasLaterReferenceInEnclosingBlock` with `requireCallSite`) —
+ *    the same local, position-scoped liveness check #2257 established,
+ *    reused here for the intermediate variable specifically because a
+ *    generic local name (`handler`) collides across unrelated
+ *    files/functions far more often than a dispatch-table's own constant
+ *    name does (see `computedDispatchTableEvidence`'s doc comment in
+ *    types.ts for why the table name itself is safe to credit graph-wide).
+ */
+function collectComputedDispatchTableEvidence(
+  declaratorNode: TreeSitterNode,
+  evidence: string[],
+): void {
+  const nameNode = declaratorNode.childForFieldName('name');
+  if (nameNode?.type !== 'identifier') return;
+  const valueNode = declaratorNode.childForFieldName('value');
+  if (valueNode?.type !== 'subscript_expression') return;
+  const objectNode = valueNode.childForFieldName('object');
+  if (objectNode?.type !== 'identifier' || BUILTIN_GLOBALS.has(objectNode.text)) return;
+  const indexNode = valueNode.childForFieldName('index');
+  if (indexNode?.type === 'string' || indexNode?.type === 'template_string') return;
+  if (!hasLaterReferenceInEnclosingBlock(declaratorNode, nameNode.text, true)) return;
+  evidence.push(objectNode.text);
 }
 
 function extractReceiverName(objNode: TreeSitterNode | null): string | undefined {
@@ -5711,6 +5878,8 @@ interface CollectorWalkTargets {
   newExpressions: string[];
   definePropertyReceivers: Map<string, string>;
   valueRefCalls: Call[];
+  /** #2260: table names with confirmed computed-access invocation evidence. */
+  computedDispatchTableEvidence: string[];
   /** #1893: same-file `ClassName.propName` → declared get/set accessor kinds. */
   localAccessors: LocalAccessorRegistry;
   imports?: Import[];
@@ -5765,6 +5934,9 @@ function runCollectorWalk(rootNode: TreeSitterNode, targets: CollectorWalkTarget
         // #2257: logical-or/nullish-coalescing/ternary default assigned to a
         // named variable, e.g. `const fetchFn = options._fetchLatest || fetchLatestVersion`.
         collectLogicalOrTernaryValueRefCall(node, targets.valueRefCalls);
+        // #2260: computed dispatch-table access assigned to a named variable,
+        // e.g. `const handler = TABLE[node.type]; ...; handler(...)`.
+        collectComputedDispatchTableEvidence(node, targets.computedDispatchTableEvidence);
         break;
       case 'expression_statement': {
         const expr = node.child(0);
@@ -5810,6 +5982,7 @@ function runCollectorWalk(rootNode: TreeSitterNode, targets: CollectorWalkTarget
             dynamic: true,
             dynamicKind: 'value-ref',
             keyExpr: node.text,
+            receiver: findEnclosingTableName(node),
           });
         }
         break;

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -4210,6 +4210,19 @@ const TABLE_NAME_PASSTHROUGH_TYPES: ReadonlySet<string> = new Set([
  * argument) simply yields no table name — the computed-access pathway then
  * requires the dot/#1895 evidence instead, matching this file's "prefer no
  * edge over a wrong one" precedent.
+ *
+ * When the table's own declaration is function-scoped (not module-level),
+ * the returned name carries a `#${qualifier}` suffix naming that enclosing
+ * function (`findEnclosingFunctionQualifier`, the same FUNCTION_SCOPE_TYPES
+ * walk `extractObjectLiteralFunctions` already uses for qualified
+ * definitions, #2033) — `#` can never appear in a real identifier, so this
+ * can't collide with an actual table name, and a module-scope table (the
+ * common case) is returned bare, unchanged from before this suffix existed.
+ * Disambiguates two different functions in the same file that each declare
+ * their own same-named local dispatch table (Greptile review, PR #2445):
+ * without it, both bindings would produce the identical `receiver` string
+ * and share one evidence-set entry, wrongly crediting each other's
+ * computed-invocation evidence.
  */
 function findEnclosingTableName(node: TreeSitterNode): string | undefined {
   let current: TreeSitterNode | null = node.parent;
@@ -4217,7 +4230,9 @@ function findEnclosingTableName(node: TreeSitterNode): string | undefined {
   while (current && hops < 6) {
     if (current.type === 'variable_declarator') {
       const nameNode = current.childForFieldName('name');
-      return nameNode?.type === 'identifier' ? nameNode.text : undefined;
+      if (nameNode?.type !== 'identifier') return undefined;
+      const scopeQualifier = findEnclosingFunctionQualifier(current);
+      return scopeQualifier === null ? nameNode.text : `${nameNode.text}#${scopeQualifier}`;
     }
     if (!TABLE_NAME_PASSTHROUGH_TYPES.has(current.type)) return undefined;
     current = current.parent;
@@ -4947,6 +4962,43 @@ function collectLogicalOrTernaryValueRefCall(declaratorNode: TreeSitterNode, cal
 }
 
 /**
+ * Walk outward from a `TABLE[computedExpr]` reference through every
+ * enclosing function scope, returning the qualifier name
+ * (`findEnclosingFunctionQualifier`'s `qualifierForFunctionScopeNode`) of
+ * the nearest one that locally declares `tableName` itself (via
+ * `introducesShadowedBinding`, the same hardened shadow-detection #2257
+ * built out) — i.e. the table is a function-local binding, not a
+ * module-level one. `undefined` when no enclosing function locally
+ * redeclares it (the common case: a module-level table referenced from
+ * inside a function), matching the bare, unsuffixed name
+ * `findEnclosingTableName` produces for that same module-level declaration
+ * on the value-ref side.
+ *
+ * Without this, two different functions each declaring their own
+ * same-named local table (Greptile review, PR #2445) would both reduce to
+ * the identical bare `tableName` and share one evidence-set entry — this
+ * makes the consumer side agree with `findEnclosingTableName`'s
+ * declaration-side scoping so the two can only match when they really are
+ * the same lexical binding.
+ */
+function findConsumerTableScopeQualifier(
+  node: TreeSitterNode,
+  tableName: string,
+): string | undefined {
+  let current: TreeSitterNode | null = node.parent;
+  while (current) {
+    if (FUNCTION_SCOPE_TYPES.has(current.type)) {
+      const body = current.childForFieldName('body');
+      if (body && introducesShadowedBinding(body, tableName)) {
+        return qualifierForFunctionScopeNode(current) ?? undefined;
+      }
+    }
+    current = current.parent;
+  }
+  return undefined;
+}
+
+/**
  * Collect computed/bracket-access dispatch-table invocation evidence (issue
  * #2260) — extends the #1771/#1895 dot-property value-ref mechanism to the
  * `const handler = TABLE[computedExpr]; ...; handler(...)` idiom (a
@@ -4974,7 +5026,8 @@ function collectLogicalOrTernaryValueRefCall(declaratorNode: TreeSitterNode, cal
  *    generic local name (`handler`) collides across unrelated
  *    files/functions far more often than a dispatch-table's own constant
  *    name does (see `computedDispatchTableEvidence`'s doc comment in
- *    types.ts for why the table name itself is safe to credit graph-wide).
+ *    types.ts for the file+scope qualification that makes crediting the
+ *    table name safe to aggregate graph-wide).
  */
 function collectComputedDispatchTableEvidence(
   declaratorNode: TreeSitterNode,
@@ -4989,7 +5042,10 @@ function collectComputedDispatchTableEvidence(
   const indexNode = valueNode.childForFieldName('index');
   if (indexNode?.type === 'string' || indexNode?.type === 'template_string') return;
   if (!hasLaterReferenceInEnclosingBlock(declaratorNode, nameNode.text, true)) return;
-  evidence.push(objectNode.text);
+  const scopeQualifier = findConsumerTableScopeQualifier(declaratorNode, objectNode.text);
+  evidence.push(
+    scopeQualifier === undefined ? objectNode.text : `${objectNode.text}#${scopeQualifier}`,
+  );
 }
 
 function extractReceiverName(objNode: TreeSitterNode | null): string | undefined {

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -4199,6 +4199,36 @@ const TABLE_NAME_PASSTHROUGH_TYPES: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * Walk outward from `node` through EVERY enclosing scope-introducing
+ * ancestor — not just function scopes — returning the start line of the
+ * nearest one that directly declares/shadows `name` itself
+ * (`introducesShadowedBinding`, the same hardened shadow-detection #2257
+ * built out, already handles function-likes, `catch`, `for`/`for-in`,
+ * `statement_block`, and `switch_body`). `undefined` when no enclosing
+ * scope redeclares it, i.e. it comes from module scope.
+ *
+ * Shared by both sides of issue #2260's computed-dispatch-table
+ * disambiguation (Greptile review, PR #2445, rounds 2 and 3): a file-scoped
+ * evidence key alone let two different FUNCTIONS in one file, each
+ * declaring their own same-named local table, share one entry; scoping by
+ * enclosing FUNCTION alone (round 2's fix) still let two sibling BLOCKS
+ * inside the SAME function do the same (e.g. an `if`/`else` each declaring
+ * their own same-named table). Walking every scope level, not just
+ * function boundaries, and identifying the match by its own line — not a
+ * human-readable qualifier, since a bare block has no name — disambiguates
+ * any two distinct lexical bindings of the same name anywhere in the file,
+ * regardless of nesting shape.
+ */
+function findDeclaringScopeLine(node: TreeSitterNode, name: string): number | undefined {
+  let current: TreeSitterNode | null = node.parent;
+  while (current) {
+    if (introducesShadowedBinding(current, name)) return current.startPosition.row;
+    current = current.parent;
+  }
+  return undefined;
+}
+
+/**
  * Walk up from a dispatch-table object-literal's `pair`/shorthand-property
  * node to find the name of the variable it's assigned to (e.g.
  * `GROOVY_NODE_HANDLERS` for `const GROOVY_NODE_HANDLERS = { ... }`) — used
@@ -4211,18 +4241,12 @@ const TABLE_NAME_PASSTHROUGH_TYPES: ReadonlySet<string> = new Set([
  * requires the dot/#1895 evidence instead, matching this file's "prefer no
  * edge over a wrong one" precedent.
  *
- * When the table's own declaration is function-scoped (not module-level),
- * the returned name carries a `#${qualifier}` suffix naming that enclosing
- * function (`findEnclosingFunctionQualifier`, the same FUNCTION_SCOPE_TYPES
- * walk `extractObjectLiteralFunctions` already uses for qualified
- * definitions, #2033) — `#` can never appear in a real identifier, so this
- * can't collide with an actual table name, and a module-scope table (the
- * common case) is returned bare, unchanged from before this suffix existed.
- * Disambiguates two different functions in the same file that each declare
- * their own same-named local dispatch table (Greptile review, PR #2445):
- * without it, both bindings would produce the identical `receiver` string
- * and share one evidence-set entry, wrongly crediting each other's
- * computed-invocation evidence.
+ * When the table's own declaration is scoped inside any block (not
+ * module-level), the returned name carries a `#${line}` suffix identifying
+ * that declaring scope (`findDeclaringScopeLine`) — `#` can never appear in
+ * a real identifier, so this can't collide with an actual table name, and a
+ * module-scope table (the common case) is returned bare, unchanged from
+ * before this suffix existed.
  */
 function findEnclosingTableName(node: TreeSitterNode): string | undefined {
   let current: TreeSitterNode | null = node.parent;
@@ -4231,8 +4255,8 @@ function findEnclosingTableName(node: TreeSitterNode): string | undefined {
     if (current.type === 'variable_declarator') {
       const nameNode = current.childForFieldName('name');
       if (nameNode?.type !== 'identifier') return undefined;
-      const scopeQualifier = findEnclosingFunctionQualifier(current);
-      return scopeQualifier === null ? nameNode.text : `${nameNode.text}#${scopeQualifier}`;
+      const scopeLine = findDeclaringScopeLine(current, nameNode.text);
+      return scopeLine === undefined ? nameNode.text : `${nameNode.text}#${scopeLine}`;
     }
     if (!TABLE_NAME_PASSTHROUGH_TYPES.has(current.type)) return undefined;
     current = current.parent;
@@ -4962,43 +4986,6 @@ function collectLogicalOrTernaryValueRefCall(declaratorNode: TreeSitterNode, cal
 }
 
 /**
- * Walk outward from a `TABLE[computedExpr]` reference through every
- * enclosing function scope, returning the qualifier name
- * (`findEnclosingFunctionQualifier`'s `qualifierForFunctionScopeNode`) of
- * the nearest one that locally declares `tableName` itself (via
- * `introducesShadowedBinding`, the same hardened shadow-detection #2257
- * built out) — i.e. the table is a function-local binding, not a
- * module-level one. `undefined` when no enclosing function locally
- * redeclares it (the common case: a module-level table referenced from
- * inside a function), matching the bare, unsuffixed name
- * `findEnclosingTableName` produces for that same module-level declaration
- * on the value-ref side.
- *
- * Without this, two different functions each declaring their own
- * same-named local table (Greptile review, PR #2445) would both reduce to
- * the identical bare `tableName` and share one evidence-set entry — this
- * makes the consumer side agree with `findEnclosingTableName`'s
- * declaration-side scoping so the two can only match when they really are
- * the same lexical binding.
- */
-function findConsumerTableScopeQualifier(
-  node: TreeSitterNode,
-  tableName: string,
-): string | undefined {
-  let current: TreeSitterNode | null = node.parent;
-  while (current) {
-    if (FUNCTION_SCOPE_TYPES.has(current.type)) {
-      const body = current.childForFieldName('body');
-      if (body && introducesShadowedBinding(body, tableName)) {
-        return qualifierForFunctionScopeNode(current) ?? undefined;
-      }
-    }
-    current = current.parent;
-  }
-  return undefined;
-}
-
-/**
  * Collect computed/bracket-access dispatch-table invocation evidence (issue
  * #2260) — extends the #1771/#1895 dot-property value-ref mechanism to the
  * `const handler = TABLE[computedExpr]; ...; handler(...)` idiom (a
@@ -5042,10 +5029,8 @@ function collectComputedDispatchTableEvidence(
   const indexNode = valueNode.childForFieldName('index');
   if (indexNode?.type === 'string' || indexNode?.type === 'template_string') return;
   if (!hasLaterReferenceInEnclosingBlock(declaratorNode, nameNode.text, true)) return;
-  const scopeQualifier = findConsumerTableScopeQualifier(declaratorNode, objectNode.text);
-  evidence.push(
-    scopeQualifier === undefined ? objectNode.text : `${objectNode.text}#${scopeQualifier}`,
-  );
+  const scopeLine = findDeclaringScopeLine(declaratorNode, objectNode.text);
+  evidence.push(scopeLine === undefined ? objectNode.text : `${objectNode.text}#${scopeLine}`);
 }
 
 function extractReceiverName(objNode: TreeSitterNode | null): string | undefined {

--- a/src/types.ts
+++ b/src/types.ts
@@ -950,8 +950,15 @@ export interface ExtractorOutput {
    * functions/files far more often than a dispatch-table's own constant
    * name does — the same reasoning #2257 used to reject a global,
    * name-only liveness check for local variables. Keying on the TABLE name
-   * instead is safe to aggregate graph-wide, matching #1895's own
-   * `invokedPropertyNames` precedent for dispatch-table property keys.
+   * is still not enough on its own, though (Greptile review, PR #2445): two
+   * unrelated files — or two different functions in the same file — can
+   * each declare their own same-named table. The consumer
+   * (`build-edges.ts`/`build_edges.rs`) scopes evidence by file, and each
+   * entry here already carries a `#${startLine}` suffix identifying its
+   * enclosing function when the table is function-scoped, bare when it's
+   * module-scoped (see `findEnclosingTableName`/`findConsumerTableScopeLine`
+   * in extractors/javascript.ts) — so aggregating these strings graph-wide
+   * is safe once file+scope qualification is applied on lookup.
    *
    * Consumed alongside `invokedPropertyNames` as an alternate liveness
    * pathway for a `dynamicKind: 'value-ref'` Call whose `receiver` (the

--- a/src/types.ts
+++ b/src/types.ts
@@ -938,6 +938,29 @@ export interface ExtractorOutput {
    */
   definePropertyReceivers?: Map<string, string>;
   /**
+   * Table names (issue #2260) confirmed to have LOCAL computed-invocation
+   * evidence: `const handler = TABLE[computedExpr]; ...; handler(...)` —
+   * `TABLE`'s name is recorded here only when the declared variable
+   * (`handler`) is later found as the callee of a call expression in its
+   * own enclosing block (mirroring #2257's local, position-scoped liveness
+   * check — see `hasLaterCallInEnclosingBlock` in extractors/javascript.ts).
+   *
+   * Deliberately NOT keyed on the intermediate variable's name (`handler`):
+   * that's a generic local identifier that collides across unrelated
+   * functions/files far more often than a dispatch-table's own constant
+   * name does — the same reasoning #2257 used to reject a global,
+   * name-only liveness check for local variables. Keying on the TABLE name
+   * instead is safe to aggregate graph-wide, matching #1895's own
+   * `invokedPropertyNames` precedent for dispatch-table property keys.
+   *
+   * Consumed alongside `invokedPropertyNames` as an alternate liveness
+   * pathway for a `dynamicKind: 'value-ref'` Call whose `receiver` (the
+   * table name, set by `collectObjectLiteralValueRefCall`) matches an
+   * entry here — extending the #1895 dot-property mechanism to the
+   * computed/bracket-access dispatch-table idiom.
+   */
+  computedDispatchTableEvidence?: readonly string[];
+  /**
    * CJS require bindings from `const { X, Y } = require('./path')` patterns.
    * Used by buildImportedNamesMap to classify X and Y as import artifacts so
    * receiver-edge resolution falls back to the global class lookup rather than

--- a/tests/integration/issue-2260-computed-dispatch-table-evidence.test.ts
+++ b/tests/integration/issue-2260-computed-dispatch-table-evidence.test.ts
@@ -32,6 +32,14 @@
  * same-named local table. `sameFileScopes.js` below regression-tests that —
  * `scopeA`'s locally-scoped `HANDLERS` earns computed-access evidence,
  * `scopeB`'s unrelated, separately-scoped `HANDLERS` must not inherit it.
+ *
+ * Scoping by enclosing FUNCTION alone still wasn't fine-grained enough for a
+ * third review round: two SIBLING BLOCKS inside the SAME function (an
+ * `if`/`else`), each declaring their own same-named table, reduced to the
+ * identical function-qualified key. `siblingBlocks.js` below regression-tests
+ * that — the `if` branch's locally-scoped `TABLE` earns computed-access
+ * evidence, the `else` branch's separately-scoped, same-named `TABLE` must
+ * not inherit it, even though both live in the same enclosing function.
  */
 
 import fs from 'node:fs';
@@ -92,6 +100,25 @@ function scopeA(node) {
 
 function scopeB() {
   const HANDLERS = { other: scopeBHandler };
+}
+`,
+  'siblingBlocks.js': `
+function ifBranchHandler(node) {
+  return node;
+}
+
+function elseBranchHandler(node) {
+  return node;
+}
+
+function dispatch(node) {
+  if (node.useIfBranch) {
+    const TABLE = { compute: ifBranchHandler };
+    const handler = TABLE[node.type];
+    if (handler) handler(node);
+  } else {
+    const TABLE = { other: elseBranchHandler };
+  }
 }
 `,
 };
@@ -179,6 +206,17 @@ function runShared(getDbPath: () => string) {
     // evidence of its own and must not inherit scopeA's.
     expect(countCallEdges(getDbPath(), 'scopeA', 'scopeAHandler')).toBeGreaterThan(0);
     expect(countIncomingCallEdges(getDbPath(), 'scopeBHandler')).toBe(0);
+  });
+
+  it('does not credit a same-named table in a sibling block, same function (Greptile review, PR #2445)', () => {
+    // siblingBlocks.js: the `if` branch's locally-scoped TABLE earns
+    // computed-access evidence (attributed to `dispatch`, the enclosing
+    // function, since the table is block-local) and its own handler gets an
+    // edge. The `else` branch's separately-scoped, same-named TABLE never
+    // earns any evidence of its own and must not inherit the if-branch's,
+    // even though both live in the same enclosing function.
+    expect(countCallEdges(getDbPath(), 'dispatch', 'ifBranchHandler')).toBeGreaterThan(0);
+    expect(countIncomingCallEdges(getDbPath(), 'elseBranchHandler')).toBe(0);
   });
 }
 

--- a/tests/integration/issue-2260-computed-dispatch-table-evidence.test.ts
+++ b/tests/integration/issue-2260-computed-dispatch-table-evidence.test.ts
@@ -26,6 +26,12 @@
  * with a handler that is never independently invoked and whose table is
  * never accessed computedly — that handler must stay dead even once
  * `dispatch.js`'s same-named table earns evidence.
+ *
+ * File-scoping alone still left one gap Greptile caught on the next review
+ * round: two different FUNCTIONS in the SAME file, each declaring their own
+ * same-named local table. `sameFileScopes.js` below regression-tests that —
+ * `scopeA`'s locally-scoped `HANDLERS` earns computed-access evidence,
+ * `scopeB`'s unrelated, separately-scoped `HANDLERS` must not inherit it.
  */
 
 import fs from 'node:fs';
@@ -69,6 +75,25 @@ const GROOVY_NODE_HANDLERS = {
   some_other_kind: unrelatedHandler,
 };
 `,
+  'sameFileScopes.js': `
+function scopeAHandler(node) {
+  return node;
+}
+
+function scopeBHandler(node) {
+  return node;
+}
+
+function scopeA(node) {
+  const HANDLERS = { compute: scopeAHandler };
+  const handler = HANDLERS[node.type];
+  if (handler) handler(node);
+}
+
+function scopeB() {
+  const HANDLERS = { other: scopeBHandler };
+}
+`,
 };
 
 const DEAD_ROLES = new Set(['dead-unresolved', 'dead-leaf', 'dead-entry', 'dead-ffi']);
@@ -104,6 +129,23 @@ function countCallEdges(dbPath: string, sourceName: string, targetName: string):
   }
 }
 
+function countIncomingCallEdges(dbPath: string, targetName: string): number {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    const row = db
+      .prepare(
+        `SELECT COUNT(*) AS cnt
+         FROM edges e
+         JOIN nodes t ON e.target_id = t.id
+         WHERE e.kind = 'calls' AND t.name = ?`,
+      )
+      .get(targetName) as { cnt: number };
+    return row.cnt;
+  } finally {
+    db.close();
+  }
+}
+
 function runShared(getDbPath: () => string) {
   it('creates a calls edge from the dispatch table to the handler reached via a computed lookup', () => {
     expect(
@@ -127,6 +169,16 @@ function runShared(getDbPath: () => string) {
     // independently invoked. Its own handler must get no calls edge even
     // though dispatch.js's same-named table has confirmed evidence.
     expect(countCallEdges(getDbPath(), 'GROOVY_NODE_HANDLERS', 'unrelatedHandler')).toBe(0);
+  });
+
+  it("does not credit a same-named table in a different function's scope, same file (Greptile review, PR #2445)", () => {
+    // sameFileScopes.js: scopeA's locally-scoped HANDLERS earns computed-
+    // access evidence (attributed to scopeA, the enclosing function, since
+    // the table itself is function-local) and its own handler gets an edge.
+    // scopeB's separately-scoped, same-named HANDLERS never earns any
+    // evidence of its own and must not inherit scopeA's.
+    expect(countCallEdges(getDbPath(), 'scopeA', 'scopeAHandler')).toBeGreaterThan(0);
+    expect(countIncomingCallEdges(getDbPath(), 'scopeBHandler')).toBe(0);
   });
 }
 

--- a/tests/integration/issue-2260-computed-dispatch-table-evidence.test.ts
+++ b/tests/integration/issue-2260-computed-dispatch-table-evidence.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Integration test for #2260: #1771/#1895 gave dot-property dispatch-table
+ * references (`{ resolve: someFn }` accessed via `x.resolve(...)`) a real
+ * `calls` edge once invocation evidence is confirmed, but never covered the
+ * computed/bracket-access idiom: `const handler = TABLE[node.type]; ...;
+ * handler(...)`. `handleGroovyInterfaceDecl` (and every other handler in
+ * `src/extractors/groovy.ts`'s `GROOVY_NODE_HANDLERS`) had `fanIn === 0` —
+ * nothing pointed to it at all — so once #2032's reachability downgrade
+ * landed, it and its own callees were wrongly flagged dead, even though
+ * they're genuinely reachable via the dispatch table.
+ *
+ * Fix: `collectComputedDispatchTableEvidence` (mirrored in the Rust engine)
+ * recognizes `const handler = TABLE[computedExpr]` followed by `handler(...)`
+ * later in the same enclosing block (reusing #2257's local, position-scoped
+ * liveness machinery, restricted to call-shape evidence specifically) and
+ * credits the WHOLE table with computed-invocation evidence — a computed key
+ * can't name one specific property statically the way a dot access can, so
+ * evidence is credited per-table rather than per-key.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+import { isNativeAvailable } from '../../src/infrastructure/native.js';
+
+const FIXTURE = {
+  'dispatch.js': `
+const GROOVY_NODE_HANDLERS = {
+  interface_definition: handleGroovyInterfaceDecl,
+  interface_declaration: handleGroovyInterfaceDecl,
+};
+
+function walkGroovyNode(node, ctx) {
+  const handler = GROOVY_NODE_HANDLERS[node.type];
+  if (handler) handler(node, ctx);
+}
+
+function handleGroovyInterfaceDecl(node, ctx) {
+  return collectGroovyParentInterfaces(node);
+}
+
+function collectGroovyParentInterfaces(node) {
+  return node;
+}
+
+export function start(node, ctx) {
+  walkGroovyNode(node, ctx);
+}
+`,
+};
+
+const DEAD_ROLES = new Set(['dead-unresolved', 'dead-leaf', 'dead-entry', 'dead-ffi']);
+
+function readNodesWithRoles(dbPath: string) {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return db.prepare('SELECT name, kind, role FROM nodes ORDER BY name').all() as Array<{
+      name: string;
+      kind: string;
+      role: string | null;
+    }>;
+  } finally {
+    db.close();
+  }
+}
+
+function countCallEdges(dbPath: string, sourceName: string, targetName: string): number {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    const row = db
+      .prepare(
+        `SELECT COUNT(*) AS cnt
+         FROM edges e
+         JOIN nodes s ON e.source_id = s.id
+         JOIN nodes t ON e.target_id = t.id
+         WHERE e.kind = 'calls' AND s.name = ? AND t.name = ?`,
+      )
+      .get(sourceName, targetName) as { cnt: number };
+    return row.cnt;
+  } finally {
+    db.close();
+  }
+}
+
+function runShared(getDbPath: () => string) {
+  it('creates a calls edge from the dispatch table to the handler reached via a computed lookup', () => {
+    expect(
+      countCallEdges(getDbPath(), 'GROOVY_NODE_HANDLERS', 'handleGroovyInterfaceDecl'),
+    ).toBeGreaterThan(0);
+  });
+
+  it('keeps the handler and its own callees reachable, not dead', () => {
+    const nodes = readNodesWithRoles(getDbPath());
+    const handler = nodes.find((n) => n.name === 'handleGroovyInterfaceDecl');
+    const callee = nodes.find((n) => n.name === 'collectGroovyParentInterfaces');
+    expect(handler, 'handleGroovyInterfaceDecl node not found').toBeDefined();
+    expect(callee, 'collectGroovyParentInterfaces node not found').toBeDefined();
+    expect(DEAD_ROLES.has(handler!.role ?? '')).toBe(false);
+    expect(DEAD_ROLES.has(callee!.role ?? '')).toBe(false);
+  });
+}
+
+describe('computed dispatch-table access gets invocation evidence (#2260) — WASM', () => {
+  let tmpDir: string;
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-2260-'));
+    for (const [rel, content] of Object.entries(FIXTURE)) {
+      fs.writeFileSync(path.join(tmpDir, rel), content);
+    }
+    await buildGraph(tmpDir, { engine: 'wasm', incremental: false, skipRegistry: true });
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  runShared(() => path.join(tmpDir, '.codegraph', 'graph.db'));
+});
+
+describe.skipIf(!isNativeAvailable())(
+  'computed dispatch-table access gets invocation evidence (#2260) — native',
+  () => {
+    let nativeTmpDir: string;
+
+    beforeAll(async () => {
+      nativeTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-2260-native-'));
+      for (const [rel, content] of Object.entries(FIXTURE)) {
+        fs.writeFileSync(path.join(nativeTmpDir, rel), content);
+      }
+      await buildGraph(nativeTmpDir, { engine: 'native', incremental: false, skipRegistry: true });
+    }, 60_000);
+
+    afterAll(() => {
+      fs.rmSync(nativeTmpDir, { recursive: true, force: true });
+    });
+
+    runShared(() => path.join(nativeTmpDir, '.codegraph', 'graph.db'));
+  },
+);

--- a/tests/integration/issue-2260-computed-dispatch-table-evidence.test.ts
+++ b/tests/integration/issue-2260-computed-dispatch-table-evidence.test.ts
@@ -16,6 +16,16 @@
  * credits the WHOLE table with computed-invocation evidence — a computed key
  * can't name one specific property statically the way a dot access can, so
  * evidence is credited per-table rather than per-key.
+ *
+ * The "credit the whole table" aggregation (both engines) was originally
+ * keyed on the table's bare variable name across the whole build pass, not
+ * scoped per-file — so a second, unrelated file declaring its own same-named
+ * table with no computed-access evidence of its own would wrongly inherit
+ * the first file's evidence (Greptile review, PR #2445). `unrelated.js`
+ * below regression-tests that: it declares its own `GROOVY_NODE_HANDLERS`
+ * with a handler that is never independently invoked and whose table is
+ * never accessed computedly — that handler must stay dead even once
+ * `dispatch.js`'s same-named table earns evidence.
  */
 
 import fs from 'node:fs';
@@ -49,6 +59,15 @@ function collectGroovyParentInterfaces(node) {
 export function start(node, ctx) {
   walkGroovyNode(node, ctx);
 }
+`,
+  'unrelated.js': `
+function unrelatedHandler(node) {
+  return node;
+}
+
+const GROOVY_NODE_HANDLERS = {
+  some_other_kind: unrelatedHandler,
+};
 `,
 };
 
@@ -100,6 +119,14 @@ function runShared(getDbPath: () => string) {
     expect(callee, 'collectGroovyParentInterfaces node not found').toBeDefined();
     expect(DEAD_ROLES.has(handler!.role ?? '')).toBe(false);
     expect(DEAD_ROLES.has(callee!.role ?? '')).toBe(false);
+  });
+
+  it("does not credit an unrelated file's same-named table with borrowed evidence (Greptile review, PR #2445)", () => {
+    // unrelated.js declares its own `GROOVY_NODE_HANDLERS` — same bare name
+    // as dispatch.js's table, but never accessed computedly and never
+    // independently invoked. Its own handler must get no calls edge even
+    // though dispatch.js's same-named table has confirmed evidence.
+    expect(countCallEdges(getDbPath(), 'GROOVY_NODE_HANDLERS', 'unrelatedHandler')).toBe(0);
   });
 }
 

--- a/tests/parsers/javascript.test.ts
+++ b/tests/parsers/javascript.test.ts
@@ -2414,6 +2414,119 @@ function runDemo(reporter: Reporter, users: string[]): void {
     });
   });
 
+  describe('computed/bracket-access dispatch-table invocation evidence (#2260)', () => {
+    // This mechanism's Call extraction is UNCONDITIONAL (like #1771/#1895 —
+    // every bare-identifier object-literal property value always produces a
+    // value-ref Call, regardless of liveness); only the RESOLVER (build-edges.ts
+    // / incremental.ts) later gates whether that Call becomes a real edge,
+    // consulting invokedPropertyNames/computedDispatchTableEvidence at that
+    // point — NOT here. So the correct thing to assert at the extractor level
+    // is computedDispatchTableEvidence's own contents (what THIS mechanism
+    // actually decides), not the calls array (which is always populated
+    // either way) — the full end-to-end edge-creation behavior is covered by
+    // the dual-engine integration test instead.
+
+    // The confirmed real-world case: an AST-node-type-keyed dispatch table
+    // (src/extractors/groovy.ts's GROOVY_NODE_HANDLERS), consumed via a
+    // computed lookup stored in an intermediate variable, then called.
+    it('records the table name when the intermediate variable is later called', () => {
+      const symbols = parseJS(`
+        const NODE_HANDLERS = {
+          interface_definition: handleInterfaceDecl,
+        };
+        function walkNode(node, ctx) {
+          const handler = NODE_HANDLERS[node.type];
+          if (handler) handler(node, ctx);
+        }
+      `);
+      expect(symbols.computedDispatchTableEvidence).toEqual(['NODE_HANDLERS']);
+    });
+
+    it('does not record the table name when the intermediate variable is only referenced, never called', () => {
+      const symbols = parseJS(`
+        const NODE_HANDLERS = {
+          interface_definition: handleInterfaceDecl,
+        };
+        function walkNode(node, ctx) {
+          const handler = NODE_HANDLERS[node.type];
+          console.log(handler);
+        }
+      `);
+      expect(symbols.computedDispatchTableEvidence).toBeUndefined();
+    });
+
+    it('does not fire for a string-literal key — already handled by the existing computed-literal path', () => {
+      const symbols = parseJS(`
+        const NODE_HANDLERS = {
+          interface_definition: handleInterfaceDecl,
+        };
+        function walkNode() {
+          const handler = NODE_HANDLERS['interface_definition'];
+          handler();
+        }
+      `);
+      expect(symbols.computedDispatchTableEvidence).toBeUndefined();
+    });
+
+    it('does not record the table name when the call is inside a nested scope that shadows the intermediate variable', () => {
+      const symbols = parseJS(`
+        const NODE_HANDLERS = {
+          interface_definition: handleInterfaceDecl,
+        };
+        function walkNode(node, ctx) {
+          const handler = NODE_HANDLERS[node.type];
+          {
+            let handler = unrelatedFn;
+            handler();
+          }
+        }
+      `);
+      expect(symbols.computedDispatchTableEvidence).toBeUndefined();
+    });
+
+    it('resolves the table name through a parenthesized/as-const wrapper', () => {
+      const symbols = parseJS(`
+        const NODE_HANDLERS = ({
+          interface_definition: handleInterfaceDecl,
+        } as const);
+        function walkNode(node, ctx) {
+          const handler = NODE_HANDLERS[node.type];
+          handler();
+        }
+      `);
+      expect(symbols.computedDispatchTableEvidence).toEqual(['NODE_HANDLERS']);
+    });
+
+    it('only records the specific table that has its own computed-invocation evidence', () => {
+      const symbols = parseJS(`
+        const HANDLERS_A = {
+          interface_definition: handleA,
+        };
+        const HANDLERS_B = {
+          interface_definition: handleB,
+        };
+        function walkNode(node, ctx) {
+          const handler = HANDLERS_A[node.type];
+          handler();
+        }
+      `);
+      expect(symbols.computedDispatchTableEvidence).toEqual(['HANDLERS_A']);
+    });
+
+    it('does not overflow the stack on a pathologically deep enclosing block', () => {
+      const depth = 300;
+      const nested = `${'if (true) {\n'.repeat(depth)}handler();\n${'}\n'.repeat(depth)}`;
+      const source = `
+        const NODE_HANDLERS = { interface_definition: handleInterfaceDecl };
+        function walkNode(node) {
+          const handler = NODE_HANDLERS[node.type];
+          ${nested}
+        }
+      `;
+      expect(() => parseJS(source)).not.toThrow();
+    });
+  });
+
   describe('inline object-literal dispatch table extraction (RES-2, #1897)', () => {
     // Mirrors the Rust `dispatch_table_emits_dt_call_and_array_elem_bindings`
     // / `dispatch_table_parenthesized_object_also_works` unit tests in


### PR DESCRIPTION
## Summary

`{ resolve: someFn }` dot-property dispatch-table references already get liveness-gated `calls` edges once #1895 confirms a real `.resolve(...)` invocation somewhere. That mechanism never covered the computed/bracket-access idiom:

```js
const handler = TABLE[node.type];
if (handler) handler(node, ctx);
```

`src/extractors/groovy.ts`'s `GROOVY_NODE_HANDLERS` dispatch table (and every handler it points to) has `fanIn === 0` under this pattern — nothing pointed to any handler via a syntactic edge — so once #2032's reachability downgrade landed, each handler and its own callees were wrongly classified dead, despite being genuinely reachable through the table.

## Fix

New `collectComputedDispatchTableEvidence`/`handle_computed_dispatch_table_evidence` (TS + Rust) recognizes `const handler = TABLE[computedExpr]` followed by a later call-site reference to `handler` in the same enclosing block — reusing #2257's local, position-scoped liveness-scanning machinery (`hasLaterReferenceInEnclosingBlock`/`has_later_reference_in_enclosing_block`), extended with a new `requireCallSite`/`require_call_site` parameter so the leaf match is restricted to identifiers that are specifically the *callee* of a call expression, matching #1895's "invoked via call syntax" precision.

Because a computed key can't statically name one specific property the way a dot access can, evidence is credited to the **whole table** (keyed on the table's own variable name) rather than per-key — the existing keyExpr gate at `resolveFallbackTargets`/`resolve_call_targets` now passes when either the per-key evidence *or* the table-level computed-access evidence is present.

## Also fixed: a durable-table parity bug found during verification

While verifying this change end-to-end, `tests/integration/issue-1852-watch-cha-pts-dynamic-sink.test.ts`'s object-rest-param suite started failing — a full native build produced an extra, incorrect `calls` edge that an incremental rebuild of the identical source correctly omitted.

Root cause: `persist_invoked_property_names` (`import_edges.rs`) — the native orchestrator's writer for the durable `invoked_property_names` table (#2087) — has its own inline copy of the "what counts as invoked-via-member-call-syntax" filter, rather than calling the shared `collect_invoked_property_names`. That inline copy was missing the `dynamic_kind != "value-ref"` exclusion this PR's own gate change depends on, so a value-ref call's own bare reference polluted the durable evidence table it later gets checked against — self-confirming its own liveness on every subsequent build. Fixed by applying the same exclusion there, matching the already-correct in-memory `collect_invoked_property_names` and the TS-side `persistInvokedPropertyNames` (which already reuses the shared, correctly-scoped helper).

## Testing

- New extractor unit tests (7 TS + 6 Rust) covering: table-name recorded when later called, not recorded when only referenced, not recorded for string-literal keys, not recorded across a shadowing nested scope, resolves through parenthesized/as-const wrappers, isolates evidence per-table (two tables, only one has call evidence), and a pathological 300-deep nesting stack-safety check.
- New dual-engine integration test (`tests/integration/issue-2260-computed-dispatch-table-evidence.test.ts`) against a Groovy-style dispatch-table fixture, asserting the edge exists on both WASM and native engines and that the handler + its callees are not classified dead.
- Full suite: 5008 tests passing (WASM + native).
- `node scripts/parity-compare.mjs`: 42/42 fixtures identical across engines.
- `npm run lint`: clean.

Closes #2260