### PR TITLE
feat(cha): nudge codegraph info when an interface gains its first instantiated implementor

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,7 @@ codegraph build --no-incremental   # Force full rebuild
 
 - **After large refactors** (renames, moves, deleted files) — the reverse-dependency cascade handles most cases, but a full rebuild ensures nothing is stale
 - **If you suspect stale analysis data** — complexity or dataflow results for files you didn't directly edit won't update incrementally
+- **If `codegraph info` nudges you** — it flags when an interface gained its first instantiated implementor since the last full build, a narrow CHA/RTA dispatch-edge gap incremental rebuilds can't self-heal (see [incremental-builds.md](docs/guides/incremental-builds.md#known-limitation-an-interfaces-first-instantiated-implementor))
 - **Periodically** — if you rely heavily on `complexity`, `dataflow`, `roles --role dead`, or `communities` queries, run a full rebuild weekly or after major merges
 - **After upgrading codegraph** — engine, schema, or version changes trigger an automatic full rebuild, but if you skip versions you may want to force one
 

--- a/docs/guides/incremental-builds.md
+++ b/docs/guides/incremental-builds.md
@@ -41,6 +41,28 @@ The most important thing to understand: **complexity, dataflow, and CFG data for
 
 For most workflows — querying callers, checking impact, finding dead code — incremental builds are perfectly accurate. The staleness only matters for analysis-heavy queries (`complexity`, `dataflow`, `cfg`) on files that weren't directly modified.
 
