### PR TITLE
fix(js/ts): .bind()/.call()/.apply() on an inline function no longer embeds its source as receiver

### DIFF
--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -5750,6 +5750,39 @@ fn extract_reflect_callee_from_arg(first_arg: Option<Node>, call_line: u32, sour
     }
 }
 
+/// Whether `node` is an inline function literal — `function(){}`, `()=>{}`,
+/// or `function*(){}` — either directly, or wrapped in exactly one level of
+/// parentheses (`(function(){})`, `(()=>{})`; arrow functions used as a
+/// `.call`/`.apply`/`.bind` receiver always need the parens). Used by
+/// `extract_call_info`'s `.call`/`.apply`/`.bind` branch (issue #2321) to
+/// recognize an anonymous callee with no meaningful name to record, rather
+/// than falling through to `extract_receiver_name`'s raw-text fallback
+/// (which would otherwise embed the entire function body as `receiver`).
+/// Only one level of parens is unwrapped. Mirrors isInlineFunctionLiteral in
+/// src/extractors/javascript.ts.
+fn is_inline_function_literal(node: &Node) -> bool {
+    fn is_fn_literal(n: &Node) -> bool {
+        matches!(
+            n.kind(),
+            "function_expression" | "arrow_function" | "generator_function"
+        )
+    }
+    if is_fn_literal(node) {
+        return true;
+    }
+    if node.kind() != "parenthesized_expression" {
+        return false;
+    }
+    for i in 0..node.child_count() {
+        if let Some(child) = node.child(i) {
+            if is_fn_literal(&child) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 fn extract_call_info(fn_node: &Node, call_node: &Node, source: &[u8]) -> Option<Call> {
     match fn_node.kind() {
         "identifier" => {
@@ -5893,6 +5926,28 @@ fn extract_call_info(fn_node: &Node, call_node: &Node, source: &[u8]) -> Option<
                                 ..Default::default()
                             });
                         }
+                    }
+                    // Inline function literal (`function(){...}.bind(this)`, or the
+                    // same wrapped in one level of parens — `(function(){}).bind(x)`,
+                    // `(() => {}).bind(x)`; arrow functions in this position always
+                    // need the parens) — there is no meaningful bound-target NAME to
+                    // record (the wrapped function is anonymous), and falling through
+                    // to the generic tail below would set `receiver` to the entire
+                    // function body's source text via extract_receiver_name's
+                    // raw-text fallback (issue #2321). Still tag the call site itself
+                    // as a dynamic/reflection invocation — same informational value
+                    // as the identifier/member_expression cases above — just without
+                    // a receiver, since none exists. Mirrors isInlineFunctionLiteral
+                    // + extractMemberExprCallInfo in src/extractors/javascript.ts.
+                    if is_inline_function_literal(obj) {
+                        return Some(Call {
+                            name: prop_text.to_string(),
+                            line: call_line,
+                            dynamic: Some(true),
+                            dynamic_kind: Some("reflection".to_string()),
+                            receiver: None,
+                            ..Default::default()
+                        });
                     }
                 }
             }
