### PR TITLE
fix(hooks): guard-git.sh checkout -- block no longer false-positives on flags

### DIFF
--- a/.claude/hooks/guard-git.sh
+++ b/.claude/hooks/guard-git.sh
@@ -97,13 +97,24 @@ if echo "$NCOMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+res
 fi
 
 # git checkout -- <file> (reverting files). Requires "--" to be its own
-# token (immediately followed by whitespace or end-of-segment/string), not
-# a longer flag that merely starts with "--" (#2280) — otherwise this also
-# denied legitimate flags sharing the same "checkout --" prefix, like
-# --detach, --track, --orphan, --no-track, --guess, --ours, --theirs, none
-# of which revert working-tree changes the way a bare "--" pathspec
-# separator does.
-if echo "$NCOMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+checkout[[:space:]]+--([[:space:]]|$)'; then
+# token, not a longer flag that merely starts with "--" (#2280) —
+# otherwise this also denied legitimate flags sharing the same
+# "checkout --" prefix, like --detach, --track, --orphan, --no-track,
+# --guess, --ours, --theirs, none of which revert working-tree changes
+# the way a bare "--" pathspec separator does.
+#
+# Deliberately NOT anchored on literal whitespace-or-end-of-line after
+# "--" (i.e. NOT `--([[:space:]]|$)`): every one of those legitimate
+# flag names starts with a plain letter right after "--", so "anything
+# that isn't a letter" is the correct, safe boundary — and it must
+# reject unquoted shell expansions too, not just literal whitespace.
+# `git checkout --${IFS}file.txt` has no literal space in the command
+# TEXT between "--" and "file.txt" (so a whitespace-anchored version of
+# this check misses it), but bash expands the unquoted `${IFS}` to
+# whitespace at actual execution time — Git still receives the exact
+# dangerous `checkout -- file.txt` (Greptile review, PR #2450). `$` is
+# not a letter, so the negated-letter-class form below still denies it.
+if echo "$NCOMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+checkout[[:space:]]+--([^A-Za-z]|$)'; then
   deny "BLOCKED: 'git checkout -- <file>' reverts working tree changes and may destroy other sessions' edits. If you need to discard your own changes, be explicit about which files."
 fi
 

--- a/.claude/hooks/guard-git.sh
+++ b/.claude/hooks/guard-git.sh
@@ -100,8 +100,8 @@ fi
 # token, not a longer flag that merely starts with "--" (#2280) —
 # otherwise this also denied legitimate flags sharing the same
 # "checkout --" prefix, like --detach, --track, --orphan, --no-track,
-# --guess, --ours, --theirs, none of which revert working-tree changes
-# the way a bare "--" pathspec separator does.
+# --guess, none of which revert working-tree changes the way a bare
+# "--" pathspec separator does.
 #
 # Deliberately NOT anchored on literal whitespace-or-end-of-line after
 # "--" (i.e. NOT `--([[:space:]]|$)`): every one of those legitimate
@@ -114,7 +114,17 @@ fi
 # whitespace at actual execution time — Git still receives the exact
 # dangerous `checkout -- file.txt` (Greptile review, PR #2450). `$` is
 # not a letter, so the negated-letter-class form below still denies it.
-if echo "$NCOMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+checkout[[:space:]]+--([^A-Za-z]|$)'; then
+#
+# --ours/--theirs are explicitly re-included in the denial (NOT covered
+# by "starts with a letter, so it's safe"): despite also sharing the
+# "checkout --" prefix, on an unmerged path they check the selected
+# merge-conflict stage into the WORKING TREE, overwriting that file's
+# on-disk content -- the same destructive-to-uncommitted-work class
+# this whole check exists to catch, just from a different source (a
+# merge stage instead of HEAD/the index). #2280's own suggested
+# exclusion list named these as safe; that premise was wrong (Greptile
+# review, PR #2450, round 2).
+if echo "$NCOMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+checkout[[:space:]]+--([^A-Za-z]|$|ours([[:space:]]|$)|theirs([[:space:]]|$))'; then
   deny "BLOCKED: 'git checkout -- <file>' reverts working tree changes and may destroy other sessions' edits. If you need to discard your own changes, be explicit about which files."
 fi
 

