### PR TITLE
fix(resolve): workspace exports resolution bypasses node_modules symlink

### DIFF
--- a/crates/codegraph-core/src/domain/graph/resolve.rs
+++ b/crates/codegraph-core/src/domain/graph/resolve.rs
@@ -340,12 +340,14 @@ fn resolve_subpath_map(
     None
 }
 
-/// Resolve a bare specifier through the package.json `exports` field.
-/// Mirrors `resolveViaExports()` in resolve.ts.
-fn resolve_via_exports(specifier: &str, root_dir: &str) -> Option<String> {
-    let (package_name, subpath) = parse_bare_specifier(specifier)?;
-    let package_dir = find_package_dir(&package_name, root_dir)?;
-    let exports = get_package_exports(&package_dir)?;
+/// Resolve `subpath` through whatever `exports` field lives at
+/// `package_dir`. Shared by `resolve_via_exports()` (node_modules-discovered
+/// package_dir) and `resolve_exports_via_dir()` (a directory the caller
+/// already knows, e.g. a workspace package's own real directory — see that
+/// function's doc comment for why the two must not both go through
+/// `find_package_dir()`).
+fn resolve_exports_in_package_dir(subpath: &str, package_dir: &str) -> Option<String> {
+    let exports = get_package_exports(package_dir)?;
 
     match &exports {
         // Simple string exports: "exports": "./index.js"
@@ -353,14 +355,14 @@ fn resolve_via_exports(specifier: &str, root_dir: &str) -> Option<String> {
             if subpath != "." {
                 return None;
             }
-            try_resolve_export_target(Some(target), &package_dir)
+            try_resolve_export_target(Some(target), package_dir)
         }
         // Array form at top level (condition fallback list)
         serde_json::Value::Array(_) => {
             if subpath != "." {
                 return None;
             }
-            try_resolve_export_target(resolve_export_condition(&exports).as_deref(), &package_dir)
+            try_resolve_export_target(resolve_export_condition(&exports).as_deref(), package_dir)
         }
         serde_json::Value::Object(map) => {
             let is_subpath_map = map.keys().any(|k| k.starts_with('.'));
@@ -370,13 +372,40 @@ fn resolve_via_exports(specifier: &str, root_dir: &str) -> Option<String> {
                 }
                 return try_resolve_export_target(
                     resolve_export_condition(&exports).as_deref(),
-                    &package_dir,
+                    package_dir,
                 );
             }
-            resolve_subpath_map(map, &subpath, &package_dir)
+            resolve_subpath_map(map, subpath, package_dir)
         }
         _ => None,
     }
+}
+
+/// Resolve a bare specifier through the package.json `exports` field.
+/// Mirrors `resolveViaExports()` in resolve.ts.
+fn resolve_via_exports(specifier: &str, root_dir: &str) -> Option<String> {
+    let (package_name, subpath) = parse_bare_specifier(specifier)?;
+    let package_dir = find_package_dir(&package_name, root_dir)?;
+    resolve_exports_in_package_dir(&subpath, &package_dir)
+}
+
+/// Resolve `specifier` through the `exports` field at a directory the
+/// caller already knows — bypassing `find_package_dir()`'s `node_modules`
+/// walk entirely. For a workspace package, `find_package_dir()` would find
+/// `node_modules/<pkg>` (a symlink workspace tools create), and resolving
+/// `exports` against THAT path string produces a `node_modules/...`-shaped
+/// absolute path — one that resolves fine on disk (symlinks are followed)
+/// but, once relativized against the project root, never matches the
+/// tracked file node at its real, glob-detected location (`packages/...`),
+/// since `node_modules` is itself excluded from file collection.
+/// `resolve_via_workspace()` already knows the package's real directory
+/// (`info.dir`, from workspace *detection*, not a `node_modules` lookup) —
+/// passing it here directly is what keeps the resolved path inside the
+/// tree the graph actually tracks (issue #2288). Mirrors
+/// `resolveExportsViaDir()` in resolve.ts.
+fn resolve_exports_via_dir(specifier: &str, package_dir: &str) -> Option<String> {
+    let (_, subpath) = parse_bare_specifier(specifier)?;
+    resolve_exports_in_package_dir(&subpath, package_dir)
 }
 
 /// Extensions probed when resolving a workspace subpath import against the
