### PR TITLE
fix(extractors): recognize array-pattern CJS require() destructures

### DIFF
--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -2481,6 +2481,50 @@ const VAR_DECL_FN_SCOPE_TYPES: [&str; 6] = [
     "generator_function",
 ];
 
+/// Detect `<destructured pattern> = require('./path')` and, if so, push a
+/// CJS-require `Import` so the receiver-edge resolver treats the destructured
+/// names as import artifacts, not local definitions (mirrors the WASM
+/// `cjsRequireBindings` mechanism, #1678). `names` is the pattern's
+/// already-collected bound names — `collect_object_pattern_names` for
+/// `const { a, b } = require(...)`, `collect_array_pattern_names` for
+/// `const [a, b] = require(...)` (issue #2268 added the array-pattern case;
+/// it was never recorded at all before, only the object-pattern shape was).
+fn record_cjs_require_import(
+    value_n: &Node,
+    source: &[u8],
+    names: Vec<String>,
+    node_line: u32,
+    imports: &mut Vec<Import>,
+) {
+    if names.is_empty() || value_n.kind() != "call_expression" {
+        return;
+    }
+    let Some(fn_node) = value_n.child_by_field_name("function") else {
+        return;
+    };
+    if node_text(&fn_node, source) != "require" {
+        return;
+    }
+    let args = value_n
+        .child_by_field_name("arguments")
+        .or_else(|| find_child(value_n, "arguments"));
+    let Some(args) = args else {
+        return;
+    };
+    let Some(str_arg) = find_child(&args, "string") else {
+        return;
+    };
+    let mod_path = node_text(&str_arg, source).replace(&['\'', '"'][..], "");
+    // CJS require bindings never populate renamed_imports — resolve_call_targets
+    // deliberately ignores the original name for these (empty target_file forces
+    // a same-file fallback match, matching WASM's importedNamesMap exclusion,
+    // #1678) — so any rename pairs the caller collected are discarded before
+    // reaching here (see the object-pattern call site's own comment).
+    let mut imp = Import::new(mod_path, names, node_line);
+    imp.cjs_require = Some(true);
+    imports.push(imp);
+}
+
 fn handle_var_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     let is_const = node
         .child(0)
@@ -2550,34 +2594,14 @@ fn handle_var_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
             // If the RHS is a CJS require() call, also add to imports so the
             // receiver-edge resolver treats the names as import artifacts, not
             // local definitions — mirroring the WASM cjsRequireBindings fix (#1678).
