### PR TITLE
fix(ast-analysis): stop misattributing complexity/CFG across same-line anonymous functions

### DIFF
--- a/crates/codegraph-core/src/ast_analysis/engine.rs
+++ b/crates/codegraph-core/src/ast_analysis/engine.rs
@@ -89,10 +89,12 @@ pub fn analyze_complexity_standalone(
             let metrics = compute_all_metrics(&node, source_bytes, lang_id)?;
             let name = function_name(&node, source_bytes);
             let line = node.start_position().row as u32 + 1;
+            let column = Some(node.start_position().column as u32);
             let end_line = Some(node.end_position().row as u32 + 1);
             Some(FunctionComplexityResult {
                 name,
                 line,
+                column,
                 end_line,
                 complexity: metrics,
             })
@@ -132,10 +134,12 @@ pub fn build_cfg_standalone(
             let cfg = build_function_cfg(&node, lang_id, source_bytes)?;
             let name = function_name(&node, source_bytes);
             let line = node.start_position().row as u32 + 1;
+            let column = Some(node.start_position().column as u32);
             let end_line = Some(node.end_position().row as u32 + 1);
             Some(FunctionCfgResult {
                 name,
                 line,
+                column,
                 end_line,
                 cfg,
             })
@@ -152,4 +156,39 @@ pub fn extract_dataflow_standalone(
 ) -> Option<DataflowResult> {
     let (tree, lang) = parse_source(source, file_path, lang_id)?;
     extract_dataflow(&tree, source.as_bytes(), lang.lang_id_str())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Issue #2265: `matchNativeResult` (JS side, engine.ts) needs each
+    /// standalone result's own column to disambiguate two anonymous
+    /// functions that share a line — confirms the native standalone
+    /// analysis functions actually populate it.
+    #[test]
+    fn analyze_complexity_standalone_populates_column() {
+        let results = analyze_complexity_standalone(
+            "const a = (x) => x, b = (x) => x;",
+            "test.js",
+            Some("javascript"),
+        );
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].column, Some(10));
+        assert_eq!(results[1].column, Some(24));
+        assert_ne!(results[0].column, results[1].column);
+    }
+
+    #[test]
+    fn build_cfg_standalone_populates_column() {
+        let results = build_cfg_standalone(
+            "function outer() { if (true) {} }\nconst a = (x) => x, b = (x) => x;",
+            "test.js",
+            Some("javascript"),
+        );
+        let a = results.iter().find(|r| r.line == 2 && r.column == Some(10));
+        let b = results.iter().find(|r| r.line == 2 && r.column == Some(24));
+        assert!(a.is_some(), "expected a result at line 2, column 10");
+        assert!(b.is_some(), "expected a result at line 2, column 25");
+    }
 }

