### PR TITLE
fix(resolve): remap .mjs/.cjs specifiers to .mts/.cts sources

### DIFF
--- a/crates/codegraph-core/src/domain/graph/resolve.rs
+++ b/crates/codegraph-core/src/domain/graph/resolve.rs
@@ -1345,8 +1345,18 @@ fn resolve_non_relative_import(
     import_source.to_string()
 }
 
-/// Probe the `.js → .ts/.tsx` remap candidates and return the first
-/// existing file's root-relative path, if any.
+/// Extension pairs to probe when a resolved path uses TypeScript's required
+/// "emitted extension" convention in relative import specifiers: a `.ts`/
+/// `.tsx` source is imported via `.js`, a `.mts` source via `.mjs`, and a
+/// `.cts` source via `.cjs` (#2299).
+const EMIT_EXTENSION_REMAPS: &[(&str, &[&str])] = &[
+    (".js", &[".ts", ".tsx"]),
+    (".mjs", &[".mts"]),
+    (".cjs", &[".cts"]),
+];
+
+/// Probe the emitted-extension remap candidates (see [`EMIT_EXTENSION_REMAPS`])
+/// and return the first existing file's root-relative path, if any.
 /// Skips candidates that exist but lie outside `root_dir` (strip_prefix
 /// would fail), preserving the original fall-through behaviour.
 fn probe_js_to_ts_remap(
@@ -1354,17 +1364,23 @@ fn probe_js_to_ts_remap(
     root_dir: &str,
     known_files: Option<&HashSet<String>>,
 ) -> Option<String> {
-    if !resolved_str.ends_with(".js") {
-        return None;
-    }
     let root = Path::new(root_dir);
-    for replacement in [".ts", ".tsx"] {
-        let candidate = resolved_str.replace(".js", replacement);
-        if file_exists(&candidate, known_files, root_dir) {
-            if let Ok(rel) = Path::new(&candidate).strip_prefix(root) {
-                return Some(normalize_path(&rel.display().to_string()));
+    for (from, targets) in EMIT_EXTENSION_REMAPS {
+        // strip_suffix anchors to the actual end of the string — `resolved_str.replace(from, ...)`
+        // would rewrite every occurrence of `from`, corrupting paths where an
+        // earlier segment happens to contain the same substring (e.g. a
+        // directory literally named `utils.js`).
+        let Some(stem) = resolved_str.strip_suffix(from) else {
+            continue;
+        };
+        for target in *targets {
+            let candidate = format!("{stem}{target}");
+            if file_exists(&candidate, known_files, root_dir) {
+                if let Ok(rel) = Path::new(&candidate).strip_prefix(root) {
+                    return Some(normalize_path(&rel.display().to_string()));
+                }
+                // candidate exists but is outside root_dir — keep probing
             }
-            // candidate exists but is outside root_dir — keep probing
         }
     }
     None
@@ -1781,6 +1797,67 @@ mod tests {
             None,
         );
         assert_eq!(result, "src/utils.ts");
+    }
+
+    #[test]
+    fn resolve_mjs_to_mts_remap_with_known_files() {
+        // #2299: TypeScript's NodeNext/Node16 module resolution requires the
+        // *emitted* extension in relative specifiers — a `.mts` source is
+        // imported via `.mjs`, not `.mts` — mirroring the existing `.js` →
+        // `.ts`/`.tsx` remap for the same reason.
+        let mut known = HashSet::new();
+        known.insert("src/utils.mts".to_string());
+
+        let aliases = PathAliases {
+            base_url: None,
+            paths: vec![],
+        };
+
+        let result = resolve_import_path_inner(
+            "/project/src/index.mts",
+            "./utils.mjs",
+            "/project",
+            &aliases,
+            Some(&known),
+            None,
+        );
+        assert_eq!(result, "src/utils.mts");
+    }
+
+    #[test]
+    fn resolve_cjs_to_cts_remap_with_known_files() {
+        let mut known = HashSet::new();
+        known.insert("src/legacy.cts".to_string());
+
+        let aliases = PathAliases {
+            base_url: None,
+            paths: vec![],
+        };
+
+        let result = resolve_import_path_inner(
+            "/project/src/index.cts",
+            "./legacy.cjs",
+            "/project",
+            &aliases,
+            Some(&known),
+            None,
+        );
+        assert_eq!(result, "src/legacy.cts");
+    }
+
+    #[test]
+    fn probe_js_to_ts_remap_does_not_corrupt_a_path_with_an_earlier_js_substring() {
+        // Regression guard: the previous implementation used
+        // `resolved_str.replace(".js", replacement)`, which rewrites EVERY
+        // occurrence of the substring — including one in an earlier path
+        // segment (e.g. a directory literally named `utils.js`), not just the
+        // trailing extension. `strip_suffix` anchors to the actual end.
+        let mut known = HashSet::new();
+        known.insert("src/utils.js/index.ts".to_string());
+
+        let result =
+            probe_js_to_ts_remap("/project/src/utils.js/index.js", "/project", Some(&known));
+        assert_eq!(result, Some("src/utils.js/index.ts".to_string()));
     }
 
     // Regression tests for #1769: a fixed-depth "grandparent equality" check

--- a/src/domain/graph/resolve.ts
+++ b/src/domain/graph/resolve.ts
@@ -366,20 +366,32 @@ export function clearWorkspaceCache(): void {
 
 // ── JS → TS extension remap cache ───────────────────────────────────
 
-/** Cache: absolute .js path → remapped .ts/.tsx relative path (or null if no TS file exists). */
+/** Cache: absolute emitted-extension path → remapped TS-source relative path (or null if none exists). */
 const _jsToTsCache: Map<string, string | null> = new Map();
 
 /**
- * If `resolved` ends with `.js`, check whether a `.ts` or `.tsx` counterpart
- * exists on disk and return its relative path from `rootDir`.  Results are
- * cached for the lifetime of the process to avoid repeated stat calls in the
- * batch hot path.
+ * Extension pairs to probe when a resolved path uses TypeScript's required
+ * "emitted extension" convention in relative import specifiers: a `.ts`/
+ * `.tsx` source is imported via `.js`, a `.mts` source via `.mjs`, and a
+ * `.cts` source via `.cjs` (#2299).
+ */
+const EMIT_EXTENSION_REMAPS: ReadonlyArray<{ from: string; to: readonly string[] }> = [
+  { from: '.js', to: ['.ts', '.tsx'] },
+  { from: '.mjs', to: ['.mts'] },
+  { from: '.cjs', to: ['.cts'] },
+];
+
+/**
+ * If `resolved` ends with `.js`, `.mjs`, or `.cjs`, check whether the
+ * matching TS-source counterpart (see `EMIT_EXTENSION_REMAPS`) exists on disk
+ * and return its relative path from `rootDir`.  Results are cached for the
+ * lifetime of the process to avoid repeated stat calls in the batch hot path.
  *
- * The cache stores **absolute** `.ts`/`.tsx` paths (or `null`) so that the
- * same cached entry is correct regardless of which `rootDir` is passed — the
+ * The cache stores **absolute** remapped paths (or `null`) so that the same
+ * cached entry is correct regardless of which `rootDir` is passed — the
  * relative path is computed on every cache hit.  This is important for MCP
- * `--multi-repo` mode where the same absolute `.js` file may be resolved with
- * different `rootDir` values.
+ * `--multi-repo` mode where the same absolute emitted-extension file may be
+ * resolved with different `rootDir` values.
  *
  * Always returns a normalised relative path from `rootDir` — both the remap
  * branch and the fallback compute `path.relative(rootDir, abs)` to ensure a
@@ -387,7 +399,8 @@ const _jsToTsCache: Map<string, string | null> = new Map();
  * absolute or relative path.
  */
 function remapJsToTs(resolved: string, rootDir: string): string {
-  if (!resolved.endsWith('.js')) return resolved;
+  const remap = EMIT_EXTENSION_REMAPS.find((r) => resolved.endsWith(r.from));
+  if (!remap) return resolved;
   const abs = path.resolve(rootDir, resolved);
   if (_jsToTsCache.has(abs)) {
     const cachedAbs = _jsToTsCache.get(abs);
@@ -395,15 +408,13 @@ function remapJsToTs(resolved: string, rootDir: string): string {
       ? normalizePath(path.relative(rootDir, cachedAbs))
       : normalizePath(path.relative(rootDir, abs));
   }
-  const tsAbs = abs.replace(/\.js$/, '.ts');
-  if (fs.existsSync(tsAbs)) {
-    _jsToTsCache.set(abs, tsAbs);
-    return normalizePath(path.relative(rootDir, tsAbs));
-  }
-  const tsxAbs = abs.replace(/\.js$/, '.tsx');
-  if (fs.existsSync(tsxAbs)) {
-    _jsToTsCache.set(abs, tsxAbs);
-    return normalizePath(path.relative(rootDir, tsxAbs));
+  const stem = abs.slice(0, -remap.from.length);
+  for (const toExt of remap.to) {
+    const candidateAbs = stem + toExt;
+    if (fs.existsSync(candidateAbs)) {
+      _jsToTsCache.set(abs, candidateAbs);
+      return normalizePath(path.relative(rootDir, candidateAbs));
+    }
   }
   _jsToTsCache.set(abs, null);
   // Normalise fallback to relative to stay consistent with the remap branch —
@@ -1132,11 +1143,14 @@ function resolveImportPathJS(
   const dir = path.dirname(fromFile);
   const resolved = path.resolve(dir, importSource);
 
-  if (resolved.endsWith('.js')) {
-    const tsCandidate = resolved.replace(/\.js$/, '.ts');
-    if (fs.existsSync(tsCandidate)) return normalizePath(path.relative(rootDir, tsCandidate));
-    const tsxCandidate = resolved.replace(/\.js$/, '.tsx');
-    if (fs.existsSync(tsxCandidate)) return normalizePath(path.relative(rootDir, tsxCandidate));
+  for (const remap of EMIT_EXTENSION_REMAPS) {
+    if (!resolved.endsWith(remap.from)) continue;
+    const stem = resolved.slice(0, -remap.from.length);
+    for (const toExt of remap.to) {
+      const candidate = stem + toExt;
+      if (fs.existsSync(candidate)) return normalizePath(path.relative(rootDir, candidate));
+    }
+    break;
   }
 
   for (const ext of [

--- a/tests/integration/issue-2299-mjs-cjs-remap.test.ts
+++ b/tests/integration/issue-2299-mjs-cjs-remap.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Regression test for #2299: import resolution never remapped a `.mjs`/
+ * `.cjs` specifier to an actual `.mts`/`.cts` source file, unlike the
+ * existing `.js` → `.ts`/`.tsx` remap.
+ *
+ * TypeScript's NodeNext/Node16 module resolution requires the *emitted*
+ * extension in relative import specifiers, not the source extension: a
+ * `.mts` file is imported via `import './foo.mjs'` (not `'./foo.mts'`), and
+ * a `.cts` file's CJS output is `.cjs`. Before the fix, `remapJsToTs`
+ * (`src/domain/graph/resolve.ts`) and its native mirror
+ * `probe_js_to_ts_remap` (`crates/codegraph-core/src/domain/graph/resolve.rs`)
+ * only checked for a trailing `.js`, so `.mjs`/`.cjs` specifiers never got
+ * remapped — the resulting `calls` edge fell back to same-directory
+ * proximity scoring (confidence 0.7) instead of the 1.0 an import-aware
+ * match gets.
+ *
+ * Fixture mirrors the issue's own repro: `util.mts` exporting `greet`,
+ * imported by `index.mts` via `./util.mjs` (the `.mjs`/`.mts` pair), plus an
+ * analogous `.cjs`/`.cts` pair (`legacyUtil.cts` imported by `legacy.cts` via
+ * `./legacyUtil.cjs`) to cover both remaps independently.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+import type { EngineMode } from '../../src/types.js';
+
+const FIXTURE: Record<string, string> = {
+  'util.mts': `export function greet(): string {
+  return "hi";
+}
+`,
+  'index.mts': `import { greet } from './util.mjs';
+
+export function main(): string {
+  return greet();
+}
+`,
+  'legacyUtil.cts': `export function shout(): string {
+  return "HI";
+}
+`,
+  'legacy.cts': `import { shout } from './legacyUtil.cjs';
+
+export function legacyMain(): string {
+  return shout();
+}
+`,
+};
+
+const ENGINES: EngineMode[] = ['wasm', 'native'];
+
+describe.each(ENGINES)('.mjs/.cjs → .mts/.cts import resolution (#2299, %s)', (engine) => {
+  let tmpDir: string;
+  let callEdges: Array<{ src: string; tgt: string; tgt_file: string; confidence: number }>;
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2299-${engine}-`));
+    for (const [rel, content] of Object.entries(FIXTURE)) {
+      fs.writeFileSync(path.join(tmpDir, rel), content);
+    }
+    await buildGraph(tmpDir, { incremental: false, skipRegistry: true, engine });
+
+    const dbPath = path.join(tmpDir, '.codegraph', 'graph.db');
+    const db = new Database(dbPath, { readonly: true });
+    try {
+      callEdges = db
+        .prepare(
+          `SELECT n1.name AS src, n2.name AS tgt, n2.file AS tgt_file, e.confidence AS confidence
+           FROM edges e
+           JOIN nodes n1 ON e.source_id = n1.id
+           JOIN nodes n2 ON e.target_id = n2.id
+           WHERE e.kind = 'calls' AND n1.name IN ('main', 'legacyMain')
+           ORDER BY n1.name`,
+        )
+        .all() as Array<{ src: string; tgt: string; tgt_file: string; confidence: number }>;
+    } finally {
+      db.close();
+    }
+  }, 60_000);
+
+  afterAll(() => {
+    if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('resolves .mjs → .mts at import-aware confidence, not proximity fallback', () => {
+    expect(
+      callEdges,
+      `Expected a calls edge main -> greet at confidence 1.0.\nEdges: ${JSON.stringify(callEdges, null, 2)}`,
+    ).toContainEqual(
+      expect.objectContaining({
+        src: 'main',
+        tgt: 'greet',
+        tgt_file: 'util.mts',
+        confidence: 1.0,
+      }),
+    );
+  });
+
+  it('resolves .cjs → .cts at import-aware confidence, not proximity fallback', () => {
+    expect(
+      callEdges,
+      `Expected a calls edge legacyMain -> shout at confidence 1.0.\nEdges: ${JSON.stringify(callEdges, null, 2)}`,
+    ).toContainEqual(
+      expect.objectContaining({
+        src: 'legacyMain',
+        tgt: 'shout',
+        tgt_file: 'legacyUtil.cts',
+        confidence: 1.0,
+      }),
+    );
+  });
+});

--- a/tests/unit/resolve.test.ts
+++ b/tests/unit/resolve.test.ts
@@ -43,7 +43,11 @@ beforeAll(() => {
   //   src/lib/index.js (for directory index resolution)
   //   src/lib/helper.ts
   //   shared/core.ts   (for alias resolution)
+  //   src/esm/util.mts (for .mjs -> .mts remap, #2299)
+  //   src/cjs/legacy.cts (for .cjs -> .cts remap, #2299)
   fs.mkdirSync(path.join(tmpDir, 'src', 'lib'), { recursive: true });
+  fs.mkdirSync(path.join(tmpDir, 'src', 'esm'), { recursive: true });
+  fs.mkdirSync(path.join(tmpDir, 'src', 'cjs'), { recursive: true });
   fs.mkdirSync(path.join(tmpDir, 'shared'), { recursive: true });
 
   fs.writeFileSync(path.join(tmpDir, 'src', 'math.js'), 'export const add = (a, b) => a + b;');
@@ -58,6 +62,8 @@ beforeAll(() => {
   );
   fs.writeFileSync(path.join(tmpDir, 'src', 'lib', 'helper.ts'), 'export function helper() {}');
   fs.writeFileSync(path.join(tmpDir, 'shared', 'core.ts'), 'export const x = 1;');
+  fs.writeFileSync(path.join(tmpDir, 'src', 'esm', 'util.mts'), 'export const greet = () => "hi";');
+  fs.writeFileSync(path.join(tmpDir, 'src', 'cjs', 'legacy.cts'), 'export const x = 1;');
 });
 
 afterAll(() => {
@@ -88,6 +94,21 @@ describe('resolveImportPathJS', () => {
     const fromFile = path.join(tmpDir, 'src', 'index.js');
     const result = resolveImportPathJS(fromFile, './utils', tmpDir, null);
     expect(result).toMatch(/utils\.tsx$/);
+  });
+
+  it('resolves .mjs import to .mts file when .mts exists (#2299)', () => {
+    // TypeScript's NodeNext/Node16 module resolution requires the *emitted*
+    // extension in relative specifiers: a .mts source is imported via .mjs,
+    // not .mts — mirroring the .js -> .ts remap above for the same reason.
+    const fromFile = path.join(tmpDir, 'src', 'esm', 'index.mts');
+    const result = resolveImportPathJS(fromFile, './util.mjs', tmpDir, null);
+    expect(result).toMatch(/util\.mts$/);
+  });
+
+  it('resolves .cjs import to .cts file when .cts exists (#2299)', () => {
+    const fromFile = path.join(tmpDir, 'src', 'cjs', 'index.cts');
+    const result = resolveImportPathJS(fromFile, './legacy.cjs', tmpDir, null);
+    expect(result).toMatch(/legacy\.cts$/);
   });
 
   it('resolves directory to index.js', () => {


### PR DESCRIPTION
## Summary
- TypeScript's NodeNext/Node16 module resolution requires the *emitted* extension in relative import specifiers, not the source extension: a `.mts` file is imported via `'./foo.mjs'` (not `'./foo.mts'`), and a `.cts` file's CJS output is `.cjs`. `remapJsToTs` (TS) and `probe_js_to_ts_remap` (Rust) only checked for a trailing `.js`, so `.mjs`/`.cjs` specifiers never got remapped to their `.mts`/`.cts` source — the resulting `calls` edge fell back to same-directory proximity confidence (0.7) instead of the 1.0 an import-aware match gets.
- Generalizes both remap functions to a small extension-pair table covering `.js`→`.ts`/`.tsx`, `.mjs`→`.mts`, and `.cjs`→`.cts`, and extends the twin inline remap in `resolveImportPathJS`'s pure-JS fallback path the same way.
- Also fixes a latent bug in `probe_js_to_ts_remap` uncovered while extending it: it used `resolved_str.replace(".js", replacement)`, which rewrites *every* occurrence of the substring, not just the trailing extension — corrupting paths where an earlier segment happens to contain the same substring (e.g. a directory literally named `utils.js`). Now uses `strip_suffix`, anchored to the actual end of the string, matching the TS side's existing regex anchor.

## Scope note
While investigating, found that the *separate* extension-less resolution path (`import './foo'` probing a fixed extension list) is also missing `.mts`/`.cts` in both engines — filed separately as #2464, since it's a distinct code path from the emitted-extension remap this issue is about.

Closes #2299

## Test plan
- [x] New unit tests: 3 Rust tests (`.mjs`/`.cjs` remap + the `strip_suffix` regression guard), 2 TS unit tests (`resolveImportPathJS`), all confirmed to fail against the pre-fix code and pass against the fix (revert-and-confirm, including a full native-addon rebuild from reverted Rust source).
- [x] New dual-engine integration test `tests/integration/issue-2299-mjs-cjs-remap.test.ts`, mirroring the issue's own repro — confirmed to fail with confidence 0.7 on both engines pre-fix, pass with confidence 1.0 post-fix.
- [x] Full test suite (318 files / 5134 tests), full Rust suite (973/973): passing.
- [x] `npm run lint`, `cargo fmt -- --check`: clean.
- [x] Dual-engine parity (`node scripts/parity-compare.mjs --json`): `ok: true`.
- [x] `codegraph diff-impact --staged -T`: 21 callers across 5 files (expected — `remapJsToTs`/`resolveImportPathJS` are core resolution primitives; the actual behavior change is narrow, scoped to `.mjs`/`.cjs` specifiers only).