@@ -8252,6 +8307,49 @@ mod tests {
     fn call_on_member_expression_receiver_tags_reflection() {
         let s = parse_js("obj.method.call({});");
         let c = s.calls.iter().find(|c| c.name == "method").unwrap();
+        assert_eq!(c.dynamic, Some(true));
+        assert_eq!(c.dynamic_kind.as_deref(), Some("reflection"));
+    }
+
+    // ── #2321: .call/.apply/.bind on an inline function literal ──────────────
+    //
+    // Before the fix, an inline function_expression/arrow_function/
+    // generator_function object fell through to the generic tail of
+    // extract_call_info, which set `receiver` to the ENTIRE function body's
+    // source text via extract_receiver_name's raw-text fallback.
+
+    #[test]
+    fn bind_on_unwrapped_function_expression_has_no_receiver() {
+        let s = parse_js(
+            "class Session {
+                isReady() { return true; }
+                checkBound() {
+                    setTimeout(function () {
+                        return this.isReady();
+                    }.bind(this), 100);
+                }
+            }",
+        );
+        let c = s.calls.iter().find(|c| c.name == "bind").unwrap();
+        assert_eq!(c.receiver, None);
+        assert_eq!(c.dynamic, Some(true));
+        assert_eq!(c.dynamic_kind.as_deref(), Some("reflection"));
+    }
+
+    #[test]
+    fn call_on_parenthesized_arrow_function_has_no_receiver() {
+        let s = parse_js("(() => { doWork(); }).call(ctx);");
+        let c = s.calls.iter().find(|c| c.name == "call").unwrap();
+        assert_eq!(c.receiver, None);
+        assert_eq!(c.dynamic, Some(true));
+        assert_eq!(c.dynamic_kind.as_deref(), Some("reflection"));
+    }
+
+    #[test]
+    fn apply_on_parenthesized_generator_function_has_no_receiver() {
+        let s = parse_js("(function* () { yield 1; }).apply(ctx, args);");
+        let c = s.calls.iter().find(|c| c.name == "apply").unwrap();
+        assert_eq!(c.receiver, None);
         assert_eq!(c.dynamic, Some(true));
         assert_eq!(c.dynamic_kind.as_deref(), Some("reflection"));
     }

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -5314,6 +5314,35 @@ function extractReflectCalleeFromArg(firstArg: TreeSitterNode | null, callLine: 
   };
 }
 
+/**
+ * Whether `node` is an inline function literal — `function(){}`, `()=>{}`, or
+ * `function*(){}` — either directly, or wrapped in exactly one level of
+ * parentheses (`(function(){})`, `(()=>{})`; confirmed by parsing both forms
+ * with tree-sitter — arrow functions used as a `.call`/`.apply`/`.bind`
+ * receiver always need the parens, since `()=>{}.bind(x)` on its own is not
+ * how the grammar attaches the member access). Used by
+ * `extractMemberExprCallInfo`'s `.call`/`.apply`/`.bind` branch (issue #2321)
+ * to recognize an anonymous callee with no meaningful name to record, rather
+ * than falling through to `extractReceiverName`'s raw-text fallback (which
+ * would otherwise embed the entire function body as `receiver`). Only one
+ * level of parens is unwrapped, mirroring `extractReceiverName`'s own
+ * documented "only one level" limitation for its analogous
+ * `(new Foo()).method()` case earlier in this file.
+ */
+function isInlineFunctionLiteral(node: TreeSitterNode): boolean {
+  const isFnLiteral = (n: TreeSitterNode): boolean =>
+    n.type === 'function_expression' ||
+    n.type === 'arrow_function' ||
+    n.type === 'generator_function';
+  if (isFnLiteral(node)) return true;
+  if (node.type !== 'parenthesized_expression') return false;
+  for (let i = 0; i < node.childCount; i++) {
+    const child = node.child(i);
+    if (child && isFnLiteral(child)) return true;
+  }
+  return false;
+}
+
 /** Extract call info from a member_expression function node (obj.method()). */
 function extractMemberExprCallInfo(fn: TreeSitterNode, callNode: TreeSitterNode): Call | null {
   const obj = fn.childForFieldName('object');
@@ -5403,6 +5432,22 @@ function extractMemberExprCallInfo(fn: TreeSitterNode, callNode: TreeSitterNode)
       const innerProp = obj.childForFieldName('property');
       if (innerProp)
         return { name: innerProp.text, line: callLine, dynamic: true, dynamicKind: 'reflection' };
+    }
+    // Inline function literal (`function(){...}.bind(this)`, or the same
+    // wrapped in one level of parens — `(function(){}).bind(x)`,
+    // `(() => {}).bind(x)`; arrow functions in this position always need the
+    // parens, confirmed by parsing both forms) — there is no meaningful
+    // bound-target NAME to record (the wrapped function is anonymous), and
+    // falling through to the generic tail below would set `receiver` to the
+    // entire function body's source text via extractReceiverName's raw-text
+    // fallback (issue #2321). Still tag the call site itself as a
+    // dynamic/reflection invocation — same informational value as the
+    // identifier/member_expression cases above — just without a receiver,
+    // since none exists. Only one level of parens is unwrapped, mirroring
+    // extractReceiverName's own documented "only one level" limitation for
+    // its analogous `(new Foo()).method()` case just above in this file.
+    if (obj && isInlineFunctionLiteral(obj)) {
+      return { name: propText, line: callLine, dynamic: true, dynamicKind: 'reflection' };
     }
   }
 

