### PR TITLE
perf(builder): dedup import edges within a file before batch insert

### DIFF
--- a/crates/codegraph-core/src/domain/graph/builder/stages/import_edges.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/import_edges.rs
@@ -612,6 +612,37 @@ fn classify_import_kind(imp: &crate::types::Import) -> &'static str {
 /// kinds are erased before runtime, so a plain `import { Foo } from 'y'` (no
 /// `type` keyword) is the only consumption signal `codegraph exports` can
 /// observe for them (#1833).
+/// Push an import/reexport edge row unless an edge with the same
+/// (source, target, kind) has already been pushed for this file. Two import
+/// statements in the same file often resolve to the same target — two
+/// `import()` calls to the same module, a named + wildcard reexport from the
+/// same source, or two reexport statements naming the same original symbol
+/// under different aliases (#2297) — so without this, the identical edge row
+/// is computed and pushed once per statement instead of once per file.
+/// `INSERT OR IGNORE` + `idx_edges_content_unique` already deduplicate the DB
+/// rows themselves at insert time; this only avoids the redundant
+/// computation and batch-insert row upstream of that. Mirrors
+/// `pushImportEdgeOnce` in stages/build-edges.ts.
+fn push_edge_once(
+    seen: &mut HashSet<(i64, i64, String)>,
+    edges: &mut Vec<EdgeRow>,
+    source_id: i64,
+    target_id: i64,
+    kind: &str,
+    confidence: f64,
+) {
+    if !seen.insert((source_id, target_id, kind.to_string())) {
+        return;
+    }
+    edges.push(EdgeRow {
+        source_id,
+        target_id,
+        kind: kind.to_string(),
+        confidence,
+        dynamic: 0,
+    });
+}
+
 fn emit_named_symbol_rows(
     edges: &mut Vec<EdgeRow>,
     file_node_id: i64,
@@ -620,6 +651,7 @@ fn emit_named_symbol_rows(
     kind: &str,
     ctx: &ImportEdgeContext,
     symbol_node_ids: &HashMap<(String, String), (i64, String)>,
+    seen_edges: &mut HashSet<(i64, i64, String)>,
 ) {
     for (_local, original, type_only) in import_name_pairs(imp) {
         let mut target_file = resolved_path.to_string();
@@ -643,13 +675,7 @@ fn emit_named_symbol_rows(
         {
             continue;
         }
-        edges.push(EdgeRow {
-            source_id: file_node_id,
-            target_id: *sym_id,
-            kind: kind.to_string(),
-            confidence: 1.0,
-            dynamic: 0,
-        });
+        push_edge_once(seen_edges, edges, file_node_id, *sym_id, kind, 1.0);
     }
 }
 
@@ -663,6 +689,7 @@ fn emit_barrel_through_rows(
     edge_kind: &str,
     ctx: &ImportEdgeContext,
     file_node_ids: &HashMap<String, i64>,
+    seen_edges: &mut HashSet<(i64, i64, String)>,
 ) {
     let is_reexport = imp.reexport.unwrap_or(false);
     if is_reexport || !ctx.is_barrel_file(resolved_path) {
@@ -685,13 +712,14 @@ fn emit_barrel_through_rows(
             continue;
         }
         if let Some(&actual_id) = file_node_ids.get(&actual_source) {
-            edges.push(EdgeRow {
-                source_id: file_node_id,
-                target_id: actual_id,
-                kind: through_kind.to_string(),
-                confidence: 0.9,
-                dynamic: 0,
-            });
+            push_edge_once(
+                seen_edges,
+                edges,
+                file_node_id,
+                actual_id,
+                through_kind,
+                0.9,
+            );
         }
     }
 }
@@ -706,6 +734,7 @@ fn emit_edges_for_import(
     ctx: &ImportEdgeContext,
     file_node_ids: &HashMap<String, i64>,
     symbol_node_ids: &HashMap<(String, String), (i64, String)>,
+    seen_edges: &mut HashSet<(i64, i64, String)>,
 ) {
     let is_reexport = imp.reexport.unwrap_or(false);
     if is_barrel_only && !is_reexport {
@@ -729,13 +758,14 @@ fn emit_edges_for_import(
             continue;
         };
         if let Some(&submodule_id) = file_node_ids.get(&submodule) {
-            edges.push(EdgeRow {
-                source_id: file_node_id,
-                target_id: submodule_id,
-                kind: "imports".to_string(),
-                confidence: 1.0,
-                dynamic: 0,
-            });
+            push_edge_once(
+                seen_edges,
+                edges,
+                file_node_id,
+                submodule_id,
+                "imports",
+                1.0,
+            );
         }
     }
 
@@ -744,13 +774,7 @@ fn emit_edges_for_import(
         None => return,
     };
     let edge_kind = classify_import_kind(imp);
-    edges.push(EdgeRow {
-        source_id: file_node_id,
-        target_id,
-        kind: edge_kind.to_string(),
-        confidence: 1.0,
-        dynamic: 0,
-    });
+    push_edge_once(seen_edges, edges, file_node_id, target_id, edge_kind, 1.0);
     // Always attempted (not just for `import type`/inline-`type` specifiers) —
     // emit_named_symbol_rows also credits plain specifiers that resolve to a
     // TypeScript interface/type-alias declaration (#1833).
@@ -763,6 +787,7 @@ fn emit_edges_for_import(
             "imports-type",
             ctx,
             symbol_node_ids,
+            seen_edges,
         );
     }
     if is_named_reexport(imp) {
@@ -774,15 +799,17 @@ fn emit_edges_for_import(
             "reexports",
             ctx,
             symbol_node_ids,
+            seen_edges,
         );
     } else if is_wildcard_reexport(imp) {
-        edges.push(EdgeRow {
-            source_id: file_node_id,
+        push_edge_once(
+            seen_edges,
+            edges,
+            file_node_id,
             target_id,
-            kind: "reexports-wildcard".to_string(),
-            confidence: 1.0,
-            dynamic: 0,
-        });
+            "reexports-wildcard",
+            1.0,
+        );
     }
     emit_barrel_through_rows(
         edges,
@@ -792,6 +819,7 @@ fn emit_edges_for_import(
         edge_kind,
         ctx,
         file_node_ids,
+        seen_edges,
     );
 }
 
@@ -815,6 +843,7 @@ pub fn build_import_edges(conn: &Connection, ctx: &ImportEdgeContext) -> Vec<Edg
 
         let abs_file = Path::new(&ctx.root_dir).join(rel_path);
         let abs_str = abs_file.to_str().unwrap_or("");
+        let mut seen_edges: HashSet<(i64, i64, String)> = HashSet::new();
 
         for imp in &symbols.imports {
             // CJS require bindings feed imported_names for receiver-edge resolution
@@ -831,6 +860,7 @@ pub fn build_import_edges(conn: &Connection, ctx: &ImportEdgeContext) -> Vec<Edg
                 ctx,
                 &file_node_ids,
                 &symbol_node_ids,
+                &mut seen_edges,
             );
         }
     }
