### PR TITLE
fix(extractors): export line matches the declaration, not the export keyword

### DIFF
--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -3003,7 +3003,7 @@ fn handle_import_stmt(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
 fn handle_export_stmt(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     let decl = node.child_by_field_name("declaration");
     if let Some(decl) = &decl {
-        handle_export_declaration(node, decl, source, symbols);
+        handle_export_declaration(decl, source, symbols);
     }
     let source_node = node
         .child_by_field_name("source")
@@ -3013,14 +3013,14 @@ fn handle_export_stmt(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     }
 }
 
-fn handle_export_declaration(node: &Node, decl: &Node, source: &[u8], symbols: &mut FileSymbols) {
+fn handle_export_declaration(decl: &Node, source: &[u8], symbols: &mut FileSymbols) {
     let (kind_str, field) = match decl.kind() {
         "function_declaration" | "generator_function_declaration" => ("function", "name"),
         "class_declaration" | "abstract_class_declaration" => ("class", "name"),
         "interface_declaration" => ("interface", "name"),
         "type_alias_declaration" => ("type", "name"),
         "lexical_declaration" | "variable_declaration" => {
-            collect_exported_var_declarations(node, decl, source, symbols);
+            collect_exported_var_declarations(decl, source, symbols);
             return;
         }
         _ => return,
@@ -3029,7 +3029,11 @@ fn handle_export_declaration(node: &Node, decl: &Node, source: &[u8], symbols: &
         symbols.exports.push(ExportInfo {
             name: node_text(&n, source).to_string(),
             kind: kind_str.to_string(),
-            line: start_line(node),
+            // #2293: the declaration's own line, not the wrapping
+            // `export_statement`'s — a leading-comment or multi-line export
+            // clause otherwise pushed every export onto the `export` keyword's
+            // line instead of the declared symbol's own line.
+            line: start_line(decl),
         });
     }
 }
@@ -3056,17 +3060,11 @@ fn handle_export_declaration(node: &Node, decl: &Node, source: &[u8], symbols: &
 /// uses to build the matching Definitions, and push one "constant" ExportInfo
 /// per bound name. Restricted to `const` for the same reason the Definition
 /// side is (#2070).
-fn collect_exported_var_declarations(
-    node: &Node,
-    decl: &Node,
-    source: &[u8],
-    symbols: &mut FileSymbols,
-) {
+fn collect_exported_var_declarations(decl: &Node, source: &[u8], symbols: &mut FileSymbols) {
     let is_const = decl
         .child(0)
         .map(|c| node_text(&c, source) == "const")
         .unwrap_or(false);
-    let line = start_line(node);
     for i in 0..decl.child_count() {
         let Some(declarator) = decl.child(i) else {
             continue;
@@ -3090,13 +3088,16 @@ fn collect_exported_var_declarations(
                     symbols.exports.push(ExportInfo {
                         name: node_text(&name_n, source).to_string(),
                         kind: "function".to_string(),
-                        line,
+                        // #2293: matches handle_var_decl's own Definition line
+                        // for this shape (#2265) — the function VALUE's start
+                        // line, not the declaration's.
+                        line: start_line(&value_n),
                     });
                 } else if is_const {
                     symbols.exports.push(ExportInfo {
                         name: node_text(&name_n, source).to_string(),
                         kind: "constant".to_string(),
-                        line,
+                        line: start_line(decl),
                     });
                 }
             }
@@ -3105,7 +3106,7 @@ fn collect_exported_var_declarations(
                     symbols.exports.push(ExportInfo {
                         name,
                         kind: "constant".to_string(),
-                        line,
+                        line: start_line(decl),
                     });
                 }
             }
@@ -3114,7 +3115,7 @@ fn collect_exported_var_declarations(
                     symbols.exports.push(ExportInfo {
                         name,
                         kind: "constant".to_string(),
-                        line,
+                        line: start_line(decl),
                     });
                 }
             }
@@ -9852,6 +9853,62 @@ mod tests {
                 s.exports
             );
         }
+    }
+
+    #[test]
+    fn export_line_uses_value_line_for_multi_binding_function_valued_const() {
+        // #2293: each function-valued declarator's export line must match its
+        // own Definition's line (the value node's line, per #2265), not a
+        // single line shared across every declarator in the statement.
+        let s = parse_js("export const first = () => 1,\n  second = () => 2;");
+        assert!(
+            s.exports
+                .iter()
+                .any(|e| e.name == "first" && e.kind == "function" && e.line == 1),
+            "expected 'first' exported as function at line 1; got: {:?}",
+            s.exports
+        );
+        assert!(
+            s.exports
+                .iter()
+                .any(|e| e.name == "second" && e.kind == "function" && e.line == 2),
+            "expected 'second' exported as function at line 2; got: {:?}",
+            s.exports
+        );
+    }
+
+    #[test]
+    fn export_line_uses_declaration_line_not_export_keyword_line_for_default_class() {
+        // #2293: collect_exported_var_declarations / handle_export_declaration
+        // used to compute a single line from the wrapping `export_statement`
+        // node, mismatching the Definition's own line whenever `export` and
+        // the declaration weren't on the same source line — silently
+        // dropping the exported=1 UPDATE (matched by name/kind/file/line).
+        // A bare `export\nclass Widget {}` isn't a valid repro here: the
+        // grammar doesn't parse a newline-separated bare `export` followed by
+        // a declaration keyword as one `export_statement` at all (filed
+        // separately as #2459) — `export default` is parsed correctly across
+        // a newline, so it's used here to exercise the line fix itself.
+        let s = parse_js("export default\nclass Widget {}");
+        assert!(
+            s.exports
+                .iter()
+                .any(|e| e.name == "Widget" && e.kind == "class" && e.line == 2),
+            "expected 'Widget' exported as class at line 2; got: {:?}",
+            s.exports
+        );
+    }
+
+    #[test]
+    fn export_line_uses_declaration_line_not_export_keyword_line_for_default_function() {
+        let s = parse_js("export default\nfunction greet() {}");
+        assert!(
+            s.exports
+                .iter()
+                .any(|e| e.name == "greet" && e.kind == "function" && e.line == 2),
+            "expected 'greet' exported as function at line 2; got: {:?}",
+            s.exports
+        );
     }
 
     #[test]

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -237,15 +237,15 @@ const EXPORT_DECL_KIND: Record<string, string> = {
  * matching Definitions, and push one 'constant' Export per bound name.
  * Restricted to `const` for the same reason the Definition side is (#2070).
  */
-function collectExportedDeclarations(
-  decl: TreeSitterNode,
-  exportLine: number,
-  exps: Export[],
-): void {
+function collectExportedDeclarations(decl: TreeSitterNode, exps: Export[]): void {
   const kind = EXPORT_DECL_KIND[decl.type];
   if (kind) {
     const n = decl.childForFieldName('name');
-    if (n) exps.push({ name: n.text, kind: kind as Export['kind'], line: exportLine });
+    // `decl` IS the function/class/interface/type declaration node itself
+    // here — the same node its own Definition is built from — so this is
+    // never a proxy for some OTHER node's line the way the branches below
+    // are (issue #2293).
+    if (n) exps.push({ name: n.text, kind: kind as Export['kind'], line: nodeStartLine(decl) });
     return;
   }
   if (decl.type !== 'lexical_declaration' && decl.type !== 'variable_declaration') return;
@@ -264,17 +264,29 @@ function collectExportedDeclarations(
         valType === 'function' ||
         valType === 'generator_function'
       ) {
-        exps.push({ name: nameN.text, kind: 'function', line: exportLine });
+        // Matches handleVarFnAssignment/handleVarFnCapture's own Definition
+        // line (the function VALUE's start, not the declaration's — #2265),
+        // not `decl`'s line, which can differ when the value starts on a
+        // later line than `const`/`let` itself (issue #2293).
+        exps.push({ name: nameN.text, kind: 'function', line: nodeStartLine(valueN) });
       } else if (isConst) {
-        exps.push({ name: nameN.text, kind: 'constant', line: exportLine });
+        // Matches handleConstIdentifierAssignment's own Definition line
+        // (`decl`'s start — the whole `const x = ...;` statement), not the
+        // wrapping `export_statement`'s line, which can differ when `export`
+        // and the declaration are on different lines (issue #2293).
+        exps.push({ name: nameN.text, kind: 'constant', line: nodeStartLine(decl) });
       }
     } else if (isConst && nameN.type === 'object_pattern') {
+      // Matches handleConstObjectPatternAssignment's own Definition line
+      // (`decl`'s start), for the same reason as the plain-identifier
+      // branch above.
       for (const name of collectObjectPatternNames(nameN)) {
-        exps.push({ name, kind: 'constant', line: exportLine });
+        exps.push({ name, kind: 'constant', line: nodeStartLine(decl) });
       }
     } else if (isConst && nameN.type === 'array_pattern') {
+      // Matches handleConstArrayPatternAssignment's own Definition line.
       for (const name of collectArrayPatternNames(nameN)) {
-        exps.push({ name, kind: 'constant', line: exportLine });
+        exps.push({ name, kind: 'constant', line: nodeStartLine(decl) });
       }
     }
   }
@@ -286,9 +298,11 @@ function handleExportCapture(
   exps: Export[],
   imports: Import[],
 ): void {
-  const exportLine = nodeStartLine(c.exp_node!);
   const decl = c.exp_node!.childForFieldName('declaration');
-  if (decl) collectExportedDeclarations(decl, exportLine, exps);
+  if (decl) collectExportedDeclarations(decl, exps);
+  // Only used for the re-export (no `decl`) branch below — there's no
+  // declaration node to match a Definition's line against in that case.
+  const exportLine = nodeStartLine(c.exp_node!);
   const source = c.exp_node!.childForFieldName('source') || findChild(c.exp_node!, 'string');
   if (source && !decl) {
     const modPath = source.text.replace(/['"]/g, '');
@@ -2391,9 +2405,11 @@ function handleImportStmt(node: TreeSitterNode, ctx: ExtractorOutput): void {
 }
 
 function handleExportStmt(node: TreeSitterNode, ctx: ExtractorOutput): void {
-  const exportLine = nodeStartLine(node);
   const decl = node.childForFieldName('declaration');
-  if (decl) collectExportedDeclarations(decl, exportLine, ctx.exports);
+  if (decl) collectExportedDeclarations(decl, ctx.exports);
+  // Only used for the re-export (no `decl`) branch below — there's no
+  // declaration node to match a Definition's line against in that case.
+  const exportLine = nodeStartLine(node);
   const source = node.childForFieldName('source') || findChild(node, 'string');
   if (source && !decl) {
     const modPath = source.text.replace(/['"]/g, '');

--- a/tests/integration/issue-2293-export-line-own-line-mismatch.test.ts
+++ b/tests/integration/issue-2293-export-line-own-line-mismatch.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Integration test for #2293: `collectExportedDeclarations`/
+ * `collect_exported_var_declarations` (extractors/javascript.ts,
+ * crates/codegraph-core/src/extractors/javascript.rs) computed a single
+ * export line from the wrapping `export_statement` node and applied it to
+ * every branch, while the matching `Definition` row for that same
+ * declaration is created from the declaration's own node (or, for a
+ * function-valued declarator, the function value's own node — #2265).
+ *
+ * Whenever `export` and its declaration start on different source lines —
+ * syntactically valid JS, since ASI does not apply between `export` and its
+ * declaration — the two lines diverged, and the `exported = 1` UPDATE
+ * (matched by name/kind/file/line, see #1728) silently never fired: the
+ * symbol was inserted as a genuine top-level definition but never marked
+ * exported.
+ *
+ * Fix: the export line now comes from the same node each branch's
+ * Definition already uses — the declaration node itself, or the function
+ * value node for function-valued declarators — so the two rows always match.
+ *
+ * Note: a bare `export\nconst x = 5;` doesn't reach this code path at all —
+ * tree-sitter-javascript fails to parse a newline-separated bare `export`
+ * followed by a declaration keyword as a single `export_statement` (filed
+ * separately as #2459). `export default` is parsed correctly across a
+ * newline, so it's used below to exercise the line fix itself.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+import { isNativeAvailable } from '../../src/infrastructure/native.js';
+
+const FIXTURE = {
+  'defaultClass.js': `export default
+class Widget {}
+`,
+  'defaultFunction.js': `export default
+function greet() {}
+`,
+  'multiBinding.js': `export const first = () => 1,
+  second = () => 2;
+`,
+};
+
+function readNode(dbPath: string, name: string): { line: number; exported: number } {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    const row = db.prepare(`SELECT line, exported FROM nodes WHERE name = ?`).get(name) as
+      | { line: number; exported: number }
+      | undefined;
+    expect(row, `no node row found for ${name}`).toBeDefined();
+    return row!;
+  } finally {
+    db.close();
+  }
+}
+
+function runShared(getDbPath: () => string) {
+  it("marks a default-exported class as exported at the class declaration's own line", () => {
+    const row = readNode(getDbPath(), 'Widget');
+    expect(row.line).toBe(2);
+    expect(row.exported).toBe(1);
+  });
+
+  it("marks a default-exported function as exported at the function declaration's own line", () => {
+    const row = readNode(getDbPath(), 'greet');
+    expect(row.line).toBe(2);
+    expect(row.exported).toBe(1);
+  });
+
+  it('marks each declarator in a multi-binding exported const as exported at its own function-value line', () => {
+    const first = readNode(getDbPath(), 'first');
+    const second = readNode(getDbPath(), 'second');
+    expect(first.line).toBe(1);
+    expect(first.exported).toBe(1);
+    expect(second.line).toBe(2);
+    expect(second.exported).toBe(1);
+  });
+}
+
+describe('export line matches the declaration, not the `export` keyword (#2293) — WASM', () => {
+  let tmpDir: string;
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-2293-'));
+    for (const [rel, content] of Object.entries(FIXTURE)) {
+      fs.writeFileSync(path.join(tmpDir, rel), content);
+    }
+    await buildGraph(tmpDir, { engine: 'wasm', incremental: false, skipRegistry: true });
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  runShared(() => path.join(tmpDir, '.codegraph', 'graph.db'));
+});
+
+describe.skipIf(!isNativeAvailable())(
+  'export line matches the declaration, not the `export` keyword (#2293) — native',
+  () => {
+    let nativeTmpDir: string;
+
+    beforeAll(async () => {
+      nativeTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-2293-native-'));
+      for (const [rel, content] of Object.entries(FIXTURE)) {
+        fs.writeFileSync(path.join(nativeTmpDir, rel), content);
+      }
+      await buildGraph(nativeTmpDir, { engine: 'native', incremental: false, skipRegistry: true });
+    }, 60_000);
+
+    afterAll(() => {
+      fs.rmSync(nativeTmpDir, { recursive: true, force: true });
+    });
+
+    runShared(() => path.join(nativeTmpDir, '.codegraph', 'graph.db'));
+  },
+);

--- a/tests/parsers/javascript.test.ts
+++ b/tests/parsers/javascript.test.ts
@@ -3835,6 +3835,50 @@ function runDemo(reporter: Reporter, users: string[]): void {
     });
   });
 
+  describe('export line matches the declaration, not the `export` keyword (#2293)', () => {
+    // Regression guard for #2293: collectExportedDeclarations computed a single
+    // `exportLine` from the wrapping `export_statement` node and applied it to
+    // every branch, so any export whose declaration didn't start on the same
+    // line as the `export` keyword got the WRONG line — mismatching the line
+    // its own Definition was recorded under, so the exported=1 UPDATE (which
+    // matches by name/kind/file/line) silently never fired.
+    // Note: a bare `export\nconst x = 5;` (the issue's own illustrative
+    // repro) doesn't actually reach this code at all — tree-sitter-javascript
+    // fails to recognize a newline-separated bare `export` followed by a
+    // declaration keyword as a single `export_statement` in the first place
+    // (confirmed by dumping the parse tree; filed separately as #2459, since
+    // it's an upstream grammar limitation, not a line-computation bug). The
+    // repros below use `export default`/`export abstract`, which the grammar
+    // *does* parse as one `export_statement` spanning multiple lines,
+    // to exercise the actual line-computation fix.
+    it("uses the function value's own line for a multi-binding exported const, not the declaration's", () => {
+      // Mirrors #2265: `export const a = fn1, b = fn2;` — each function-valued
+      // declarator's export line must match its own Definition's line (the
+      // value node's line), not a shared line derived from the statement.
+      const symbols = parseJS(`export const first = () => 1,\n  second = () => 2;`);
+      expect(symbols.exports).toContainEqual(
+        expect.objectContaining({ name: 'first', kind: 'function', line: 1 }),
+      );
+      expect(symbols.exports).toContainEqual(
+        expect.objectContaining({ name: 'second', kind: 'function', line: 2 }),
+      );
+    });
+
+    it('uses the declaration line, not the export keyword line, for a default-exported class', () => {
+      const symbols = parseJS(`export default\nclass Widget {}`);
+      expect(symbols.exports).toContainEqual(
+        expect.objectContaining({ name: 'Widget', kind: 'class', line: 2 }),
+      );
+    });
+
+    it('uses the declaration line, not the export keyword line, for a default-exported function', () => {
+      const symbols = parseJS(`export default\nfunction greet() {}`);
+      expect(symbols.exports).toContainEqual(
+        expect.objectContaining({ name: 'greet', kind: 'function', line: 2 }),
+      );
+    });
+  });
+
   describe('top-level const with a non-"literal-shaped" initializer (#1819)', () => {
     it('extracts a const with a parenthesized member-expression initializer as a definition (repro)', () => {
       // Repro from #1819: `(...).version` isn't one of the recognized "literal"


### PR DESCRIPTION
## Summary
- `collectExportedDeclarations`/`collect_exported_var_declarations` computed a single export line from the wrapping `export_statement` node and applied it to every branch, while the matching `Definition` row for that declaration is built from the declaration's own node (or the function value's own node for a function-valued declarator, per #2265).
- Whenever `export` and its declaration start on different lines — valid JS, ASI doesn't apply between `export` and its declaration — the two rows diverged and the `exported=1` UPDATE (matched by name/kind/file/line, #1728) silently never fired: the symbol was extracted as a genuine definition but never marked exported.
- Each branch now sources its line from the same node its own Definition already uses, mirrored in both engines (TS/WASM `src/extractors/javascript.ts` and Rust `crates/codegraph-core/src/extractors/javascript.rs`).

## Note on scope
While writing regression tests, found that a bare `export\n<declaration>` (the issue's own illustrative repro) doesn't actually reach this code at all — tree-sitter-javascript fails to parse a newline-separated bare `export` followed by a declaration keyword as a single `export_statement`, silently dropping the export relationship entirely (worse than a line mismatch). That's an upstream grammar limitation, filed separately as #2459 — not addressed here. This PR's tests use `export default`/multi-binding `export const` reproductions, which the grammar does parse correctly across multiple lines, to exercise the actual line-computation fix.

Closes #2293

## Test plan
- [x] New unit tests in `tests/parsers/javascript.test.ts` (TS/WASM) and `crates/codegraph-core/src/extractors/javascript.rs` (native), both confirmed to fail against the pre-fix code and pass against the fix (revert-and-confirm).
- [x] New dual-engine integration test `tests/integration/issue-2293-export-line-own-line-mismatch.test.ts` verifying the `nodes.exported`/`nodes.line` DB columns on both engines.
- [x] Full test suite (`npm test`): 317 files / 5128 tests passing.
- [x] `npm run lint`, `cargo fmt -- --check`: clean.
- [x] Dual-engine parity (`node scripts/parity-compare.mjs --json`): `ok: true` across all languages.
- [x] `codegraph diff-impact --staged -T`: contained blast radius (3 functions, 7 callers, 1 file).