--- a/tests/parsers/javascript.test.ts
+++ b/tests/parsers/javascript.test.ts
@@ -1077,6 +1077,47 @@ describe('JavaScript parser', () => {
     expect(methodCall.dynamicKind).toBe('reflection');
   });
 
+  it('does not embed the function source as receiver for .bind() on an inline function expression (#2321)', () => {
+    // The exact repro from the issue: `.bind()` invoked directly on an inline
+    // function_expression, not a named reference. Before the fix, this fell
+    // through to the generic tail of extractMemberExprCallInfo, which set
+    // `receiver` to the ENTIRE function body's source text via
+    // extractReceiverName's raw-text fallback.
+    const symbols = parseJS(
+      `class Session {
+        isReady() { return true; }
+        checkBound() {
+          setTimeout(function () {
+            return this.isReady();
+          }.bind(this), 100);
+        }
+      }`,
+    );
+    const bindCall = symbols.calls.find((c) => c.name === 'bind');
+    expect(bindCall).toBeDefined();
+    expect(bindCall.receiver).toBeUndefined();
+    expect(bindCall.dynamic).toBe(true);
+    expect(bindCall.dynamicKind).toBe('reflection');
+  });
+
+  it('does not embed the arrow function source as receiver for .call()', () => {
+    const symbols = parseJS(`(() => { doWork(); }).call(ctx);`);
+    const callCall = symbols.calls.find((c) => c.name === 'call');
+    expect(callCall).toBeDefined();
+    expect(callCall.receiver).toBeUndefined();
+    expect(callCall.dynamic).toBe(true);
+    expect(callCall.dynamicKind).toBe('reflection');
+  });
+
+  it('does not embed the generator function source as receiver for .apply()', () => {
+    const symbols = parseJS(`(function* () { yield 1; }).apply(ctx, args);`);
+    const applyCall = symbols.calls.find((c) => c.name === 'apply');
+    expect(applyCall).toBeDefined();
+    expect(applyCall.receiver).toBeUndefined();
+    expect(applyCall.dynamic).toBe(true);
+    expect(applyCall.dynamicKind).toBe('reflection');
+  });
+
   describe('callback pattern extraction', () => {
     // Commander patterns
     it('extracts Commander .command().action() with arrow function', () => {


### PR DESCRIPTION
## Summary

`extractCallInfo`'s `.call`/`.apply`/`.bind` special case only recognized an `identifier` or `member_expression` as the object being bound. When invoked directly on an inline `function_expression`/`arrow_function`/`generator_function` (or the same wrapped in one level of parens, e.g. `(() => {}).bind(x)`), neither branch matched, so execution fell through to the generic tail: `extractReceiverName` has no case for a function literal, so it fell back to the raw source text of the entire function body as `receiver` — harmless for correctness (never resolves to a real symbol) but wasteful (embeds large text blobs) and inconsistent with every other receiver, which is a short identifier/class name.

Adds `isInlineFunctionLiteral()` (TS) / `is_inline_function_literal()` (Rust), recognizing the function literal directly or through one level of parens (arrow functions in this position always need the parens, confirmed by parsing both forms — a plain function expression doesn't require them, matching the issue's own repro). When matched, the call site is still tagged `dynamic`/`reflection` (same informational value as the identifier/member_expression cases), just with no `receiver`, since none exists.

## Test plan
- [x] Full test suite (`npm test`) — 324 files / 5231 tests pass
- [x] `npm run build` / `npm run lint` clean
- [x] `cargo fmt --check` / `cargo build` / `cargo test` clean
- [x] Dual-engine parity (`scripts/parity-compare.mjs --langs javascript,typescript`) — OK
- [x] New tests cover the unwrapped `function_expression` (the issue's exact repro), a parenthesized arrow function, and a parenthesized generator function, in both engines

Closes #2321