### PR TITLE
refactor(builder): consolidate barrel-trace-with-fallback duplicates onto traceBarrelTarget

### DIFF
--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -238,15 +238,7 @@ function emitNamedSymbolEdges(
 ): void {
   if (!ctx.nodesByNameAndFile) return;
   for (const { original, typeOnly } of importNamePairs(imp)) {
-    let targetFile = resolvedPath;
-    let targetName = original;
-    if (isBarrelFile(ctx, resolvedPath)) {
-      const resolved = resolveBarrelExportCached(ctx, resolvedPath, original);
-      if (resolved) {
-        targetFile = resolved.file;
-        targetName = resolved.name;
-      }
-    }
+    const { file: targetFile, name: targetName } = traceBarrelTarget(ctx, resolvedPath, original);
     const candidates = ctx.nodesByNameAndFile.get(`${targetName}|${targetFile}`);
     if (!candidates || candidates.length === 0) continue;
     const target = candidates[0]!;
@@ -354,9 +346,8 @@ function buildBarrelEdges(
 ): void {
   const resolvedSources = new Set<string>();
   for (const { original } of importNamePairs(imp)) {
-    const resolved = resolveBarrelExportCached(ctx, resolvedPath, original);
-    const actualSource = resolved?.file;
-    if (actualSource && actualSource !== resolvedPath && !resolvedSources.has(actualSource)) {
+    const { file: actualSource } = traceBarrelTarget(ctx, resolvedPath, original);
+    if (actualSource !== resolvedPath && !resolvedSources.has(actualSource)) {
       resolvedSources.add(actualSource);
       const actualRow = getNodeIdStmt.get(actualSource, 'file', actualSource, 0);
       if (actualRow) {
@@ -1138,15 +1129,7 @@ function buildImportedNamesForNative(
         importedNames.push({ name: local, file: submodule, namespace: true });
         continue;
       }
-      let targetFile = resolvedPath;
-      let targetName = original;
-      if (isBarrelFile(ctx, resolvedPath)) {
-        const resolved = resolveBarrelExportCached(ctx, resolvedPath, original);
-        if (resolved) {
-          targetFile = resolved.file;
-          targetName = resolved.name;
-        }
-      }
+      const { file: targetFile, name: targetName } = traceBarrelTarget(ctx, resolvedPath, original);
       // `imported` carries the name actually declared in `targetFile` so the
       // native resolver can look it up there instead of the local alias
       // (which only exists in this file, #1730) or the barrel's external


### PR DESCRIPTION
## Summary
- #2071 extracted a shared `traceBarrelTarget(ctx, resolvedPath, name)` helper in `resolve-imports.ts` — a single implementation of "resolve through a possible barrel hop, falling back to the original file/name when it isn't a barrel or resolution finds nothing" — replacing two divergent private copies in `build-edges.ts`.
- Three more call sites in `build-edges.ts` (`emitNamedSymbolEdges`, `buildBarrelEdges`, `buildImportedNamesForNative`) inlined the identical `isBarrelFile` + `resolveBarrelExportCached` + fallback pattern by hand. None of these three were currently buggy — this is a pure consolidation to remove duplication before it drifts the same way #2071's did.
- Rewrites all three onto `traceBarrelTarget`. No behavior change.

## Scope note
While investigating, found that Rust's `import_edges.rs` has the identical inline duplication in three places (`collect_symbol_lookup_pairs`, `emit_named_symbol_rows`, `emit_barrel_through_rows`), with no existing helper to consolidate onto at all. That's a larger, distinct task (creating a new Rust helper from scratch, not mirroring an existing one) — filed separately as #2461, not addressed here, per this issue's own TS-only scope.

Closes #2295

## Test plan
- [x] No behavior change — full test suite (317 files / 5128 tests) passes unchanged.
- [x] Dual-engine parity (`node scripts/parity-compare.mjs --json`): `ok: true`.
- [x] `npm run lint`, `cargo fmt -- --check` (no Rust changes in this PR): clean.
- [x] `codegraph diff-impact --staged -T`: contained to the 3 edited functions + 1 nested closure, 7 callers, 1 file.