-            if value_n.kind() == "call_expression" {
-                if let Some(fn_node) = value_n.child_by_field_name("function") {
-                    if node_text(&fn_node, source) == "require" {
-                        let args = value_n
-                            .child_by_field_name("arguments")
-                            .or_else(|| find_child(&value_n, "arguments"));
-                        if let Some(args) = args {
-                            if let Some(str_arg) = find_child(&args, "string") {
-                                let mod_path =
-                                    node_text(&str_arg, source).replace(&['\'', '"'][..], "");
-                                // CJS require bindings never populate renamed_imports —
-                                // resolve_call_targets deliberately ignores the original
-                                // name for these (empty target_file forces a same-file
-                                // fallback match, matching WASM's importedNamesMap
-                                // exclusion, #1678) — so the rename pairs collected here
-                                // are discarded.
-                                let names =
-                                    collect_object_pattern_names(&name_n, source, &mut Vec::new());
-                                if !names.is_empty() {
-                                    let mut imp = Import::new(mod_path, names, start_line(node));
-                                    imp.cjs_require = Some(true);
-                                    symbols.imports.push(imp);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+            let names = collect_object_pattern_names(&name_n, source, &mut Vec::new());
+            record_cjs_require_import(
+                &value_n,
+                source,
+                names,
+                start_line(node),
+                &mut symbols.imports,
+            );
         } else if is_const && name_n.kind() == "identifier" && !in_function_scope {
             // Any other initializer shape becomes a "constant" Definition, regardless of
             // complexity (call/member/parenthesized expressions, etc.) — mirroring how
@@ -2612,6 +2636,16 @@ fn handle_var_decl(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
                 start_line(node),
                 end_line(node),
                 &mut symbols.definitions,
+            );
+            // Mirrors the object_pattern branch above: `const [a, b] = require('./mod')`
+            // never got recorded as a CJS-require import artifact by either engine (#2268).
+            let names = collect_array_pattern_names(&name_n, source);
+            record_cjs_require_import(
+                &value_n,
+                source,
+                names,
+                start_line(node),
+                &mut symbols.imports,
             );
         } else if !is_const
             && value_n.kind() == "object"
@@ -7900,6 +7934,38 @@ mod tests {
     #[test]
     fn finds_cjs_require_with_object_rest_destructuring() {
         let s = parse_js("const { a, ...rest } = require('./mod');");
+        let cjs_imports: Vec<_> = s
+            .imports
+            .iter()
+            .filter(|i| i.cjs_require == Some(true))
+            .collect();
+        assert_eq!(cjs_imports.len(), 1);
+        assert_eq!(cjs_imports[0].source, "./mod");
+        assert_eq!(
+            cjs_imports[0].names,
+            vec!["a".to_string(), "rest".to_string()]
+        );
+    }
+
+    /// Issue #2268: only the object-pattern require() destructure was ever
+    /// recorded as a CJS-require import artifact — `const [a, b] =
+    /// require('./mod')` was silently dropped by both engines.
+    #[test]
+    fn finds_cjs_require_with_array_pattern_destructuring() {
+        let s = parse_js("const [a, b] = require('./mod');");
+        let cjs_imports: Vec<_> = s
+            .imports
+            .iter()
+            .filter(|i| i.cjs_require == Some(true))
+            .collect();
+        assert_eq!(cjs_imports.len(), 1);
+        assert_eq!(cjs_imports[0].source, "./mod");
+        assert_eq!(cjs_imports[0].names, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn finds_cjs_require_with_array_pattern_rest_destructuring() {
+        let s = parse_js("const [a, ...rest] = require('./mod');");
         let cjs_imports: Vec<_> = s
             .imports
             .iter()

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -1157,17 +1157,35 @@ function extractDestructuredDeclarators(
         nodeEndLine(declNode),
         definitions,
       );
+      // Record CJS require bindings so importedNames can classify these names
+      // as import artifacts, preventing false local-definition blocking (#1661) —
+      // mirrors the object_pattern branch above; array-pattern requires
+      // (`const [a, b] = require('./mod')`) were never recorded at all (#2268).
+      if (cjsRequireBindings) {
+        const valueN = declarator.childForFieldName('value');
+        const binding = extractCjsRequireBinding(nameN, valueN);
+        if (binding) cjsRequireBindings.push(binding);
+      }
     }
   }
 }
 
 /**
- * Compute a `const { X } = require('./path')` CJS binding record from a destructured
- * object-pattern name node and its declarator's value node, for import-artifact
- * classification (#1661). Returns null when the value isn't a static require() call or
- * no destructured names could be extracted. Shared by the walk-based
- * (extractDestructuredDeclarators) and query-based (handleVariableDecl) const-destructuring
- * paths, which independently need the identical extraction.
+ * Compute a `const { X } = require('./path')` (or `const [a, b] = require(...)`)
+ * CJS binding record from a destructured object- or array-pattern name node and
+ * its declarator's value node, for import-artifact classification (#1661).
+ * Returns null when the value isn't a static require() call or no destructured
+ * names could be extracted. Shared by the walk-based (extractDestructuredDeclarators)
+ * and query-based (handleVariableDecl) const-destructuring paths, which
+ * independently need the identical extraction.
+ *
+ * Delegates name collection to `collectObjectPatternNames`/`collectArrayPatternNames`
+ * — the same shared, declaration-order-correct helpers `extractDestructuredBindings`/
+ * `extractArrayPatternBindings` and `collectExportedDeclarations` already use — rather
+ * than maintaining a third, partial reimplementation. Previously this had its own
+ * inline object-pattern-only loop (missing e.g. a renamed binding's own default
+ * value) and no array-pattern case at all, so a `const [a, b] = require('./mod')`
+ * never got classified as import-sourced by either engine (issue #2268).
  */
 function extractCjsRequireBinding(
   nameN: TreeSitterNode,
@@ -1180,29 +1198,10 @@ function extractCjsRequireBinding(
   const strArg = args && findChild(args, 'string');
   if (!strArg) return null;
   const modPath = strArg.text.replace(/['"]/g, '');
-  const names: string[] = [];
-  for (let k = 0; k < nameN.childCount; k++) {
-    const prop = nameN.child(k);
-    if (!prop) continue;
-    if (
-      prop.type === 'shorthand_property_identifier_pattern' ||
-      prop.type === 'shorthand_property_identifier'
-    ) {
-      names.push(prop.text);
-    } else if (prop.type === 'pair_pattern' || prop.type === 'pair') {
-      const val = prop.childForFieldName('value');
-      if (val?.type === 'identifier' || val?.type === 'shorthand_property_identifier_pattern') {
-        names.push(val.text);
-      }
-    } else if (prop.type === 'rest_pattern' || prop.type === 'rest_element') {
-      // { a, ...rest } = require(...) — without this branch the rest binding
-      // was silently dropped from the CJS-require import-artifact classification
-      // (issue #2037), a parity gap with Rust's collect_object_pattern_names
-      // (which the native require() path already reuses correctly).
-      const inner = extractRestPatternIdentifier(prop);
-      if (inner) names.push(inner);
-    }
-  }
+  const names =
+    nameN.type === 'array_pattern'
+      ? collectArrayPatternNames(nameN)
+      : collectObjectPatternNames(nameN);
   if (names.length === 0) return null;
   return { names, source: modPath };
 }
@@ -1881,9 +1880,7 @@ function handleVariableDeclarator(
   } else if (isConst && nameN.type === 'object_pattern' && !hasFunctionScopeAncestor(node)) {
     handleConstObjectPatternAssignment(node, nameN, valueN, ctx);
   } else if (isConst && nameN.type === 'array_pattern' && !hasFunctionScopeAncestor(node)) {
-    // Array destructuring: `const [x, y] = ...` — one constant Definition per
-    // bound identifier (#1901). Scope guard mirrors the object_pattern branch above.
-    extractArrayPatternBindings(nameN, nodeStartLine(node), nodeEndLine(node), ctx.definitions);
+    handleConstArrayPatternAssignment(node, nameN, valueN, ctx);
   }
 }
 
@@ -1958,6 +1955,28 @@ function handleConstObjectPatternAssignment(
   // handle_var_decl (Rust path) — skips bindings inside function bodies.
   extractDestructuredBindings(nameN, nodeStartLine(node), nodeEndLine(node), ctx.definitions);
   // Record CJS require bindings for import-artifact classification (#1661).
+  const binding = extractCjsRequireBinding(nameN, valueN);
+  if (binding) {
+    if (!ctx.cjsRequireBindings) ctx.cjsRequireBindings = [];
+    ctx.cjsRequireBindings.push(binding);
+  }
+}
+
+/**
+ * Handle `const [a, b] = value` — destructured array-pattern const bindings.
+ * Mirrors `handleConstObjectPatternAssignment` above, including the CJS
+ * require-binding recording — `const [a, b] = require('./mod')` never got
+ * classified as import-sourced by either engine (#2268).
+ */
+function handleConstArrayPatternAssignment(
+  node: TreeSitterNode,
+  nameN: TreeSitterNode,
+  valueN: TreeSitterNode,
+  ctx: ExtractorOutput,
+): void {
+  // Array destructuring: `const [x, y] = ...` — one constant Definition per
+  // bound identifier (#1901). Scope guard mirrors the object_pattern branch above.
+  extractArrayPatternBindings(nameN, nodeStartLine(node), nodeEndLine(node), ctx.definitions);
   const binding = extractCjsRequireBinding(nameN, valueN);
   if (binding) {
     if (!ctx.cjsRequireBindings) ctx.cjsRequireBindings = [];

--- a/tests/integration/issue-2268-cjs-require-array-pattern.test.ts
+++ b/tests/integration/issue-2268-cjs-require-array-pattern.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Integration test for #2268: CJS `require()` import-artifact classification
+ * (`cjsRequireBindings` in TS, `Import.cjs_require` in Rust — see #1661) only
+ * ever recognized an object-pattern destructure of the require() result.
+ * `const [a, b] = require('./mod')` never got recorded as import-sourced by
+ * either engine — the bound names were extracted as plain `constant`
+ * Definitions but never classified as import artifacts.
+ *
+ * Observable consequence, per `resolveReceiverEdge`'s own #1539 rule (a local
+ * same-file symbol always wins over a same-named cross-file one *unless* it's
+ * classified as an import artifact, in which case resolution correctly falls
+ * back to the global/cross-file candidate): `consumer.js` below destructures
+ * `Logger` via an array-pattern require, then does `new Logger()` — before
+ * the fix, `Logger` was wrongly treated as a *locally-owned* symbol (a
+ * `constant`-kind Definition, which fails the `RECEIVER_KINDS` filter), so
+ * the receiver edge to `loggerMod.js`'s real `class Logger` was silently
+ * dropped instead of falling back to it.
+ *
+ * Fix: `extractCjsRequireBinding`/`record_cjs_require_import` now handle
+ * array-pattern destructures too, in the WASM query path
+ * (`extractDestructuredDeclarators`), the WASM walk path
+ * (`handleConstArrayPatternAssignment`), and the Rust extractor
+ * (`handle_var_decl`).
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+import { isNativeAvailable } from '../../src/infrastructure/native.js';
+
+const FIXTURE = {
+  'loggerMod.js': `
+class Logger {
+  log() { return 1; }
+}
+module.exports = { Logger };
+`,
+  'consumer.js': `
+const [Logger] = require('./loggerMod');
+function run() {
+  const l = new Logger();
+  l.log();
+}
+`,
+};
+
+function countReceiverEdges(
+  dbPath: string,
+  sourceName: string,
+  targetName: string,
+  targetFile: string,
+): number {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    const row = db
+      .prepare(
+        `SELECT COUNT(*) AS cnt
+         FROM edges e
+         JOIN nodes s ON e.source_id = s.id
+         JOIN nodes t ON e.target_id = t.id
+         WHERE e.kind = 'receiver' AND s.name = ? AND t.name = ? AND t.file = ?`,
+      )
+      .get(sourceName, targetName, targetFile) as { cnt: number };
+    return row.cnt;
+  } finally {
+    db.close();
+  }
+}
+
+function runShared(getDbPath: () => string) {
+  it('resolves the array-pattern-required name to the cross-file class, not the local constant', () => {
+    expect(countReceiverEdges(getDbPath(), 'run', 'Logger', 'loggerMod.js')).toBeGreaterThan(0);
+  });
+}
+
+describe('CJS require() array-pattern destructure gets import-artifact classification (#2268) — WASM', () => {
+  let tmpDir: string;
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-2268-'));
+    for (const [rel, content] of Object.entries(FIXTURE)) {
+      fs.writeFileSync(path.join(tmpDir, rel), content);
+    }
+    await buildGraph(tmpDir, { engine: 'wasm', incremental: false, skipRegistry: true });
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  runShared(() => path.join(tmpDir, '.codegraph', 'graph.db'));
+});
+
+describe.skipIf(!isNativeAvailable())(
+  'CJS require() array-pattern destructure gets import-artifact classification (#2268) — native',
+  () => {
+    let nativeTmpDir: string;
+
+    beforeAll(async () => {
+      nativeTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-2268-native-'));
+      for (const [rel, content] of Object.entries(FIXTURE)) {
+        fs.writeFileSync(path.join(nativeTmpDir, rel), content);
+      }
+      await buildGraph(nativeTmpDir, { engine: 'native', incremental: false, skipRegistry: true });
+    }, 60_000);
+
+    afterAll(() => {
+      fs.rmSync(nativeTmpDir, { recursive: true, force: true });
+    });
+
+    runShared(() => path.join(nativeTmpDir, '.codegraph', 'graph.db'));
+  },
+);

--- a/tests/parsers/javascript.test.ts
+++ b/tests/parsers/javascript.test.ts
@@ -433,6 +433,23 @@ describe('JavaScript parser', () => {
     });
   });
 
+  describe('CJS require() array-pattern destructuring (#2268)', () => {
+    // `extractCjsRequireBinding` only ever recognized an object_pattern
+    // destructure of the require() result — `const [a, b] = require(...)`
+    // never got recorded as a CJS-require import artifact at all, in either
+    // engine, unlike the object-pattern shape.
+
+    it('records a plain array-pattern require destructure', () => {
+      const symbols: any = parseJS(`const [a, b] = require('./mod');`);
+      expect(symbols.cjsRequireBindings).toEqual([{ names: ['a', 'b'], source: './mod' }]);
+    });
+
+    it('includes a rest binding in an array-pattern require destructure', () => {
+      const symbols: any = parseJS(`const [a, ...rest] = require('./mod');`);
+      expect(symbols.cjsRequireBindings).toEqual([{ names: ['a', 'rest'], source: './mod' }]);
+    });
+  });
+
   it('extracts call expressions', () => {
     const symbols = parseJS(`import { foo } from './bar'; foo(); baz();`);
     expect(symbols.calls).toContainEqual(expect.objectContaining({ name: 'foo' }));


### PR DESCRIPTION
## Summary

Both engines' CJS `require()` import-artifact classification (`cjsRequireBindings` in TS, `Import.cjs_require` in Rust — see #1661) only ever recognized an **object-pattern** destructure of the require() result:

- TS: `extractCjsRequireBinding` (`src/extractors/javascript.ts`) had its own partial, object-pattern-only inline loop.
- Rust: `handle_var_decl`'s CJS-require branch (`crates/codegraph-core/src/extractors/javascript.rs`) gated on `name_n.kind() == "object_pattern"` the same way.

`const [a, b] = require('./mod')` was extracted as plain `constant` Definitions but never classified as import-sourced by either engine — symmetric between engines (not a parity divergence), a pure missing-feature gap.

## Why this matters

Per `resolveReceiverEdge`'s own `#1539` rule: a local same-file symbol always wins over a same-named cross-file one — *unless* it's classified as an import artifact, in which case resolution correctly falls back to the cross-file candidate. Without this fix, an array-pattern-required name shadows the real cross-file target and the receiver edge to it is silently **dropped** (not just resolved to the wrong place — dropped entirely, since the local `constant`-kind stand-in fails the `RECEIVER_KINDS` filter with no fallback).

## Fix

- `extractCjsRequireBinding` (TS) now delegates name collection to `collectObjectPatternNames`/`collectArrayPatternNames` — the same shared, declaration-order-correct helpers `extractDestructuredBindings`/`extractArrayPatternBindings` and `collectExportedDeclarations` already use — replacing its own partial reimplementation, rather than adding a third one for the array-pattern case.
- Both TS extraction paths now record array-pattern require bindings: the query path (`extractDestructuredDeclarators`) and the walk path (new `handleConstArrayPatternAssignment`, mirroring the existing `handleConstObjectPatternAssignment`).
- Rust's `handle_var_decl` gained the same array-pattern branch, factored through a new shared `record_cjs_require_import` helper instead of duplicating the inline require()-detection logic a second time.

## Testing

- New unit tests in `tests/parsers/javascript.test.ts` (walk path) and 2 new Rust tests, covering plain and rest-binding array-pattern require destructures.
- New dual-engine integration test (`tests/integration/issue-2268-cjs-require-array-pattern.test.ts`) exploiting the concrete, observable `#1539` behavior described above: `new Logger()` where `Logger` comes from an array-pattern require correctly resolves a `receiver` edge to the cross-file `class Logger`, on both WASM and native engines.
- Verified the new integration test actually catches the regression: reverted the fix locally, confirmed the `receiver` edge disappears entirely (not just resolves wrong), then restored it.
- Full suite: 5028 tests passing (WASM + native).
- `node scripts/parity-compare.mjs`: 42/42 fixtures identical across engines.
- `npm run lint` / `cargo fmt --check`: clean.

Closes #2268