--- a/.claude/hooks/guard-git.sh
+++ b/.claude/hooks/guard-git.sh
@@ -96,8 +96,14 @@ if echo "$NCOMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+res
   deny "BLOCKED: 'git reset' can unstage or destroy other sessions' work. To unstage your own files, use: git restore --staged <file>"
 fi
 
-# git checkout -- <file> (reverting files)
-if echo "$NCOMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+checkout[[:space:]]+--'; then
+# git checkout -- <file> (reverting files). Requires "--" to be its own
+# token (immediately followed by whitespace or end-of-segment/string), not
+# a longer flag that merely starts with "--" (#2280) — otherwise this also
+# denied legitimate flags sharing the same "checkout --" prefix, like
+# --detach, --track, --orphan, --no-track, --guess, --ours, --theirs, none
+# of which revert working-tree changes the way a bare "--" pathspec
+# separator does.
+if echo "$NCOMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+checkout[[:space:]]+--([[:space:]]|$)'; then
   deny "BLOCKED: 'git checkout -- <file>' reverts working tree changes and may destroy other sessions' edits. If you need to discard your own changes, be explicit about which files."
 fi
 

--- a/.claude/hooks/guard-git.sh
+++ b/.claude/hooks/guard-git.sh
@@ -123,8 +123,13 @@ fi
 # this whole check exists to catch, just from a different source (a
 # merge stage instead of HEAD/the index). #2280's own suggested
 # exclusion list named these as safe; that premise was wrong (Greptile
-# review, PR #2450, round 2).
-if echo "$NCOMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+checkout[[:space:]]+--([^A-Za-z]|$|ours([[:space:]]|$)|theirs([[:space:]]|$))'; then
+# review, PR #2450, round 2). Their own trailing boundary is a negated
+# letter class too, not literal whitespace-or-end-of-line, for the same
+# ${IFS}-expansion reason as the outer "--" boundary above:
+# `git checkout --ours${IFS}file.txt` has no literal space in the
+# command TEXT right after "ours" either (Greptile review, PR #2450,
+# round 3).
+if echo "$NCOMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+checkout[[:space:]]+--([^A-Za-z]|$|ours([^A-Za-z]|$)|theirs([^A-Za-z]|$))'; then
   deny "BLOCKED: 'git checkout -- <file>' reverts working tree changes and may destroy other sessions' edits. If you need to discard your own changes, be explicit about which files."
 fi
 

--- a/docs/examples/claude-code-hooks/guard-git.sh
+++ b/docs/examples/claude-code-hooks/guard-git.sh
@@ -97,13 +97,24 @@ if echo "$NCOMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+res
 fi
 
 # git checkout -- <file> (reverting files). Requires "--" to be its own
-# token (immediately followed by whitespace or end-of-segment/string), not
-# a longer flag that merely starts with "--" (#2280) — otherwise this also
-# denied legitimate flags sharing the same "checkout --" prefix, like
-# --detach, --track, --orphan, --no-track, --guess, --ours, --theirs, none
-# of which revert working-tree changes the way a bare "--" pathspec
-# separator does.
-if echo "$NCOMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+checkout[[:space:]]+--([[:space:]]|$)'; then
+# token, not a longer flag that merely starts with "--" (#2280) —
+# otherwise this also denied legitimate flags sharing the same
+# "checkout --" prefix, like --detach, --track, --orphan, --no-track,
+# --guess, --ours, --theirs, none of which revert working-tree changes
+# the way a bare "--" pathspec separator does.
+#
+# Deliberately NOT anchored on literal whitespace-or-end-of-line after
+# "--" (i.e. NOT `--([[:space:]]|$)`): every one of those legitimate
+# flag names starts with a plain letter right after "--", so "anything
+# that isn't a letter" is the correct, safe boundary — and it must
+# reject unquoted shell expansions too, not just literal whitespace.
+# `git checkout --${IFS}file.txt` has no literal space in the command
+# TEXT between "--" and "file.txt" (so a whitespace-anchored version of
+# this check misses it), but bash expands the unquoted `${IFS}` to
+# whitespace at actual execution time — Git still receives the exact
+# dangerous `checkout -- file.txt` (Greptile review, PR #2450). `$` is
+# not a letter, so the negated-letter-class form below still denies it.
+if echo "$NCOMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+checkout[[:space:]]+--([^A-Za-z]|$)'; then
   deny "BLOCKED: 'git checkout -- <file>' reverts working tree changes and may destroy other sessions' edits. If you need to discard your own changes, be explicit about which files."
 fi
 

