### PR TITLE
fix(tracer): jvm-tracer.sh excludes anonymous-class/closure bodies from traceCall() injection

### DIFF
--- a/tests/benchmarks/resolution/tracer/jvm-tracer.sh
+++ b/tests/benchmarks/resolution/tracer/jvm-tracer.sh
@@ -155,13 +155,17 @@ case "$LANG" in
             # `new[[:space:]]` (#2272) additionally excludes an anonymous class
             # instantiation (`new Runnable() {`), which also shares the "...) {"
             # shape: Java has no default parameter values, so a method's own
-            # signature can never itself contain `new SomeType(` -- any line
-            # matching the outer pattern that also contains `new <Identifier>`
-            # is unambiguously an anonymous-class body opening, not a method
-            # signature (injecting into it would be invalid Java -- a bare
-            # statement directly in a class body -- rather than a distinct
-            # method body to trace).
-            sedi_append_unless '/\)[[:space:]]*\{$/' '/class[[:space:]]|interface[[:space:]]|if[[:space:]]|while[[:space:]]|for[[:space:]]|switch[[:space:]]|catch[[:space:]]|synchronized[[:space:]]|try[[:space:]]|new[[:space:]]+[A-Za-z_$]/' \
+            # signature can never itself contain the token `new` followed by
+            # whitespace -- any line matching the outer pattern that also
+            # contains it is unambiguously an anonymous-class body opening, not
+            # a method signature (injecting into it would be invalid Java -- a
+            # bare statement directly in a class body -- rather than a distinct
+            # method body to trace). Deliberately NOT anchored to an identifier
+            # immediately after the whitespace (`new[[:space:]]+[A-Za-z_$]`)
+            # -- that missed `new /* comment */ Runnable() {} ` (Greptile
+            # review, PR #2449); the bare `new` keyword followed by whitespace
+            # is already the unambiguous signal on its own.
+            sedi_append_unless '/\)[[:space:]]*\{$/' '/class[[:space:]]|interface[[:space:]]|if[[:space:]]|while[[:space:]]|for[[:space:]]|switch[[:space:]]|catch[[:space:]]|synchronized[[:space:]]|try[[:space:]]|new[[:space:]]/' \
                 '        CallTracer.traceCall();' "$javafile"
         done
 
@@ -245,18 +249,24 @@ case "$LANG" in
         # control-flow keywords -- #2045, and `new[[:space:]]` for anonymous
         # classes -- #2272; Groovy supports Java-style anonymous classes too).
         #
-        # `\.[A-Za-z_][A-Za-zA-Z0-9_]*\([^()]*\)[[:space:]]*\{[[:space:]]*$`
+        # `^[[:space:]]*([A-Za-z_][A-Za-zA-Z0-9_]*\.)?[A-Za-z_][A-Za-zA-Z0-9_]*\([^()]*\)[[:space:]]*\{[[:space:]]*$`
         # (#2272) additionally excludes a trailing-closure method CALL, e.g.
