### PR TITLE
fix(ast-analysis): LOC comment detection tracks block-comment state

### DIFF
--- a/crates/codegraph-core/src/ast_analysis/complexity.rs
+++ b/crates/codegraph-core/src/ast_analysis/complexity.rs
@@ -2142,22 +2142,28 @@ pub fn halstead_rules(lang_id: &str) -> Option<&'static HalsteadRules> {
     }
 }
 
-/// Comment line prefixes per language, used for LOC metrics.
-pub fn comment_prefixes(lang_id: &str) -> &'static [&'static str] {
+/// Single-line comment prefixes per language, used for LOC metrics.
+///
+/// Deliberately excludes `/*`/`*/`/a bare `*` continuation marker: a bare
+/// `*` also opens a pointer-dereference assignment (`*ptr = 5;`) in every
+/// block-comment language below that supports one, so trusting it as a
+/// standalone comment signal misclassified real code as a comment (issue
+/// #2287). Block-comment lines are instead recognized via explicit
+/// `/* ... */` state tracking in `compute_all_metrics`, scoped to languages
+/// where [`is_block_comment_lang`] returns true.
+pub fn line_comment_prefixes(lang_id: &str) -> &'static [&'static str] {
     match lang_id {
-        // c/cpp/cuda/objc/kotlin/swift/scala all use the same `/** ... */`
-        // block-comment style as JS/Java/C# — the 2-entry list omitted
-        // bare `*`/`*/` continuation lines, undercounting commentLines for
-        // any multi-line Javadoc-style comment (issue #2058).
-        "javascript" | "typescript" | "tsx" | "go" | "rust" | "java" | "csharp" | "c" | "cpp"
-        | "cuda" | "objc" | "kotlin" | "swift" | "scala" | "groovy" => &["//", "/*", "*", "*/"],
         "python" | "ruby" | "r" => &["#"],
-        "php" => &["//", "#", "/*", "*", "*/"],
+        "php" => &["//", "#"],
         "bash" => &["#"],
         "lua" => &["--"],
-        "zig" => &["//"],
-        _ => &["//", "/*", "*", "*/"],
+        _ => &["//"],
     }
+}
+
+/// Languages using `/** ... */`-style block comments (issue #2058, #2287).
+pub fn is_block_comment_lang(lang_id: &str) -> bool {
+    !matches!(lang_id, "python" | "ruby" | "r" | "bash" | "lua" | "zig")
 }
 
 // ─── Merged Single-Pass: Complexity + Halstead + LOC + MI ─────────────────