+### Known limitation: an interface's first instantiated implementor
+
+There is one narrower, structural gap around virtual-dispatch resolution
+(CHA/RTA — the `cha`/`super-dispatch` edge techniques). The incremental CHA
+post-pass discovers callers to revisit by following *existing* `cha`/
+`super-dispatch` edges from some other implementor of a touched interface. If
+an interface had **zero instantiated implementors** when a caller's file was
+last parsed, that caller has no such edge anywhere in the graph — so when a
+later incremental rebuild gives the interface its *first* instantiated
+implementor, there's nothing for the post-pass to search from, and the
+caller is never revisited. Its dispatch edge to the new implementor stays
+silently missing until a full rebuild runs.
+
+`codegraph info` detects this automatically: it snapshots which interfaces
+have zero instantiated implementors at the end of every full build, and on
+a later run compares that snapshot against the current graph. If one of
+those interfaces has since gained an implementor, `info` prints a nudge to
+run `codegraph build --no-incremental` (issue #2315). This is a diagnostic
+only — closing the gap itself would need either a DB schema change to track
+unresolved-but-typed call sites, or an O(all-files) rescan per touched
+interface, both deferred pending a proven workload need.
+
 ---
 
 ## When to run a full rebuild

--- a/src/cli/commands/info.ts
+++ b/src/cli/commands/info.ts
@@ -11,28 +11,39 @@ const CHA_NUDGE_MAX_NAMED = 3;
  * when there's nothing to report.
  *
  * `raw` is the `cha_zero_implementor_interfaces` build_meta snapshot — a
- * JSON array of interface/base-class names that had ZERO instantiated
- * implementors as of the last FULL build (written by
+ * JSON array of `deriveZeroImplementorInterfaces` entries (bare names, or
+ * `${name}|${file}` composite keys for roots disambiguated via
+ * `implementorsByFile` — issue #2237) that had ZERO transitively-reachable
+ * instantiated implementors as of the last FULL build (written by
  * `persistChaZeroImplementorSnapshot` in `domain/graph/builder/stages/finalize.ts`,
  * and its sibling call site in `native-orchestrator.ts`'s all-Rust fast
  * path). This compares that snapshot against a FRESH `buildChaContextFromDb`
- * call against this same `db`. Any name present in the snapshot that now has
- * at least one instantiated implementor has gained one since that full
- * build: the one caller-discovery gap `findChaSiblingCallerFiles`
+ * call against this same `db`, via `hasInstantiatedImplementor` — the exact
+ * same file-scoped-preferred, transitive check `deriveZeroImplementorInterfaces`
+ * itself uses, so the write and read sides can never disagree on what "has
+ * an instantiated implementor" means (issue #2315, Greptile review PR #2473:
+ * the original bare-name, direct-children-only check could both miss a real
+ * transition and print a false nudge). Any entry that now has an
+ * instantiated implementor has gained one since that full build: the one
+ * caller-discovery gap `findChaSiblingCallerFiles`
  * (`domain/graph/builder/incremental.ts`) cannot close by searching existing
- * edges alone (issue #2315) — a caller typed against that interface may
- * still be missing its dispatch edge to the new implementor until a full
- * (non-incremental) rebuild runs.
+ * edges alone — a caller typed against that interface may still be missing
+ * its dispatch edge to the new implementor until a full (non-incremental)
+ * rebuild runs.
  *
  * `db` must still be open when this is called — it re-queries `nodes`/`edges`.
- * `buildChaContextFromDb` is passed in (rather than dynamically imported
- * here) so `printBuildMetadata` only pays for one dynamic import of
- * `cha.js` and reads `CHA_ZERO_IMPLEMENTOR_META_KEY` from the same module.
+ * `cha` bundles the three `cha.js` exports this needs (rather than importing
+ * them individually here) so `printBuildMetadata` only pays for one dynamic
+ * import of that module.
  */
 function buildChaZeroImplementorNudge(
   db: BetterSqlite3Database,
   raw: string | null,
-  buildChaContextFromDb: typeof import('../../domain/graph/builder/cha.js').buildChaContextFromDb,
+  cha: {
+    buildChaContextFromDb: typeof import('../../domain/graph/builder/cha.js').buildChaContextFromDb;
+    hasInstantiatedImplementor: typeof import('../../domain/graph/builder/cha.js').hasInstantiatedImplementor;
+    displayNameForZeroImplementorKey: typeof import('../../domain/graph/builder/cha.js').displayNameForZeroImplementorKey;
+  },
 ): string | null {
   if (!raw) return null;
   let snapshot: unknown;
@@ -44,12 +55,11 @@ function buildChaZeroImplementorNudge(
   }
   if (!Array.isArray(snapshot) || snapshot.length === 0) return null;
 
-  const chaCtx = buildChaContextFromDb(db);
-  const nowImplemented = snapshot.filter((name): name is string => {
-    if (typeof name !== 'string') return false;
-    const implementorNames = chaCtx.implementors.get(name);
-    return implementorNames?.some((cls) => chaCtx.instantiatedTypes.has(cls)) ?? false;
-  });
+  const chaCtx = cha.buildChaContextFromDb(db);
+  const nowImplemented = snapshot
+    .filter((key): key is string => typeof key === 'string')
+    .filter((key) => cha.hasInstantiatedImplementor(key, chaCtx))
+    .map((key) => cha.displayNameForZeroImplementorKey(key));
   if (nowImplemented.length === 0) return null;
 
   const plural = nowImplemented.length > 1;
@@ -118,9 +128,12 @@ export async function printBuildMetadata(
 ): Promise<void> {
   try {
     const { findDbPath, getBuildMeta, resolveBusyTimeoutMs } = await import('../../db/index.js');
-    const { buildChaContextFromDb, CHA_ZERO_IMPLEMENTOR_META_KEY } = await import(
-      '../../domain/graph/builder/cha.js'
-    );
+    const {
+      buildChaContextFromDb,
+      CHA_ZERO_IMPLEMENTOR_META_KEY,
+      hasInstantiatedImplementor,
+      displayNameForZeroImplementorKey,
+    } = await import('../../domain/graph/builder/cha.js');
     const Database = (await import('better-sqlite3')).default;
     const dbPath = findDbPath(opts.db as string | undefined);
     const fs = await import('node:fs');
@@ -132,11 +145,11 @@ export async function printBuildMetadata(
       const builtAt = getBuildMeta(db, 'built_at');
       const chaZeroImplementorRaw = getBuildMeta(db, CHA_ZERO_IMPLEMENTOR_META_KEY);
       // Computed while `db` is still open: buildChaZeroImplementorNudge re-queries it.
-      const chaNudge = buildChaZeroImplementorNudge(
-        db,
-        chaZeroImplementorRaw,
+      const chaNudge = buildChaZeroImplementorNudge(db, chaZeroImplementorRaw, {
         buildChaContextFromDb,
-      );
+        hasInstantiatedImplementor,
+        displayNameForZeroImplementorKey,
+      });
       db.close();
 
       if (buildEngine || buildVersion || builtAt) {

--- a/src/cli/commands/info.ts
+++ b/src/cli/commands/info.ts
@@ -1,7 +1,68 @@
 import { debug } from '../../infrastructure/logger.js';
 import { toErrorMessage } from '../../shared/errors.js';
-import type { NativeAddon } from '../../types.js';
+import type { BetterSqlite3Database, NativeAddon } from '../../types.js';
 import type { CliContext, CommandDefinition, CommandOpts } from '../types.js';
+
+/** Max interface names to print by name in the CHA-zero-implementor nudge before falling back to a count. */
+const CHA_NUDGE_MAX_NAMED = 3;
+
+/**
+ * Build the CHA-zero-implementor nudge line for `codegraph info`, or `null`
+ * when there's nothing to report.
+ *
+ * `raw` is the `cha_zero_implementor_interfaces` build_meta snapshot — a
+ * JSON array of interface/base-class names that had ZERO instantiated
+ * implementors as of the last FULL build (written by
+ * `persistChaZeroImplementorSnapshot` in `domain/graph/builder/stages/finalize.ts`,
+ * and its sibling call site in `native-orchestrator.ts`'s all-Rust fast
+ * path). This compares that snapshot against a FRESH `buildChaContextFromDb`
+ * call against this same `db`. Any name present in the snapshot that now has
+ * at least one instantiated implementor has gained one since that full
+ * build: the one caller-discovery gap `findChaSiblingCallerFiles`
+ * (`domain/graph/builder/incremental.ts`) cannot close by searching existing
+ * edges alone (issue #2315) — a caller typed against that interface may
+ * still be missing its dispatch edge to the new implementor until a full
+ * (non-incremental) rebuild runs.
+ *
+ * `db` must still be open when this is called — it re-queries `nodes`/`edges`.
+ * `buildChaContextFromDb` is passed in (rather than dynamically imported
+ * here) so `printBuildMetadata` only pays for one dynamic import of
+ * `cha.js` and reads `CHA_ZERO_IMPLEMENTOR_META_KEY` from the same module.
+ */
+function buildChaZeroImplementorNudge(
+  db: BetterSqlite3Database,
+  raw: string | null,
+  buildChaContextFromDb: typeof import('../../domain/graph/builder/cha.js').buildChaContextFromDb,
+): string | null {
+  if (!raw) return null;
+  let snapshot: unknown;
+  try {
+    snapshot = JSON.parse(raw);
+  } catch (e) {
+    debug(`cha_zero_implementor_interfaces build_meta is not valid JSON: ${toErrorMessage(e)}`);
+    return null;
+  }
+  if (!Array.isArray(snapshot) || snapshot.length === 0) return null;
+
+  const chaCtx = buildChaContextFromDb(db);
+  const nowImplemented = snapshot.filter((name): name is string => {
+    if (typeof name !== 'string') return false;
+    const implementorNames = chaCtx.implementors.get(name);
+    return implementorNames?.some((cls) => chaCtx.instantiatedTypes.has(cls)) ?? false;
+  });
+  if (nowImplemented.length === 0) return null;
+
+  const plural = nowImplemented.length > 1;
+  const named =
+    nowImplemented.length <= CHA_NUDGE_MAX_NAMED
+      ? nowImplemented.join(', ')
+      : `${nowImplemented.length} interfaces`;
+  return (
+    `  \u26A0 ${named} gained ${plural ? 'their' : 'its'} first instantiated implementor since ` +
+    `the last full build; existing callers may be missing dispatch edges. ` +
+    `Consider: codegraph build --no-incremental`
+  );
+}
 
 /** Print the "Native version" diagnostic line (reconciles npm package vs. loaded binary version). */
 function printNativeVersionInfo(
@@ -57,6 +118,9 @@ export async function printBuildMetadata(
 ): Promise<void> {
   try {
     const { findDbPath, getBuildMeta, resolveBusyTimeoutMs } = await import('../../db/index.js');
+    const { buildChaContextFromDb, CHA_ZERO_IMPLEMENTOR_META_KEY } = await import(
+      '../../domain/graph/builder/cha.js'
+    );
     const Database = (await import('better-sqlite3')).default;
     const dbPath = findDbPath(opts.db as string | undefined);
     const fs = await import('node:fs');
@@ -66,6 +130,13 @@ export async function printBuildMetadata(
       const buildEngine = getBuildMeta(db, 'engine');
       const buildVersion = getBuildMeta(db, 'codegraph_version');
       const builtAt = getBuildMeta(db, 'built_at');
+      const chaZeroImplementorRaw = getBuildMeta(db, CHA_ZERO_IMPLEMENTOR_META_KEY);
+      // Computed while `db` is still open: buildChaZeroImplementorNudge re-queries it.
+      const chaNudge = buildChaZeroImplementorNudge(
+        db,
+        chaZeroImplementorRaw,
+        buildChaContextFromDb,
+      );
       db.close();
 
       if (buildEngine || buildVersion || builtAt) {
@@ -87,6 +158,7 @@ export async function printBuildMetadata(
             `  \u26A0 DB was built with ${buildEngine} engine, active is ${activeName}. Consider: codegraph build --no-incremental`,
           );
         }
+        if (chaNudge) console.log(chaNudge);
         console.log();
       }
     }

--- a/src/domain/graph/builder/cha.ts
+++ b/src/domain/graph/builder/cha.ts
@@ -295,6 +295,61 @@ export function buildChaContextFromDb(db: BetterSqlite3Database): ChaContext {
   return { implementors, implementorsByFile, parents, parentsByFile, instantiatedTypes };
 }
 
+/**
+ * build_meta key for the CHA-zero-implementor snapshot (issue #2315).
+ * JSON-encoded array of interface/base-class names. Written by
+ * `persistChaZeroImplementorSnapshot` in both `builder/stages/finalize.ts`
+ * (WASM/JS full-build path, and any native full build that reaches
+ * `finalize()`) and `builder/stages/native-orchestrator.ts`'s
+ * `tryNativeOrchestrator` (the all-Rust fast path that otherwise bypasses
+ * `finalize()` entirely) — shared here as the single source of truth so
+ * both writers and `codegraph info`'s reader (`cli/commands/info.ts`) never
+ * drift out of sync on the literal key name.
+ */
+export const CHA_ZERO_IMPLEMENTOR_META_KEY = 'cha_zero_implementor_interfaces';
+
+/**
+ * Given a `ChaContext`, return the interface/base-class names that currently
+ * have ZERO instantiated implementors — i.e. every entry in
+ * `implementors.get(name)` is absent from `instantiatedTypes`.
+ *
+ * Pure: takes a plain `ChaContext` and returns plain data, independent of
+ * where that context came from (in-memory full build or `buildChaContextFromDb`)
+ * — trivial to unit test with hand-built fixtures.
+ *
+ * Used for the CHA-zero-implementor health check (issue #2315):
+ * `findChaSiblingCallerFiles` (`builder/incremental.ts`) discovers callers to
+ * revisit during an INCREMENTAL rebuild by following EXISTING `cha`/
+ * `super-dispatch` edges from some *other* implementor of a touched
+ * interface. If an interface had zero instantiated implementors when a
+ * caller's file was last parsed, that caller has no such edge anywhere in
+ * the DB — so when a later incremental rebuild gives the interface its
+ * FIRST instantiated implementor, there is nothing for
+ * `findChaSiblingCallerFiles` to search from, and the caller is never
+ * revisited. The caller's dispatch edge to the new implementor then stays
+ * silently missing until a full (non-incremental) rebuild.
+ *
+ * This function only *detects* the zero-implementor set for snapshotting —
+ * it does not close that gap (see the issue for why: a real fix needs either
+ * a schema change to persist unresolved-but-typed call sites, or an
+ * O(all-files) rescan per touched interface, both explicitly deferred
+ * pending a proven workload need). `persistChaZeroImplementorSnapshot`
+ * (`builder/stages/finalize.ts`) snapshots this set into `build_meta` at the
+ * end of every FULL build; `codegraph info` (`cli/commands/info.ts`) compares
+ * that snapshot against a fresh call to detect the transition and nudge a
+ * full rebuild.
+ */
+export function deriveZeroImplementorInterfaces(ctx: ChaContext): string[] {
+  const result: string[] = [];
+  for (const [name, implementorNames] of ctx.implementors) {
+    const hasInstantiatedImplementor = implementorNames.some((cls) =>
+      ctx.instantiatedTypes.has(cls),
+    );
+    if (!hasInstantiatedImplementor) result.push(name);
+  }
+  return result;
+}
+
 // ── this / self / super resolution ──────────────────────────────────────────
 
 /**

--- a/src/domain/graph/builder/cha.ts
+++ b/src/domain/graph/builder/cha.ts
@@ -309,9 +309,100 @@ export function buildChaContextFromDb(db: BetterSqlite3Database): ChaContext {
 export const CHA_ZERO_IMPLEMENTOR_META_KEY = 'cha_zero_implementor_interfaces';
 
 /**
- * Given a `ChaContext`, return the interface/base-class names that currently
- * have ZERO instantiated implementors — i.e. every entry in
- * `implementors.get(name)` is absent from `instantiatedTypes`.
+ * Parse a zero-implementor snapshot entry (see `deriveZeroImplementorInterfaces`)
+ * back into its name and, when file-scoped, its declaring file. Mirrors the
+ * `${name}|${file}` composite-key convention `implementorsByFile`/`parentsByFile`
+ * already use elsewhere in this module (issue #2237) — a bare name (no `|`)
+ * means the root was never disambiguated to a specific file (issue #2315).
+ */
+function parseZeroImplementorKey(key: string): { name: string; file: string | null } {
+  const sep = key.indexOf('|');
+  return sep === -1
+    ? { name: key, file: null }
+    : { name: key.slice(0, sep), file: key.slice(sep + 1) };
+}
+
+/**
+ * BFS over `implementors`/`implementorsByFile` starting from `rootName`
+ * (scoped to `rootFile` when known), collecting every transitively reachable
+ * class name. Mirrors `resolveChaTargets`'s own traversal — same
+ * file-scoped-preferred-with-bare-fallback semantics at every step (a child
+ * discovered only through the bare map has an unknown file, so its own
+ * children keep resolving through the bare map too — legitimate multi-file
+ * hierarchies must keep working, see `resolveChaTargets`'s doc comment), and
+ * the same requirement to keep traversing non-instantiated classes since
+ * they may have instantiated subclasses (e.g. `IFoo → AbstractFoo →
+ * ConcreteFoo`) — without method resolution, since callers here only need
+ * the reachable set itself, not a dispatch target (issue #2315, Greptile
+ * review PR #2473: the original direct-children-only check missed exactly
+ * this transitive case).
+ */
+function collectTransitiveImplementors(
+  rootName: string,
+  rootFile: string | null,
+  ctx: ChaContext,
+): ReadonlySet<string> {
+  const reachable = new Set<string>();
+  const queue: Array<{ name: string; file: string | null }> = [{ name: rootName, file: rootFile }];
+  const visited = new Set<string>([rootName]);
+  while (queue.length > 0) {
+    const { name: current, file: currentFile } = queue.shift()!;
+    const scoped = currentFile
+      ? ctx.implementorsByFile.get(`${current}|${currentFile}`)
+      : undefined;
+    const children = scoped ?? ctx.implementors.get(current);
+    const childFile = scoped ? currentFile : null;
+    if (!children?.length) continue;
+    for (const cls of children) {
+      if (visited.has(cls)) continue;
+      visited.add(cls);
+      reachable.add(cls);
+      queue.push({ name: cls, file: childFile });
+    }
+  }
+  return reachable;
+}
+
+/**
+ * Whether the root identified by `key` (a `deriveZeroImplementorInterfaces`
+ * entry — bare name, or `${name}|${file}`) currently has at least one
+ * transitively-reachable instantiated implementor. Shared by the write side
+ * (`deriveZeroImplementorInterfaces` below) and the read side (`codegraph
+ * info`'s `buildChaZeroImplementorNudge`, `cli/commands/info.ts`) so both
+ * derive "has an instantiated implementor" the exact same way — issue #2315.
+ */
+export function hasInstantiatedImplementor(key: string, ctx: ChaContext): boolean {
+  const { name, file } = parseZeroImplementorKey(key);
+  const reachable = collectTransitiveImplementors(name, file, ctx);
+  for (const cls of reachable) {
+    if (ctx.instantiatedTypes.has(cls)) return true;
+  }
+  return false;
+}
+
+/**
+ * Display name for a zero-implementor snapshot entry — strips the
+ * `|${file}` file-scope suffix, if any, for user-facing output.
+ */
+export function displayNameForZeroImplementorKey(key: string): string {
+  return parseZeroImplementorKey(key).name;
+}
+
+/**
+ * Given a `ChaContext`, return identifiers for every interface/base-class
+ * root that currently has ZERO transitively-reachable instantiated
+ * implementors.
+ *
+ * Each root is identified by a bare name (never disambiguated to a specific
+ * file — the same "legitimate multi-file hierarchy, file identity unknown"
+ * fallback `resolveChaTargets` itself falls back to) or a `${name}|${file}`
+ * composite key (disambiguated via `implementorsByFile`, exactly as
+ * `resolveChaTargets` prefers when a child's own file also locally declares
+ * a same-named parent — issue #2237). Checking every DISTINCT
+ * `implementorsByFile` entry as its own root, rather than merging everything
+ * under one bare-name bucket, is what avoids a false transition (or a missed
+ * one) when two unrelated files each declare their own same-named interface
+ * with independent implementors (issue #2315, Greptile review PR #2473).
  *
  * Pure: takes a plain `ChaContext` and returns plain data, independent of
  * where that context came from (in-memory full build or `buildChaContextFromDb`)
@@ -340,12 +431,22 @@ export const CHA_ZERO_IMPLEMENTOR_META_KEY = 'cha_zero_implementor_interfaces';
  * full rebuild.
  */
 export function deriveZeroImplementorInterfaces(ctx: ChaContext): string[] {
+  const roots: string[] = [];
+  const scopedRootNames = new Set<string>();
+  for (const key of ctx.implementorsByFile.keys()) {
+    scopedRootNames.add(parseZeroImplementorKey(key).name);
+    roots.push(key);
+  }
+  // Bare-name roots that were NEVER disambiguated to a specific file for ANY
+  // caller — the only remaining source of the cross-file bare-name ambiguity
+  // this function must accept (matches resolveChaTargets's own fallback).
+  for (const name of ctx.implementors.keys()) {
+    if (!scopedRootNames.has(name)) roots.push(name);
+  }
+
   const result: string[] = [];
-  for (const [name, implementorNames] of ctx.implementors) {
-    const hasInstantiatedImplementor = implementorNames.some((cls) =>
-      ctx.instantiatedTypes.has(cls),
-    );
-    if (!hasInstantiatedImplementor) result.push(name);
+  for (const key of roots) {
+    if (!hasInstantiatedImplementor(key, ctx)) result.push(key);
   }
   return result;
 }

--- a/src/domain/graph/builder/stages/finalize.ts
+++ b/src/domain/graph/builder/stages/finalize.ts
@@ -17,6 +17,11 @@ import { computeConfigHash } from '../../../../infrastructure/config.js';
 import { debug, info, warn } from '../../../../infrastructure/logger.js';
 import { CODEGRAPH_VERSION } from '../../../../shared/version.js';
 import { writeJournalHeader } from '../../journal.js';
+import {
+  buildChaContextFromDb,
+  CHA_ZERO_IMPLEMENTOR_META_KEY,
+  deriveZeroImplementorInterfaces,
+} from '../cha.js';
 import type { PipelineContext } from '../context.js';
 
 /** Release cached WASM parse trees to free memory. */
@@ -137,6 +142,71 @@ function persistBuildMetadata(
     }
   } catch (err) {
     warn(`Failed to write build metadata: ${(err as Error).message}`);
+  }
+}
+
+/**
+ * Snapshot which interfaces/base classes currently have ZERO instantiated
+ * implementors, for `codegraph info`'s CHA-zero-implementor nudge (#2315).
+ *
+ * NOT the only call site: `tryNativeOrchestrator` (`native-orchestrator.ts`)
+ * runs an entirely separate, all-Rust "fast path" (#695) that bypasses the
+ * rest of the JS pipeline — including this `finalize()` stage — whenever it
+ * succeeds. That function has its own copy of this same snapshot logic,
+ * gated on its own `result.isFullBuild`, right after its own CHA/dispatch
+ * post-passes commit their edges. This one only fires for builds that
+ * actually reach `finalize()`: the plain WASM/JS full-build path, or a
+ * native build where `tryNativeOrchestrator` fails/falls back to the JS
+ * pipeline (in which case `useNativeDb` below can still be true if native
+ * acceleration remains active for individual stages).
+ *
+ * Only meaningful as of a FULL build — skipped entirely otherwise. The
+ * incremental CHA post-pass (`findChaSiblingCallerFiles`, `builder/incremental.ts`)
+ * discovers callers to revisit by following EXISTING `cha`/`super-dispatch`
+ * edges from some *other* implementor of a touched interface; a caller typed
+ * against an interface that had zero instantiated implementors as of the
+ * last full build has no such edge anywhere in the DB, so if that interface
+ * gains its FIRST instantiated implementor mid-incremental-session, the
+ * caller is never revisited and its dispatch edge to the new implementor can
+ * stay silently missing until a full rebuild runs. This snapshot is what
+ * lets `codegraph info` detect that specific transition later — comparing
+ * "current state" against "state as of the last FULL build" is only valid
+ * when this key is written on full builds alone; writing it on an
+ * incremental build would corrupt that comparison.
+ *
+ * Recomputed via `buildChaContextFromDb` against `ctx.db` rather than reused
+ * from any in-memory `ChaContext` built earlier in this same pipeline run —
+ * neither the WASM/JS full-build path (`buildChaContext` in `build-edges.ts`)
+ * nor the native orchestrator's own CHA post-pass keeps that context
+ * reachable from `PipelineContext` once edges are committed, and by this
+ * point in `finalize()` all edges (including CHA/RTA dispatch edges, from
+ * either engine) are already committed and visible to `ctx.db` — the WAL
+ * checkpoint + `refreshJsDb` right before `finalize()` runs guarantee that.
+ * Re-deriving from the DB is two cheap SQL queries (the same primitive the
+ * incremental rebuild path already relies on for the same reason, #1852) —
+ * negligible next to a full build's parse cost, and correct regardless of
+ * which engine wrote the graph, since the schema itself is engine-agnostic.
+ * It also keeps the write side and `codegraph info`'s later read side
+ * (`buildChaZeroImplementorNudge` in `cli/commands/info.ts`) computing the
+ * zero-implementor set the exact same way, from the exact same source of
+ * truth — reusing the pre-edge-insertion in-memory `ChaContext` here instead
+ * would risk a subtle mismatch against the DB-derived state the read side
+ * checks against later.
+ */
+function persistChaZeroImplementorSnapshot(ctx: PipelineContext): void {
+  if (!ctx.isFullBuild) return;
+  const useNativeDb = ctx.engineName === 'native' && !!ctx.nativeDb;
+  try {
+    const chaCtx = buildChaContextFromDb(ctx.db);
+    const zeroImplementorNames = deriveZeroImplementorInterfaces(chaCtx);
+    const value = JSON.stringify(zeroImplementorNames);
+    if (useNativeDb) {
+      ctx.nativeDb!.setBuildMeta([{ key: CHA_ZERO_IMPLEMENTOR_META_KEY, value }]);
+    } else {
+      setBuildMeta(ctx.db, { [CHA_ZERO_IMPLEMENTOR_META_KEY]: value });
+    }
+  } catch (err) {
+    warn(`Failed to write CHA zero-implementor snapshot: ${(err as Error).message}`);
   }
 }
 
@@ -267,6 +337,7 @@ export async function finalize(ctx: PipelineContext): Promise<void> {
 
   detectIncrementalDrift(ctx, nodeCount, actualEdgeCount);
   persistBuildMetadata(ctx, nodeCount, actualEdgeCount, buildNow);
+  persistChaZeroImplementorSnapshot(ctx);
 
   // Skip expensive advisory queries for incremental builds — these are
   // informational warnings that don't affect correctness and cost ~40-60ms.

--- a/src/domain/graph/builder/stages/native-orchestrator.ts
+++ b/src/domain/graph/builder/stages/native-orchestrator.ts
@@ -50,7 +50,12 @@ import { isConstructorMethodSuffix, type ResolvedCandidate } from '../../resolve
 import type { CallNodeLookup } from '../call-resolver.js';
 import { RECEIVER_KINDS, resolveDefinePropertyAccessorTarget } from '../call-resolver.js';
 import type { ChaContext } from '../cha.js';
-import { resolveThisDispatch } from '../cha.js';
+import {
+  buildChaContextFromDb,
+  CHA_ZERO_IMPLEMENTOR_META_KEY,
+  deriveZeroImplementorInterfaces,
+  resolveThisDispatch,
+} from '../cha.js';
 import type { PipelineContext } from '../context.js';
 import {
   batchInsertEdges,
@@ -2730,6 +2735,40 @@ class NativeOrchestrationSession {
 }
 
 /**
+ * Snapshot which interfaces/base classes currently have ZERO instantiated
+ * implementors, for `codegraph info`'s CHA-zero-implementor nudge (#2315).
+ *
+ * Sibling of `persistChaZeroImplementorSnapshot` in `builder/stages/finalize.ts`
+ * — same key, same derivation, same "full builds only" gating, same
+ * rationale (see that function's doc comment for the full explanation of
+ * the gap this snapshot exists to make visible). A separate copy is needed
+ * here because `tryNativeOrchestrator`'s all-Rust fast path (#695) returns
+ * its `BuildResult` directly and never reaches `finalize()` — so `finalize.ts`'s
+ * copy of this logic is simply never called on that path.
+ *
+ * Called after `runPostNativePasses` so CHA/RTA dispatch edges (from the
+ * `cha` post-pass, backfill, and this/super dispatch) are already committed
+ * and visible on `ctx.db` — mirroring `finalize.ts`'s own timing requirement.
+ * Uses the plain JS `setBuildMeta(ctx.db, ...)` write (no `useNativeDb`
+ * branch): by this point in the function `ctx.db` is already guaranteed to
+ * be a proper better-sqlite3 connection (see the "DB handoff" comment above
+ * this call site), matching this file's own existing precedent for writing
+ * build_meta post-handoff (the `engine`/`built_at` sync a few dozen lines up).
+ */
+function persistChaZeroImplementorSnapshotNative(ctx: PipelineContext, isFullBuild: boolean): void {
+  if (!isFullBuild) return;
+  try {
+    const chaCtx = buildChaContextFromDb(ctx.db);
+    const zeroImplementorNames = deriveZeroImplementorInterfaces(chaCtx);
+    setBuildMeta(ctx.db, {
+      [CHA_ZERO_IMPLEMENTOR_META_KEY]: JSON.stringify(zeroImplementorNames),
+    });
+  } catch (err) {
+    warn(`Failed to write CHA zero-implementor snapshot: ${toErrorMessage(err)}`);
+  }
+}
+
+/**
  * Try the native build orchestrator.
  *
  * Returns:
@@ -2844,6 +2883,13 @@ export async function tryNativeOrchestrator(
   }
 
   const postPassTimings = await runPostNativePasses(ctx, result);
+
+  // Snapshot CHA-zero-implementor interfaces for `codegraph info`'s nudge
+  // (#2315) — must run after runPostNativePasses (CHA/RTA dispatch edges
+  // just committed above) and only for full builds; see the function's own
+  // doc comment for why finalize.ts's copy of this logic can't cover this
+  // all-Rust fast path.
+  persistChaZeroImplementorSnapshotNative(ctx, !!result.isFullBuild);
 
   // ── Structure and analysis fallback (run after edge-writing so roles see full graph) ──
   // Reconstruct fileSymbols once for both structure and analysis to avoid two

--- a/src/domain/graph/builder/stages/native-orchestrator.ts
+++ b/src/domain/graph/builder/stages/native-orchestrator.ts
@@ -2750,10 +2750,19 @@ class NativeOrchestrationSession {
  * `cha` post-pass, backfill, and this/super dispatch) are already committed
  * and visible on `ctx.db` — mirroring `finalize.ts`'s own timing requirement.
  * Uses the plain JS `setBuildMeta(ctx.db, ...)` write (no `useNativeDb`
- * branch): by this point in the function `ctx.db` is already guaranteed to
- * be a proper better-sqlite3 connection (see the "DB handoff" comment above
- * this call site), matching this file's own existing precedent for writing
- * build_meta post-handoff (the `engine`/`built_at` sync a few dozen lines up).
+ * branch): `ctx.db` is NOT necessarily a real better-sqlite3 connection at
+ * this exact call site — `ensureJsDbForPostPasses` (called above, before
+ * `runPostNativePasses`) only reopens/hands off the connection when
+ * `needsStructure || needsAnalysisFallback`; when neither is needed it
+ * returns `true` without touching `ctx.db`, which can still be the
+ * `NativeDbProxy` from the earlier native build. That's fine here: both
+ * `buildChaContextFromDb`'s `.prepare().all()` reads and `setBuildMeta`'s
+ * `.prepare().run()` write are part of `NativeDbProxy`'s own implemented
+ * `BetterSqlite3Database` interface (`builder/native-db-proxy.ts`) — this
+ * function only needs that shared interface, never a real-better-sqlite3-
+ * only API like `.prepare().iterate()` (which the proxy explicitly does not
+ * support), so it works correctly through either connection type (Greptile
+ * review, PR #2473).
  */
 function persistChaZeroImplementorSnapshotNative(ctx: PipelineContext, isFullBuild: boolean): void {
   if (!isFullBuild) return;

--- a/tests/integration/issue-2315-cha-zero-implementor-nudge.test.ts
+++ b/tests/integration/issue-2315-cha-zero-implementor-nudge.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Regression test for #2315: a follow-up to #2078/#2314 flagged by Greptile.
+ *
+ * `findChaSiblingCallerFiles` (`applyChaDispatchPostPass`,
+ * `src/domain/graph/builder/incremental.ts`) discovers callers to revisit
+ * during an INCREMENTAL rebuild by following EXISTING `cha`/`super-dispatch`
+ * edges pointing at some other implementor of a touched interface. If an
+ * interface had ZERO instantiated implementors when a caller's file was
+ * last parsed, that caller has no such edge anywhere in the DB — so when a
+ * later incremental rebuild gives the interface its FIRST instantiated
+ * implementor, there is nothing for the post-pass to search from, and the
+ * caller is never revisited. Its dispatch edge to the new implementor stays
+ * silently missing until a full (non-incremental) rebuild.
+ *
+ * The issue explicitly scopes the fix to a cheap, honest diagnostic instead
+ * of the two expensive correctness fixes (a new DB schema, or an
+ * O(all-files) rescan) — see the issue body for why. This test exercises
+ * that diagnostic end-to-end:
+ *
+ *   1. Full build a fixture where `IUncalled` has exactly one implementor
+ *      (`GhostImpl`) that is never instantiated — `codegraph info`'s
+ *      `cha_zero_implementor_interfaces` build_meta snapshot must capture it.
+ *   2. Add `RealImpl` — a NEW, self-instantiating `IUncalled` implementor —
+ *      via an INCREMENTAL single-file rebuild (`rebuildFile`, the exact
+ *      function `codegraph watch` calls per file-change event).
+ *   3. Call `printBuildMetadata` (the function behind `codegraph info`) and
+ *      assert it nudges the user to run `codegraph build --no-incremental`
+ *      because `IUncalled` gained its first instantiated implementor since
+ *      the last full build.
+ *
+ * This does NOT assert on (and does not fix) the underlying missing-edge
+ * gap itself — that remains out of scope per the issue. See
+ * `tests/integration/issue-2078-cha-sibling-caller.test.ts` for the sibling
+ * -caller-discovery mechanism this gap falls outside of.
+ *
+ * Console-spy note: `vi.spyOn(console, 'log')` must be set up in
+ * `beforeEach`/torn down in `afterEach` here, not inline inside an `it()`
+ * body — mirroring `tests/presentation/result-formatter.test.ts`'s established
+ * pattern. Vitest's own per-test console capture interacts with an inline
+ * spy+restore in a way that silently drops every call.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CliContext } from '../../src/cli/types.js';
+import { getBuildMeta, initSchema, openDb } from '../../src/db/index.js';
+import { buildChaContextFromDb } from '../../src/domain/graph/builder/cha.js';
+import { rebuildFile } from '../../src/domain/graph/builder/incremental.js';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+import { isNativeAvailable } from '../../src/infrastructure/native.js';
+import { CODEGRAPH_VERSION } from '../../src/shared/version.js';
+import type { EngineMode } from '../../src/types.js';
+import { createIncrementalStmts } from '../helpers/incremental-stmts.js';
+
+const IUNCALLED_SOURCE = `export interface IUncalled {
+  doThing(): string;
+}
+`;
+
+// Sole implementor at full-build time — declared but never instantiated
+// anywhere, so RTA excludes it from CHA dispatch targets and IUncalled ends
+// up with zero *instantiated* implementors despite having one implementor.
+const GHOST_IMPL_SOURCE = `import type { IUncalled } from './IUncalled.js';
+
+export class GhostImpl implements IUncalled {
+  doThing(): string {
+    return 'ghost';
+  }
+}
+`;
+
+// Typed parameter — typeMap will record x: IUncalled (confidence 0.9). CHA
+// would expand x.doThing() to every instantiated IUncalled implementor, but
+// at full-build time there are none, so this call site produces zero
+// cha/super-dispatch edges to seed later sibling-caller discovery from.
+const CALLER_SOURCE = `import type { IUncalled } from './IUncalled.js';
+
+export function callIt(x: IUncalled): string {
+  return x.doThing();
+}
+`;
+
+// Added mid-incremental-session: a brand-new, SELF-instantiating IUncalled
+// implementor — gives IUncalled its first instantiated implementor.
+const REAL_IMPL_SOURCE = `import type { IUncalled } from './IUncalled.js';
+
+export class RealImpl implements IUncalled {
+  doThing(): string {
+    return 'real';
+  }
+}
+
+// Self-contained RTA instantiation evidence.
+export function makeRealImpl(): RealImpl {
+  return new RealImpl();
+}
+`;
+
+function writeFixture(dir: string): void {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'IUncalled.ts'), IUNCALLED_SOURCE);
+  fs.writeFileSync(path.join(dir, 'GhostImpl.ts'), GHOST_IMPL_SOURCE);
+  fs.writeFileSync(path.join(dir, 'Caller.ts'), CALLER_SOURCE);
+}
+
+async function rebuildOneFile(dir: string, relFile: string, engine: EngineMode): Promise<void> {
+  const dbPath = path.join(dir, '.codegraph', 'graph.db');
+  const db = openDb(dbPath);
+  try {
+    initSchema(db);
+    const stmts = createIncrementalStmts(db);
+    await rebuildFile(db, dir, path.join(dir, relFile), stmts, { engine } as never, null);
+  } finally {
+    db.close();
+  }
+}
+
+function runScenario(engine: EngineMode): void {
+  describe(`codegraph info: CHA-zero-implementor nudge on first instantiated implementor (#2315) — ${engine}`, () => {
+    let tmpDir: string;
+    let dbPath: string;
+    let logSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeAll(async () => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2315-cha-zero-impl-${engine}-`));
+      dbPath = path.join(tmpDir, '.codegraph', 'graph.db');
+      writeFixture(tmpDir);
+      await buildGraph(tmpDir, { engine, incremental: false, skipRegistry: true });
+    }, 60_000);
+
+    afterAll(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    beforeEach(() => {
+      logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      logSpy.mockRestore();
+    });
+
+    async function printBuildMetadataOutput(): Promise<string> {
+      const { printBuildMetadata } = await import('../../src/cli/commands/info.js');
+      const ctx = { program: { version: () => CODEGRAPH_VERSION } } as unknown as CliContext;
+      await printBuildMetadata(ctx, { db: dbPath }, engine === 'native' ? 'native' : 'wasm');
+      return logSpy.mock.calls.map((args) => args.join(' ')).join('\n');
+    }
+
+    it('snapshots IUncalled as zero-implementor in build_meta after the full build', () => {
+      const db = openDb(dbPath);
+      try {
+        const raw = getBuildMeta(db, 'cha_zero_implementor_interfaces');
+        expect(raw, 'cha_zero_implementor_interfaces build_meta key was not written').toBeTruthy();
+        const snapshot = JSON.parse(raw as string) as string[];
+        expect(snapshot).toContain('IUncalled');
+      } finally {
+        db.close();
+      }
+    });
+
+    it('codegraph info prints the build metadata header, but no CHA nudge yet', async () => {
+      const output = await printBuildMetadataOutput();
+      expect(output).toContain('Build metadata');
+      expect(output).not.toContain('gained');
+    });
+
+    describe('after RealImpl is added via an INCREMENTAL rebuild', () => {
+      beforeAll(async () => {
+        fs.writeFileSync(path.join(tmpDir, 'RealImpl.ts'), REAL_IMPL_SOURCE);
+        await rebuildOneFile(tmpDir, 'RealImpl.ts', engine);
+      }, 60_000);
+
+      it('IUncalled now has an instantiated implementor per a fresh buildChaContextFromDb', () => {
+        const db = openDb(dbPath);
+        try {
+          const chaCtx = buildChaContextFromDb(db);
+          const implementors = chaCtx.implementors.get('IUncalled') ?? [];
+          expect(implementors).toContain('RealImpl');
+          expect(implementors.some((cls) => chaCtx.instantiatedTypes.has(cls))).toBe(true);
+        } finally {
+          db.close();
+        }
+      });
+
+      it('the build_meta snapshot itself is untouched by the incremental rebuild (still lists IUncalled as of the last full build)', () => {
+        const db = openDb(dbPath);
+        try {
+          const raw = getBuildMeta(db, 'cha_zero_implementor_interfaces');
+          const snapshot = JSON.parse(raw as string) as string[];
+          expect(snapshot).toContain('IUncalled');
+        } finally {
+          db.close();
+        }
+      });
+
+      it('codegraph info now nudges that IUncalled gained its first instantiated implementor', async () => {
+        const output = await printBuildMetadataOutput();
+        expect(output).toContain('IUncalled');
+        expect(output).toContain('gained');
+        expect(output).toContain('codegraph build --no-incremental');
+      });
+    });
+  });
+}
+
+runScenario('wasm');
+describe.skipIf(!isNativeAvailable())('native engine coverage', () => {
+  runScenario('native');
+});

--- a/tests/unit/cha.test.ts
+++ b/tests/unit/cha.test.ts
@@ -12,6 +12,7 @@ import { describe, expect, it } from 'vitest';
 import type { CallNodeLookup } from '../../src/domain/graph/builder/call-resolver.js';
 import {
   type ChaContext,
+  deriveZeroImplementorInterfaces,
   resolveChaTargets,
   resolveThisDispatch,
 } from '../../src/domain/graph/builder/cha.js';
@@ -434,5 +435,65 @@ describe('resolveChaTargets — inherited (non-overriding) method walk (issue #2
 
     const result = resolveChaTargets('Handler', 'run', chaCtx, lookup);
     expect(result).toEqual([]);
+  });
+});
+
+describe('deriveZeroImplementorInterfaces (issue #2315)', () => {
+  it('returns an interface whose only implementor is never instantiated', () => {
+    const chaCtx = makeChaTargetsCtx({
+      implementors: { IWorker: ['GhostWorker'] },
+      instantiatedTypes: [],
+    });
+
+    expect(deriveZeroImplementorInterfaces(chaCtx)).toEqual(['IWorker']);
+  });
+
+  it('excludes an interface that has at least one instantiated implementor', () => {
+    const chaCtx = makeChaTargetsCtx({
+      implementors: { IWorker: ['ConcreteWorker', 'GhostWorker'] },
+      instantiatedTypes: ['ConcreteWorker'],
+    });
+
+    expect(deriveZeroImplementorInterfaces(chaCtx)).toEqual([]);
+  });
+
+  it('reports only the zero-implementor interface among several', () => {
+    const chaCtx = makeChaTargetsCtx({
+      implementors: {
+        IWorker: ['ConcreteWorker'],
+        IShape: ['GhostShape'],
+        Handler: ['ConcreteHandler'],
+      },
+      instantiatedTypes: ['ConcreteWorker', 'ConcreteHandler'],
+    });
+
+    expect(deriveZeroImplementorInterfaces(chaCtx)).toEqual(['IShape']);
+  });
+
+  it('returns [] when every interface has an instantiated implementor', () => {
+    const chaCtx = makeChaTargetsCtx({
+      implementors: { IWorker: ['ConcreteWorker', 'MockWorker'] },
+      instantiatedTypes: ['ConcreteWorker', 'MockWorker'],
+    });
+
+    expect(deriveZeroImplementorInterfaces(chaCtx)).toEqual([]);
+  });
+
+  it('returns [] for an empty ChaContext', () => {
+    const chaCtx = makeChaTargetsCtx({});
+    expect(deriveZeroImplementorInterfaces(chaCtx)).toEqual([]);
+  });
+
+  it('treats a base class reached only via `extends` the same as an `implements` interface', () => {
+    // `implementors` also records extends-derived parent -> children (used
+    // for CHA dispatch expansion via inheritance, not just `implements`) —
+    // the zero-implementor check is agnostic to which heritage kind produced
+    // the entry.
+    const chaCtx = makeChaTargetsCtx({
+      implementors: { AbstractShape: ['Square'] },
+      instantiatedTypes: [],
+    });
+
+    expect(deriveZeroImplementorInterfaces(chaCtx)).toEqual(['AbstractShape']);
   });
 });

--- a/tests/unit/cha.test.ts
+++ b/tests/unit/cha.test.ts
@@ -13,6 +13,8 @@ import type { CallNodeLookup } from '../../src/domain/graph/builder/call-resolve
 import {
   type ChaContext,
   deriveZeroImplementorInterfaces,
+  displayNameForZeroImplementorKey,
+  hasInstantiatedImplementor,
   resolveChaTargets,
   resolveThisDispatch,
 } from '../../src/domain/graph/builder/cha.js';
@@ -495,5 +497,69 @@ describe('deriveZeroImplementorInterfaces (issue #2315)', () => {
     });
 
     expect(deriveZeroImplementorInterfaces(chaCtx)).toEqual(['AbstractShape']);
+  });
+
+  it('recognizes a transitively-instantiated descendant reached through an uninstantiated intermediate class (Greptile review, PR #2473)', () => {
+    // IWorker -> AbstractWorker (never instantiated) -> ConcreteWorker
+    // (instantiated). The original direct-children-only check saw only
+    // AbstractWorker under IWorker, found it uninstantiated, and stopped —
+    // never looking one level further to ConcreteWorker.
+    const chaCtx = makeChaTargetsCtx({
+      implementors: { IWorker: ['AbstractWorker'], AbstractWorker: ['ConcreteWorker'] },
+      instantiatedTypes: ['ConcreteWorker'],
+    });
+
+    expect(deriveZeroImplementorInterfaces(chaCtx)).toEqual([]);
+    expect(hasInstantiatedImplementor('IWorker', chaCtx)).toBe(true);
+  });
+
+  it('still reports zero when a transitive chain never reaches an instantiated class', () => {
+    const chaCtx = makeChaTargetsCtx({
+      implementors: { IWorker: ['AbstractWorker'], AbstractWorker: ['GhostWorker'] },
+      instantiatedTypes: [],
+    });
+
+    // AbstractWorker is itself a distinct root (a caller could be typed
+    // against it directly) that ALSO has zero instantiated implementors
+    // down its own chain — both it and IWorker are correctly reported.
+    expect(deriveZeroImplementorInterfaces(chaCtx).sort()).toEqual(['AbstractWorker', 'IWorker']);
+  });
+
+  it('disambiguates two unrelated files that each declare their own same-named interface (Greptile review, PR #2473)', () => {
+    // fileA.ts's IHandler has an uninstantiated implementor (GhostA);
+    // fileB.ts's unrelated IHandler has an instantiated one (ConcreteB).
+    // The bare `implementors` map merges both under one "IHandler" key —
+    // without implementorsByFile disambiguation, this would either report
+    // NO zero-implementor interface (a real transition on fileA's IHandler
+    // would then be silently missed) or incorrectly report one that already
+    // has an instantiated implementor via fileB (a false nudge).
+    const chaCtx = makeChaTargetsCtx({
+      implementors: { IHandler: ['GhostA', 'ConcreteB'] },
+      implementorsByFile: {
+        'IHandler|fileA.ts': ['GhostA'],
+        'IHandler|fileB.ts': ['ConcreteB'],
+      },
+      instantiatedTypes: ['ConcreteB'],
+    });
+
+    const result = deriveZeroImplementorInterfaces(chaCtx);
+    expect(result).toEqual(['IHandler|fileA.ts']);
+    expect(hasInstantiatedImplementor('IHandler|fileA.ts', chaCtx)).toBe(false);
+    expect(hasInstantiatedImplementor('IHandler|fileB.ts', chaCtx)).toBe(true);
+    expect(displayNameForZeroImplementorKey('IHandler|fileA.ts')).toBe('IHandler');
+  });
+
+  it("detects the transition once fileA.ts's IHandler gains its own instantiated implementor", () => {
+    const chaCtx = makeChaTargetsCtx({
+      implementors: { IHandler: ['RealA', 'ConcreteB'] },
+      implementorsByFile: {
+        'IHandler|fileA.ts': ['RealA'],
+        'IHandler|fileB.ts': ['ConcreteB'],
+      },
+      instantiatedTypes: ['RealA', 'ConcreteB'],
+    });
+
+    expect(deriveZeroImplementorInterfaces(chaCtx)).toEqual([]);
+    expect(hasInstantiatedImplementor('IHandler|fileA.ts', chaCtx)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

The incremental CHA post-pass (`findChaSiblingCallerFiles`, `src/domain/graph/builder/incremental.ts`) discovers callers to revisit by following EXISTING `cha`/`super-dispatch` edges from some other implementor of a touched interface. If an interface had zero instantiated implementors when a caller's file was last parsed, that caller has no such edge anywhere in the DB — so when a later incremental rebuild gives the interface its first instantiated implementor, there's nothing to search from, and the caller is never revisited. Its dispatch edge to the new implementor can stay silently missing until a full rebuild.

Per the issue, closing this gap outright needs either a schema change (persist unresolved-but-typed call sites) or an O(all-files) rescan per touched interface — both explicitly deferred pending a proven workload need. This PR implements the recommended cheap alternative instead:

- Snapshots which interfaces/base classes have zero instantiated implementors into a new `build_meta` key (`cha_zero_implementor_interfaces`) at the end of every FULL build — both the JS/WASM `finalize()` path and `native-orchestrator.ts`'s all-Rust fast path (which bypasses `finalize()` entirely when it succeeds — confirmed empirically, hence the second call site).
- `codegraph info` compares that snapshot against a fresh read of the graph and prints a nudge (`Consider: codegraph build --no-incremental`) when one of those interfaces has since gained an instantiated implementor.
- Documents the limitation in `docs/guides/incremental-builds.md` and README's "when to run a full rebuild" section.

This is a diagnostic only — it does not close the underlying gap, per the issue's own scoping.

## Test plan
- [x] Full test suite (`npm test`) — 322 files / 5192 tests pass
- [x] `npm run build` / `npm run lint` clean
- [x] New unit tests for `deriveZeroImplementorInterfaces` (pure function)
- [x] New integration test: full build (interface with an uninstantiated implementor) → incremental rebuild adding a self-instantiating implementor → `codegraph info` asserts the nudge fires, for both engines
- [x] Confirmed `built_at`/`engine`/`codegraph_version`/etc. are unchanged — purely additive

Closes #2315