--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -2521,7 +2521,12 @@ fn handle_var_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             symbols.definitions.push(Definition {
                 name: node_text(&name_n, source).to_string(),
                 kind: "function".to_string(),
-                line: start_line(node),
+                // #2265: the function VALUE's own start line, not the
+                // enclosing statement's — `node` spans the whole
+                // `const a = fn1, b = fn2;` declaration, so every declarator
+                // in a multi-binding statement previously got the identical
+                // (wrong, for every declarator but the first) line.
+                line: start_line(&value_n),
                 end_line: Some(end_line(&value_n)),
                 decorators: None,
                 complexity: compute_all_metrics(&value_n, source, "javascript"),
@@ -7135,6 +7140,23 @@ mod tests {
         assert_eq!(s.definitions.len(), 1);
         assert_eq!(s.definitions[0].name, "add");
         assert_eq!(s.definitions[0].kind, "function");
+    }
+
+    /// Issue #2265: a multi-declarator `const a = fn1, b = fn2;` statement
+    /// previously gave every declarator the SAME `line` (the whole
+    /// statement's start, not each function value's own start) — misleading
+    /// for anything keyed on line, including the JS-side complexity/CFG
+    /// matcher this mirrors (`matchResultToDef` in apply-results.ts).
+    #[test]
+    fn multi_declarator_var_fn_assignment_uses_each_functions_own_line() {
+        let s = parse_js(
+            "const a = (x) => {\n  if (x) { return 1; }\n  return 0;\n}, b = (x) => {\n  return 2;\n};\n",
+        );
+        let a = s.definitions.iter().find(|d| d.name == "a").unwrap();
+        let b = s.definitions.iter().find(|d| d.name == "b").unwrap();
+        assert_eq!(a.line, 1);
+        assert_eq!(b.line, 4);
+        assert_ne!(a.line, b.line);
     }
 
     #[test]

--- a/crates/codegraph-core/src/types.rs
+++ b/crates/codegraph-core/src/types.rs
@@ -614,6 +614,17 @@ impl FileSymbols {
 pub struct FunctionComplexityResult {
     pub name: String,
     pub line: u32,
+    /// 0-based source column of this function node's own start position —
+    /// mirrors tree-sitter's own convention directly (unlike `line`, never
+    /// `+1`-adjusted for display), since this is purely an internal
+    /// disambiguation key for `matchNativeResult` (issue #2265), never
+    /// rendered to users. Lets the JS engine's line-keyed match fall back to
+    /// an exact line+column match when a `Definition`'s own column is known
+    /// (currently only for JS/TS var/const-assigned anonymous function
+    /// values, where two such functions can share a `Definition.line` but
+    /// never share a column) — the same-line ambiguity a name-only
+    /// disambiguator can never resolve for an anonymous function.
+    pub column: Option<u32>,
     #[napi(js_name = "endLine")]
     pub end_line: Option<u32>,
     pub complexity: ComplexityMetrics,
@@ -624,6 +635,8 @@ pub struct FunctionComplexityResult {
 pub struct FunctionCfgResult {
     pub name: String,
     pub line: u32,
+    /// See `FunctionComplexityResult.column`'s doc comment.
+    pub column: Option<u32>,
     #[napi(js_name = "endLine")]
     pub end_line: Option<u32>,
     pub cfg: CfgData,

--- a/src/ast-analysis/apply-results.ts
+++ b/src/ast-analysis/apply-results.ts
@@ -72,13 +72,32 @@ export function indexByLine<T extends { funcNode: TreeSitterNode }>(
   return byLine;
 }
 
-/** Find the best matching result for a definition by line + name. */
+/**
+ * Find the best matching result for a definition by line + name, preferring
+ * an exact column match when available.
+ *
+ * `name` can only disambiguate a *named* function/method Definition — an
+ * arrow function has no name field at all, and a function *expression*'s
+ * own internal name (if any) is not the variable it was assigned to, so
+ * `name` never disambiguates a var/const-assigned closure (issue #2265).
+ * `defColumn` (only populated for exactly that Definition category — see
+ * `Definition.column`'s doc comment) closes that gap: two functions can
+ * share a `line` — a multi-declarator statement collapsed onto one
+ * (now-fixed) line, or two genuinely same-line closures — but never share
+ * both line AND column. Checked before the name fallback since it's a
+ * strictly more precise signal whenever it's available on both sides.
+ */
 export function matchResultToDef<T extends { funcNode: TreeSitterNode }>(
   candidates: T[] | undefined,
   defName: string,
+  defColumn?: number,
 ): T | undefined {
   if (!candidates) return undefined;
   if (candidates.length === 1) return candidates[0];
+  if (defColumn != null) {
+    const byColumn = candidates.find((r) => r.funcNode.startPosition.column === defColumn);
+    if (byColumn) return byColumn;
+  }
   return (
     candidates.find((r) => {
       const n = r.funcNode.childForFieldName('name');
@@ -111,7 +130,7 @@ export function storeComplexityResults(
       !def.complexity &&
       def.bodyless !== true
     ) {
-      const funcResult = matchResultToDef(byLine.get(def.line), def.name);
+      const funcResult = matchResultToDef(byLine.get(def.line), def.name, def.column);
       if (!funcResult) continue;
       const { metrics } = funcResult;
       const loc = computeLOCMetrics(funcResult.funcNode, langId);
@@ -155,7 +174,7 @@ export function storeCfgResults(results: WalkResults, defs: Definition[]): void 
       !def.cfg?.blocks?.length &&
       def.bodyless !== true
     ) {
-      const cfgResult = matchResultToDef(byLine.get(def.line), def.name);
+      const cfgResult = matchResultToDef(byLine.get(def.line), def.name, def.column);
       if (!cfgResult) continue;
       def.cfg = { blocks: cfgResult.blocks, edges: cfgResult.edges };
     }

--- a/src/ast-analysis/engine.ts
+++ b/src/ast-analysis/engine.ts
@@ -210,12 +210,25 @@ function indexNativeByLine<T extends { line: number; name: string }>(
   return byLine;
 }
 
-function matchNativeResult<T extends { name: string }>(
+/**
+ * See `matchResultToDef`'s (apply-results.ts) doc comment for the full
+ * rationale — this is the structurally-identical fix applied to the
+ * separate native-standalone-analysis matching copy (issue #2265): `name`
+ * never disambiguates a var/const-assigned anonymous function, so an exact
+ * column match (when both the native result and the Definition carry one)
+ * is checked first.
+ */
+function matchNativeResult<T extends { name: string; column?: number | null }>(
   candidates: T[] | undefined,
   defName: string,
+  defColumn?: number,
 ): T | undefined {
   if (!candidates) return undefined;
   if (candidates.length === 1) return candidates[0];
+  if (defColumn != null) {
+    const byColumn = candidates.find((r) => r.column === defColumn);
+    if (byColumn) return byColumn;
+  }
   return candidates.find((r) => r.name === defName) ?? candidates[0];
 }
 
@@ -228,7 +241,7 @@ function storeNativeComplexityResults(
 
   for (const def of defs) {
     if ((def.kind === 'function' || def.kind === 'method') && def.line && !def.complexity) {
-      const match = matchNativeResult(byLine.get(def.line), def.name);
+      const match = matchNativeResult(byLine.get(def.line), def.name, def.column);
       if (!match) continue;
       const { complexity: c } = match;
       def.complexity = {
@@ -281,7 +294,7 @@ function storeNativeCfgResults(results: NativeFunctionCfgResult[], defs: Definit
       def.cfg !== null &&
       !def.cfg?.blocks?.length
     ) {
-      const match = matchNativeResult(byLine.get(def.line), def.name);
+      const match = matchNativeResult(byLine.get(def.line), def.name, def.column);
       if (!match) continue;
       def.cfg = match.cfg;
     }

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -134,15 +134,27 @@ function handleFnCapture(c: Record<string, TreeSitterNode>, definitions: Definit
   });
 }
 
-/** Handle variable_declarator with arrow_function / function_expression capture. */
+/**
+ * Handle variable_declarator with arrow_function / function_expression capture.
+ *
+ * Uses the function VALUE's own start position — not the enclosing
+ * declaration statement's — for `line`/`column` (issue #2265): a
+ * `const a = fn1, b = fn2;` multi-declarator statement previously gave
+ * every declarator the identical statement-start line, so any declarator
+ * but the first collided with a sibling's real complexity/CFG result once
+ * `matchResultToDef` (apply-results.ts) indexed by each function node's own
+ * (correct) line. `column` additionally survives even a genuine same-line
+ * collision (two anonymous closures both starting on one physical line),
+ * which `name`-based disambiguation can never resolve for an anonymous
+ * function/arrow value.
+ */
 function handleVarFnCapture(c: Record<string, TreeSitterNode>, definitions: Definition[]): void {
-  const declNode = c.varfn_name!.parent?.parent;
-  const line = declNode ? nodeStartLine(declNode) : nodeStartLine(c.varfn_name!);
   const varFnChildren = extractParameters(c.varfn_value!);
   definitions.push({
     name: c.varfn_name!.text,
     kind: 'function',
-    line,
+    line: nodeStartLine(c.varfn_value!),
+    column: c.varfn_value!.startPosition.column,
     endLine: nodeEndLine(c.varfn_value!),
     children: varFnChildren.length > 0 ? varFnChildren : undefined,
   });
@@ -1848,7 +1860,7 @@ function handleVariableDeclarator(
     valType === 'function' ||
     valType === 'generator_function'
   ) {
-    handleVarFnAssignment(node, nameN, valueN, ctx);
+    handleVarFnAssignment(nameN, valueN, ctx);
   } else if (isConst && nameN.type === 'identifier' && !hasFunctionScopeAncestor(node)) {
     // Any other initializer shape becomes a 'constant' Definition, regardless of
     // complexity (call/member/parenthesized expressions, etc.) — mirroring how
@@ -1875,9 +1887,20 @@ function handleVariableDeclarator(
   }
 }
 
-/** Handle `const/let fn = (...) => {...}` — a function/arrow value assigned to a variable. */
+/**
+ * Handle `const/let fn = (...) => {...}` — a function/arrow value assigned
+ * to a variable.
+ *
+ * Uses `valueN`'s (the function itself) own start position, not `node`'s
+ * (the enclosing declaration statement) — issue #2265: `node` spans the
+ * whole `const a = fn1, b = fn2;` statement, so every declarator got the
+ * identical statement-start line, colliding with a sibling declarator's
+ * real complexity/CFG result once `matchResultToDef` (apply-results.ts)
+ * indexed by each function node's own (correct) line. See
+ * `handleVarFnCapture`'s fuller comment (query path) for the rest of the
+ * rationale — `column` mirrors the same fix there.
+ */
 function handleVarFnAssignment(
-  node: TreeSitterNode,
   nameN: TreeSitterNode,
   valueN: TreeSitterNode,
   ctx: ExtractorOutput,
@@ -1886,7 +1909,8 @@ function handleVarFnAssignment(
   ctx.definitions.push({
     name: nameN.text,
     kind: 'function',
-    line: nodeStartLine(node),
+    line: nodeStartLine(valueN),
+    column: valueN.startPosition.column,
     endLine: nodeEndLine(valueN),
     children: varFnChildren.length > 0 ? varFnChildren : undefined,
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -464,6 +464,20 @@ export interface Definition {
   name: string;
   kind: SymbolKind;
   line: number;
+  /**
+   * 0-based source column of this Definition's own node — mirrors
+   * tree-sitter's own convention directly (unlike `line`, never
+   * `+1`-adjusted for display), since this is purely an internal
+   * disambiguation key for `matchResultToDef`/`matchNativeResult` (issue
+   * #2265), never rendered to users. Only populated for var/const-assigned
+   * anonymous function values (`handleVarFnAssignment`/`handleVarFnCapture`
+   * in extractors/javascript.ts) — the one Definition category where two
+   * distinct functions can legitimately share `line` (a multi-declarator
+   * statement, or two genuinely same-line closures) and where `name`
+   * (the variable bound, not the function's own — usually absent —
+   * internal name) can never disambiguate them.
+   */
+  column?: number;
   endLine?: number;
   children?: SubDeclaration[];
   visibility?: 'public' | 'private' | 'protected';
@@ -2692,6 +2706,8 @@ export interface NativeAddon {
 export interface NativeFunctionComplexityResult {
   name: string;
   line: number;
+  /** See `Definition.column`'s doc comment (issue #2265). */
+  column?: number | null;
   endLine: number | null;
   complexity: {
     cognitive: number;
@@ -2718,6 +2734,8 @@ export interface NativeFunctionComplexityResult {
 export interface NativeFunctionCfgResult {
   name: string;
   line: number;
+  /** See `Definition.column`'s doc comment (issue #2265). */
+  column?: number | null;
   endLine: number | null;
   cfg: { blocks: CfgBlock[]; edges: CfgEdge[] };
 }

--- a/tests/integration/issue-2265-anonymous-fn-complexity-misattribution.test.ts
+++ b/tests/integration/issue-2265-anonymous-fn-complexity-misattribution.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Integration test for #2265: `handleVarFnAssignment`/`handleVarFnCapture`
+ * (extractors/javascript.ts) set a var/const-assigned function's
+ * `Definition.line` from the ENCLOSING declaration statement, not the
+ * function value's own node — so `const a = fn1, b = fn2;` gave every
+ * declarator but the first the wrong `line`. `storeComplexityResults`/
+ * `storeCfgResults` (ast-analysis/apply-results.ts) index visitor results by
+ * each function node's own (correct) real line, then disambiguate same-line
+ * ties via `name` — always null for an anonymous arrow/function-expression
+ * value, so the mismatched `Definition.line` silently misattributed one
+ * sibling's complexity/CFG onto another.
+ *
+ * Fix: `Definition.line`/`column` now come from the function value's own
+ * node (mirrored in Rust's `handle_var_decl`), and `matchResultToDef`/
+ * `matchNativeResult` prefer an exact column match before falling back to
+ * name/first-candidate — closing the residual gap for two genuinely
+ * same-line anonymous functions the line fix alone can't resolve.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+import { isNativeAvailable } from '../../src/infrastructure/native.js';
+
+const FIXTURE = {
+  'multiDeclarator.js': `
+const a = (x) => {
+  if (x) { return 1; }
+  return 0;
+}, b = (x) => {
+  return 2;
+};
+a(1); b(2);
+`,
+  'sameLine.js': `
+function outer(x) { if (x) { return 1; } return 0; }
+
+const same1 = (y) => { return y; }, same2 = (y) => { if (y) {
+  return 3;
+}
+return 4; };
+same1(1); same2(2); outer(3);
+`,
+};
+
+function readComplexity(dbPath: string, name: string): { cyclomatic: number; cognitive: number } {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    const row = db
+      .prepare(
+        `SELECT fc.cyclomatic AS cyclomatic, fc.cognitive AS cognitive
+         FROM function_complexity fc
+         JOIN nodes n ON fc.node_id = n.id
+         WHERE n.name = ?`,
+      )
+      .get(name) as { cyclomatic: number; cognitive: number } | undefined;
+    expect(row, `no function_complexity row found for ${name}`).toBeDefined();
+    return row!;
+  } finally {
+    db.close();
+  }
+}
+
+function runShared(getDbPath: () => string) {
+  it('gives each declarator in a multi-declarator statement its own, correctly-attributed complexity', () => {
+    // `a` branches (cyclomatic 2); `b` does not (cyclomatic 1). Before the
+    // fix, both got Definition.line=1 (the statement start) while only
+    // `a`'s real complexity result was ever indexed there — `b` silently
+    // inherited `a`'s metrics.
+    const a = readComplexity(getDbPath(), 'a');
+    const b = readComplexity(getDbPath(), 'b');
+    expect(a.cyclomatic).toBe(2);
+    expect(a.cognitive).toBe(1);
+    expect(b.cyclomatic).toBe(1);
+    expect(b.cognitive).toBe(0);
+  });
+
+  it('disambiguates two genuinely same-line anonymous functions by column', () => {
+    // same1 and same2's arrow functions start on the identical physical
+    // line (only their columns differ) — same1 has no branch, same2 does.
+    const same1 = readComplexity(getDbPath(), 'same1');
+    const same2 = readComplexity(getDbPath(), 'same2');
+    expect(same1.cyclomatic).toBe(1);
+    expect(same1.cognitive).toBe(0);
+    expect(same2.cyclomatic).toBe(2);
+    expect(same2.cognitive).toBe(1);
+  });
+}
+
+describe('var/const-assigned anonymous function complexity misattribution (#2265) — WASM', () => {
+  let tmpDir: string;
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-2265-'));
+    for (const [rel, content] of Object.entries(FIXTURE)) {
+      fs.writeFileSync(path.join(tmpDir, rel), content);
+    }
+    await buildGraph(tmpDir, { engine: 'wasm', incremental: false, skipRegistry: true });
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  runShared(() => path.join(tmpDir, '.codegraph', 'graph.db'));
+});
+
+describe.skipIf(!isNativeAvailable())(
+  'var/const-assigned anonymous function complexity misattribution (#2265) — native',
+  () => {
+    let nativeTmpDir: string;
+
+    beforeAll(async () => {
+      nativeTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-2265-native-'));
+      for (const [rel, content] of Object.entries(FIXTURE)) {
+        fs.writeFileSync(path.join(nativeTmpDir, rel), content);
+      }
+      await buildGraph(nativeTmpDir, { engine: 'native', incremental: false, skipRegistry: true });
+    }, 60_000);
+
+    afterAll(() => {
+      fs.rmSync(nativeTmpDir, { recursive: true, force: true });
+    });
+
+    runShared(() => path.join(nativeTmpDir, '.codegraph', 'graph.db'));
+  },
+);

--- a/tests/parsers/javascript.test.ts
+++ b/tests/parsers/javascript.test.ts
@@ -2618,6 +2618,45 @@ function runDemo(reporter: Reporter, users: string[]): void {
     });
   });
 
+  describe('var/const-assigned function Definition.line/column (#2265)', () => {
+    it('gives each declarator in a multi-declarator statement its own function-node line, not the statement start', () => {
+      const symbols = parseJS(`
+        const a = (x) => {
+          if (x) { return 1; }
+          return 0;
+        }, b = (x) => {
+          return 2;
+        };
+        a(1); b(2);
+      `);
+      const a = symbols.definitions.find((d) => d.name === 'a');
+      const b = symbols.definitions.find((d) => d.name === 'b');
+      expect(a?.line).toBe(2);
+      expect(b?.line).toBe(5);
+      expect(a?.line).not.toBe(b?.line);
+    });
+
+    it('records each declarator its own start column, distinct even on a shared line', () => {
+      const symbols = parseJS(
+        `const a = (y) => { return y; }, b = (y) => { if (y) { return 1; } return 0; };`,
+      );
+      const a = symbols.definitions.find((d) => d.name === 'a');
+      const b = symbols.definitions.find((d) => d.name === 'b');
+      expect(a?.line).toBe(b?.line);
+      expect(a?.column).toBeDefined();
+      expect(b?.column).toBeDefined();
+      expect(a?.column).not.toBe(b?.column);
+    });
+
+    it('uses the function-expression value node line for a single named/anonymous function-expression declarator too', () => {
+      const symbols = parseJS(`const solo = function (x) { return x; };`);
+      const solo = symbols.definitions.find((d) => d.name === 'solo');
+      // Single-declarator statement: statement start and value-node start
+      // coincide here, so this must keep passing unchanged by the #2265 fix.
+      expect(solo?.line).toBe(1);
+    });
+  });
+
   describe('instanceof value-ref extraction (#1784)', () => {
     it('extracts a value-ref call for `instanceof ClassName`', () => {
       const symbols = parseJS(`

--- a/tests/unit/apply-results.test.ts
+++ b/tests/unit/apply-results.test.ts
@@ -19,9 +19,14 @@ import {
 import type { Definition, TreeSitterNode, WalkResults } from '../../src/types.js';
 
 /** Minimal fake tree-sitter node satisfying only what the merge functions read. */
-function fakeFuncNode(row: number, name: string | null, text = 'function f() {}'): TreeSitterNode {
+function fakeFuncNode(
+  row: number,
+  name: string | null,
+  text = 'function f() {}',
+  column = 0,
+): TreeSitterNode {
   return {
-    startPosition: { row, column: 0 },
+    startPosition: { row, column },
     text,
     childForFieldName: (field: string) => (field === 'name' && name ? { text: name } : null),
   } as unknown as TreeSitterNode;
@@ -85,6 +90,41 @@ describe('indexByLine / matchResultToDef', () => {
 
   it('returns undefined when there are no candidates at all', () => {
     expect(matchResultToDef(undefined, 'a')).toBeUndefined();
+  });
+
+  describe('column disambiguation (#2265)', () => {
+    // Anonymous functions (arrow functions, most function expressions) have
+    // no `name` field at all, so the name-based fallback can never
+    // disambiguate them — these regression-guard the column-based tier that
+    // now runs before it.
+    it('prefers an exact column match over the name fallback for two anonymous candidates sharing a line', () => {
+      const results = [
+        { funcNode: fakeFuncNode(2, null, 'x => x', 10) },
+        { funcNode: fakeFuncNode(2, null, 'y => y', 40) },
+      ];
+      const byLine = indexByLine(results);
+      expect(matchResultToDef(byLine.get(3), 'b', 40)).toBe(results[1]);
+      expect(matchResultToDef(byLine.get(3), 'b', 10)).toBe(results[0]);
+    });
+
+    it('falls back to the name/first-candidate tiers when defColumn is not provided', () => {
+      const results = [
+        { funcNode: fakeFuncNode(2, null, 'x => x', 10) },
+        { funcNode: fakeFuncNode(2, null, 'y => y', 40) },
+      ];
+      const byLine = indexByLine(results);
+      expect(matchResultToDef(byLine.get(3), 'nonexistent')).toBe(results[0]);
+    });
+
+    it('falls back to the name/first-candidate tiers when no candidate column matches', () => {
+      const results = [
+        { funcNode: fakeFuncNode(2, 'named', 'function named() {}', 10) },
+        { funcNode: fakeFuncNode(2, null, 'y => y', 40) },
+      ];
+      const byLine = indexByLine(results);
+      // defColumn (99) matches nothing — falls through to the name match.
+      expect(matchResultToDef(byLine.get(3), 'named', 99)).toBe(results[0]);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Found while addressing #2036 (Greptile review on PR #2264): the shared complexity/CFG result-matching path (`matchResultToDef` in `src/ast-analysis/apply-results.ts`) keys candidates by `Definition.line`, disambiguating same-line ties via `funcNode.childForFieldName('name')?.text === defName` — falling back to `candidates[0]` when that fails, which it always does for an anonymous function (no `name` field at all).

Root cause is two compounding bugs:

1. **Wrong `Definition.line`.** `handleVarFnAssignment`/`handleVarFnCapture` (`src/extractors/javascript.ts`) and `handle_var_decl` (Rust) set a var/const-assigned function's `Definition.line` from the *enclosing declaration statement*, not the function value's own node. `const a = fn1, b = fn2;` gave every declarator but the first the identical (wrong) line — the statement's start — so `b`'s Definition collided with `a`'s real, correctly line-keyed complexity/CFG result once the visitor walk indexed by each function node's own actual line.
2. **No disambiguation signal for anonymous functions.** Even with #1 fixed, two functions can still genuinely start on the same physical line — `matchResultToDef`'s only fallback (`name`) can never break that tie for an arrow function or a var-assigned function expression (whose own internal name, if any, is never the variable it was assigned to).

## Fix

- `Definition.line`/`Definition.column` now come from the function value's own AST node in all three extraction sites (TS walk path, TS query path, Rust `handle_var_decl`) — `column` is new, populated *only* for this Definition category (var/const-assigned anonymous function values), since it's the one case where `name` structurally can never disambiguate.
- `matchResultToDef` (apply-results.ts, WASM/visitor path) and `matchNativeResult` (engine.ts, native-standalone-analysis fallback path) both gained a column-first disambiguation tier, checked before the name/first-candidate fallback. These stay two separate, structurally mirrored implementations rather than one shared function — one operates on live tree-sitter nodes (needed elsewhere for LOC metrics), the other on native-computed plain objects with no such node — but both apply the identical algorithm now.
- `column` was added narrowly to the two NAPI-crossing structs the native-standalone fallback already returns (`FunctionComplexityResult`, `FunctionCfgResult`), *not* to the widely-constructed shared `Definition` struct in Rust, which has ~200 unrelated literal-construction sites across every language extractor and doesn't need this field — native's own inline full-pipeline complexity/CFG attachment computes each Definition's metrics directly from its own value node and was never vulnerable to the line-keyed misattribution in the first place. It still needed the `line` fix on its own merits, since `Definition.line` also feeds `contentHash`/incremental-rebuild reconnection and `codegraph where`.

## Testing

- New unit tests: `tests/unit/apply-results.test.ts` (column-disambiguation tiers for `matchResultToDef`), 3 new Rust tests (`multi_declarator_var_fn_assignment_uses_each_functions_own_line`, `analyze_complexity_standalone_populates_column`, `build_cfg_standalone_populates_column`).
- New extractor tests in `tests/parsers/javascript.test.ts` covering the multi-declarator line fix and same-line column disambiguation.
- New dual-engine integration test (`tests/integration/issue-2265-anonymous-fn-complexity-misattribution.test.ts`) reproducing the issue's own repro plus a genuinely-same-line case, asserting correct (not misattributed) `cyclomatic`/`cognitive` on both WASM and native engines.
- Manually verified against the issue's exact repro before/after: `a` (has a branch) now correctly shows `cyclomatic=2`, `b` (no branch) now correctly shows `cyclomatic=1` — previously both showed `2`.
- Full suite: 5024 tests passing (WASM + native).
- `node scripts/parity-compare.mjs`: 42/42 fixtures identical across engines.
- `npm run lint` / `cargo fmt --check`: clean.

Closes #2265