@@ -2249,16 +2255,41 @@ pub fn compute_all_metrics(
     let func_text = String::from_utf8_lossy(func_source);
     let lines: Vec<&str> = func_text.split('\n').collect();
     let loc_total = lines.len() as u32;
-    let prefixes = comment_prefixes(lang_id);
+    let line_prefixes = line_comment_prefixes(lang_id);
+    let supports_block_comments = is_block_comment_lang(lang_id);
 
     let mut comment_lines: u32 = 0;
     let mut blank_lines: u32 = 0;
+    let mut in_block_comment = false;
     for line in &lines {
         let trimmed = line.trim();
+
+        if in_block_comment {
+            comment_lines += 1;
+            if trimmed.contains("*/") {
+                in_block_comment = false;
+            }
+            continue;
+        }
+
         if trimmed.is_empty() {
             blank_lines += 1;
-        } else if prefixes.iter().any(|p| trimmed.starts_with(p)) {
+            continue;
+        }
+
+        if line_prefixes.iter().any(|p| trimmed.starts_with(p)) {
             comment_lines += 1;
+            continue;
+        }
+
+        if supports_block_comments && trimmed.starts_with("/*") {
+            comment_lines += 1;
+            // Search after the opening 2 chars so a 2-char close can't
+            // overlap the opening `/*` itself (e.g. "/*/" is NOT a closed
+            // empty comment).
+            if !trimmed[2..].contains("*/") {
+                in_block_comment = true;
+            }
         }
     }
     let sloc = (loc_total
@@ -2531,24 +2562,79 @@ mod tests {
     use tree_sitter::Parser;
 
     #[test]
-    fn comment_prefixes_c_family_and_jvm_langs_match_continuation_lines() {
+    fn is_block_comment_lang_covers_c_family_and_jvm_langs() {
         // Regression guard (issue #2058): c/cpp/cuda/objc/kotlin/swift/scala
-        // all use the same `/** ... */` block-comment style as JS/Java/C# —
-        // the old 2-entry list omitted bare `*`/`*/` continuation lines,
-        // undercounting commentLines for any multi-line Javadoc-style comment.
+        // all use the same `/** ... */` block-comment style as JS/Java/C#.
         for lang in [
             "c", "cpp", "cuda", "objc", "kotlin", "swift", "scala", "groovy",
         ] {
-            let prefixes = comment_prefixes(lang);
             assert!(
-                prefixes.contains(&"*"),
-                "{lang} should match bare '*' continuation lines"
-            );
-            assert!(
-                prefixes.contains(&"*/"),
-                "{lang} should match closing '*/' lines"
+                is_block_comment_lang(lang),
+                "{lang} should support /* ... */ block comments"
             );
         }
+    }
+
+    #[test]
+    fn is_block_comment_lang_excludes_hash_and_dash_comment_langs() {
+        for lang in ["python", "ruby", "r", "bash", "lua", "zig"] {
+            assert!(
+                !is_block_comment_lang(lang),
+                "{lang} should not support /* ... */ block comments"
+            );
+        }
+    }
+
+    fn compute_rust(code: &str) -> ComplexityMetrics {
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
+        let tree = parser.parse(code.as_bytes(), None).unwrap();
+        let root = tree.root_node();
+        let func = find_first_function(&root, &RUST_LANG_RULES).expect("no function found");
+        compute_all_metrics(&func, code.as_bytes(), "rust").expect("no metrics computed")
+    }
+
+    #[test]
+    fn loc_metrics_does_not_misclassify_pointer_dereference_as_a_comment_continuation() {
+        // Issue #2287: a bare `*` prefix (trusted unconditionally by the old
+        // flat comment-prefix list, to match Javadoc-style `* ...`
+        // continuation lines) also opens a pointer-dereference assignment in
+        // Rust/C/C#/Go, wrongly counting real code as a comment line.
+        let metrics = compute_rust(
+            "fn deref_heavy(ptr: *mut i32) -> i32 {\n    unsafe {\n        *ptr = 5;\n        *ptr = *ptr + 1;\n        return *ptr;\n    }\n}",
+        );
+        let loc = metrics.loc.expect("loc metrics missing");
+        assert_eq!(loc.comment_lines, 0, "no line here is a real comment");
+        assert_eq!(loc.sloc, loc.loc, "every non-blank line is real code");
+    }
+
+    #[test]
+    fn loc_metrics_still_tracks_a_genuine_multiline_block_comment() {
+        // Regression guard for #2058's own fix: a real Javadoc-style
+        // continuation line (opened by an actual `/*`) must still count as
+        // a comment under the new block-tracking state machine. The comment
+        // must be INSIDE the function body: a leading doc comment before the
+        // function signature is a sibling AST node, not part of the
+        // function node's own text span, so it would never reach this loop
+        // regardless of the prefix logic being tested here.
+        let metrics = compute_rust(
+            "fn documented() -> i32 {\n    /**\n     * Doc comment.\n     * More doc.\n     */\n    return 1;\n}",
+        );
+        let loc = metrics.loc.expect("loc metrics missing");
+        assert_eq!(
+            loc.comment_lines, 4,
+            "the 4-line doc comment must be fully counted"
+        );
+    }
+
+    #[test]
+    fn loc_metrics_closes_a_single_line_block_comment_without_entering_block_state() {
+        let metrics = compute_rust("fn f() -> i32 {\n    /* inline */\n    return 1;\n}");
+        let loc = metrics.loc.expect("loc metrics missing");
+        assert_eq!(loc.comment_lines, 1);
+        assert_eq!(loc.sloc, loc.loc - loc.comment_lines);
     }
 
     fn compute_js(code: &str) -> ComplexityMetrics {

--- a/crates/codegraph-core/src/ast_analysis/complexity.rs
+++ b/crates/codegraph-core/src/ast_analysis/complexity.rs
@@ -2166,6 +2166,42 @@ pub fn is_block_comment_lang(lang_id: &str) -> bool {
     !matches!(lang_id, "python" | "ruby" | "r" | "bash" | "lua" | "zig")
 }
 
+/// Languages whose block comments can nest (`/* outer /* inner */ still
+/// outer */`) — Rust and Swift, unlike the other block-comment languages
+/// here, where an inner opening marker inside an already-open comment is
+/// inert text and the FIRST closing marker ends the whole thing.
+pub fn is_nestable_block_comment_lang(lang_id: &str) -> bool {
+    matches!(lang_id, "rust" | "swift")
+}
+
+/// Scan `text` for block-comment opening/closing markers, returning the
+/// nesting depth after the scan (0 = not in a comment). `start_depth` is
+/// the depth entering `text`. For a non-nestable language, depth never
+/// exceeds 1 under this scan (an inner opener while already at depth 1 is
+/// ignored, matching how those languages' own parsers treat it), so the
+/// first closer always fully closes it — nesting support only changes
+/// whether an inner opener is allowed to push depth past 1 (Greptile
+/// review, PR #2456: the original boolean-state version closed a
+/// Rust/Swift nested comment at its first, inner closing marker instead of
+/// its outer one).
+fn scan_block_comment_depth(text: &str, start_depth: u32, nestable: bool) -> u32 {
+    let bytes = text.as_bytes();
+    let mut depth = start_depth;
+    let mut i = 0;
+    while i + 1 < bytes.len() {
+        if bytes[i] == b'/' && bytes[i + 1] == b'*' && (depth == 0 || nestable) {
+            depth += 1;
+            i += 2;
+        } else if bytes[i] == b'*' && bytes[i + 1] == b'/' && depth > 0 {
+            depth -= 1;
+            i += 2;
+        } else {
+            i += 1;
+        }
+    }
+    depth
+}
+
 // ─── Merged Single-Pass: Complexity + Halstead + LOC + MI ─────────────────
 
 use crate::types::{HalsteadMetrics, LocMetrics};
@@ -2257,18 +2293,17 @@ pub fn compute_all_metrics(
     let loc_total = lines.len() as u32;
     let line_prefixes = line_comment_prefixes(lang_id);
     let supports_block_comments = is_block_comment_lang(lang_id);
+    let nestable = is_nestable_block_comment_lang(lang_id);
 
     let mut comment_lines: u32 = 0;
     let mut blank_lines: u32 = 0;
-    let mut in_block_comment = false;
+    let mut block_depth: u32 = 0;
     for line in &lines {
         let trimmed = line.trim();
 
-        if in_block_comment {
+        if block_depth > 0 {
             comment_lines += 1;
-            if trimmed.contains("*/") {
-                in_block_comment = false;
-            }
+            block_depth = scan_block_comment_depth(trimmed, block_depth, nestable);
             continue;
         }
 
@@ -2284,12 +2319,7 @@ pub fn compute_all_metrics(
 
         if supports_block_comments && trimmed.starts_with("/*") {
             comment_lines += 1;
-            // Search after the opening 2 chars so a 2-char close can't
-            // overlap the opening `/*` itself (e.g. "/*/" is NOT a closed
-            // empty comment).
-            if !trimmed[2..].contains("*/") {
-                in_block_comment = true;
-            }
+            block_depth = scan_block_comment_depth(trimmed, 0, nestable);
         }
     }
     let sloc = (loc_total
@@ -2632,6 +2662,32 @@ mod tests {
     #[test]
     fn loc_metrics_closes_a_single_line_block_comment_without_entering_block_state() {
         let metrics = compute_rust("fn f() -> i32 {\n    /* inline */\n    return 1;\n}");
+        let loc = metrics.loc.expect("loc metrics missing");
+        assert_eq!(loc.comment_lines, 1);
+        assert_eq!(loc.sloc, loc.loc - loc.comment_lines);
+    }
+
+    #[test]
+    fn loc_metrics_does_not_close_a_nested_rust_block_comment_at_the_inner_closer() {
+        // Greptile review, PR #2456: Rust (unlike the other block-comment
+        // languages here) allows /* ... */ to nest. A boolean in/out-of-comment
+        // state closes at the FIRST */, wrongly ending the comment at the
+        // inner one and counting the remaining outer-comment lines as SLOC.
+        let metrics = compute_rust(
+            "fn documented() -> i32 {\n    /* outer\n     /* inner */\n     still outer\n     */\n    1\n}",
+        );
+        let loc = metrics.loc.expect("loc metrics missing");
+        // /* outer, /* inner */, still outer, */ — all 4 lines are comment.
+        assert_eq!(
+            loc.comment_lines, 4,
+            "the whole nested comment must be counted, not just up to the inner closer"
+        );
+    }
+
+    #[test]
+    fn loc_metrics_single_line_nested_rust_block_comment_still_closes() {
+        let metrics =
+            compute_rust("fn f() -> i32 {\n    /* outer /* inner */ still outer */\n    1\n}");
         let loc = metrics.loc.expect("loc metrics missing");
         assert_eq!(loc.comment_lines, 1);
         assert_eq!(loc.sloc, loc.loc - loc.comment_lines);

--- a/src/ast-analysis/metrics.ts
+++ b/src/ast-analysis/metrics.ts
@@ -108,14 +108,50 @@ const LINE_COMMENT_PREFIXES = new Map<string, string[]>([
 const NO_BLOCK_COMMENT_LANGS = new Set(['python', 'ruby', 'bash', 'lua', 'zig', 'r']);
 
 /**
+ * Languages whose block comments can nest (`/* outer /* inner *\/ still
+ * outer *\/`) — Rust and Swift, unlike the other block-comment languages
+ * here, where an inner opening marker inside an already-open comment is
+ * inert text and the FIRST closing marker ends the whole thing.
+ */
+const NESTABLE_BLOCK_COMMENT_LANGS = new Set(['rust', 'swift']);
+
+/**
+ * Scan `text` for block-comment opening/closing markers, returning the
+ * nesting depth after the scan (0 = not in a comment). `startDepth` is the
+ * depth entering `text`. For a non-nestable language, depth never exceeds
+ * 1 under this scan (an inner opener while already at depth 1 is ignored,
+ * matching how those languages' own parsers treat it), so the first closer
+ * always fully closes it — nesting support only changes whether an inner
+ * opener is allowed to push depth past 1 (Greptile review, PR #2456: the
+ * original boolean-state version closed a Rust/Swift nested comment at its
+ * first, inner closing marker instead of its outer one).
+ */
+function scanBlockCommentDepth(text: string, startDepth: number, nestable: boolean): number {
+  let depth = startDepth;
+  let i = 0;
+  while (i < text.length - 1) {
+    if (text[i] === '/' && text[i + 1] === '*' && (depth === 0 || nestable)) {
+      depth++;
+      i += 2;
+    } else if (text[i] === '*' && text[i + 1] === '/' && depth > 0) {
+      depth--;
+      i += 2;
+    } else {
+      i++;
+    }
+  }
+  return depth;
+}
+
+/**
  * Compute LOC metrics from a function node's source text.
  *
- * Tracks Javadoc-style block-comment state across lines rather than
- * trusting a bare opening/continuation/closing marker unconditionally: a
- * line is only a block-comment continuation while a genuine block-opening
- * line has been seen and the block hasn't closed yet. Without this,
- * `*ptr = 5;` (a pointer-dereference assignment, valid in every
- * block-comment language here) was wrongly counted as a Javadoc-style
+ * Tracks Javadoc-style block-comment nesting depth across lines rather
+ * than trusting a bare opening/continuation/closing marker unconditionally:
+ * a line is only a block-comment continuation while a genuine
+ * block-opening line has been seen and the block hasn't closed yet.
+ * Without this, `*ptr = 5;` (a pointer-dereference assignment, valid in
+ * every block-comment language here) was wrongly counted as a Javadoc-style
  * continuation line (issue #2287).
  *
  * @param {object} functionNode - tree-sitter node
@@ -128,17 +164,18 @@ export function computeLOCMetrics(functionNode: TreeSitterNode, language?: strin
   const loc = lines.length;
   const linePrefixes = (language && LINE_COMMENT_PREFIXES.get(language)) || LINE_COMMENT_PREFIX;
   const supportsBlockComments = !language || !NO_BLOCK_COMMENT_LANGS.has(language);
+  const nestable = !!language && NESTABLE_BLOCK_COMMENT_LANGS.has(language);
 
   let commentLines = 0;
   let blankLines = 0;
-  let inBlockComment = false;
+  let blockDepth = 0;
 
   for (const line of lines) {
     const trimmed = line.trim();
 
-    if (inBlockComment) {
+    if (blockDepth > 0) {
       commentLines++;
-      if (trimmed.includes('*/')) inBlockComment = false;
+      blockDepth = scanBlockCommentDepth(trimmed, blockDepth, nestable);
       continue;
     }
 
@@ -154,9 +191,7 @@ export function computeLOCMetrics(functionNode: TreeSitterNode, language?: strin
 
     if (supportsBlockComments && trimmed.startsWith('/*')) {
       commentLines++;
-      // Search after the opening 2 chars so a 2-char close can't overlap the
-      // opening `/*` itself (e.g. "/*/" is NOT a closed empty comment).
-      if (!trimmed.slice(2).includes('*/')) inBlockComment = true;
+      blockDepth = scanBlockCommentDepth(trimmed, 0, nestable);
     }
   }
 

--- a/src/ast-analysis/metrics.ts
+++ b/src/ast-analysis/metrics.ts
@@ -58,62 +58,105 @@ export function computeHalsteadDerived(
 
 // ─── LOC Metrics ──────────────────────────────────────────────────────────
 
-const C_STYLE_PREFIXES = ['//', '/*', '*', '*/'];
+const LINE_COMMENT_PREFIX = ['//'];
 
-// See native `comment_prefixes()` in crates/codegraph-core/src/ast_analysis/complexity.rs
-// for the source of truth this must stay byte-for-byte identical to (both
-// engines must agree on which lines count as comments for the MI calculation).
-const COMMENT_PREFIXES = new Map<string, string[]>([
-  ['javascript', C_STYLE_PREFIXES],
-  ['typescript', C_STYLE_PREFIXES],
-  ['tsx', C_STYLE_PREFIXES],
-  ['go', C_STYLE_PREFIXES],
-  ['rust', C_STYLE_PREFIXES],
-  ['java', C_STYLE_PREFIXES],
-  ['csharp', C_STYLE_PREFIXES],
+// See native `line_comment_prefixes()`/`is_block_comment_lang()` in
+// crates/codegraph-core/src/ast_analysis/complexity.rs for the source of
+// truth this must stay byte-for-byte identical to (both engines must agree
+// on which lines count as comments for the MI calculation).
+//
+// Only genuine single-line comment markers live here. `/*`/`*/`/a bare `*`
+// continuation line are NOT prefixes to trust unconditionally — a bare `*`
+// also opens a pointer-dereference assignment (`*ptr = 5;`) in every
+// language below that supports one, so treating it as a comment signal on
+// its own misclassified real code as a comment (issue #2287). Block-comment
+// lines are instead recognized via explicit `/* ... */` state tracking in
+// `computeLOCMetrics`, scoped to the languages NOT in `NO_BLOCK_COMMENT_LANGS`.
+const LINE_COMMENT_PREFIXES = new Map<string, string[]>([
+  ['javascript', LINE_COMMENT_PREFIX],
+  ['typescript', LINE_COMMENT_PREFIX],
+  ['tsx', LINE_COMMENT_PREFIX],
+  ['go', LINE_COMMENT_PREFIX],
+  ['rust', LINE_COMMENT_PREFIX],
+  ['java', LINE_COMMENT_PREFIX],
+  ['csharp', LINE_COMMENT_PREFIX],
   ['python', ['#']],
   ['ruby', ['#']],
-  ['php', ['//', '#', '/*', '*', '*/']],
-  // c/cpp/cuda/objc/kotlin/swift/scala use the same `/** ... */` block-comment
-  // style as JS/Java/C# — the old 2-entry list omitted bare `*`/`*/`
-  // continuation lines, undercounting commentLines for any multi-line
-  // Javadoc-style comment (issue #2058).
-  ['c', C_STYLE_PREFIXES],
-  ['cpp', C_STYLE_PREFIXES],
-  ['cuda', C_STYLE_PREFIXES],
-  ['objc', C_STYLE_PREFIXES],
-  ['kotlin', C_STYLE_PREFIXES],
-  ['swift', C_STYLE_PREFIXES],
-  ['scala', C_STYLE_PREFIXES],
+  ['php', ['//', '#']],
+  ['c', LINE_COMMENT_PREFIX],
+  ['cpp', LINE_COMMENT_PREFIX],
+  ['cuda', LINE_COMMENT_PREFIX],
+  ['objc', LINE_COMMENT_PREFIX],
+  ['kotlin', LINE_COMMENT_PREFIX],
+  ['swift', LINE_COMMENT_PREFIX],
+  ['scala', LINE_COMMENT_PREFIX],
   ['bash', ['#']],
   ['lua', ['--']],
-  ['zig', ['//']],
-  ['groovy', C_STYLE_PREFIXES],
+  ['zig', LINE_COMMENT_PREFIX],
+  ['groovy', LINE_COMMENT_PREFIX],
   ['r', ['#']],
 ]);
 
 /**
+ * Languages that do NOT use Javadoc-style block comments (issue #2058,
+ * #2287). Inverted (exclusion) rather than an inclusion set so an unlisted
+ * language string falls back to full C-style/block-comment support — the
+ * same fallback `computeLOCMetrics` already gives an unlisted language for
+ * its line-comment prefix (`LINE_COMMENT_PREFIX`, `//`), matching the native
+ * mirror's own pre-fix catch-all default of full C-style support.
+ */
+const NO_BLOCK_COMMENT_LANGS = new Set(['python', 'ruby', 'bash', 'lua', 'zig', 'r']);
+
+/**
  * Compute LOC metrics from a function node's source text.
  *
+ * Tracks Javadoc-style block-comment state across lines rather than
+ * trusting a bare opening/continuation/closing marker unconditionally: a
+ * line is only a block-comment continuation while a genuine block-opening
+ * line has been seen and the block hasn't closed yet. Without this,
+ * `*ptr = 5;` (a pointer-dereference assignment, valid in every
+ * block-comment language here) was wrongly counted as a Javadoc-style
+ * continuation line (issue #2287).
+ *
  * @param {object} functionNode - tree-sitter node
- * @param {string} [language] - Language ID (falls back to C-style prefixes)
+ * @param {string} [language] - Language ID (falls back to C-style, block-comment-supporting behavior)
  * @returns {{ loc: number, sloc: number, commentLines: number }}
  */
 export function computeLOCMetrics(functionNode: TreeSitterNode, language?: string): LOCMetrics {
   const text = functionNode.text;
   const lines = text.split('\n');
   const loc = lines.length;
-  const prefixes = (language && COMMENT_PREFIXES.get(language)) || C_STYLE_PREFIXES;
+  const linePrefixes = (language && LINE_COMMENT_PREFIXES.get(language)) || LINE_COMMENT_PREFIX;
+  const supportsBlockComments = !language || !NO_BLOCK_COMMENT_LANGS.has(language);
 
   let commentLines = 0;
   let blankLines = 0;
+  let inBlockComment = false;
 
   for (const line of lines) {
     const trimmed = line.trim();
+
+    if (inBlockComment) {
+      commentLines++;
+      if (trimmed.includes('*/')) inBlockComment = false;
+      continue;
+    }
+
     if (trimmed === '') {
       blankLines++;
-    } else if (prefixes.some((p) => trimmed.startsWith(p))) {
+      continue;
+    }
+
+    if (linePrefixes.some((p) => trimmed.startsWith(p))) {
       commentLines++;
+      continue;
+    }
+
+    if (supportsBlockComments && trimmed.startsWith('/*')) {
+      commentLines++;
+      // Search after the opening 2 chars so a 2-char close can't overlap the
+      // opening `/*` itself (e.g. "/*/" is NOT a closed empty comment).
+      if (!trimmed.slice(2).includes('*/')) inBlockComment = true;
     }
   }
 

--- a/tests/integration/issue-2287-loc-comment-block-state.test.ts
+++ b/tests/integration/issue-2287-loc-comment-block-state.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Integration test for #2287: LOC comment-line detection misclassified a
+ * code line starting with a comment-prefix character as a comment.
+ *
+ * `computeLOCMetrics()` (TS) and the LOC-counting logic in
+ * `compute_all_metrics()` (native, `crates/codegraph-core/src/ast_analysis/complexity.rs`)
+ * classified a line as a comment purely by checking whether the trimmed
+ * line text starts with any of a language's comment prefixes. For any
+ * language whose comment prefixes included a bare `*` (needed to match
+ * Javadoc-style continuation lines), this also matched any line that
+ * merely happens to start with `*` after trimming — most notably a
+ * pointer-dereference assignment (`*ptr = 5;`), which Rust, C, C#, and Go
+ * all allow as a statement.
+ *
+ * The fix tracks Javadoc-style block-comment state across lines instead of
+ * trusting a bare opening/continuation/closing marker unconditionally: a
+ * line is only a block-comment continuation while a genuine block-opening
+ * line has been seen and the block hasn't closed yet. Mirrored identically
+ * in both engines.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+import { isNativeAvailable } from '../../src/infrastructure/native.js';
+
+const FIXTURE = {
+  // The issue's own exact repro: a pointer-dereference-heavy function with
+  // no real comments at all.
+  'deref.rs': `
+fn deref_heavy(ptr: *mut i32) -> i32 {
+    unsafe {
+        *ptr = 5;
+        *ptr = *ptr + 1;
+        return *ptr;
+    }
+}
+`,
+  // A genuine multi-line block comment inside a function body, to guard
+  // against the fix over-correcting and losing #2058's own coverage.
+  'documented.rs': `
+fn documented() -> i32 {
+    /**
+     * Doc comment.
+     * More doc.
+     */
+    1
+}
+`,
+};
+
+function locRow(
+  dbPath: string,
+  file: string,
+  name: string,
+): { loc: number; sloc: number; comment_lines: number } {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    const row = db
+      .prepare(
+        `SELECT fc.loc AS loc, fc.sloc AS sloc, fc.comment_lines AS comment_lines
+         FROM function_complexity fc
+         JOIN nodes n ON n.id = fc.node_id
+         WHERE n.file = ? AND n.name = ?`,
+      )
+      .get(file, name) as { loc: number; sloc: number; comment_lines: number } | undefined;
+    expect(row, `no function_complexity row for ${file}:${name}`).toBeDefined();
+    return row!;
+  } finally {
+    db.close();
+  }
+}
+
+function runShared(getDbPath: () => string) {
+  it('does not misclassify pointer-dereference assignments as comment continuation lines', () => {
+    const row = locRow(getDbPath(), 'deref.rs', 'deref_heavy');
+    expect(row.comment_lines).toBe(0);
+    expect(row.sloc).toBe(row.loc);
+  });
+
+  it('still tracks a genuine multi-line block comment inside the function body', () => {
+    const row = locRow(getDbPath(), 'documented.rs', 'documented');
+    expect(row.comment_lines).toBe(4);
+  });
+}
+
+describe('issue #2287: LOC comment-line block-comment-state tracking — WASM', () => {
+  let tmpDir: string;
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-2287-'));
+    for (const [rel, content] of Object.entries(FIXTURE)) {
+      fs.writeFileSync(path.join(tmpDir, rel), content);
+    }
+    await buildGraph(tmpDir, { engine: 'wasm', incremental: false, skipRegistry: true });
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  runShared(() => path.join(tmpDir, '.codegraph', 'graph.db'));
+});
+
+describe.skipIf(!isNativeAvailable())(
+  'issue #2287: LOC comment-line block-comment-state tracking — native',
+  () => {
+    let nativeTmpDir: string;
+
+    beforeAll(async () => {
+      nativeTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-2287-native-'));
+      for (const [rel, content] of Object.entries(FIXTURE)) {
+        fs.writeFileSync(path.join(nativeTmpDir, rel), content);
+      }
+      await buildGraph(nativeTmpDir, { engine: 'native', incremental: false, skipRegistry: true });
+    }, 60_000);
+
+    afterAll(() => {
+      fs.rmSync(nativeTmpDir, { recursive: true, force: true });
+    });
+
+    runShared(() => path.join(nativeTmpDir, '.codegraph', 'graph.db'));
+  },
+);

--- a/tests/unit/complexity.test.ts
+++ b/tests/unit/complexity.test.ts
@@ -408,14 +408,34 @@ describe('computeLOCMetrics', () => {
     const root = parse(`
       function commented() {
         // line comment
-        /* block comment */
-        * star comment
+        /* block comment
+         * continuation line
+         */
         return 1;
       }
     `);
     const funcNode = getFunctionBody(root);
     const result = computeLOCMetrics(funcNode);
-    expect(result.commentLines).toBeGreaterThanOrEqual(3);
+    // // line comment, /* block comment, * continuation line, */ — 4 lines.
+    expect(result.commentLines).toBeGreaterThanOrEqual(4);
+  });
+
+  it('does not treat a bare "*" line as a comment unless a real block comment is open (issue #2287)', () => {
+    // A multiplication-operator continuation line is real JS code that
+    // starts with a bare "*" — with no preceding, still-open `/*`, it must
+    // not be misclassified as a Javadoc-style comment continuation. (The
+    // Rust `loc()` test below covers the issue's own pointer-dereference
+    // repro, which JS has no equivalent syntax for.)
+    const root = parse(`
+      function notAComment() {
+        const x = 5
+          * 2;
+        return x;
+      }
+    `);
+    const funcNode = getFunctionBody(root);
+    const result = computeLOCMetrics(funcNode);
+    expect(result.commentLines).toBe(0);
   });
 
   it('SLOC excludes blanks and comments', () => {
@@ -666,7 +686,7 @@ describe('Go complexity', () => {
 // ─── Rust ────────────────────────────────────────────────────────────────
 
 describe('Rust complexity', () => {
-  const { analyze, halstead } = makeHelpers('rust', sharedParsers());
+  const { analyze, halstead, loc } = makeHelpers('rust', sharedParsers());
 
   it('simple function', () => {
     const r = analyze('fn add(a: i32, b: i32) -> i32 {\n    a + b\n}\n');
@@ -721,6 +741,25 @@ describe('Rust complexity', () => {
     const h = halstead('fn add(a: i32, b: i32) -> i32 {\n    a + b\n}\n');
     expect(h).not.toBeNull();
     expect(h.volume).toBeGreaterThan(0);
+  });
+
+  it('LOC: does not misclassify pointer-dereference assignments as comment continuation lines (issue #2287)', () => {
+    // A bare `*` prefix (trusted unconditionally by the old flat
+    // comment-prefix list, to match Javadoc-style `* ...` continuation
+    // lines) also opens a pointer-dereference assignment in Rust — this is
+    // the issue's own exact repro.
+    const l = loc(
+      'fn deref_heavy(ptr: *mut i32) -> i32 {\n    unsafe {\n        *ptr = 5;\n        *ptr = *ptr + 1;\n        return *ptr;\n    }\n}\n',
+    );
+    expect(l.commentLines).toBe(0);
+    expect(l.sloc).toBe(l.loc);
+  });
+
+  it('LOC: still tracks a genuine multi-line block comment inside the function body', () => {
+    const l = loc(
+      'fn documented() -> i32 {\n    /**\n     * Doc comment.\n     * More doc.\n     */\n    1\n}\n',
+    );
+    expect(l.commentLines).toBe(4);
   });
 });
 

--- a/tests/unit/complexity.test.ts
+++ b/tests/unit/complexity.test.ts
@@ -761,6 +761,24 @@ describe('Rust complexity', () => {
     );
     expect(l.commentLines).toBe(4);
   });
+
+  it('LOC: does not close a nested Rust block comment at the inner closing marker (Greptile review, PR #2456)', () => {
+    // Rust (unlike the other block-comment languages here) allows block
+    // comments to nest. A boolean in/out-of-comment state closes at the
+    // FIRST closing marker, wrongly ending the comment at the inner one and
+    // counting the remaining outer-comment lines as SLOC.
+    const l = loc(
+      'fn documented() -> i32 {\n    /* outer\n     /* inner */\n     still outer\n     */\n    1\n}\n',
+    );
+    // /* outer, /* inner */, still outer, */ — all 4 lines are comment.
+    expect(l.commentLines).toBe(4);
+  });
+
+  it('LOC: a single-line nested Rust block comment still closes fully', () => {
+    const l = loc('fn f() -> i32 {\n    /* outer /* inner */ still outer */\n    1\n}\n');
+    expect(l.commentLines).toBe(1);
+    expect(l.sloc).toBe(l.loc - l.commentLines);
+  });
 });
 
 // ─── Java ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #2287

`computeLOCMetrics()` (TS) and the LOC-counting logic in `compute_all_metrics()` (native) classified a line as a comment purely by checking whether the trimmed line starts with any of a language's comment prefixes. For languages using the 4-entry prefix list (`//`, `/*`, `*`, `*/` — needed to match Javadoc-style continuation lines), a bare `*` prefix matched *unconditionally*, so a pointer-dereference assignment (`*ptr = 5;`) — valid in Rust, C, C#, and Go — was wrongly counted as a comment line, undercounting `sloc` and skewing the Maintainability Index input.

## Fix

Track block-comment state across lines instead of trusting a bare prefix character: a line is only a block-comment continuation while a genuine block-opening line has been seen and the block hasn't closed yet. Split the flat prefix list into:
- single-line prefixes (`//`, `#`, `--`) — trusted unconditionally, as before
- a per-language block-comment-support flag — state-tracked, closing the misclassification

Mirrored identically in both engines (`src/ast-analysis/metrics.ts` / `crates/codegraph-core/src/ast_analysis/complexity.rs`), matching the issue's own scope note.

## Test plan

- [x] New unit tests in `tests/unit/complexity.test.ts`: the issue's own Rust pointer-dereference repro (`comment_lines: 0`), a genuine multi-line block comment still tracked correctly, and a JS-native repro (a multiplication-continuation line starting with `*`) since JS has no pointer-dereference syntax.
- [x] New Rust unit tests in `complexity.rs`: mirrored pointer-dereference and block-comment-tracking cases, plus `is_block_comment_lang` coverage for the full language list.
- [x] New dual-engine integration test (`tests/integration/issue-2287-loc-comment-block-state.test.ts`): the issue's exact repro end-to-end via `buildGraph`, both WASM and native.
- [x] Verified the fix and tests by temporarily reverting `metrics.ts` and confirming the new test fails with the exact wrong `comment_lines: 2` the issue describes, then restoring.
- [x] Full test suite (native addon + dist rebuilt from source in this worktree): 314 files / 5107 tests passed.
- [x] `npm run lint` / `cargo fmt --check`: clean.
- [x] Dual-engine parity (`scripts/parity-compare.mjs`): clean.
- [x] `codegraph diff-impact --staged`: 1 function changed (`computeLOCMetrics`), 11 transitive callers across 5 files — matches the shared-predicate fix scope exactly.