@@ -413,16 +442,18 @@ fn resolve_via_workspace(
     let info = workspaces.get(&package_name)?;
 
     if subpath == "." {
-        // Try the exports field first (reuses existing exports logic),
-        // matching resolveViaWorkspace()'s root-import branch.
-        if let Some(exports_result) = resolve_via_exports(specifier, root_dir) {
+        // Try the exports field first, resolved against the
+        // workspace-detected real directory (info.dir) rather than a
+        // node_modules walk — see resolve_exports_via_dir()'s doc comment
+        // (issue #2288).
+        if let Some(exports_result) = resolve_exports_via_dir(specifier, &info.dir) {
             return Some(exports_result);
         }
         return info.entry.clone();
     }
 
     // Subpath import — try exports, then filesystem probe.
-    if let Some(exports_result) = resolve_via_exports(specifier, root_dir) {
+    if let Some(exports_result) = resolve_exports_via_dir(specifier, &info.dir) {
         return Some(exports_result);
     }
 
@@ -3061,16 +3092,14 @@ path = "custom/location/mod.rs"
     fn resolve_via_workspace_prefers_exports_field_over_registered_entry() {
         // A workspace package whose `exports` field points somewhere other
         // than its registered entry — exports must win, matching
-        // resolveViaWorkspace()'s root-import branch. Workspace tools
-        // (npm/yarn/pnpm workspaces) symlink workspace packages into
-        // node_modules, which is what find_package_dir()'s node_modules
-        // walk (used by resolve_via_exports) actually discovers — so only
-        // the node_modules copy needs to exist for this test; the
-        // WorkspaceEntry's own `dir`/`entry` are deliberately bogus paths to
-        // prove they're never consulted when exports resolves successfully.
+        // resolveViaWorkspace()'s root-import branch. The package.json
+        // lives at the workspace-detected real directory (info.dir), not
+        // under node_modules — see issue #2288 and the dedicated
+        // node_modules-symlink regression test below for why that
+        // distinction matters.
         let tmp = std::env::temp_dir().join("codegraph_workspace_exports_test");
         let _ = fs::remove_dir_all(&tmp);
-        let pkg_dir = tmp.join("node_modules/@myorg/core");
+        let pkg_dir = tmp.join("packages/core");
         fs::create_dir_all(&pkg_dir).unwrap();
         fs::write(
             pkg_dir.join("package.json"),
@@ -3085,7 +3114,7 @@ path = "custom/location/mod.rs"
         workspaces.insert(
             "@myorg/core".to_string(),
             WorkspaceEntry {
-                dir: "/nonexistent/packages/core".to_string(),
+                dir: pkg_dir.to_string_lossy().to_string(),
                 entry: Some("/nonexistent/packages/core/some-other-entry.js".to_string()),
             },
         );
@@ -3093,6 +3122,62 @@ path = "custom/location/mod.rs"
         let resolved =
             resolve_via_workspace("@myorg/core", &workspaces, tmp.to_str().unwrap(), None);
         assert_eq!(resolved, Some(normalized(&pkg_dir.join("dist/index.js"))));
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn resolve_via_workspace_root_import_uses_workspace_dir_not_node_modules_symlink() {
+        // Issue #2288: workspace tools (npm/yarn/pnpm workspaces) symlink
+        // workspace packages into node_modules. find_package_dir()'s
+        // node_modules walk resolves fine through that symlink on disk,
+        // but the resulting path string is node_modules-shaped and never
+        // matches the tracked file node at its real, glob-detected
+        // location — since node_modules is itself excluded from file
+        // collection. Set up a node_modules copy with a DIFFERENT (and
+        // non-existent) exports target to prove resolution never consults
+        // it: if it did, this would either resolve to the wrong file or
+        // fail entirely (the node_modules copy's target file doesn't
+        // exist), not the real, correct dist/index.js under packages/core.
+        let tmp = std::env::temp_dir().join("codegraph_workspace_exports_symlink_test");
+        let _ = fs::remove_dir_all(&tmp);
+
+        let real_pkg_dir = tmp.join("packages/core");
+        fs::create_dir_all(&real_pkg_dir).unwrap();
+        fs::write(
+            real_pkg_dir.join("package.json"),
+            r#"{"name": "@myorg/core", "exports": "./dist/index.js"}"#,
+        )
+        .unwrap();
+        fs::create_dir_all(real_pkg_dir.join("dist")).unwrap();
+        fs::write(real_pkg_dir.join("dist/index.js"), "module.exports = {};").unwrap();
+
+        let nm_pkg_dir = tmp.join("node_modules/@myorg/core");
+        fs::create_dir_all(&nm_pkg_dir).unwrap();
+        fs::write(
+            nm_pkg_dir.join("package.json"),
+            r#"{"name": "@myorg/core", "exports": "./wrong-target.js"}"#,
+        )
+        .unwrap();
+        // Deliberately no wrong-target.js: if resolution went through
+        // node_modules, tryResolveTarget would fail to find it.
+        clear_exports_cache();
+
+        let mut workspaces = HashMap::new();
+        workspaces.insert(
+            "@myorg/core".to_string(),
+            WorkspaceEntry {
+                dir: real_pkg_dir.to_string_lossy().to_string(),
+                entry: None,
+            },
+        );
+
+        let resolved =
+            resolve_via_workspace("@myorg/core", &workspaces, tmp.to_str().unwrap(), None);
+        assert_eq!(
+            resolved,
+            Some(normalized(&real_pkg_dir.join("dist/index.js")))
+        );
 
         let _ = fs::remove_dir_all(&tmp);
     }

--- a/src/domain/graph/resolve.ts
+++ b/src/domain/graph/resolve.ts
@@ -154,13 +154,14 @@ function resolveSubpathMap(
   return null;
 }
 
-export function resolveViaExports(specifier: string, rootDir: string): string | null {
-  const parsed = parseBareSpecifier(specifier);
-  if (!parsed) return null;
-
-  const packageDir = findPackageDir(parsed.packageName, rootDir);
-  if (!packageDir) return null;
-
+/**
+ * Resolve `parsed` through whatever `exports` field lives at `packageDir`.
+ * Shared by `resolveViaExports()` (node_modules-discovered packageDir) and
+ * `resolveExportsViaDir()` (a directory the caller already knows, e.g. a
+ * workspace package's own real directory — see that function's doc
+ * comment for why the two must not both go through `findPackageDir()`).
+ */
+function resolveExportsInPackageDir(parsed: BareSpecifier, packageDir: string): string | null {
   const exports = getPackageExports(packageDir);
   if (exports == null) return null;
 
@@ -187,6 +188,38 @@ export function resolveViaExports(specifier: string, rootDir: string): string | 
   }
 
   return resolveSubpathMap(exports as Record<string, unknown>, subpath, packageDir);
+}
+
+export function resolveViaExports(specifier: string, rootDir: string): string | null {
+  const parsed = parseBareSpecifier(specifier);
+  if (!parsed) return null;
+
+  const packageDir = findPackageDir(parsed.packageName, rootDir);
+  if (!packageDir) return null;
+
+  return resolveExportsInPackageDir(parsed, packageDir);
+}
+
+/**
+ * Resolve `specifier` through the `exports` field at a directory the
+ * caller already knows — bypassing `findPackageDir()`'s `node_modules`
+ * walk entirely. For a workspace package, `findPackageDir()` would find
+ * `node_modules/<pkg>` (a symlink workspace tools create), and resolving
+ * `exports` against THAT path string produces a `node_modules/...`-shaped
+ * absolute path — one that resolves fine on disk (Node's `fs` follows
+ * symlinks) but, once relativized against the project root, never matches
+ * the tracked file node at its real, glob-detected location
+ * (`packages/...`), since `node_modules` is itself excluded from file
+ * collection. `resolveViaWorkspace()` already knows the package's real
+ * directory (`info.dir`, from workspace *detection*, not a `node_modules`
+ * lookup) — passing it here directly is what keeps the resolved path
+ * inside the tree the graph actually tracks (issue #2288).
+ */
+export function resolveExportsViaDir(specifier: string, packageDir: string): string | null {
+  const parsed = parseBareSpecifier(specifier);
+  if (!parsed) return null;
+
+  return resolveExportsInPackageDir(parsed, packageDir);
 }
 
 /** Clear the exports cache (for testing). */
@@ -258,15 +291,17 @@ export function resolveViaWorkspace(specifier: string, rootDir: string): string 
 
   // Root import ("@myorg/utils") — use the entry point
   if (parsed.subpath === '.') {
-    // Try exports field first (reuses existing exports logic)
-    const exportsResult = resolveViaExports(specifier, rootDir);
+    // Try exports field first, resolved against the workspace-detected real
+    // directory (info.dir) rather than a node_modules walk — see
+    // resolveExportsViaDir()'s doc comment (issue #2288).
+    const exportsResult = resolveExportsViaDir(specifier, info.dir);
     if (exportsResult) return exportsResult;
     // Fall back to workspace entry
     return info.entry;
   }
 
   // Subpath import ("@myorg/utils/helpers") — try exports, then filesystem probe
-  const exportsResult = resolveViaExports(specifier, rootDir);
+  const exportsResult = resolveExportsViaDir(specifier, info.dir);
   if (exportsResult) return exportsResult;
 
   // Filesystem probe within the package directory

--- a/tests/integration/issue-2288-workspace-exports-symlink.test.ts
+++ b/tests/integration/issue-2288-workspace-exports-symlink.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Integration test for #2288: workspace root-import resolution via the
+ * `exports` field returned a `node_modules`-symlink path that never
+ * matched the tracked file node for that file.
+ *
+ * `resolveViaWorkspace()`'s root-import branch (`src/domain/graph/resolve.ts`)
+ * tried the package's `exports` field first via `resolveViaExports()`,
+ * which locates the package directory through `findPackageDir()` — a
+ * `node_modules` walk. For a real monorepo where workspace tools (npm/yarn/
+ * pnpm workspaces) symlink workspace packages into `node_modules`, this
+ * returns a path like `node_modules/@myorg/core/lib/index.js`. But
+ * `detectWorkspaces()` registers each package's real directory from the
+ * glob-matched path (`packages/core`), which is also where the file
+ * collector finds and tracks the source file (`node_modules` is excluded
+ * from collection). So the `imports`/`calls` edges were silently dropped
+ * entirely for a workspace package whose `package.json` has only an
+ * `exports` field (no `main`).
+ *
+ * The fix resolves `exports` against the workspace-detected real directory
+ * directly, bypassing the `node_modules` walk for workspace packages.
+ * Mirrored identically in both engines.
+ *
+ * Fixture matches the issue's own repro: a real `node_modules` symlink
+ * (created via `fs.symlinkSync(..., 'junction')`, the cross-platform-safe
+ * form already used elsewhere in this test suite — see `builder.test.ts`)
+ * pointing at the real workspace package directory.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+import { isNativeAvailable } from '../../src/infrastructure/native.js';
+
+const FIXTURE: Record<string, string> = {
+  'package.json': JSON.stringify({
+    name: 'issue-2288-fixture',
+    private: true,
+    workspaces: ['packages/*'],
+  }),
+  'packages/core/package.json': JSON.stringify({
+    name: '@myorg/core',
+    version: '1.0.0',
+    exports: './lib/index.js',
+  }),
+  'packages/core/lib/index.js': 'export function greet() { return "hi"; }\n',
+  'packages/app/src/main.js':
+    'import { greet } from "@myorg/core";\nexport function run() { return greet(); }\n',
+};
+
+function writeFixture(tmpDir: string): void {
+  for (const [rel, content] of Object.entries(FIXTURE)) {
+    const full = path.join(tmpDir, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content);
+  }
+}
+
+/** Returns false (and the test should skip) if symlinks aren't permitted here. */
+function createWorkspaceSymlink(tmpDir: string): boolean {
+  const nmScopeDir = path.join(tmpDir, 'node_modules', '@myorg');
+  fs.mkdirSync(nmScopeDir, { recursive: true });
+  try {
+    fs.symlinkSync(
+      path.join(tmpDir, 'packages', 'core'),
+      path.join(nmScopeDir, 'core'),
+      'junction',
+    );
+    return true;
+  } catch {
+    // Symlinks may require elevated privileges on Windows — skip gracefully.
+    return false;
+  }
+}
+
+function importEdgeRows(
+  dbPath: string,
+): Array<{ sourceFile: string; targetFile: string; kind: string }> {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return db
+      .prepare(
+        `SELECT s.file AS sourceFile, t.file AS targetFile, e.kind AS kind
+         FROM edges e
+         JOIN nodes s ON e.source_id = s.id
+         JOIN nodes t ON e.target_id = t.id
+         WHERE e.kind IN ('imports', 'calls')`,
+      )
+      .all() as Array<{ sourceFile: string; targetFile: string; kind: string }>;
+  } finally {
+    db.close();
+  }
+}
+
+// `skipped` is decided inside beforeAll (creating the symlink is itself the
+// first thing that can fail), so each assertion checks it at run time and
+// bails out early rather than trying to use vitest's skipIf (evaluated at
+// collection time, before beforeAll has run) — mirrors the try/catch-return
+// convention `builder.test.ts` already uses for the same platform concern.
+function runShared(getDbPath: () => string, isSkipped: () => boolean) {
+  it('resolves the imports edge to the real packages/ path, not a node_modules-shaped path', () => {
+    if (isSkipped()) return;
+    const rows = importEdgeRows(getDbPath());
+    const importsEdge = rows.find(
+      (r) => r.kind === 'imports' && r.sourceFile.includes('packages/app'),
+    );
+    expect(importsEdge, 'expected an imports edge from packages/app/src/main.js').toBeDefined();
+    expect(importsEdge?.targetFile).toBe('packages/core/lib/index.js');
+    expect(importsEdge?.targetFile).not.toContain('node_modules');
+  });
+
+  it('resolves the calls edge from run() to greet() (cross-file call attribution)', () => {
+    if (isSkipped()) return;
+    const rows = importEdgeRows(getDbPath());
+    const callsEdge = rows.find((r) => r.kind === 'calls' && r.sourceFile.includes('packages/app'));
+    expect(callsEdge, 'expected a calls edge from run() to greet()').toBeDefined();
+    expect(callsEdge?.targetFile).toBe('packages/core/lib/index.js');
+  });
+}
+
+describe('issue #2288: workspace exports-field resolution through a node_modules symlink — WASM', () => {
+  let tmpDir: string;
+  let skipped = false;
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-2288-'));
+    writeFixture(tmpDir);
+    if (!createWorkspaceSymlink(tmpDir)) {
+      skipped = true;
+      return;
+    }
+    await buildGraph(tmpDir, { engine: 'wasm', incremental: false, skipRegistry: true });
+  });
+
+  afterAll(() => {
+    if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  runShared(
+    () => path.join(tmpDir, '.codegraph', 'graph.db'),
+    () => skipped,
+  );
+});
+
+describe.skipIf(!isNativeAvailable())(
+  'issue #2288: workspace exports-field resolution through a node_modules symlink — native',
+  () => {
+    let nativeTmpDir: string;
+    let skipped = false;
+
+    beforeAll(async () => {
+      nativeTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-2288-native-'));
+      writeFixture(nativeTmpDir);
+      if (!createWorkspaceSymlink(nativeTmpDir)) {
+        skipped = true;
+        return;
+      }
+      await buildGraph(nativeTmpDir, { engine: 'native', incremental: false, skipRegistry: true });
+    }, 60_000);
+
+    afterAll(() => {
+      if (nativeTmpDir) fs.rmSync(nativeTmpDir, { recursive: true, force: true });
+    });
+
+    runShared(
+      () => path.join(nativeTmpDir, '.codegraph', 'graph.db'),
+      () => skipped,
+    );
+  },
+);

--- a/tests/unit/resolve.test.ts
+++ b/tests/unit/resolve.test.ts
@@ -605,6 +605,55 @@ describe('resolveViaWorkspace', () => {
   });
 });
 
+// ─── resolveViaWorkspace with exports-only packages (issue #2288) ─────
+
+describe('resolveViaWorkspace with an exports-only package (issue #2288)', () => {
+  let wsRoot: string;
+  let realPkgDir: string;
+
+  beforeAll(() => {
+    wsRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-ws-exports-'));
+
+    // packages/core: the real, workspace-detected directory — has only an
+    // `exports` field, no `main`.
+    realPkgDir = path.join(wsRoot, 'packages', 'core');
+    fs.mkdirSync(path.join(realPkgDir, 'lib'), { recursive: true });
+    fs.writeFileSync(path.join(realPkgDir, 'lib', 'index.js'), 'export default 1;');
+    fs.writeFileSync(
+      path.join(realPkgDir, 'package.json'),
+      JSON.stringify({ name: '@myorg/core', exports: './lib/index.js' }),
+    );
+
+    // node_modules/@myorg/core: what a workspace tool's symlink resolves
+    // through on disk — deliberately given a DIFFERENT exports target that
+    // doesn't exist, so if resolution consulted this instead of the real
+    // workspace dir, it would either resolve the wrong file or fail
+    // entirely, not silently produce the correct result.
+    const nmPkgDir = path.join(wsRoot, 'node_modules', '@myorg', 'core');
+    fs.mkdirSync(nmPkgDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(nmPkgDir, 'package.json'),
+      JSON.stringify({ name: '@myorg/core', exports: './wrong-target.js' }),
+    );
+
+    setWorkspaces(wsRoot, new Map([['@myorg/core', { dir: realPkgDir, entry: null }]]));
+  });
+
+  afterAll(() => {
+    clearWorkspaceCache();
+    if (wsRoot) fs.rmSync(wsRoot, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    clearExportsCache();
+  });
+
+  it('resolves the root import via exports at the real workspace directory, not the node_modules symlink target', () => {
+    const result = resolveViaWorkspace('@myorg/core', wsRoot);
+    expect(result).toBe(path.join(realPkgDir, 'lib', 'index.js'));
+  });
+});
+
 // ─── resolveImportPathJS with workspaces ─────────────────────────────
 
 describe('resolveImportPathJS with workspace resolution', () => {


### PR DESCRIPTION
## Summary

Closes #2288

`resolveViaWorkspace()`'s root-import branch tried the package's `exports` field first via `resolveViaExports()`, which locates the package directory through `findPackageDir()` — a `node_modules` walk. For a real monorepo where workspace tools (npm/yarn/pnpm workspaces) symlink workspace packages into `node_modules`, this returns a path like `node_modules/@myorg/core/lib/index.js`. But workspace *detection* registers each package's real directory from the glob-matched path (`packages/core`), which is also where the file collector tracks the source file (`node_modules` is excluded from collection) — so the `imports`/`calls` edges were silently dropped entirely for any workspace package whose `package.json` has only `exports` (no `main`).

## Fix

Split `resolveViaExports()` into a shared exports-parsing helper (`resolveExportsInPackageDir`) plus a new `resolveExportsViaDir()`, which resolves the `exports` field against a directory the caller already knows — workspace detection's own `info.dir` — bypassing the `node_modules` walk entirely for workspace packages. `resolveViaWorkspace()`'s two `exports`-first call sites now use this instead. Mirrored identically in both engines (`resolve.ts` / `resolve.rs`).

## Test plan

- [x] New unit tests in both `resolve.test.ts` and `resolve.rs`: a workspace package with only `exports` (no `main`) resolves correctly, including a scenario with a *misleading* `node_modules` copy present (different/non-existent exports target) to prove resolution never consults it.
- [x] New dual-engine integration test (`tests/integration/issue-2288-workspace-exports-symlink.test.ts`) reproduces the issue's exact repro end-to-end via a **real** `fs.symlinkSync(..., 'junction')` symlink (the cross-platform-safe form already used in `builder.test.ts`) — verifies both the `imports` and `calls` edges resolve to the real `packages/` path, not a `node_modules`-shaped one.
- [x] Verified the fix and every new test by temporarily reverting each engine's change and confirming the exact wrong/missing result the issue describes, then restoring.
- [x] Fixed an existing Rust unit test whose own fixture had baked in the bug (it asserted the `node_modules`-shaped result was correct, with a comment explicitly noting the `WorkspaceEntry`'s real `dir` was "deliberately bogus" and never consulted).
- [x] Full test suite (native addon + dist rebuilt from source in this worktree): 315 files / 5114 tests passed.
- [x] `npm run lint` / `cargo fmt --check`: clean.
- [x] Dual-engine parity (`scripts/parity-compare.mjs`): clean.
- [x] `codegraph diff-impact --staged`: 4 functions changed, 11 transitive callers across 3 files — matches the refactor scope exactly.