--- a/docs/examples/claude-code-hooks/guard-git.sh
+++ b/docs/examples/claude-code-hooks/guard-git.sh
@@ -100,8 +100,8 @@ fi
 # token, not a longer flag that merely starts with "--" (#2280) —
 # otherwise this also denied legitimate flags sharing the same
 # "checkout --" prefix, like --detach, --track, --orphan, --no-track,
-# --guess, --ours, --theirs, none of which revert working-tree changes
-# the way a bare "--" pathspec separator does.
+# --guess, none of which revert working-tree changes the way a bare
+# "--" pathspec separator does.
 #
 # Deliberately NOT anchored on literal whitespace-or-end-of-line after
 # "--" (i.e. NOT `--([[:space:]]|$)`): every one of those legitimate
@@ -114,7 +114,17 @@ fi
 # whitespace at actual execution time — Git still receives the exact
 # dangerous `checkout -- file.txt` (Greptile review, PR #2450). `$` is
 # not a letter, so the negated-letter-class form below still denies it.
-if echo "$NCOMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+checkout[[:space:]]+--([^A-Za-z]|$)'; then
+#
+# --ours/--theirs are explicitly re-included in the denial (NOT covered
+# by "starts with a letter, so it's safe"): despite also sharing the
+# "checkout --" prefix, on an unmerged path they check the selected
+# merge-conflict stage into the WORKING TREE, overwriting that file's
+# on-disk content -- the same destructive-to-uncommitted-work class
+# this whole check exists to catch, just from a different source (a
+# merge stage instead of HEAD/the index). #2280's own suggested
+# exclusion list named these as safe; that premise was wrong (Greptile
+# review, PR #2450, round 2).
+if echo "$NCOMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+checkout[[:space:]]+--([^A-Za-z]|$|ours([[:space:]]|$)|theirs([[:space:]]|$))'; then
   deny "BLOCKED: 'git checkout -- <file>' reverts working tree changes and may destroy other sessions' edits. If you need to discard your own changes, be explicit about which files."
 fi
 

--- a/docs/examples/claude-code-hooks/guard-git.sh
+++ b/docs/examples/claude-code-hooks/guard-git.sh
@@ -96,8 +96,14 @@ if echo "$NCOMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+res
   deny "BLOCKED: 'git reset' can unstage or destroy other sessions' work. To unstage your own files, use: git restore --staged <file>"
 fi
 
-# git checkout -- <file> (reverting files)
-if echo "$NCOMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+checkout[[:space:]]+--'; then
+# git checkout -- <file> (reverting files). Requires "--" to be its own
+# token (immediately followed by whitespace or end-of-segment/string), not
+# a longer flag that merely starts with "--" (#2280) — otherwise this also
+# denied legitimate flags sharing the same "checkout --" prefix, like
+# --detach, --track, --orphan, --no-track, --guess, --ours, --theirs, none
+# of which revert working-tree changes the way a bare "--" pathspec
+# separator does.
+if echo "$NCOMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+checkout[[:space:]]+--([[:space:]]|$)'; then
   deny "BLOCKED: 'git checkout -- <file>' reverts working tree changes and may destroy other sessions' edits. If you need to discard your own changes, be explicit about which files."
 fi
 

--- a/docs/examples/claude-code-hooks/guard-git.sh
+++ b/docs/examples/claude-code-hooks/guard-git.sh
@@ -123,8 +123,13 @@ fi
 # this whole check exists to catch, just from a different source (a
 # merge stage instead of HEAD/the index). #2280's own suggested
 # exclusion list named these as safe; that premise was wrong (Greptile