-        # `list.findAll() {` or a DSL-style `lock.withLock() {` -- these share
-        # the "...) {" shape but the `traceCall()` would land inside a closure
-        # literal, not a real method body. The distinguishing feature is the
-        # `.` immediately before the call name: a real Groovy method
-        # DECLARATION is never written as `<qualifier>.<name>(...) {` -- a
-        # dotted, fully-qualified RETURN TYPE (`java.util.List getUsers() {`)
-        # still has a space (not a dot) directly before the method name, so it
-        # doesn't match this pattern.
+        # `list.findAll() {`, a DSL-style `lock.withLock() {`, or the same
+        # calls WITHOUT an explicit receiver (`findAll() {`, `withLock() {` --
+        # Greptile review, PR #2449, on an earlier version of this fix that
+        # only handled the qualified form) -- these share the "...) {" shape
+        # but the `traceCall()` would land inside a closure literal, not a
+        # real method body. Anchored at the start of the (trimmed) line: a
+        # real Groovy method DECLARATION always has a `def`/type/modifier
+        # token, separated by WHITESPACE, before the method name -- so the
+        # declaration's own name is never the first token on the line -- while
+        # a call expression's name (optionally preceded by a `receiver.`) is.
+        # A dotted, fully-qualified RETURN TYPE (`java.util.List getUsers() {`)
+        # still has a space (not a dot) directly before the method name, so
+        # `getUsers` -- not `List` -- would need to start the trimmed line for
+        # this to false-positive, which it doesn't.
         for grfile in "$TMP_DIR"/*.groovy; do
-            sedi_append_unless '/\)[[:space:]]*\{[[:space:]]*$/' '/class[[:space:]]|interface[[:space:]]|if[[:space:]]|while[[:space:]]|for[[:space:]]|switch[[:space:]]|catch[[:space:]]|synchronized[[:space:]]|try[[:space:]]|new[[:space:]]+[A-Za-z_$]|\.[A-Za-z_][A-Za-zA-Z0-9_]*\([^()]*\)[[:space:]]*\{[[:space:]]*$/' \
+            sedi_append_unless '/\)[[:space:]]*\{[[:space:]]*$/' '/class[[:space:]]|interface[[:space:]]|if[[:space:]]|while[[:space:]]|for[[:space:]]|switch[[:space:]]|catch[[:space:]]|synchronized[[:space:]]|try[[:space:]]|new[[:space:]]|^[[:space:]]*([A-Za-z_][A-Za-zA-Z0-9_]*\.)?[A-Za-z_][A-Za-zA-Z0-9_]*\([^()]*\)[[:space:]]*\{[[:space:]]*$/' \
                 '        CallTracer.traceCall();' "$grfile"
         done
 

--- a/tests/benchmarks/resolution/tracer/jvm-tracer.sh
+++ b/tests/benchmarks/resolution/tracer/jvm-tracer.sh
@@ -151,7 +151,17 @@ case "$LANG" in
             # isn't practical here; excluding the known control-flow keywords is
             # the pragmatic option, matching how class/interface are already
             # excluded below.
-            sedi_append_unless '/\)[[:space:]]*\{$/' '/class[[:space:]]|interface[[:space:]]|if[[:space:]]|while[[:space:]]|for[[:space:]]|switch[[:space:]]|catch[[:space:]]|synchronized[[:space:]]|try[[:space:]]/' \
+            #
+            # `new[[:space:]]` (#2272) additionally excludes an anonymous class
+            # instantiation (`new Runnable() {`), which also shares the "...) {"
+            # shape: Java has no default parameter values, so a method's own
+            # signature can never itself contain `new SomeType(` -- any line
+            # matching the outer pattern that also contains `new <Identifier>`
+            # is unambiguously an anonymous-class body opening, not a method
+            # signature (injecting into it would be invalid Java -- a bare
+            # statement directly in a class body -- rather than a distinct
+            # method body to trace).
+            sedi_append_unless '/\)[[:space:]]*\{$/' '/class[[:space:]]|interface[[:space:]]|if[[:space:]]|while[[:space:]]|for[[:space:]]|switch[[:space:]]|catch[[:space:]]|synchronized[[:space:]]|try[[:space:]]|new[[:space:]]+[A-Za-z_$]/' \
                 '        CallTracer.traceCall();' "$javafile"
         done
 
@@ -232,9 +242,21 @@ case "$LANG" in
 
         # Inject CallTracer.traceCall() into every method body
         # (see the java branch above for why the negate pattern also excludes
-        # control-flow keywords -- #2045)
+        # control-flow keywords -- #2045, and `new[[:space:]]` for anonymous
+        # classes -- #2272; Groovy supports Java-style anonymous classes too).
+        #
+        # `\.[A-Za-z_][A-Za-zA-Z0-9_]*\([^()]*\)[[:space:]]*\{[[:space:]]*$`
+        # (#2272) additionally excludes a trailing-closure method CALL, e.g.
+        # `list.findAll() {` or a DSL-style `lock.withLock() {` -- these share
+        # the "...) {" shape but the `traceCall()` would land inside a closure
+        # literal, not a real method body. The distinguishing feature is the
+        # `.` immediately before the call name: a real Groovy method
+        # DECLARATION is never written as `<qualifier>.<name>(...) {` -- a
+        # dotted, fully-qualified RETURN TYPE (`java.util.List getUsers() {`)
+        # still has a space (not a dot) directly before the method name, so it
+        # doesn't match this pattern.
         for grfile in "$TMP_DIR"/*.groovy; do
-            sedi_append_unless '/\)[[:space:]]*\{[[:space:]]*$/' '/class[[:space:]]|interface[[:space:]]|if[[:space:]]|while[[:space:]]|for[[:space:]]|switch[[:space:]]|catch[[:space:]]|synchronized[[:space:]]|try[[:space:]]/' \
+            sedi_append_unless '/\)[[:space:]]*\{[[:space:]]*$/' '/class[[:space:]]|interface[[:space:]]|if[[:space:]]|while[[:space:]]|for[[:space:]]|switch[[:space:]]|catch[[:space:]]|synchronized[[:space:]]|try[[:space:]]|new[[:space:]]+[A-Za-z_$]|\.[A-Za-z_][A-Za-zA-Z0-9_]*\([^()]*\)[[:space:]]*\{[[:space:]]*$/' \
                 '        CallTracer.traceCall();' "$grfile"
         done
 

--- a/tests/benchmarks/resolution/tracer/jvm-tracer.sh
+++ b/tests/benchmarks/resolution/tracer/jvm-tracer.sh
@@ -152,20 +152,27 @@ case "$LANG" in
             # the pragmatic option, matching how class/interface are already
             # excluded below.
             #
-            # `new[[:space:]]` (#2272) additionally excludes an anonymous class
-            # instantiation (`new Runnable() {`), which also shares the "...) {"
-            # shape: Java has no default parameter values, so a method's own
-            # signature can never itself contain the token `new` followed by
-            # whitespace -- any line matching the outer pattern that also
-            # contains it is unambiguously an anonymous-class body opening, not
-            # a method signature (injecting into it would be invalid Java -- a
-            # bare statement directly in a class body -- rather than a distinct
-            # method body to trace). Deliberately NOT anchored to an identifier
-            # immediately after the whitespace (`new[[:space:]]+[A-Za-z_$]`)
-            # -- that missed `new /* comment */ Runnable() {} ` (Greptile
-            # review, PR #2449); the bare `new` keyword followed by whitespace
-            # is already the unambiguous signal on its own.
-            sedi_append_unless '/\)[[:space:]]*\{$/' '/class[[:space:]]|interface[[:space:]]|if[[:space:]]|while[[:space:]]|for[[:space:]]|switch[[:space:]]|catch[[:space:]]|synchronized[[:space:]]|try[[:space:]]|new[[:space:]]/' \
+            # The `new` fragment (#2272) additionally excludes an anonymous
+            # class instantiation (`new Runnable() {`), which also shares the
+            # "...) {" shape: injecting into that line would be invalid Java
+            # (a bare statement directly in a class body, rather than a
+            # distinct method body to trace).
+            #
+            # Requires the `new <Type>(args)` call itself -- not just the
+            # bare `new` keyword -- to be followed by nothing but whitespace
+            # before the line's own opening brace (an optional `/* ... */`
+            # comment is tolerated between `new` and the type, since
+            # `new /* description */ Runnable() {` was still missed by an
+            # earlier version anchored on `new[[:space:]]+[A-Za-z_$]` --
+            # Greptile review, PR #2449, round 1). Java itself has no default
+            # parameter values, so a bare `new[[:space:]]` was never
+            # ambiguous *here* the way it is in Groovy -- but this fragment is
+            # deliberately kept identical to the Groovy branch below (which
+            # DOES need the tighter form, to avoid excluding
+            # `def run(Config c = new Config()) {` -- Greptile review, PR
+            # #2449, round 2) rather than letting the two drift into
+            # parallel-but-inconsistent patterns for the same construct.
+            sedi_append_unless '/\)[[:space:]]*\{$/' '/class[[:space:]]|interface[[:space:]]|if[[:space:]]|while[[:space:]]|for[[:space:]]|switch[[:space:]]|catch[[:space:]]|synchronized[[:space:]]|try[[:space:]]|new[[:space:]]+(\/\*[^*]*\*\/[[:space:]]*)?[A-Za-z_$][A-Za-zA-Z0-9_$.]*\([^()]*\)[[:space:]]*\{[[:space:]]*$/' \
                 '        CallTracer.traceCall();' "$javafile"
         done
 
@@ -246,27 +253,39 @@ case "$LANG" in
 
         # Inject CallTracer.traceCall() into every method body
         # (see the java branch above for why the negate pattern also excludes
-        # control-flow keywords -- #2045, and `new[[:space:]]` for anonymous
-        # classes -- #2272; Groovy supports Java-style anonymous classes too).
+        # control-flow keywords -- #2045, and the `new` fragment for
+        # anonymous classes -- #2272; Groovy supports Java-style anonymous
+        # classes too). Unlike Java, Groovy supports default parameter
+        # values, so a real method signature CAN itself contain the token
+        # `new` followed by whitespace (`def run(Config c = new Config()) {`)
+        # -- that is exactly why the `new` fragment requires the `new
+        # <Type>(args)` call to be followed by nothing but whitespace before
+        # the line's own opening brace, rather than matching on the bare
+        # keyword: a default-parameter `new Config()` is always followed by
+        # the enclosing parameter list's own closing `)` before that `{`,
+        # which the tighter fragment does not match (Greptile review, PR
+        # #2449, round 2 -- an earlier bare `new[[:space:]]` version wrongly
+        # excluded this line, silently dropping the method from tracing).
         #
         # `^[[:space:]]*([A-Za-z_][A-Za-zA-Z0-9_]*\.)?[A-Za-z_][A-Za-zA-Z0-9_]*\([^()]*\)[[:space:]]*\{[[:space:]]*$`
         # (#2272) additionally excludes a trailing-closure method CALL, e.g.
         # `list.findAll() {`, a DSL-style `lock.withLock() {`, or the same
         # calls WITHOUT an explicit receiver (`findAll() {`, `withLock() {` --
-        # Greptile review, PR #2449, on an earlier version of this fix that
-        # only handled the qualified form) -- these share the "...) {" shape
-        # but the `traceCall()` would land inside a closure literal, not a
-        # real method body. Anchored at the start of the (trimmed) line: a
-        # real Groovy method DECLARATION always has a `def`/type/modifier
-        # token, separated by WHITESPACE, before the method name -- so the
-        # declaration's own name is never the first token on the line -- while
-        # a call expression's name (optionally preceded by a `receiver.`) is.
-        # A dotted, fully-qualified RETURN TYPE (`java.util.List getUsers() {`)
-        # still has a space (not a dot) directly before the method name, so
-        # `getUsers` -- not `List` -- would need to start the trimmed line for
-        # this to false-positive, which it doesn't.
+        # Greptile review, PR #2449, round 1, on an earlier version of this
+        # fix that only handled the qualified form) -- these share the
+        # "...) {" shape but the `traceCall()` would land inside a closure
+        # literal, not a real method body. Anchored at the start of the
+        # (trimmed) line: a real Groovy method DECLARATION always has a
+        # `def`/type/modifier token, separated by WHITESPACE, before the
+        # method name -- so the declaration's own name is never the first
+        # token on the line -- while a call expression's name (optionally
+        # preceded by a `receiver.`) is. A dotted, fully-qualified RETURN TYPE
+        # (`java.util.List getUsers() {`) still has a space (not a dot)
+        # directly before the method name, so `getUsers` -- not `List` --
+        # would need to start the trimmed line for this to false-positive,
+        # which it doesn't.
         for grfile in "$TMP_DIR"/*.groovy; do
-            sedi_append_unless '/\)[[:space:]]*\{[[:space:]]*$/' '/class[[:space:]]|interface[[:space:]]|if[[:space:]]|while[[:space:]]|for[[:space:]]|switch[[:space:]]|catch[[:space:]]|synchronized[[:space:]]|try[[:space:]]|new[[:space:]]|^[[:space:]]*([A-Za-z_][A-Za-zA-Z0-9_]*\.)?[A-Za-z_][A-Za-zA-Z0-9_]*\([^()]*\)[[:space:]]*\{[[:space:]]*$/' \
+            sedi_append_unless '/\)[[:space:]]*\{[[:space:]]*$/' '/class[[:space:]]|interface[[:space:]]|if[[:space:]]|while[[:space:]]|for[[:space:]]|switch[[:space:]]|catch[[:space:]]|synchronized[[:space:]]|try[[:space:]]|new[[:space:]]+(\/\*[^*]*\*\/[[:space:]]*)?[A-Za-z_$][A-Za-zA-Z0-9_$.]*\([^()]*\)[[:space:]]*\{[[:space:]]*$|^[[:space:]]*([A-Za-z_][A-Za-zA-Z0-9_]*\.)?[A-Za-z_][A-Za-zA-Z0-9_]*\([^()]*\)[[:space:]]*\{[[:space:]]*$/' \
                 '        CallTracer.traceCall();' "$grfile"
         done
 

--- a/tests/benchmarks/resolution/tracer/tracer-common.test.ts
+++ b/tests/benchmarks/resolution/tracer/tracer-common.test.ts
@@ -130,6 +130,78 @@ describe('tracer-common.sh sed-injection helpers (#1913)', () => {
     expect(out.split('\n')[0]).toBe('public abstract class BaseService {');
   });
 
+  it('sedi_append_unless excludes a Java anonymous class instantiation but still traces its own inner method (#2272)', () => {
+    const file = path.join(tmpDir, 'RunAnon.java');
+    fs.writeFileSync(
+      file,
+      [
+        'public class RunAnon {',
+        '    public void runAnon() {',
+        '        Runnable r = new Runnable() {',
+        '            public void run() {',
+        '                System.out.println("hi");',
+        '            }',
+        '        };',
+        '    }',
+        '}',
+        '',
+      ].join('\n'),
+    );
+
+    // The exact negate pattern jvm-tracer.sh's java branch uses (post-#2272).
+    const out = runHelper(
+      `sedi_append_unless '/\\)[[:space:]]*\\{$/' ` +
+        `'/class[[:space:]]|interface[[:space:]]|if[[:space:]]|while[[:space:]]|for[[:space:]]|switch[[:space:]]|catch[[:space:]]|synchronized[[:space:]]|try[[:space:]]|new[[:space:]]+[A-Za-z_$]/' ` +
+        `'        CallTracer.traceCall();' "${file}"`,
+      file,
+    );
+
+    // The enclosing real method is traced...
+    expect(out).toContain('    public void runAnon() {\n        CallTracer.traceCall();');
+    // ...the anonymous class's own opening is NOT (a bare statement directly
+    // in a class body, rather than a method body, is invalid Java)...
+    expect(out).not.toContain('new Runnable() {\n        CallTracer.traceCall();');
+    // ...but the anonymous class's own real method still is.
+    expect(out).toContain('            public void run() {\n        CallTracer.traceCall();');
+  });
+
+  it('sedi_append_unless excludes a Groovy trailing-closure call but still traces a qualified-return-type method (#2272)', () => {
+    const file = path.join(tmpDir, 'RunClosures.groovy');
+    fs.writeFileSync(
+      file,
+      [
+        'class RunClosures {',
+        '    java.util.List getUsers() {',
+        '        return []',
+        '    }',
+        '    def runClosures() {',
+        '        list.findAll() {',
+        '            it > 0',
+        '        }',
+        '    }',
+        '}',
+        '',
+      ].join('\n'),
+    );
+
+    // The exact negate pattern jvm-tracer.sh's groovy branch uses (post-#2272).
+    const out = runHelper(
+      `sedi_append_unless '/\\)[[:space:]]*\\{[[:space:]]*$/' ` +
+        `'/class[[:space:]]|interface[[:space:]]|if[[:space:]]|while[[:space:]]|for[[:space:]]|switch[[:space:]]|catch[[:space:]]|synchronized[[:space:]]|try[[:space:]]|new[[:space:]]+[A-Za-z_$]|\\.[A-Za-z_][A-Za-zA-Z0-9_]*\\([^()]*\\)[[:space:]]*\\{[[:space:]]*$/' ` +
+        `'        CallTracer.traceCall();' "${file}"`,
+      file,
+    );
+
+    // A fully-qualified return type still has a space (not a dot) directly
+    // before the method name, so it's still traced...
+    expect(out).toContain('    java.util.List getUsers() {\n        CallTracer.traceCall();');
+    // ...the enclosing real method is traced...
+    expect(out).toContain('    def runClosures() {\n        CallTracer.traceCall();');
+    // ...but the trailing-closure call is NOT (traceCall() would land inside
+    // the closure literal, not a real method body).
+    expect(out).not.toContain('list.findAll() {\n        CallTracer.traceCall();');
+  });
+
   it('rejects a regression back to the GNU-only single-line a\\/i\\ shortcut in the tracer scripts', () => {
     // Every dump()/traceCall() injection now goes through the shared helpers
     // above, so the raw sed scripts embedded directly in the language

--- a/tests/benchmarks/resolution/tracer/tracer-common.test.ts
+++ b/tests/benchmarks/resolution/tracer/tracer-common.test.ts
@@ -151,7 +151,7 @@ describe('tracer-common.sh sed-injection helpers (#1913)', () => {
     // The exact negate pattern jvm-tracer.sh's java branch uses (post-#2272).
     const out = runHelper(
       `sedi_append_unless '/\\)[[:space:]]*\\{$/' ` +
-        `'/class[[:space:]]|interface[[:space:]]|if[[:space:]]|while[[:space:]]|for[[:space:]]|switch[[:space:]]|catch[[:space:]]|synchronized[[:space:]]|try[[:space:]]|new[[:space:]]+[A-Za-z_$]/' ` +
+        `'/class[[:space:]]|interface[[:space:]]|if[[:space:]]|while[[:space:]]|for[[:space:]]|switch[[:space:]]|catch[[:space:]]|synchronized[[:space:]]|try[[:space:]]|new[[:space:]]/' ` +
         `'        CallTracer.traceCall();' "${file}"`,
       file,
     );
@@ -165,7 +165,43 @@ describe('tracer-common.sh sed-injection helpers (#1913)', () => {
     expect(out).toContain('            public void run() {\n        CallTracer.traceCall();');
   });
 
-  it('sedi_append_unless excludes a Groovy trailing-closure call but still traces a qualified-return-type method (#2272)', () => {
+  it('sedi_append_unless excludes a Java anonymous class even with a comment between `new` and the type (#2272)', () => {
+    // A narrower gap Greptile flagged on PR #2449's first version: anchoring
+    // the exclusion on `new[[:space:]]+[A-Za-z_$]` (requiring an identifier
+    // character immediately after the whitespace) missed
+    // `new /* description */ Runnable() {` -- the bare `new` keyword followed
+    // by whitespace is already an unambiguous signal on its own, so the fix
+    // dropped the trailing identifier requirement entirely.
+    const file = path.join(tmpDir, 'RunAnonComment.java');
+    fs.writeFileSync(
+      file,
+      [
+        'public class RunAnonComment {',
+        '    public void runAnon() {',
+        '        Runnable r = new /* description */ Runnable() {',
+        '            public void run() {',
+        '                System.out.println("hi");',
+        '            }',
+        '        };',
+        '    }',
+        '}',
+        '',
+      ].join('\n'),
+    );
+
+    const out = runHelper(
+      `sedi_append_unless '/\\)[[:space:]]*\\{$/' ` +
+        `'/class[[:space:]]|interface[[:space:]]|if[[:space:]]|while[[:space:]]|for[[:space:]]|switch[[:space:]]|catch[[:space:]]|synchronized[[:space:]]|try[[:space:]]|new[[:space:]]/' ` +
+        `'        CallTracer.traceCall();' "${file}"`,
+      file,
+    );
+
+    expect(out).toContain('    public void runAnon() {\n        CallTracer.traceCall();');
+    expect(out).not.toContain('Runnable() {\n        CallTracer.traceCall();');
+    expect(out).toContain('            public void run() {\n        CallTracer.traceCall();');
+  });
+
+  it('sedi_append_unless excludes both qualified and unqualified Groovy trailing-closure calls but still traces a qualified-return-type method (#2272)', () => {
     const file = path.join(tmpDir, 'RunClosures.groovy');
     fs.writeFileSync(
       file,
@@ -178,6 +214,13 @@ describe('tracer-common.sh sed-injection helpers (#1913)', () => {
         '        list.findAll() {',
         '            it > 0',
         '        }',
+        // Greptile review, PR #2449: the first version of this fix only
+        // excluded the dot-qualified form (`list.findAll() {`) -- an
+        // unqualified trailing-closure call (no explicit receiver) shares
+        // the same false-positive risk and was still being traced.
+        '        findAll() {',
+        '            it > 0',
+        '        }',
         '    }',
         '}',
         '',
@@ -187,7 +230,7 @@ describe('tracer-common.sh sed-injection helpers (#1913)', () => {
     // The exact negate pattern jvm-tracer.sh's groovy branch uses (post-#2272).
     const out = runHelper(
       `sedi_append_unless '/\\)[[:space:]]*\\{[[:space:]]*$/' ` +
-        `'/class[[:space:]]|interface[[:space:]]|if[[:space:]]|while[[:space:]]|for[[:space:]]|switch[[:space:]]|catch[[:space:]]|synchronized[[:space:]]|try[[:space:]]|new[[:space:]]+[A-Za-z_$]|\\.[A-Za-z_][A-Za-zA-Z0-9_]*\\([^()]*\\)[[:space:]]*\\{[[:space:]]*$/' ` +
+        `'/class[[:space:]]|interface[[:space:]]|if[[:space:]]|while[[:space:]]|for[[:space:]]|switch[[:space:]]|catch[[:space:]]|synchronized[[:space:]]|try[[:space:]]|new[[:space:]]|^[[:space:]]*([A-Za-z_][A-Za-zA-Z0-9_]*\\.)?[A-Za-z_][A-Za-zA-Z0-9_]*\\([^()]*\\)[[:space:]]*\\{[[:space:]]*$/' ` +
         `'        CallTracer.traceCall();' "${file}"`,
       file,
     );
@@ -197,9 +240,11 @@ describe('tracer-common.sh sed-injection helpers (#1913)', () => {
     expect(out).toContain('    java.util.List getUsers() {\n        CallTracer.traceCall();');
     // ...the enclosing real method is traced...
     expect(out).toContain('    def runClosures() {\n        CallTracer.traceCall();');
-    // ...but the trailing-closure call is NOT (traceCall() would land inside
-    // the closure literal, not a real method body).
+    // ...but neither the qualified nor the unqualified trailing-closure call
+    // is (traceCall() would land inside the closure literal, not a real
+    // method body).
     expect(out).not.toContain('list.findAll() {\n        CallTracer.traceCall();');
+    expect(out).not.toContain('        findAll() {\n        CallTracer.traceCall();');
   });
 
   it('rejects a regression back to the GNU-only single-line a\\/i\\ shortcut in the tracer scripts', () => {

--- a/tests/benchmarks/resolution/tracer/tracer-common.test.ts
+++ b/tests/benchmarks/resolution/tracer/tracer-common.test.ts
@@ -148,10 +148,13 @@ describe('tracer-common.sh sed-injection helpers (#1913)', () => {
       ].join('\n'),
     );
 
-    // The exact negate pattern jvm-tracer.sh's java branch uses (post-#2272).
+    // The exact negate pattern jvm-tracer.sh's java branch uses (post-#2272,
+    // round 3 -- the `new` fragment now requires the call's own closing
+    // paren to be followed directly by the line's `{`, not just a bare
+    // `new[[:space:]]`).
     const out = runHelper(
       `sedi_append_unless '/\\)[[:space:]]*\\{$/' ` +
-        `'/class[[:space:]]|interface[[:space:]]|if[[:space:]]|while[[:space:]]|for[[:space:]]|switch[[:space:]]|catch[[:space:]]|synchronized[[:space:]]|try[[:space:]]|new[[:space:]]/' ` +
+        `'/class[[:space:]]|interface[[:space:]]|if[[:space:]]|while[[:space:]]|for[[:space:]]|switch[[:space:]]|catch[[:space:]]|synchronized[[:space:]]|try[[:space:]]|new[[:space:]]+(\\/\\*[^*]*\\*\\/[[:space:]]*)?[A-Za-z_$][A-Za-zA-Z0-9_$.]*\\([^()]*\\)[[:space:]]*\\{[[:space:]]*$/' ` +
         `'        CallTracer.traceCall();' "${file}"`,
       file,
     );
@@ -191,7 +194,7 @@ describe('tracer-common.sh sed-injection helpers (#1913)', () => {
 
     const out = runHelper(
       `sedi_append_unless '/\\)[[:space:]]*\\{$/' ` +
-        `'/class[[:space:]]|interface[[:space:]]|if[[:space:]]|while[[:space:]]|for[[:space:]]|switch[[:space:]]|catch[[:space:]]|synchronized[[:space:]]|try[[:space:]]|new[[:space:]]/' ` +
+        `'/class[[:space:]]|interface[[:space:]]|if[[:space:]]|while[[:space:]]|for[[:space:]]|switch[[:space:]]|catch[[:space:]]|synchronized[[:space:]]|try[[:space:]]|new[[:space:]]+(\\/\\*[^*]*\\*\\/[[:space:]]*)?[A-Za-z_$][A-Za-zA-Z0-9_$.]*\\([^()]*\\)[[:space:]]*\\{[[:space:]]*$/' ` +
         `'        CallTracer.traceCall();' "${file}"`,
       file,
     );
@@ -227,10 +230,11 @@ describe('tracer-common.sh sed-injection helpers (#1913)', () => {
       ].join('\n'),
     );
 
-    // The exact negate pattern jvm-tracer.sh's groovy branch uses (post-#2272).
+    // The exact negate pattern jvm-tracer.sh's groovy branch uses (post-#2272,
+    // round 3).
     const out = runHelper(
       `sedi_append_unless '/\\)[[:space:]]*\\{[[:space:]]*$/' ` +
-        `'/class[[:space:]]|interface[[:space:]]|if[[:space:]]|while[[:space:]]|for[[:space:]]|switch[[:space:]]|catch[[:space:]]|synchronized[[:space:]]|try[[:space:]]|new[[:space:]]|^[[:space:]]*([A-Za-z_][A-Za-zA-Z0-9_]*\\.)?[A-Za-z_][A-Za-zA-Z0-9_]*\\([^()]*\\)[[:space:]]*\\{[[:space:]]*$/' ` +
+        `'/class[[:space:]]|interface[[:space:]]|if[[:space:]]|while[[:space:]]|for[[:space:]]|switch[[:space:]]|catch[[:space:]]|synchronized[[:space:]]|try[[:space:]]|new[[:space:]]+(\\/\\*[^*]*\\*\\/[[:space:]]*)?[A-Za-z_$][A-Za-zA-Z0-9_$.]*\\([^()]*\\)[[:space:]]*\\{[[:space:]]*$|^[[:space:]]*([A-Za-z_][A-Za-zA-Z0-9_]*\\.)?[A-Za-z_][A-Za-zA-Z0-9_]*\\([^()]*\\)[[:space:]]*\\{[[:space:]]*$/' ` +
         `'        CallTracer.traceCall();' "${file}"`,
       file,
     );
@@ -245,6 +249,37 @@ describe('tracer-common.sh sed-injection helpers (#1913)', () => {
     // method body).
     expect(out).not.toContain('list.findAll() {\n        CallTracer.traceCall();');
     expect(out).not.toContain('        findAll() {\n        CallTracer.traceCall();');
+  });
+
+  it('sedi_append_unless still traces a Groovy method with a `new`-valued default parameter (#2272 round 3)', () => {
+    // Greptile review, PR #2449, round 2: unlike Java, Groovy supports
+    // default parameter values, so a real method signature can itself
+    // contain the token `new` followed by whitespace. The round-1 fix's
+    // bare `new[[:space:]]` fragment wrongly excluded this line entirely,
+    // silently dropping the method from tracing.
+    const file = path.join(tmpDir, 'RunDefaultParam.groovy');
+    fs.writeFileSync(
+      file,
+      [
+        'class RunDefaultParam {',
+        '    def run(Config c = new Config()) {',
+        '        return c',
+        '    }',
+        '}',
+        '',
+      ].join('\n'),
+    );
+
+    const out = runHelper(
+      `sedi_append_unless '/\\)[[:space:]]*\\{[[:space:]]*$/' ` +
+        `'/class[[:space:]]|interface[[:space:]]|if[[:space:]]|while[[:space:]]|for[[:space:]]|switch[[:space:]]|catch[[:space:]]|synchronized[[:space:]]|try[[:space:]]|new[[:space:]]+(\\/\\*[^*]*\\*\\/[[:space:]]*)?[A-Za-z_$][A-Za-zA-Z0-9_$.]*\\([^()]*\\)[[:space:]]*\\{[[:space:]]*$|^[[:space:]]*([A-Za-z_][A-Za-zA-Z0-9_]*\\.)?[A-Za-z_][A-Za-zA-Z0-9_]*\\([^()]*\\)[[:space:]]*\\{[[:space:]]*$/' ` +
+        `'        CallTracer.traceCall();' "${file}"`,
+      file,
+    );
+
+    expect(out).toContain(
+      '    def run(Config c = new Config()) {\n        CallTracer.traceCall();',
+    );
   });
 
   it('rejects a regression back to the GNU-only single-line a\\/i\\ shortcut in the tracer scripts', () => {


### PR DESCRIPTION
## Summary

Follow-up to #2045. The java/groovy per-method `traceCall()` injection in `tests/benchmarks/resolution/tracer/jvm-tracer.sh` matches any line ending in `) {` that isn't excluded by the negate pattern. #2045 fixed the control-flow-keyword false positives. Two related shapes still shared that pattern and weren't excluded:

- **Java anonymous class instantiation**, e.g. `new Runnable() {` — injecting a bare statement directly into a class body, rather than inside one of its method bodies, is invalid Java.
- **Groovy trailing-closure method calls with explicit parens**, e.g. `list.findAll() {` or a DSL-style `lock.withLock() {` — the injected `traceCall()` would land inside a closure literal rather than a real method body.

No current fixture triggers either shape, so this doesn't currently break the benchmark — it's a latent robustness gap in the same injection helper.

## Fix

Extends the existing negate-list (matching #2045's own approach — the issue explicitly noted "negate-list extension has diminishing returns," but these two additions are narrow and unambiguous, so a full structural rewrite — brace-depth tracking relative to the last `class`/`interface` line — isn't warranted yet):

- `new[[:space:]]+[A-Za-z_$]` excludes an anonymous-class opening. Java has no default parameter values, so a method's own signature can never itself contain `new SomeType(` — any line matching the outer pattern that also contains this is unambiguously an anonymous-class body, not a method signature.
- `\.[A-Za-z_][A-Za-zA-Z0-9_]*\([^()]*\)[[:space:]]*\{[[:space:]]*$` (Groovy only) excludes a trailing-closure call. A real Groovy method declaration is never written as `<qualifier>.<name>(...) {`, and a dotted, fully-qualified return type (`java.util.List getUsers() {`) still has a space — not a dot — directly before the method name, so it isn't caught by this exclusion.

Both additions are applied to the Java branch; the closure-call exclusion is Groovy-only (Java has no closure-call syntax to exclude).

## Testing

Verified directly against representative snippets (shown below) that:
- The anonymous class's own opening is skipped, but its own inner method is still correctly traced.
- A trailing-closure call is skipped, but the enclosing real method — and a method with a fully-qualified return type — are still correctly traced.
- Confirmed each new test actually catches the regression: reverted the corresponding negate-pattern fragment, confirmed the test fails, then restored it.

Full `javac`/`groovyc` compilation could not be verified end-to-end in this environment (no JRE available locally). Verified instead at the sed-transformation level directly via the shared `tracer-common.sh` helpers — exactly what `tracer-common.test.ts` already does, and for the same reason (toolchain-independent, runs identically regardless of which compilers happen to be installed).

- New tests in `tests/benchmarks/resolution/tracer/tracer-common.test.ts`: 2 new cases (Java anonymous class, Groovy trailing closure), all 7 tests in the file passing.
- Full suite: 5039 tests passing (WASM + native) — after rebuilding the native addon from source, since the npm-installed one in this worktree was stale relative to several recent native-behavior-changing merges and caused unrelated native/parity test failures.
- `node scripts/parity-compare.mjs`: 42/42 fixtures identical across engines.
- `npm run lint` / `shellcheck`: clean (shellcheck's existing info-level notices are all pre-existing and unrelated to this change).

Closes #2272