@@ -1186,6 +1216,7 @@ mod tests {
         );
 
         let mut edges = Vec::new();
+        let mut seen_edges = HashSet::new();
         emit_named_symbol_rows(
             &mut edges,
             1,
@@ -1194,6 +1225,7 @@ mod tests {
             "imports-type",
             &ctx,
             &symbol_node_ids,
+            &mut seen_edges,
         );
 
         assert_eq!(edges.len(), 1);
@@ -1216,6 +1248,7 @@ mod tests {
         );
 
         let mut edges = Vec::new();
+        let mut seen_edges = HashSet::new();
         emit_named_symbol_rows(
             &mut edges,
             1,
@@ -1224,6 +1257,7 @@ mod tests {
             "imports-type",
             &ctx,
             &symbol_node_ids,
+            &mut seen_edges,
         );
 
         assert!(edges.is_empty());
@@ -1244,6 +1278,7 @@ mod tests {
         );
 
         let mut edges = Vec::new();
+        let mut seen_edges = HashSet::new();
         emit_named_symbol_rows(
             &mut edges,
             1,
@@ -1252,9 +1287,37 @@ mod tests {
             "imports-type",
             &ctx,
             &symbol_node_ids,
+            &mut seen_edges,
         );
 
         assert!(edges.is_empty());
+    }
+
+    #[test]
+    fn push_edge_once_drops_a_repeat_of_the_same_source_target_kind() {
+        // #2297: two import statements in the same file resolving to the same
+        // (source, target, kind) must only push one edge row — the second
+        // push is redundant computation the DB-level unique constraint would
+        // silently discard anyway, but should never reach the batch at all.
+        let mut seen = HashSet::new();
+        let mut edges = Vec::new();
+        push_edge_once(&mut seen, &mut edges, 1, 2, "imports", 1.0);
+        push_edge_once(&mut seen, &mut edges, 1, 2, "imports", 1.0);
+
+        assert_eq!(edges.len(), 1);
+    }
+
+    #[test]
+    fn push_edge_once_keeps_rows_that_differ_only_by_kind() {
+        // Two edges kinds for the same (source, target) pair are NOT
+        // duplicates of each other — e.g. a plain `imports` edge and an
+        // `imports-type` symbol-level edge to the same file must both survive.
+        let mut seen = HashSet::new();
+        let mut edges = Vec::new();
+        push_edge_once(&mut seen, &mut edges, 1, 2, "imports", 1.0);
+        push_edge_once(&mut seen, &mut edges, 1, 2, "imports-type", 1.0);
+
+        assert_eq!(edges.len(), 2);
     }
 
     #[test]

--- a/src/domain/graph/builder/stages/build-edges.ts
+++ b/src/domain/graph/builder/stages/build-edges.ts
@@ -228,6 +228,32 @@ function importEdgeKind(imp: Import): string {
  *     so a plain `import { Foo } from 'y'` (no `type` keyword) is the only
  *     consumption signal `codegraph exports` can observe for them (#1833).
  */
+/**
+ * Push an import/reexport edge row unless an edge with the same
+ * (source, target, kind) has already been pushed for this file. Two import
+ * statements in the same file often resolve to the same target — two
+ * `import()` calls to the same module, a named + wildcard reexport from the
+ * same source, or two reexport statements naming the same original symbol
+ * under different aliases (#2297) — so without this, the identical edge row
+ * is computed and pushed once per statement instead of once per file. Both
+ * engines already deduplicate the DB rows themselves at insert time via
+ * `idx_edges_content_unique` (#2072); this only avoids the redundant
+ * computation and batch-insert row upstream of that.
+ */
+function pushImportEdgeOnce(
+  seenImportEdges: Set<string>,
+  edgeRows: EdgeRowTuple[],
+  sourceId: number,
+  targetId: number,
+  kind: string,
+  confidence: number,
+): void {
+  const key = `${sourceId}|${targetId}|${kind}`;
+  if (seenImportEdges.has(key)) return;
+  seenImportEdges.add(key);
+  edgeRows.push([sourceId, targetId, kind, confidence, 0, null, null]);
+}
+
 function emitNamedSymbolEdges(
   ctx: PipelineContext,
   imp: Import,
@@ -235,6 +261,7 @@ function emitNamedSymbolEdges(
   fileNodeId: number,
   allEdgeRows: EdgeRowTuple[],
   edgeKind: 'imports-type' | 'reexports',
+  seenImportEdges: Set<string>,
 ): void {
   if (!ctx.nodesByNameAndFile) return;
   for (const { original, typeOnly } of importNamePairs(imp)) {
@@ -249,7 +276,7 @@ function emitNamedSymbolEdges(
     ) {
       continue;
     }
-    allEdgeRows.push([fileNodeId, target.id, edgeKind, 1.0, 0, null, null]);
+    pushImportEdgeOnce(seenImportEdges, allEdgeRows, fileNodeId, target.id, edgeKind, 1.0);
   }
 }
 
@@ -264,6 +291,7 @@ function emitEdgesForImport(
   relPath: string,
   getNodeIdStmt: NodeIdStmt,
   allEdgeRows: EdgeRowTuple[],
+  seenImportEdges: Set<string>,
 ): void {
   const resolvedPath = getResolved(ctx, path.join(ctx.rootDir, relPath), imp.source);
 
@@ -281,24 +309,41 @@ function emitEdgesForImport(
     );
     if (!submodule) continue;
     const submoduleRow = getNodeIdStmt.get(submodule, 'file', submodule, 0);
-    if (submoduleRow)
-      allEdgeRows.push([fileNodeId, submoduleRow.id, 'imports', 1.0, 0, null, null]);
+    if (submoduleRow) {
+      pushImportEdgeOnce(seenImportEdges, allEdgeRows, fileNodeId, submoduleRow.id, 'imports', 1.0);
+    }
   }
 
   const targetRow = getNodeIdStmt.get(resolvedPath, 'file', resolvedPath, 0);
   if (!targetRow) return;
 
   const edgeKind = importEdgeKind(imp);
-  allEdgeRows.push([fileNodeId, targetRow.id, edgeKind, 1.0, 0, null, null]);
+  pushImportEdgeOnce(seenImportEdges, allEdgeRows, fileNodeId, targetRow.id, edgeKind, 1.0);
 
   // Always attempted (not just for `import type`/inline-`type` specifiers) —
   // emitNamedSymbolEdges also credits plain specifiers that resolve to a
   // TypeScript interface/type-alias declaration (#1833).
   if (!imp.reexport) {
-    emitNamedSymbolEdges(ctx, imp, resolvedPath, fileNodeId, allEdgeRows, 'imports-type');
+    emitNamedSymbolEdges(
+      ctx,
+      imp,
+      resolvedPath,
+      fileNodeId,
+      allEdgeRows,
+      'imports-type',
+      seenImportEdges,
+    );
   }
   if (imp.reexport && !imp.wildcardReexport) {
-    emitNamedSymbolEdges(ctx, imp, resolvedPath, fileNodeId, allEdgeRows, 'reexports');
+    emitNamedSymbolEdges(
+      ctx,
+      imp,
+      resolvedPath,
+      fileNodeId,
+      allEdgeRows,
+      'reexports',
+      seenImportEdges,
+    );
   } else if (imp.reexport && imp.wildcardReexport) {
     // A genuine wildcard needs to be distinguishable from a named reexport
     // even when a *different* statement in the same file names specific
@@ -306,11 +351,27 @@ function emitEdgesForImport(
     // "only these symbols are re-exported" apart from "everything is
     // re-exported, and these happen to also be individually named" (#1849
     // review). See `collectReexportedSymbols` in domain/analysis/exports.ts.
-    allEdgeRows.push([fileNodeId, targetRow.id, 'reexports-wildcard', 1.0, 0, null, null]);
+    pushImportEdgeOnce(
+      seenImportEdges,
+      allEdgeRows,
+      fileNodeId,
+      targetRow.id,
+      'reexports-wildcard',
+      1.0,
+    );
   }
 
   if (!imp.reexport && isBarrelFile(ctx, resolvedPath)) {
-    buildBarrelEdges(ctx, imp, resolvedPath, fileNodeId, edgeKind, getNodeIdStmt, allEdgeRows);
+    buildBarrelEdges(
+      ctx,
+      imp,
+      resolvedPath,
+      fileNodeId,
+      edgeKind,
+      getNodeIdStmt,
+      allEdgeRows,
+      seenImportEdges,
+    );
   }
 }
 
@@ -326,11 +387,20 @@ function buildImportEdges(
     const fileNodeRow = getNodeIdStmt.get(relPath, 'file', relPath, 0);
     if (!fileNodeRow) continue;
     const fileNodeId = fileNodeRow.id;
+    const seenImportEdges = new Set<string>();
 
     for (const imp of symbols.imports) {
       // Barrel-only files: only emit reexport edges, skip regular imports
       if (isBarrelOnly && !imp.reexport) continue;
-      emitEdgesForImport(ctx, imp, fileNodeId, relPath, getNodeIdStmt, allEdgeRows);
+      emitEdgesForImport(
+        ctx,
+        imp,
+        fileNodeId,
+        relPath,
+        getNodeIdStmt,
+        allEdgeRows,
+        seenImportEdges,
+      );
     }
   }
 }
@@ -343,6 +413,7 @@ function buildBarrelEdges(
   edgeKind: string,
   getNodeIdStmt: NodeIdStmt,
   edgeRows: EdgeRowTuple[],
+  seenImportEdges: Set<string>,
 ): void {
   const resolvedSources = new Set<string>();
   for (const { original } of importNamePairs(imp)) {
@@ -357,7 +428,7 @@ function buildBarrelEdges(
             : edgeKind === 'dynamic-imports'
               ? 'dynamic-imports'
               : 'imports';
-        edgeRows.push([fileNodeId, actualRow.id, kind, 0.9, 0, null, null]);
+        pushImportEdgeOnce(seenImportEdges, edgeRows, fileNodeId, actualRow.id, kind, 0.9);
       }
     }
   }


### PR DESCRIPTION
## Summary
- `emitEdgesForImport`/`emit_edges_for_import` pushed a file-level edge (and, for named specifiers, a symbol-level edge) once per import statement, with no cross-statement dedup within the same file. Two statements in the same file resolving to the same `(source, target, kind)` — two `import()` calls to the same module, a named + wildcard reexport from the same source, two reexport aliases of the same original symbol — computed and pushed the identical edge row twice.
- Both engines already deduplicate the DB rows themselves at insert time via `idx_edges_content_unique` (#2072), so this was harmless for final correctness — just wasted computation and batch-insert rows that scale with how many import statements a file has to the same target.
- Adds a per-file `Set<string>` (TS) / `HashSet<(i64,i64,String)>` (Rust) keyed by `source|target|kind`, threaded through `emitEdgesForImport`/`buildBarrelEdges` and their native mirrors, mirroring the existing `seenCallEdges`/`seen_edges` pattern already used for calls/receiver/hierarchy edges in the same files.

Closes #2297

## Test plan
- [x] No correctness change — full test suite (317 files / 5128 tests) passes unchanged, including the two existing tests the issue cites as exercising the exact duplicate-emission path (`issue-1742-reexport-symbol-scope.test.ts`, `issue-1781-dynamic-import-destructure-consumer.test.ts`).
- [x] New Rust unit tests for the new `push_edge_once` helper (dedup by key; kept when only `kind` differs).
- [x] Full Rust test suite (970/970), `cargo fmt -- --check`: clean.
- [x] `npm run lint`: clean.
- [x] Dual-engine parity (`node scripts/parity-compare.mjs --json`): `ok: true`.
- [x] `codegraph diff-impact --staged -T`: contained to the 5 edited/added functions, 7 callers, 1 file.