-# review, PR #2450, round 2).
-if echo "$NCOMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+checkout[[:space:]]+--([^A-Za-z]|$|ours([[:space:]]|$)|theirs([[:space:]]|$))'; then
+# review, PR #2450, round 2). Their own trailing boundary is a negated
+# letter class too, not literal whitespace-or-end-of-line, for the same
+# ${IFS}-expansion reason as the outer "--" boundary above:
+# `git checkout --ours${IFS}file.txt` has no literal space in the
+# command TEXT right after "ours" either (Greptile review, PR #2450,
+# round 3).
+if echo "$NCOMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*)git[[:space:]]+checkout[[:space:]]+--([^A-Za-z]|$|ours([^A-Za-z]|$)|theirs([^A-Za-z]|$))'; then
   deny "BLOCKED: 'git checkout -- <file>' reverts working tree changes and may destroy other sessions' edits. If you need to discard your own changes, be explicit about which files."
 fi
 

--- a/tests/unit/hook-guard-git-clean.test.ts
+++ b/tests/unit/hook-guard-git-clean.test.ts
@@ -242,6 +242,38 @@ describe('guard-git.sh mask-quoted-text.mjs', () => {
   });
 });
 
+describe('guard-git.sh checkout -- boundary requires a bare "--" token (#2280)', () => {
+  it('still blocks the real file-reverting form', () => {
+    expect(isDenied('git checkout -- file.txt')).toBe(true);
+    expect(isDenied('git checkout -- file1.txt file2.txt')).toBe(true);
+  });
+
+  it('still blocks a bare trailing -- with no pathspec (ambiguous, same as before)', () => {
+    expect(isDenied('git checkout --')).toBe(true);
+  });
+
+  it('allows --detach, which shares the "checkout --" prefix but does not revert working-tree changes', () => {
+    expect(isDenied('git checkout --detach origin/main')).toBe(false);
+    expect(isDenied('git checkout --detach')).toBe(false);
+  });
+
+  it('allows --track, --orphan, --no-track, and --guess for the same reason', () => {
+    expect(isDenied('git checkout --track origin/feature')).toBe(false);
+    expect(isDenied('git checkout --orphan new-branch')).toBe(false);
+    expect(isDenied('git checkout --no-track feature')).toBe(false);
+    expect(isDenied('git checkout --guess')).toBe(false);
+  });
+
+  it('allows --ours/--theirs (merge-conflict side selection, not a working-tree revert)', () => {
+    expect(isDenied('git checkout --ours file.txt')).toBe(false);
+    expect(isDenied('git checkout --theirs file.txt')).toBe(false);
+  });
+
+  it('still blocks a real revert chained after an allowed --detach invocation', () => {
+    expect(isDenied('git checkout --detach && git checkout -- file.txt')).toBe(true);
+  });
+});
+
 describe('guard-git.sh docs example stays in sync (#2105)', () => {
   // docs/examples/claude-code-hooks/guard-git.sh is meant to be a working
   // copy of the live hook for users setting up their own repo — it had

--- a/tests/unit/hook-guard-git-clean.test.ts
+++ b/tests/unit/hook-guard-git-clean.test.ts
@@ -264,9 +264,15 @@ describe('guard-git.sh checkout -- boundary requires a bare "--" token (#2280)',
     expect(isDenied('git checkout --guess')).toBe(false);
   });
 
-  it('allows --ours/--theirs (merge-conflict side selection, not a working-tree revert)', () => {
-    expect(isDenied('git checkout --ours file.txt')).toBe(false);
-    expect(isDenied('git checkout --theirs file.txt')).toBe(false);
+  it('still blocks --ours/--theirs (Greptile review, PR #2450, round 2): on an unmerged path these overwrite the working-tree file from a merge-conflict stage, the same destructive class this check exists to catch', () => {
+    expect(isDenied('git checkout --ours file.txt')).toBe(true);
+    expect(isDenied('git checkout --theirs file.txt')).toBe(true);
+    expect(isDenied('git checkout --ours')).toBe(true);
+    expect(isDenied('git checkout --theirs')).toBe(true);
+  });
+
+  it('does not over-match a hypothetical flag that merely starts with "ours"/"theirs"', () => {
+    expect(isDenied('git checkout --oursight')).toBe(false);
   });
 
   it('still blocks a real revert chained after an allowed --detach invocation', () => {

--- a/tests/unit/hook-guard-git-clean.test.ts
+++ b/tests/unit/hook-guard-git-clean.test.ts
@@ -290,6 +290,18 @@ describe('guard-git.sh checkout -- boundary requires a bare "--" token (#2280)',
     expect(isDenied('git checkout --${IFS}file.txt')).toBe(true);
     expect(isDenied('git checkout --$IFS')).toBe(true);
   });
+
+  it('still blocks the same IFS-expansion bypass applied to --ours/--theirs (Greptile review, PR #2450, round 3)', () => {
+    // Round 3's negated-letter-class boundary on the outer "--" doesn't
+    // automatically cover --ours/--theirs' OWN trailing boundary, which was
+    // still anchored on literal whitespace-or-end-of-line — so
+    // `--ours${IFS}file.txt` had no literal space right after "ours" either
+    // and slipped through the same way the outer "--" case did in round 1.
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal bash syntax under test, not a missed template literal
+    expect(isDenied('git checkout --ours${IFS}file.txt')).toBe(true);
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal bash syntax under test, not a missed template literal
+    expect(isDenied('git checkout --theirs${IFS}file.txt')).toBe(true);
+  });
 });
 
 describe('guard-git.sh docs example stays in sync (#2105)', () => {

--- a/tests/unit/hook-guard-git-clean.test.ts
+++ b/tests/unit/hook-guard-git-clean.test.ts
@@ -272,6 +272,18 @@ describe('guard-git.sh checkout -- boundary requires a bare "--" token (#2280)',
   it('still blocks a real revert chained after an allowed --detach invocation', () => {
     expect(isDenied('git checkout --detach && git checkout -- file.txt')).toBe(true);
   });
+
+  it('still blocks an IFS-expansion bypass with no literal whitespace between -- and the path (Greptile review, PR #2450)', () => {
+    // `${IFS}` (unquoted) is bash's own whitespace-field-separator variable
+    // — the command TEXT has no literal space between "--" and "file.txt",
+    // but bash expands `${IFS}` to whitespace before git ever sees it, so
+    // git actually receives `checkout -- file.txt`. A check anchored on
+    // literal `[[:space:]]` after "--" misses this; the negated-letter-class
+    // form does not, since "$" is not a letter.
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal bash syntax under test, not a missed template literal
+    expect(isDenied('git checkout --${IFS}file.txt')).toBe(true);
+    expect(isDenied('git checkout --$IFS')).toBe(true);
+  });
 });
 
 describe('guard-git.sh docs example stays in sync (#2105)', () => {


### PR DESCRIPTION
## Summary

Closes #2280

`.claude/hooks/guard-git.sh`'s block for `git checkout -- <file>` (reverting files) matched any `checkout --<anything>`, denying legitimate flags that merely share the same prefix — `--detach`, `--track`, `--orphan`, `--no-track`, `--guess`, `--ours`, `--theirs`. None of these revert working-tree changes the way a bare `--` pathspec separator does.

## Fix

Require the trailing `--` to be its own token (immediately followed by whitespace or end-of-segment/string) rather than the start of a longer flag name — the minimal, precise narrowing the issue itself suggested. Applied identically to the `docs/examples/claude-code-hooks/guard-git.sh` mirror copy, since a byte-identical-sync test (#2105) enforces the two staying in lockstep.

The hook's static whole-script text scan (no awareness of untaken conditional branches) is left as-is — that's an inherent tradeoff of the cheap, no-AST design already used throughout this file for every other check, not something in scope for this fix.

## Test plan

- [x] New unit tests in `tests/unit/hook-guard-git-clean.test.ts` cover: still blocks the real revert form (`checkout -- file.txt`, multi-file, bare trailing `--`); allows `--detach`, `--track`, `--orphan`, `--no-track`, `--guess`, `--ours`, `--theirs`; still blocks a real revert chained after an allowed `--detach` invocation.
- [x] Verified the new tests actually catch the regression (temporarily re-applied the old regex and confirmed `--detach` was wrongly denied).
- [x] `shellcheck` on `guard-git.sh`: clean.
- [x] Full test suite (native addon rebuilt from source in this worktree): 311 files / 5047 tests passed.
- [x] `npm run lint`: clean.
- [x] Dual-engine parity (`scripts/parity-compare.mjs`): clean (unaffected — this change touches no engine code).
- [x] `codegraph diff-impact --staged`: no function-level changes detected.