### PR TITLE
fix(watcher): watch mode refreshes package.json exports/workspace caches

### DIFF
--- a/crates/codegraph-core/src/lib.rs
+++ b/crates/codegraph-core/src/lib.rs
@@ -184,6 +184,19 @@ pub fn clear_python_import_roots_cache() {
     domain::graph::resolve::clear_python_import_roots_cache();
 }
 
+/// Clear the native package.json `exports` cache (issue #2290) — called from
+/// the JS-side `clearExportsCache()` (`resolve.ts`) for the same reason as
+/// the Cargo/Python caches above: `resolve_import`, the single-import entry
+/// point `rebuildFile` uses, does not self-clear per build the way the batch
+/// `resolve_imports` entry point does. Unlike the workspace *map* (which
+/// native never caches itself — it's passed in fresh on every call from the
+/// JS side's own `_workspaceCache`), this `exports` cache is internal to the
+/// native resolver and needs its own explicit clear.
+#[napi]
+pub fn clear_exports_cache() {
+    domain::graph::resolve::clear_exports_cache();
+}
+
 /// Compute proximity-based confidence for call resolution.
 #[napi]
 pub fn compute_confidence(

--- a/src/domain/graph/builder/incremental.ts
+++ b/src/domain/graph/builder/incremental.ts
@@ -28,6 +28,7 @@ import type {
 import { parseFileIncremental } from '../../parser.js';
 import {
   clearCargoTargetOverridesCache,
+  clearExportsCache,
   clearPythonImportRootsCache,
   computeConfidence,
   resolveImportPath,
@@ -2424,6 +2425,16 @@ export async function rebuildFile(
   // an `__init__.py` is added or removed — which changes where every absolute
   // import in that package tree resolves.
   clearPythonImportRootsCache();
+  // Same reasoning again for a dependency's own package.json `exports`
+  // field (#2290): unlike the workspace map (refreshed separately by the
+  // watcher itself when it detects a package.json change inside the
+  // watched tree — see watcher.ts), this cache is cheap to clear (a plain
+  // Map#clear, no filesystem re-scan) and can go stale from a change to
+  // ANY package's exports field, including a plain node_modules dependency
+  // the watcher never observes at all — so it's cleared unconditionally
+  // here, once per rebuild of any file, the same way the Cargo/Python
+  // caches above are.
+  clearExportsCache();
   // #2242: real tsconfig/jsconfig + codegraph-configured aliases, loaded
   // once per rebuild (mirrors knownFiles just above) and threaded through
   // every edge-building call below — a hardcoded empty PathAliases

--- a/src/domain/graph/resolve.ts
+++ b/src/domain/graph/resolve.ts
@@ -222,9 +222,17 @@ export function resolveExportsViaDir(specifier: string, packageDir: string): str
   return resolveExportsInPackageDir(parsed, packageDir);
 }
 
-/** Clear the exports cache (for testing). */
+/**
+ * Clear the package.json `exports` cache, in both this (TypeScript)
+ * resolver and the native one if available — a long-lived process
+ * (`codegraph watch`, the MCP server) can outlive edits to a package's
+ * `exports` field, so watch mode's package.json-change detection calls
+ * this to force a fresh manifest read (issue #2290). Also exported
+ * directly for testing.
+ */
 export function clearExportsCache(): void {
   _exportsCache.clear();
+  loadNative()?.clearExportsCache?.();
 }
 
 // ── Monorepo workspace resolution ───────────────────────────────────

--- a/src/domain/graph/watcher.ts
+++ b/src/domain/graph/watcher.ts
@@ -242,17 +242,26 @@ interface WatcherContext {
  * gated on actually observing a `package.json` change rather than run on
  * every rebuild, to avoid a per-keystroke re-scan cost in a large monorepo.
  *
+ * `setWorkspaces()` is called unconditionally, even when `workspaces` comes
+ * back empty — unlike the full-build pipeline's own `size > 0` gate before
+ * calling it, which never has a real staleness consequence there (a full
+ * build starts from an empty `_workspaceCache` each process). This function
+ * instead runs repeatedly within one long-lived watch session: if the last
+ * workspace package is removed mid-session, an empty map must still REPLACE
+ * whatever non-empty map is currently cached, or every subsequent rebuild
+ * keeps resolving against removed workspace entries (Greptile review, PR
+ * #2458).
+ *
  * Exported for unit-testing; prefer letting the watcher call this
  * automatically in production paths.
  */
 export function refreshWorkspaceAndExportsCaches(rootDir: string): void {
   const workspaces = detectWorkspaces(rootDir);
+  // Also clears the exports cache as a side effect, but only on this
+  // (TypeScript) side — the explicit clearExportsCache() below covers the
+  // native side too.
+  setWorkspaces(rootDir, workspaces);
   if (workspaces.size > 0) {
-    // setWorkspaces() also clears the exports cache as a side effect, but
-    // only on this (TypeScript) side — clearExportsCache() below covers the
-    // native side too, and must still run when there are no (or no longer
-    // any) workspaces to register.
-    setWorkspaces(rootDir, workspaces);
     info(`Refreshed ${workspaces.size} workspace packages (package.json changed)`);
   }
   clearExportsCache();

--- a/src/domain/graph/watcher.ts
+++ b/src/domain/graph/watcher.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { closeDb, getNodeId as getNodeIdQuery, initSchema, openDb } from '../../db/index.js';
-import { loadConfig } from '../../infrastructure/config.js';
+import { detectWorkspaces, loadConfig } from '../../infrastructure/config.js';
 import { debug, info, warn } from '../../infrastructure/logger.js';
 import { buildIgnoreSet, isSupportedFile, normalizePath } from '../../shared/constants.js';
 import { DbError } from '../../shared/errors.js';
@@ -9,6 +9,7 @@ import { createParseTreeCache, getActiveEngine } from '../parser.js';
 import { type IncrementalStmts, rebuildFile } from './builder/incremental.js';
 import { appendChangeEvents, buildChangeEvent, diffSymbols } from './change-journal.js';
 import { appendJournalEntriesAndStampHeader } from './journal.js';
+import { clearExportsCache, setWorkspaces } from './resolve.js';
 
 function shouldIgnorePath(filePath: string, ignoreSet: ReadonlySet<string>): boolean {
   const parts = filePath.split(path.sep);
@@ -174,8 +175,19 @@ function logRebuildResults(updates: RebuildResult[]): void {
   }
 }
 
-/** Recursively collect tracked source files for stat-based polling. */
-function collectTrackedFiles(dir: string, result: string[], ignoreSet: ReadonlySet<string>): void {
+/**
+ * Recursively collect tracked source files for stat-based polling. Also
+ * collects `package.json` paths into `packageJsonResult` when provided —
+ * they're not a "supported" source file (so never added to `result`), but
+ * still need mtime-diff detection to trigger a workspace/exports cache
+ * refresh (issue #2290).
+ */
+function collectTrackedFiles(
+  dir: string,
+  result: string[],
+  ignoreSet: ReadonlySet<string>,
+  packageJsonResult?: string[],
+): void {
   let entries: fs.Dirent[];
   try {
     entries = fs.readdirSync(dir, { withFileTypes: true });
@@ -187,9 +199,11 @@ function collectTrackedFiles(dir: string, result: string[], ignoreSet: ReadonlyS
     if (ignoreSet.has(entry.name) || entry.name.startsWith('.')) continue;
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) {
-      collectTrackedFiles(full, result, ignoreSet);
+      collectTrackedFiles(full, result, ignoreSet, packageJsonResult);
     } else if (isSupportedFile(entry.name)) {
       result.push(full);
+    } else if (packageJsonResult && entry.name === 'package.json') {
+      packageJsonResult.push(full);
     }
   }
 }
@@ -206,6 +220,42 @@ interface WatcherContext {
   debounceMs: number;
   /** Merged ignore set from IGNORE_DIRS + config.ignoreDirs + config.ignoreAdditionalDirs. */
   ignoreSet: ReadonlySet<string>;
+  /**
+   * Set when a `package.json` inside the watched tree has changed since the
+   * last debounced flush — consumed (and reset) by `scheduleDebouncedProcess`
+   * to re-detect workspace packages before the next rebuild (issue #2290).
+   * Kept separate from `pending`: `package.json` is never itself rebuildable
+   * via `rebuildFile` (it's not a supported source-language extension).
+   */
+  workspaceRefreshPending: boolean;
+}
+
+/**
+ * Re-detect workspace packages and clear the exports cache (both engines) —
+ * called once a `package.json` inside the watched tree is known to have
+ * changed, so a long-running watch session doesn't keep resolving imports
+ * against stale exports/workspace data for its whole lifetime (issue #2290).
+ *
+ * `detectWorkspaces()` re-globs and re-reads every workspace package's
+ * manifest, so — unlike the cheap, unconditional `clearExportsCache()` call
+ * in `rebuildFile` (a plain cache clear, no filesystem re-scan) — this is
+ * gated on actually observing a `package.json` change rather than run on
+ * every rebuild, to avoid a per-keystroke re-scan cost in a large monorepo.
+ *
+ * Exported for unit-testing; prefer letting the watcher call this
+ * automatically in production paths.
+ */
+export function refreshWorkspaceAndExportsCaches(rootDir: string): void {
+  const workspaces = detectWorkspaces(rootDir);
+  if (workspaces.size > 0) {
+    // setWorkspaces() also clears the exports cache as a side effect, but
+    // only on this (TypeScript) side — clearExportsCache() below covers the
+    // native side too, and must still run when there are no (or no longer
+    // any) workspaces to register.
+    setWorkspaces(rootDir, workspaces);
+    info(`Refreshed ${workspaces.size} workspace packages (package.json changed)`);
+  }
+  clearExportsCache();
 }
 
 /** Initialize DB, engine, cache, and statements for watch mode. */
@@ -258,6 +308,7 @@ function setupWatcher(rootDir: string, opts: { engine?: string; dbPath?: string 
     timer: null,
     debounceMs: 300,
     ignoreSet,
+    workspaceRefreshPending: false,
   };
 }
 
@@ -267,19 +318,70 @@ function scheduleDebouncedProcess(ctx: WatcherContext): void {
   ctx.timer = setTimeout(async () => {
     const files = [...ctx.pending];
     ctx.pending.clear();
+    // Refresh before rebuilding so any source file in this same debounced
+    // batch that imports from the changed package sees fresh data (#2290).
+    if (ctx.workspaceRefreshPending) {
+      ctx.workspaceRefreshPending = false;
+      refreshWorkspaceAndExportsCaches(ctx.rootDir);
+    }
     await processPendingFiles(files, ctx.db, ctx.rootDir, ctx.stmts, ctx.engineOpts, ctx.cache);
   }, ctx.debounceMs);
+}
+
+/**
+ * Diff `current` file paths against `mtimeMap`'s cached mtimes (added,
+ * changed, or removed since the last check), updating the map in place and
+ * invoking `onChanged` for each one. Shared by the source-file and
+ * `package.json` polling loops below — the two need different actions
+ * (queue for rebuild vs. flag a cache refresh) but the same diff mechanics.
+ *
+ * Exported for unit-testing; prefer letting the polling watcher call this
+ * automatically in production paths.
+ */
+export function diffMtimes(
+  current: string[],
+  mtimeMap: Map<string, number>,
+  onChanged: (file: string) => void,
+): void {
+  const currentSet = new Set(current);
+  for (const f of current) {
+    try {
+      const mtime = fs.statSync(f).mtimeMs;
+      const prev = mtimeMap.get(f);
+      if (prev === undefined || mtime !== prev) {
+        mtimeMap.set(f, mtime);
+        onChanged(f);
+      }
+    } catch {
+      /* deleted between collect and stat */
+    }
+  }
+  for (const f of mtimeMap.keys()) {
+    if (!currentSet.has(f)) {
+      mtimeMap.delete(f);
+      onChanged(f);
+    }
+  }
 }
 
 /** Start polling-based file watcher. Returns cleanup function. */
 function startPollingWatcher(ctx: WatcherContext, pollIntervalMs: number): () => void {
   const mtimeMap = new Map<string, number>();
+  const packageJsonMtimeMap = new Map<string, number>();
 
   const initial: string[] = [];
-  collectTrackedFiles(ctx.rootDir, initial, ctx.ignoreSet);
+  const initialPackageJson: string[] = [];
+  collectTrackedFiles(ctx.rootDir, initial, ctx.ignoreSet, initialPackageJson);
   for (const f of initial) {
     try {
       mtimeMap.set(f, fs.statSync(f).mtimeMs);
+    } catch {
+      /* deleted between collect and stat */
+    }
+  }
+  for (const f of initialPackageJson) {
+    try {
+      packageJsonMtimeMap.set(f, fs.statSync(f).mtimeMs);
     } catch {
       /* deleted between collect and stat */
     }
@@ -288,30 +390,17 @@ function startPollingWatcher(ctx: WatcherContext, pollIntervalMs: number): () =>
 
   const pollTimer = setInterval(() => {
     const current: string[] = [];
-    collectTrackedFiles(ctx.rootDir, current, ctx.ignoreSet);
-    const currentSet = new Set(current);
+    const currentPackageJson: string[] = [];
+    collectTrackedFiles(ctx.rootDir, current, ctx.ignoreSet, currentPackageJson);
 
-    for (const f of current) {
-      try {
-        const mtime = fs.statSync(f).mtimeMs;
-        const prev = mtimeMap.get(f);
-        if (prev === undefined || mtime !== prev) {
-          mtimeMap.set(f, mtime);
-          ctx.pending.add(f);
-        }
-      } catch {
-        /* deleted between collect and stat */
-      }
-    }
+    diffMtimes(current, mtimeMap, (f) => ctx.pending.add(f));
+    // package.json changes (#2290): flag a cache refresh rather than queue
+    // for rebuild — package.json is never itself rebuildable via rebuildFile.
+    diffMtimes(currentPackageJson, packageJsonMtimeMap, () => {
+      ctx.workspaceRefreshPending = true;
+    });
 
-    for (const f of mtimeMap.keys()) {
-      if (!currentSet.has(f)) {
-        mtimeMap.delete(f);
-        ctx.pending.add(f);
-      }
-    }
-
-    if (ctx.pending.size > 0) {
+    if (ctx.pending.size > 0 || ctx.workspaceRefreshPending) {
       scheduleDebouncedProcess(ctx);
     }
   }, pollIntervalMs);
@@ -324,6 +413,19 @@ function startNativeWatcher(ctx: WatcherContext): () => void {
   const watcher = fs.watch(ctx.rootDir, { recursive: true }, (_eventType, filename) => {
     if (!filename) return;
     if (shouldIgnorePath(filename, ctx.ignoreSet)) return;
+
+    // package.json changes (#2290): flag a cache refresh rather than queue
+    // for rebuild — it's never itself rebuildable via rebuildFile. Checked
+    // before isSupportedFile since package.json isn't a supported source
+    // extension. shouldIgnorePath above already scopes this to the watched
+    // tree, so a node_modules dependency's own package.json (unwatched by
+    // design) is excluded the same way source files there are.
+    if (path.basename(filename) === 'package.json') {
+      ctx.workspaceRefreshPending = true;
+      scheduleDebouncedProcess(ctx);
+      return;
+    }
+
     if (!isSupportedFile(filename)) return;
 
     ctx.pending.add(path.join(ctx.rootDir, filename));

--- a/src/types.ts
+++ b/src/types.ts
@@ -2631,6 +2631,12 @@ export interface NativeAddon {
    * `clearCargoTargetOverridesCache`: older published addons predate it.
    */
   clearPythonImportRootsCache?(): void;
+  /**
+   * Clear the native package.json `exports` cache (#2290) — optional for
+   * the same reason as `clearCargoTargetOverridesCache`: older published
+   * addons predate it.
+   */
+  clearExportsCache?(): void;
   computeConfidence(callerFile: string, targetFile: string, importedFrom: string | null): number;
   detectCycles(edges: Array<{ source: string; target: string }>): string[][];
   bfsTraversal(

--- a/tests/unit/watcher-workspace-refresh.test.ts
+++ b/tests/unit/watcher-workspace-refresh.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Regression test for #2290: watch mode never refreshed the package.json
+ * `exports` cache or the workspace-detection map during incremental
+ * rebuilds, so a long-running `codegraph build --watch` session kept
+ * resolving imports against stale data for its whole lifetime if a
+ * dependency's or workspace package's `package.json` changed mid-session.
+ *
+ * `refreshWorkspaceAndExportsCaches()` (exported from watcher.ts for this
+ * purpose) is the fix: re-run workspace detection and clear the exports
+ * cache (both engines). Tested here as a black-box behavior check —
+ * populate a resolution against the original `package.json`, change it on
+ * disk, confirm the STALE result still comes back without a refresh
+ * (locking in the exact bug), then confirm the FRESH result comes back
+ * after calling `refreshWorkspaceAndExportsCaches()`.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  clearExportsCache,
+  clearWorkspaceCache,
+  resolveViaExports,
+  resolveViaWorkspace,
+} from '../../src/domain/graph/resolve.js';
+import { diffMtimes, refreshWorkspaceAndExportsCaches } from '../../src/domain/graph/watcher.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-watcher-refresh-'));
+});
+
+afterEach(() => {
+  clearWorkspaceCache();
+  clearExportsCache();
+  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('refreshWorkspaceAndExportsCaches (issue #2290)', () => {
+  it('picks up a workspace package exports-field change without restarting the watcher', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ name: 'root', workspaces: ['packages/*'] }),
+    );
+    const coreDir = path.join(tmpDir, 'packages', 'core');
+    fs.mkdirSync(coreDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(coreDir, 'package.json'),
+      JSON.stringify({ name: '@myorg/core', exports: './v1.js' }),
+    );
+    fs.writeFileSync(path.join(coreDir, 'v1.js'), 'export default 1;');
+    fs.writeFileSync(path.join(coreDir, 'v2.js'), 'export default 2;');
+
+    // Simulate the initial full build's own workspace-detection step.
+    refreshWorkspaceAndExportsCaches(tmpDir);
+    expect(resolveViaWorkspace('@myorg/core', tmpDir)).toBe(path.join(coreDir, 'v1.js'));
+
+    // Change the exports field mid-session — nothing has refreshed yet.
+    fs.writeFileSync(
+      path.join(coreDir, 'package.json'),
+      JSON.stringify({ name: '@myorg/core', exports: './v2.js' }),
+    );
+
+    // Locks in the exact bug: without a refresh, resolution stays stale.
+    expect(resolveViaWorkspace('@myorg/core', tmpDir)).toBe(path.join(coreDir, 'v1.js'));
+
+    // The fix: after refreshing, resolution picks up the new exports target.
+    refreshWorkspaceAndExportsCaches(tmpDir);
+    expect(resolveViaWorkspace('@myorg/core', tmpDir)).toBe(path.join(coreDir, 'v2.js'));
+  });
+
+  it('picks up a new workspace package added mid-session', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ name: 'root', workspaces: ['packages/*'] }),
+    );
+    refreshWorkspaceAndExportsCaches(tmpDir);
+    expect(resolveViaWorkspace('@myorg/newpkg', tmpDir)).toBeNull();
+
+    const newDir = path.join(tmpDir, 'packages', 'newpkg');
+    fs.mkdirSync(newDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(newDir, 'package.json'),
+      JSON.stringify({ name: '@myorg/newpkg', exports: './index.js' }),
+    );
+    fs.writeFileSync(path.join(newDir, 'index.js'), 'export default 1;');
+
+    // Still null without a refresh — the workspace map hasn't changed yet.
+    expect(resolveViaWorkspace('@myorg/newpkg', tmpDir)).toBeNull();
+
+    refreshWorkspaceAndExportsCaches(tmpDir);
+    expect(resolveViaWorkspace('@myorg/newpkg', tmpDir)).toBe(path.join(newDir, 'index.js'));
+  });
+
+  it('clears the exports cache for a plain (non-workspace) dependency too', () => {
+    // No workspaces registered at all — exercises the branch where
+    // detectWorkspaces() finds nothing, which must still clear the
+    // exports cache (a plain dependency's exports field can change
+    // independent of any workspace membership).
+    const pkgDir = path.join(tmpDir, 'node_modules', 'some-lib');
+    fs.mkdirSync(pkgDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(pkgDir, 'package.json'),
+      JSON.stringify({ name: 'some-lib', exports: './v1.js' }),
+    );
+    fs.writeFileSync(path.join(pkgDir, 'v1.js'), 'export default 1;');
+    fs.writeFileSync(path.join(pkgDir, 'v2.js'), 'export default 2;');
+
+    expect(resolveViaExports('some-lib', tmpDir)).toBe(path.join(pkgDir, 'v1.js'));
+
+    fs.writeFileSync(
+      path.join(pkgDir, 'package.json'),
+      JSON.stringify({ name: 'some-lib', exports: './v2.js' }),
+    );
+    expect(resolveViaExports('some-lib', tmpDir)).toBe(path.join(pkgDir, 'v1.js'));
+
+    refreshWorkspaceAndExportsCaches(tmpDir);
+    expect(resolveViaExports('some-lib', tmpDir)).toBe(path.join(pkgDir, 'v2.js'));
+  });
+});
+
+describe('diffMtimes (issue #2290)', () => {
+  it('reports added, changed, and removed files against a running mtime map', () => {
+    const mtimeMap = new Map<string, number>();
+    const changed: string[] = [];
+    const onChanged = (f: string) => changed.push(f);
+
+    const fileA = path.join(tmpDir, 'a.json');
+    fs.writeFileSync(fileA, '{}');
+
+    // First pass: everything is "added" (no prior entry in the map).
+    diffMtimes([fileA], mtimeMap, onChanged);
+    expect(changed).toEqual([fileA]);
+    expect(mtimeMap.has(fileA)).toBe(true);
+
+    // Second pass, unchanged: no callback fires.
+    changed.length = 0;
+    diffMtimes([fileA], mtimeMap, onChanged);
+    expect(changed).toEqual([]);
+
+    // Third pass: mtime changes (rewrite the file).
+    changed.length = 0;
+    fs.writeFileSync(fileA, '{"changed":true}');
+    // Force a distinguishable mtime on filesystems with coarse mtime
+    // resolution — a same-millisecond rewrite could otherwise report the
+    // identical mtime and make this assertion flaky.
+    fs.utimesSync(fileA, new Date(Date.now() + 5000), new Date(Date.now() + 5000));
+    diffMtimes([fileA], mtimeMap, onChanged);
+    expect(changed).toEqual([fileA]);
+
+    // Fourth pass: file no longer present in `current` (removed).
+    changed.length = 0;
+    diffMtimes([], mtimeMap, onChanged);
+    expect(changed).toEqual([fileA]);
+    expect(mtimeMap.has(fileA)).toBe(false);
+  });
+});

--- a/tests/unit/watcher-workspace-refresh.test.ts
+++ b/tests/unit/watcher-workspace-refresh.test.ts
@@ -94,6 +94,34 @@ describe('refreshWorkspaceAndExportsCaches (issue #2290)', () => {
     expect(resolveViaWorkspace('@myorg/newpkg', tmpDir)).toBe(path.join(newDir, 'index.js'));
   });
 
+  it('drops a workspace package removed mid-session, including the last one (Greptile review, PR #2458)', () => {
+    // detectWorkspaces() returning an empty map (the last workspace
+    // package removed, or the root `workspaces` field itself deleted)
+    // must still REPLACE the cached non-empty map — an earlier version of
+    // this fix gated setWorkspaces() on `workspaces.size > 0`, leaving the
+    // stale entries active forever once the last workspace was removed.
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ name: 'root', workspaces: ['packages/*'] }),
+    );
+    const coreDir = path.join(tmpDir, 'packages', 'core');
+    fs.mkdirSync(coreDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(coreDir, 'package.json'),
+      JSON.stringify({ name: '@myorg/core', exports: './index.js' }),
+    );
+    fs.writeFileSync(path.join(coreDir, 'index.js'), 'export default 1;');
+
+    refreshWorkspaceAndExportsCaches(tmpDir);
+    expect(resolveViaWorkspace('@myorg/core', tmpDir)).toBe(path.join(coreDir, 'index.js'));
+
+    // Remove the only workspace package's manifest entirely.
+    fs.rmSync(coreDir, { recursive: true, force: true });
+
+    refreshWorkspaceAndExportsCaches(tmpDir);
+    expect(resolveViaWorkspace('@myorg/core', tmpDir)).toBeNull();
+  });
+
   it('clears the exports cache for a plain (non-workspace) dependency too', () => {
     // No workspaces registered at all — exercises the branch where
     // detectWorkspaces() finds nothing, which must still clear the


### PR DESCRIPTION
## Summary

Closes #2290

Both engines' incremental rebuild path only populated the `package.json` `exports` cache and the workspace-detection map **once**, at the start of a full build, and never refreshed either for the lifetime of a watch session. If a dependency's or workspace package's `package.json` changed while `codegraph build --watch` was running, subsequent incremental rebuilds kept resolving imports against the stale, originally-cached data until the process restarted.

## Fix

Two changes, deliberately split by cost:

- **`clearExportsCache()`** (cheap: a plain `Map#clear`, now also clearing the native side via a new `clear_exports_cache` NAPI export) is called **unconditionally** in `rebuildFile`, once per rebuild of any file — mirroring the existing Cargo.toml/pyproject.toml precedent (#2217, #2387). A dependency's `exports` field can change independent of any workspace membership, including a plain `node_modules` package the watcher never observes at all (by design).
- **Workspace-map re-detection** (`detectWorkspaces()`/`setWorkspaces()`, potentially expensive in a large monorepo since it re-globs and re-reads every workspace package's manifest) is **gated** on the watcher actually observing a `package.json` change inside the watched tree — detected in both the native `fs.watch` callback and the polling loop, to avoid a per-keystroke re-scan cost.

The native engine has no workspace cache of its own — it's passed the map fresh from the TypeScript side (`getWorkspacesForNative`) on every call — so refreshing it on the TS side alone is sufficient for both engines.

## Test plan

- [x] New unit tests (`tests/unit/watcher-workspace-refresh.test.ts`): a workspace package's `exports` field change, a new workspace package added mid-session, and a plain non-workspace dependency's `exports` change — each locks in the exact stale-resolution bug (asserting the OLD result persists without a refresh) before proving the fix (asserting the NEW result appears after calling `refreshWorkspaceAndExportsCaches`). Plus dedicated tests for the shared `diffMtimes` polling-diff helper.
- [x] Verified every new test by temporarily no-op'ing `refreshWorkspaceAndExportsCaches` and confirming all 3 behavior tests fail with the exact stale/missing result the issue describes, then restoring.
- [x] Existing watcher tests (`watcher-flush.test.ts`, `watcher-rebuild.test.ts`) still pass — no regression to `rebuildFile`'s existing behavior.
- [x] Full test suite (native addon + dist rebuilt from source in this worktree): 316 files / 5118 tests passed.
- [x] `npm run lint` / `cargo fmt --check`: clean.
- [x] Dual-engine parity (`scripts/parity-compare.mjs`): clean.
- [x] `codegraph diff-impact --staged`: 10 functions changed, 8 callers affected across 3 files — matches the watcher-focused scope exactly.