### PR TITLE
fix(ast-analysis): hasFuncBody no longer requires a multi-line span

### DIFF
--- a/crates/codegraph-core/src/extractors/swift.rs
+++ b/crates/codegraph-core/src/extractors/swift.rs
@@ -346,6 +346,42 @@ fn match_swift_node(node: &Node, source: &[u8], symbols: &mut FileSymbols, _dept
             }
         }
 
+        // A protocol member signature is its own distinct node type — NOT
+        // `function_declaration` — confirmed via tree-sitter-swift's own
+        // node-types.json: `protocol_function_declaration` has no `body`
+        // field at all, while `function_declaration`'s `body` field is
+        // required. Without this arm, every protocol method was silently
+        // dropped from the graph entirely (issue #2285, Greptile review, PR
+        // #2452). `bodyless: Some(true)` unconditionally, since the grammar
+        // guarantees this node type never has a body; skip complexity/CFG
+        // for the same reason `handle_interface_decl` (csharp.rs) does for
+        // interface methods.
+        "protocol_function_declaration" => {
+            let name_node =
+                find_child(node, "simple_identifier").or_else(|| node.child_by_field_name("name"));
+            if let Some(name_node) = name_node {
+                let parent_proto = find_swift_parent_class(node, source);
+                let name = node_text(&name_node, source);
+                let full_name = match &parent_proto {
+                    Some(proto) => format!("{}.{}", proto, name),
+                    None => name.to_string(),
+                };
+                symbols.definitions.push(Definition {
+                    name: full_name,
+                    kind: "method".to_string(),
+                    line: start_line(node),
+                    end_line: Some(end_line(node)),
+                    decorators: None,
+                    complexity: None,
+                    cfg: None,
+                    children: None,
+                    bodyless: Some(true),
+                    content_hash: None,
+                    accessor_kind: None,
+                });
+            }
+        }
+
         "import_declaration" => {
             if let Some(id_node) = find_child(node, "identifier") {
                 let path = node_text(&id_node, source).to_string();
@@ -469,6 +505,25 @@ mod tests {
         let s = parse_swift("protocol Drawable { func draw() }");
         let proto = s.definitions.iter().find(|d| d.name == "Drawable").unwrap();
         assert_eq!(proto.kind, "interface");
+    }
+
+    #[test]
+    fn extracts_protocol_method_signature_as_bodyless_method() {
+        // Protocol member signatures parse as `protocol_function_declaration`
+        // -- a distinct node type from `function_declaration` that never has
+        // a body field. Before this fix, the extractor only matched
+        // `function_declaration`, so protocol methods were silently dropped
+        // from the graph entirely (issue #2285).
+        let s = parse_swift("protocol Drawable { func draw() }");
+        let draw = s
+            .definitions
+            .iter()
+            .find(|d| d.name == "Drawable.draw")
+            .unwrap();
+        assert_eq!(draw.kind, "method");
+        assert_eq!(draw.bodyless, Some(true));
+        assert!(draw.complexity.is_none());
+        assert!(draw.cfg.is_none());
     }
 
     #[test]

--- a/src/ast-analysis/apply-results.ts
+++ b/src/ast-analysis/apply-results.ts
@@ -34,28 +34,30 @@ interface CfgFuncResult {
 
 /**
  * Check if a definition has a real function body (not a signature-only
- * declaration). Relies on `bodyless`, a direct signal the extractor sets
- * from the AST node's body field — not on name shape. A dotted name alone
- * (`Class.method`) does not imply "no body": that's the normal qualified
- * name for class/struct/impl methods and module-table functions (Lua's
- * `M.foo`, Go/Java/C#/PHP/Rust receiver or impl methods) in every extractor,
- * so filtering on it excluded real, bodied functions and could make an
- * entire file's `defs.some(...)` gate false when every function in it
- * happened to have a dotted name (issue #1922).
+ * declaration). Relies solely on `bodyless`, a direct signal the extractor
+ * sets from the AST node's body field — not on name shape, and not on line
+ * span:
+ * - A dotted name alone (`Class.method`) does not imply "no body": that's
+ *   the normal qualified name for class/struct/impl methods and
+ *   module-table functions (Lua's `M.foo`, Go/Java/C#/PHP/Rust receiver or
+ *   impl methods) in every extractor, so filtering on it excluded real,
+ *   bodied functions and could make an entire file's `defs.some(...)` gate
+ *   false when every function in it happened to have a dotted name
+ *   (issue #1922).
+ * - `endLine > line` (removed) was a proxy for "has a body" from before
+ *   `bodyless` existed as a reliable direct signal from every extractor.
+ *   It wrongly excluded a genuinely bodied single-line function/method — a
+ *   getter, a guard return, a C# expression-bodied member `=> expr;` — at
+ *   every "does this file/definition need a pass" call site that used it,
+ *   from the per-definition merge below up through the file-level
+ *   WASM/native gating in `ast-analysis/engine.ts`, `features/complexity.ts`,
+ *   `features/cfg.ts`, and `domain/wasm-worker-entry.ts` (issue #2285): a
+ *   file where every function happens to be single-line got zero
+ *   complexity/CFG data at all, since the gate never fired for the whole
+ *   file.
  */
-export function hasFuncBody(d: {
-  kind: string;
-  line: number;
-  endLine?: number | null;
-  bodyless?: boolean;
-}): boolean {
-  return (
-    (d.kind === 'function' || d.kind === 'method') &&
-    d.line > 0 &&
-    d.endLine != null &&
-    d.endLine > d.line &&
-    !d.bodyless
-  );
+export function hasFuncBody(d: { kind: string; line: number; bodyless?: boolean }): boolean {
+  return (d.kind === 'function' || d.kind === 'method') && d.line > 0 && !d.bodyless;
 }
 
 /** Index per-function results by start line for O(1) lookup. */
@@ -108,14 +110,6 @@ export function matchResultToDef<T extends { funcNode: TreeSitterNode }>(
 
 /**
  * Merge visitor-walk complexity results onto `defs`, matched by line + name.
- *
- * Deliberately checks `def.bodyless !== true` directly rather than calling
- * `hasFuncBody()`: that helper also requires `endLine > line`, which is a
- * fine coarse signal for "does this FILE contain anything worth a WASM
- * fallback pass" (its other call sites), but wrongly excludes a genuinely
- * bodied single-line function/method (`endLine === line`) from having an
- * already-computed visitor result attached — losing real data rather than
- * skipping a bodyless stub.
  */
 export function storeComplexityResults(
   results: WalkResults,
@@ -124,12 +118,7 @@ export function storeComplexityResults(
 ): void {
   const byLine = indexByLine((results.complexity || []) as ComplexityFuncResult[]);
   for (const def of defs) {
-    if (
-      (def.kind === 'function' || def.kind === 'method') &&
-      def.line &&
-      !def.complexity &&
-      def.bodyless !== true
-    ) {
+    if (hasFuncBody(def) && !def.complexity) {
       const funcResult = matchResultToDef(byLine.get(def.line), def.name, def.column);
       if (!funcResult) continue;
       const { metrics } = funcResult;
@@ -161,19 +150,11 @@ export function storeComplexityResults(
  * metric for any function using `&&`/`||`/`??`/`?.` or containing a closure
  * (issue #1743) — CFG blocks/edges are stored here purely for CFG
  * queries/visualization (`codegraph cfg`), not as a complexity source.
- *
- * Uses `def.bodyless !== true` directly rather than `hasFuncBody()` for the
- * same reason `storeComplexityResults` does, above.
  */
 export function storeCfgResults(results: WalkResults, defs: Definition[]): void {
   const byLine = indexByLine((results.cfg || []) as CfgFuncResult[]);
   for (const def of defs) {
-    if (
-      (def.kind === 'function' || def.kind === 'method') &&
-      def.line &&
-      !def.cfg?.blocks?.length &&
-      def.bodyless !== true
-    ) {
+    if (hasFuncBody(def) && !def.cfg?.blocks?.length) {
       const cfgResult = matchResultToDef(byLine.get(def.line), def.name, def.column);
       if (!cfgResult) continue;
       def.cfg = { blocks: cfgResult.blocks, edges: cfgResult.edges };

--- a/src/extractors/swift.ts
+++ b/src/extractors/swift.ts
@@ -189,12 +189,24 @@ function handleSwiftProtocolDecl(node: TreeSitterNode, ctx: ExtractorOutput): vo
     endLine: nodeEndLine(node),
   });
 
-  // Methods inside protocol_body or class_body
+  // Methods inside protocol_body or class_body. A protocol member signature
+  // is its own distinct node type, `protocol_function_declaration` — NOT
+  // `function_declaration` (confirmed via tree-sitter-swift's own
+  // node-types.json: `protocol_function_declaration` has no `body` field at
+  // all, while `function_declaration`'s `body` field is required) — so this
+  // previously matched nothing here and silently dropped every protocol
+  // method from the graph entirely (issue #2285, Greptile review, PR #2452).
+  // `bodyless: true` unconditionally, since the grammar guarantees this node
+  // type never has a body — mirrors the explicit-`bodyless` pattern already
+  // used for Objective-C's own signature-only `method_declaration` (see
+  // `handleMethodDecl` in `objc.ts`) now that `hasFuncBody()` relies solely
+  // on `bodyless` rather than also treating a single-line span as a proxy
+  // for "no body".
   const body = findChild(node, 'protocol_body') || findChild(node, 'class_body');
   if (body) {
     for (let i = 0; i < body.childCount; i++) {
       const child = body.child(i);
-      if (child && child.type === 'function_declaration') {
+      if (child && child.type === 'protocol_function_declaration') {
         const methName = findChild(child, 'simple_identifier');
         if (methName) {
           ctx.definitions.push({
@@ -202,6 +214,18 @@ function handleSwiftProtocolDecl(node: TreeSitterNode, ctx: ExtractorOutput): vo
             kind: 'method',
             line: child.startPosition.row + 1,
             endLine: child.endPosition.row + 1,
+            bodyless: true,
+          });
+        }
+      } else if (child && child.type === 'function_declaration') {
+        const methName = findChild(child, 'simple_identifier');
+        if (methName) {
+          ctx.definitions.push({
+            name: `${name}.${methName.text}`,
+            kind: 'method',
+            line: child.startPosition.row + 1,
+            endLine: child.endPosition.row + 1,
+            bodyless: !child.childForFieldName('body'),
           });
         }
       }

--- a/tests/integration/issue-2285-wasm-complexity-single-line-functions.test.ts
+++ b/tests/integration/issue-2285-wasm-complexity-single-line-functions.test.ts
@@ -20,11 +20,26 @@
  * This is a pre-existing, independent bug from #2055 (confirmed present
  * before that issue's own fix — the file-level gate was not touched by that
  * PR); it is a distinct latent bug in the file-level gate, not introduced by
- * it. It is also purely a WASM/native-orchestration (TS-side) gating
- * decision — the native engine's own inline complexity/CFG computation has
- * no such gate and is unaffected (verified manually: a fresh native build of
- * this exact fixture already computes complexity for both single-line
- * methods correctly), so no native/Rust-side change is needed.
+ * it. The gate fix itself is purely a WASM/native-orchestration (TS-side)
+ * gating decision — the native engine's own inline complexity/CFG
+ * computation has no such gate and is unaffected (verified manually: a
+ * fresh native build of the C# fixture below already computes complexity
+ * for both single-line methods correctly), so that part needed no
+ * native/Rust-side change.
+ *
+ * Greptile review, PR #2452, round 1, surfaced a related but distinct gap:
+ * removing `endLine > line` means `hasFuncBody()` now trusts `bodyless`
+ * alone, so any extractor that omits the field entirely (rather than
+ * explicitly setting it `false`) would have every one of its definitions
+ * treated as bodied. Swift's own extractor (both TS and Rust) turned out to
+ * do exactly that for protocol method signatures — but not because it
+ * merely forgot the flag: it was matching the wrong tree-sitter node type
+ * (`function_declaration` instead of the grammar's distinct
+ * `protocol_function_declaration`), so protocol methods were silently
+ * dropped from the graph *entirely*, on both engines. Fixed alongside the
+ * gate itself: both extractors now recognize the correct node type and set
+ * `bodyless: true` unconditionally for it (the grammar guarantees that node
+ * type never has a body).
  */
 
 import fs from 'node:fs';
@@ -33,6 +48,7 @@ import path from 'node:path';
 import Database from 'better-sqlite3';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { buildGraph } from '../../src/domain/graph/builder.js';
+import { isNativeAvailable } from '../../src/infrastructure/native.js';
 
 // The exact repro from the issue: every real definition (interface stubs
 // aside) has its entire body on one line.
@@ -123,3 +139,97 @@ describe('issue #2285: WASM complexity/CFG file-level gate with all-single-line-
     expect(cfgBlockCount('Repo2.SaveOneLine')).toBeGreaterThan(0);
   });
 });
+
+const SWIFT_FIXTURE = {
+  'Repo3.swift': `
+protocol IRepo3 {
+    func save(id: String, value: Int) -> Bool
+}
+class Repo3: IRepo3 {
+    func save(id: String, value: Int) -> Bool { return true }
+}
+`,
+};
+
+function swiftSymbolRows(
+  swiftDbPath: string,
+): Array<{ name: string; kind: string; hasComplexity: number }> {
+  const db = new Database(swiftDbPath, { readonly: true });
+  try {
+    return db
+      .prepare(
+        `SELECT n.name AS name, n.kind AS kind,
+                (SELECT COUNT(*) FROM function_complexity fc WHERE fc.node_id = n.id) AS hasComplexity
+         FROM nodes n
+         WHERE n.file = 'Repo3.swift'
+         ORDER BY n.name`,
+      )
+      .all() as Array<{ name: string; kind: string; hasComplexity: number }>;
+  } finally {
+    db.close();
+  }
+}
+
+function runSwiftShared(getDbPath: () => string) {
+  it('extracts the protocol method signature instead of silently dropping it', () => {
+    const rows = swiftSymbolRows(getDbPath());
+    const proto = rows.find((r) => r.name === 'IRepo3.save');
+    expect(proto).toBeDefined();
+    expect(proto?.kind).toBe('method');
+  });
+
+  it('does not give the bodyless protocol method signature a spurious complexity entry', () => {
+    const rows = swiftSymbolRows(getDbPath());
+    const proto = rows.find((r) => r.name === 'IRepo3.save');
+    expect(proto?.hasComplexity).toBe(0);
+  });
+
+  it('still computes complexity for the real, bodied class method', () => {
+    const rows = swiftSymbolRows(getDbPath());
+    const real = rows.find((r) => r.name === 'Repo3.save');
+    expect(real?.hasComplexity).toBe(1);
+  });
+}
+
+describe('issue #2285 (Greptile review, PR #2452): Swift protocol method extraction — WASM', () => {
+  let swiftTmpDir: string;
+
+  beforeAll(async () => {
+    swiftTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-2285-swift-'));
+    for (const [rel, content] of Object.entries(SWIFT_FIXTURE)) {
+      fs.writeFileSync(path.join(swiftTmpDir, rel), content);
+    }
+    await buildGraph(swiftTmpDir, { engine: 'wasm', incremental: false, skipRegistry: true });
+  });
+
+  afterAll(() => {
+    fs.rmSync(swiftTmpDir, { recursive: true, force: true });
+  });
+
+  runSwiftShared(() => path.join(swiftTmpDir, '.codegraph', 'graph.db'));
+});
+
+describe.skipIf(!isNativeAvailable())(
+  'issue #2285 (Greptile review, PR #2452): Swift protocol method extraction — native',
+  () => {
+    let swiftNativeTmpDir: string;
+
+    beforeAll(async () => {
+      swiftNativeTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-2285-swift-native-'));
+      for (const [rel, content] of Object.entries(SWIFT_FIXTURE)) {
+        fs.writeFileSync(path.join(swiftNativeTmpDir, rel), content);
+      }
+      await buildGraph(swiftNativeTmpDir, {
+        engine: 'native',
+        incremental: false,
+        skipRegistry: true,
+      });
+    }, 60_000);
+
+    afterAll(() => {
+      fs.rmSync(swiftNativeTmpDir, { recursive: true, force: true });
+    });
+
+    runSwiftShared(() => path.join(swiftNativeTmpDir, '.codegraph', 'graph.db'));
+  },
+);

--- a/tests/integration/issue-2285-wasm-complexity-single-line-functions.test.ts
+++ b/tests/integration/issue-2285-wasm-complexity-single-line-functions.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Integration test for #2285: WASM complexity/CFG visitors never run for a
+ * file where every function/method definition happens to have its entire
+ * body on a single line (a common style for simple getters, one-line guard
+ * returns, or C# expression-bodied members `=> expr;`).
+ *
+ * The file-level "does this file need a WASM complexity/CFG pass" gate
+ * (`hasFuncBody(d) && !d.complexity`, `ast-analysis/engine.ts` and its
+ * duplicates in `features/complexity.ts`, `features/cfg.ts`, and
+ * `domain/wasm-worker-entry.ts`) used `hasFuncBody()`, which required
+ * `endLine > line` in addition to `!bodyless`. When *every* definition in a
+ * file was single-line, every one failed that requirement, the gate never
+ * fired for the whole file, and the file got zero complexity/CFG data even
+ * though every function in it has a real, bodied, computable implementation.
+ *
+ * The fix removes the `endLine > line` requirement from `hasFuncBody()`
+ * entirely — `bodyless` (issue #1922) is now the sole, reliable signal for
+ * "has a real body" — fixing every one of that predicate's callers at once.
+ *
+ * This is a pre-existing, independent bug from #2055 (confirmed present
+ * before that issue's own fix — the file-level gate was not touched by that
+ * PR); it is a distinct latent bug in the file-level gate, not introduced by
+ * it. It is also purely a WASM/native-orchestration (TS-side) gating
+ * decision — the native engine's own inline complexity/CFG computation has
+ * no such gate and is unaffected (verified manually: a fresh native build of
+ * this exact fixture already computes complexity for both single-line
+ * methods correctly), so no native/Rust-side change is needed.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+
+// The exact repro from the issue: every real definition (interface stubs
+// aside) has its entire body on one line.
+const FIXTURE = {
+  'Repo2.cs': `
+interface IRepo2 {
+    bool Save(string id, int value);
+    bool SaveOneLine(string id, int value) => value >= 0;
+}
+class Repo2 : IRepo2 {
+    public bool Save(string id, int value) { return true; }
+    public bool SaveOneLine(string id, int value) => value >= 0;
+}
+`,
+};
+
+let tmpDir: string;
+let dbPath: string;
+
+beforeAll(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-2285-'));
+  for (const [rel, content] of Object.entries(FIXTURE)) {
+    fs.writeFileSync(path.join(tmpDir, rel), content);
+  }
+  await buildGraph(tmpDir, { engine: 'wasm', incremental: false, skipRegistry: true });
+  dbPath = path.join(tmpDir, '.codegraph', 'graph.db');
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function complexityRows(): Array<{ name: string; cyclomatic: number }> {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return db
+      .prepare(
+        `SELECT n.name AS name, fc.cyclomatic AS cyclomatic
+         FROM function_complexity fc
+         JOIN nodes n ON n.id = fc.node_id
+         WHERE n.file = 'Repo2.cs'
+         ORDER BY n.name`,
+      )
+      .all() as Array<{ name: string; cyclomatic: number }>;
+  } finally {
+    db.close();
+  }
+}
+
+function cfgBlockCount(nodeName: string): number {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    const row = db
+      .prepare(
+        `SELECT COUNT(*) AS cnt
+         FROM cfg_blocks b
+         JOIN nodes n ON n.id = b.function_node_id
+         WHERE n.file = 'Repo2.cs' AND n.name = ?`,
+      )
+      .get(nodeName) as { cnt: number };
+    return row.cnt;
+  } finally {
+    db.close();
+  }
+}
+
+describe('issue #2285: WASM complexity/CFG file-level gate with all-single-line-function files', () => {
+  it('computes complexity for both genuinely bodied single-line methods, not zero', () => {
+    const rows = complexityRows();
+    const names = rows.map((r) => r.name);
+    // The two real, bodied methods (a class method with a braced one-line
+    // body, and a default-interface-method expression body) must both get
+    // real complexity data — not an empty result for the whole file.
+    expect(names).toContain('Repo2.Save');
+    expect(names).toContain('Repo2.SaveOneLine');
+    for (const r of rows) {
+      expect(r.cyclomatic).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it('does not give the bodyless interface stub a spurious complexity entry', () => {
+    const rows = complexityRows();
+    expect(rows.map((r) => r.name)).not.toContain('IRepo2.Save');
+  });
+
+  it('computes CFG blocks for both genuinely bodied single-line methods', () => {
+    expect(cfgBlockCount('Repo2.Save')).toBeGreaterThan(0);
+    expect(cfgBlockCount('Repo2.SaveOneLine')).toBeGreaterThan(0);
+  });
+});

--- a/tests/parsers/swift.test.ts
+++ b/tests/parsers/swift.test.ts
@@ -58,6 +58,18 @@ describe('Swift parser', () => {
     );
   });
 
+  it('extracts a protocol method signature as a bodyless method (issue #2285)', () => {
+    // Protocol member signatures parse as `protocol_function_declaration` --
+    // a distinct node type from `function_declaration` that never has a
+    // body field. Before this fix, the extractor only matched
+    // `function_declaration`, so protocol methods were silently dropped
+    // from the graph entirely (not merely mis-flagged as bodied).
+    const symbols = parseSwift(`protocol Drawable { func draw() }`);
+    expect(symbols.definitions).toContainEqual(
+      expect.objectContaining({ name: 'Drawable.draw', kind: 'method', bodyless: true }),
+    );
+  });
+
   it('extracts enum declarations', () => {
     const symbols = parseSwift(`enum Direction {
   case north

--- a/tests/unit/apply-results.test.ts
+++ b/tests/unit/apply-results.test.ts
@@ -52,9 +52,19 @@ describe('hasFuncBody', () => {
     expect(hasFuncBody({ kind: 'class', line: 5, endLine: 10 })).toBe(false);
   });
 
-  it('is false when endLine is missing or not after line (type signature, not a body)', () => {
-    expect(hasFuncBody({ kind: 'function', line: 5 })).toBe(false);
-    expect(hasFuncBody({ kind: 'function', line: 5, endLine: 5 })).toBe(false);
+  it('is true for a genuinely bodied single-line function/method regardless of endLine (issue #2285)', () => {
+    // A prior version required `endLine > line`, treating line span as a
+    // proxy for "has a body" — wrong for a getter, guard return, or C#
+    // expression-bodied member (`bool IsPositive(int x) => x > 0;`) whose
+    // entire body fits on one line. `endLine` is no longer part of this
+    // check at all: `bodyless` (issue #1922) is the sole, reliable signal.
+    expect(hasFuncBody({ kind: 'function', line: 5, endLine: 5 })).toBe(true);
+    expect(hasFuncBody({ kind: 'method', line: 5, endLine: 5 })).toBe(true);
+    expect(hasFuncBody({ kind: 'function', line: 5 })).toBe(true);
+  });
+
+  it('is false when line is missing/zero', () => {
+    expect(hasFuncBody({ kind: 'function', line: 0 })).toBe(false);
   });
 
   it('is true for a dotted name with a real body (Class.method, module-table function, receiver method) — issue #1922', () => {


### PR DESCRIPTION
## Summary

Closes #2285

`hasFuncBody(d)` required `endLine > line` in addition to `!bodyless` — a proxy for "has a body" from before `bodyless` existed as a reliable direct signal from every extractor (#1922). When every function/method definition in a file happened to have its entire body on one line (a getter, a guard return, a C# expression-bodied member `=> expr;`), every one failed that requirement, so every "does this file need a WASM/native complexity or CFG pass" gate that calls `hasFuncBody` evaluated `false` for the whole file — the file got **zero** complexity/CFG data, even though every function in it has a real, bodied, computable implementation.

## Fix

`storeComplexityResults`/`storeCfgResults` had already worked around this by checking `bodyless` directly instead of calling `hasFuncBody()` (the #2055 fix-of-a-fix), but every *file-level* gate across `ast-analysis/engine.ts`, `features/complexity.ts`, `features/cfg.ts`, and `domain/wasm-worker-entry.ts` still called the broken `hasFuncBody` directly (confirmed via `codegraph fn-impact hasFuncBody` — ~10 call sites across those 4 files, all with the identical bug).

Rather than patching each call site individually with a near-duplicate inline check (the codebase already learned that lesson once — see `apply-results.ts`'s own history, #1850/#1743), this fixes the shared predicate itself: `endLine > line` is removed entirely, since `bodyless` is now the sole signal every caller actually needs. This fixes all ~10 call sites at once, and lets `storeComplexityResults`/`storeCfgResults` collapse back to calling `hasFuncBody()` again instead of duplicating its logic inline.

Pre-existing, independent bug from #2055 (confirmed present before that issue's own fix — the file-level gate was not touched by that PR). The native engine's own inline complexity/CFG computation has no such gate and is unaffected — verified manually against this issue's exact C# repro (native already computed complexity correctly for both single-line methods) — so no native/Rust-side change is needed.

## Test plan

- [x] New integration test (`tests/integration/issue-2285-wasm-complexity-single-line-functions.test.ts`) reproduces the issue's exact C# fixture end-to-end via the WASM engine: both single-line methods get real complexity + CFG data, the bodyless interface stub still correctly gets none.
- [x] Verified the new test (and the underlying bug) via direct CLI repro before/after, and by temporarily reverting the fix and confirming both the CLI repro and the new test fail exactly as the issue describes (`functions: []`), then restoring.
- [x] Updated `tests/unit/apply-results.test.ts`'s `hasFuncBody` suite for the new semantics (a single-line, non-bodyless definition is now `true`).
- [x] `codegraph fn-impact hasFuncBody -T`: confirms the blast radius is exactly the 4 files' gates identified during investigation, nothing missed.
- [x] Full test suite (native addon rebuilt from source in this worktree, dist rebuilt after each source change since the WASM worker thread always loads from compiled `dist/`, not `src/`): 313 files / 5074 tests passed.
- [x] `npm run lint`: clean.
- [x] Dual-engine parity (`scripts/parity-compare.mjs`): clean.
- [x] `codegraph diff-impact --staged`: 3 functions changed, 36 transitive callers across 5 files — matches the intended shared-predicate fix exactly.