### PR TITLE
fix(hooks): resync docs/examples/claude-code-hooks with the live hooks

### DIFF
--- a/.claude/hooks/post-git-ops.sh
+++ b/.claude/hooks/post-git-ops.sh
@@ -44,6 +44,13 @@ if [ -f "$DB_PATH" ]; then
   if command -v codegraph &>/dev/null; then
     codegraph build "$PROJECT_DIR" -d "$DB_PATH" --no-incremental 2>/dev/null && BUILD_OK=1 || true
   else
+    # Uses the local build here (this repo IS codegraph's own source) rather
+    # than npx, so dogfooding always rebuilds with the exact checked-out
+    # source instead of silently falling back to whatever version is
+    # currently published to npm. docs/examples/claude-code-hooks/post-git-
+    # ops.sh — the template external consumers copy — intentionally differs
+    # on this one line: it falls back to `npx --yes @optave/codegraph`
+    # instead, since a copied project has no local dist/cli.js to prefer.
     node "${CLAUDE_PROJECT_DIR:-$PROJECT_DIR}/dist/cli.js" build "$PROJECT_DIR" -d "$DB_PATH" --no-incremental 2>/dev/null && BUILD_OK=1 || true
   fi
   # Update staleness marker only if the full rebuild succeeded

--- a/.claude/hooks/pre-commit.sh
+++ b/.claude/hooks/pre-commit.sh
@@ -46,9 +46,17 @@ if [ -f "$LOG_FILE" ] && [ -s "$LOG_FILE" ]; then
   EDITED_FILES=$(awk '{print $2}' "$LOG_FILE" | sort -u)
 fi
 
-# Run all checks in a single Node.js process
+# Run all checks in a single Node.js process. Prefer a compiled .js copy
+# (what this repo ships) so every commit here skips the type-stripping
+# step; fall back to running the .ts source directly (what the docs/
+# examples copy ships, so external users need no build step of their own).
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
-RESULT=$(node "$HOOK_DIR/pre-commit-checks.js" "$WORK_ROOT" "$EDITED_FILES" "$STAGED" 2>/dev/null) || true
+if [ -f "$HOOK_DIR/pre-commit-checks.js" ]; then
+  RESULT=$(node "$HOOK_DIR/pre-commit-checks.js" "$WORK_ROOT" "$EDITED_FILES" "$STAGED" 2>/dev/null) || true
+else
+  STRIP_FLAG=$(node -e "const [M,m]=process.versions.node.split('.').map(Number); console.log(M>=23?'--strip-types':'--experimental-strip-types')")
+  RESULT=$(node $STRIP_FLAG "$HOOK_DIR/pre-commit-checks.ts" "$WORK_ROOT" "$EDITED_FILES" "$STAGED" 2>/dev/null) || true
+fi
 
 if [ -z "$RESULT" ]; then
   exit 0

--- a/.claude/hooks/update-graph.sh
+++ b/.claude/hooks/update-graph.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# rebuild-graph.sh — PostToolUse hook for Edit and Write tools
+# update-graph.sh — PostToolUse hook for Edit and Write tools
 # Incrementally updates the codegraph after source file edits.
 # On the first edit of a stale session (no full rebuild in >24h), upgrades
 # to a full rebuild so complexity/dataflow/cohesion data stays fresh.
@@ -110,6 +110,10 @@ fi
 # version than the one actually checked out here, and building with it
 # silently downgrades this project's build_meta / parsing results. Only
 # fall back to the global binary when the project has no local build at all.
+# docs/examples/claude-code-hooks/update-graph.sh — the template external
+# consumers copy — intentionally differs here: it falls back to
+# `npx --yes @optave/codegraph` instead, since a copied project has no
+# local dist/cli.js to prefer.
 BUILD_OK=0
 BUILD_ERR=""
 CLI_ENTRY="$PROJECT_DIR/dist/cli.js"

--- a/docs/examples/claude-code-hooks/enrich-context.sh
+++ b/docs/examples/claude-code-hooks/enrich-context.sh
@@ -36,35 +36,52 @@ if [ ! -f "$DB_PATH" ]; then
   exit 0
 fi
 
-# Run codegraph deps and capture output
-DEPS=""
+# Guard: codegraph must be available
+if ! command -v codegraph &>/dev/null && ! command -v npx &>/dev/null; then
+  exit 0
+fi
+
+# Run codegraph brief and capture output (silent no-op on older installs without the brief command)
+BRIEF=""
 if command -v codegraph &>/dev/null; then
-  DEPS=$(codegraph deps "$REL_PATH" --json -d "$DB_PATH" 2>/dev/null) || true
+  BRIEF=$(codegraph brief "$REL_PATH" --json -d "$DB_PATH" 2>/dev/null) || true
 else
-  DEPS=$(npx --yes @optave/codegraph deps "$REL_PATH" --json -d "$DB_PATH" 2>/dev/null) || true
+  BRIEF=$(npx --yes @optave/codegraph brief "$REL_PATH" --json -d "$DB_PATH" 2>/dev/null) || true
 fi
 
 # Guard: no output or error
-if [ -z "$DEPS" ] || [ "$DEPS" = "null" ]; then
+if [ -z "$BRIEF" ] || [ "$BRIEF" = "null" ]; then
   exit 0
 fi
 
 # Output as additionalContext so it surfaces in Claude's context
-printf '%s' "$DEPS" | node -e "
+printf '%s' "$BRIEF" | node -e "
   let d='';
   process.stdin.on('data',c=>d+=c);
   process.stdin.on('end',()=>{
     try {
       const o=JSON.parse(d);
       const r=o.results?.[0]||{};
-      const imports=(r.imports||[]).map(i=>i.file).join(', ');
-      const importedBy=(r.importedBy||[]).map(i=>i.file).join(', ');
-      const defs=(r.definitions||[]).map(d=>d.kind+' '+d.name).join(', ');
-      const file=o.file||'unknown';
-      let ctx='[codegraph] '+file;
+      const file=r.file||o.file||'unknown';
+      const risk=r.risk||'unknown';
+      const imports=(r.imports||[]).join(', ');
+      const importedBy=(r.importedBy||[]).join(', ');
+      const transitive=r.totalImporterCount||0;
+      const direct=(r.importedBy||[]).length;
+      const extra=transitive-direct;
+      const syms=(r.symbols||[]).map(s=>{
+        const tags=[];
+        if(s.role)tags.push(s.role);
+        tags.push(s.callerCount+' caller'+(s.callerCount!==1?'s':''));
+        return s.name+' ['+tags.join(', ')+']';
+      }).join(', ');
+      let ctx='[codegraph] '+file+' ['+risk.toUpperCase()+' RISK]';
+      if(syms)ctx+='\n  Symbols: '+syms;
       if(imports)ctx+='\n  Imports: '+imports;
-      if(importedBy)ctx+='\n  Imported by: '+importedBy;
-      if(defs)ctx+='\n  Defines: '+defs;
+      if(importedBy){
+        const suffix=extra>0?' (+'+extra+' transitive)':'';
+        ctx+='\n  Imported by: '+importedBy+suffix;
+      }
       console.log(JSON.stringify({
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',

--- a/docs/examples/claude-code-hooks/post-git-ops.sh
+++ b/docs/examples/claude-code-hooks/post-git-ops.sh
@@ -32,10 +32,11 @@ fi
 # Use git worktree root so each worktree session has its own state
 PROJECT_DIR=$(git rev-parse --show-toplevel 2>/dev/null) || PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
 
-# --- 1. Full rebuild of codegraph ---
-# Git operations (merge, rebase, pull) can change many files at once. A full
-# rebuild ensures complexity, dataflow, and directory cohesion metrics are
-# recomputed for all affected files — not just direct edits.
+# --- 1. Rebuild codegraph ---
+# Git operations (merge, rebase, pull) can change many files at once, including
+# files not directly edited in this session. A full rebuild ensures complexity,
+# dataflow, and directory cohesion metrics are recomputed for all affected files
+# — not just the ones the incremental pipeline would detect via reverse-deps.
 # See docs/guides/incremental-builds.md for what incremental skips.
 DB_PATH="$PROJECT_DIR/.codegraph/graph.db"
 if [ -f "$DB_PATH" ]; then
@@ -43,6 +44,13 @@ if [ -f "$DB_PATH" ]; then
   if command -v codegraph &>/dev/null; then
     codegraph build "$PROJECT_DIR" -d "$DB_PATH" --no-incremental 2>/dev/null && BUILD_OK=1 || true
   else
+    # Falls back to npx here since this is the template external consumers
+    # copy into their own project — they have no local dist/cli.js to prefer.
+    # codegraph's own repo copy of this hook (.claude/hooks/post-git-ops.sh)
+    # intentionally differs on this one line: it uses `node dist/cli.js`
+    # instead, so dogfooding this repo always rebuilds with the exact
+    # checked-out source rather than silently falling back to whatever
+    # version is currently published to npm.
     npx --yes @optave/codegraph build "$PROJECT_DIR" -d "$DB_PATH" --no-incremental 2>/dev/null && BUILD_OK=1 || true
   fi
   # Update staleness marker only if the full rebuild succeeded

--- a/docs/examples/claude-code-hooks/pre-commit.sh
+++ b/docs/examples/claude-code-hooks/pre-commit.sh
@@ -46,10 +46,17 @@ if [ -f "$LOG_FILE" ] && [ -s "$LOG_FILE" ]; then
   EDITED_FILES=$(awk '{print $2}' "$LOG_FILE" | sort -u)
 fi
 
-# Run all checks in a single Node.js process
+# Run all checks in a single Node.js process. Prefer a compiled .js copy
+# (what this repo ships) so every commit here skips the type-stripping
+# step; fall back to running the .ts source directly (what the docs/
+# examples copy ships, so external users need no build step of their own).
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
-STRIP_FLAG=$(node -e "const [M,m]=process.versions.node.split('.').map(Number); console.log(M>=23?'--strip-types':'--experimental-strip-types')")
-RESULT=$(node $STRIP_FLAG "$HOOK_DIR/pre-commit-checks.ts" "$WORK_ROOT" "$EDITED_FILES" "$STAGED" 2>/dev/null) || true
+if [ -f "$HOOK_DIR/pre-commit-checks.js" ]; then
+  RESULT=$(node "$HOOK_DIR/pre-commit-checks.js" "$WORK_ROOT" "$EDITED_FILES" "$STAGED" 2>/dev/null) || true
+else
+  STRIP_FLAG=$(node -e "const [M,m]=process.versions.node.split('.').map(Number); console.log(M>=23?'--strip-types':'--experimental-strip-types')")
+  RESULT=$(node $STRIP_FLAG "$HOOK_DIR/pre-commit-checks.ts" "$WORK_ROOT" "$EDITED_FILES" "$STAGED" 2>/dev/null) || true
+fi
 
 if [ -z "$RESULT" ]; then
   exit 0

--- a/docs/examples/claude-code-hooks/update-graph.sh
+++ b/docs/examples/claude-code-hooks/update-graph.sh
@@ -24,10 +24,26 @@ if [ -z "$FILE_PATH" ]; then
   exit 0
 fi
 
-# Only rebuild for source files codegraph tracks
-# Skip docs, configs, test fixtures, and non-code files
-case "$FILE_PATH" in
-  *.js|*.ts|*.tsx|*.jsx|*.py|*.go|*.rs|*.java|*.cs|*.php|*.rb|*.tf|*.hcl)
+# Derive PROJECT_DIR from the EDITED FILE's own git toplevel, not the
+# session's cwd (issue #2134). A session can be cwd'ed into worktree A while
+# an Edit/Write touches a file entirely outside it (a different repo, or a
+# scratch path with no repo at all) — resolving from cwd would rebuild A's
+# graph in response to a change that has nothing to do with it. If the file
+# isn't inside any git repo, there is no project to rebuild.
+PROJECT_DIR=$(git -C "$(dirname "$FILE_PATH")" rev-parse --show-toplevel 2>/dev/null) || exit 0
+
+# Only rebuild for source files codegraph tracks.
+# Skip docs, configs, test fixtures, and non-code files.
+#
+# codegraph's own repo copy of this hook derives this allowlist from its
+# LANGUAGE_REGISTRY and snapshots it to dist/hook-extensions.txt on every
+# build, so it never drifts out of sync with the languages codegraph
+# actually parses. A copied project has no such snapshot, so this template
+# ships the static list directly — keep it in sync with LANGUAGE_REGISTRY
+# (src/domain/parser.ts in the codegraph repo) if you maintain a fork.
+EXT=".${FILE_PATH##*.}"
+case "$EXT" in
+  .R|.bash|.c|.cc|.cjs|.clj|.cljc|.cljs|.cpp|.cs|.cts|.cu|.cuh|.cxx|.dart|.erl|.ex|.exs|.fs|.fsi|.fsx|.gemspec|.gleam|.go|.groovy|.gvy|.h|.hcl|.hpp|.hrl|.hs|.java|.jl|.js|.jsx|.kt|.kts|.lua|.m|.mjs|.ml|.mli|.mts|.php|.phtml|.py|.pyi|.r|.rake|.rb|.rs|.scala|.sh|.sol|.sv|.swift|.tf|.ts|.tsx|.v|.zig)
     ;;
   *)
     exit 0
@@ -40,7 +56,6 @@ if echo "$FILE_PATH" | grep -qE '(fixtures|__fixtures__|testdata)/'; then
 fi
 
 # Guard: codegraph DB must exist (project has been built at least once)
-PROJECT_DIR=$(git rev-parse --show-toplevel 2>/dev/null) || PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
 DB_PATH="$PROJECT_DIR/.codegraph/graph.db"
 if [ ! -f "$DB_PATH" ]; then
   exit 0
@@ -78,7 +93,11 @@ fi
 # outside your project (no network, registry down, wrong/missing package),
 # and a bare 2>/dev/null + `|| true` used to give no signal at all that
 # graph auto-rebuild wasn't active (issue #2302, same pattern #2074 applied
-# to this repo's own copy of this hook).
+# to this repo's own copy of this hook). Falls back to npx here since a
+# copied project has no local dist/cli.js to prefer — codegraph's own repo
+# copy of this hook (.claude/hooks/update-graph.sh) intentionally differs
+# here: it prefers its own local build over npx, so dogfooding always
+# rebuilds with the exact checked-out source (issue #2134).
 BUILD_OK=0
 BUILD_ERR=""
 if command -v codegraph &>/dev/null; then

--- a/tests/unit/hooks-docs-sync-2330.test.ts
+++ b/tests/unit/hooks-docs-sync-2330.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Regression guard for issue #2330: docs/examples/claude-code-hooks/
+ * pre-commit.sh, post-git-ops.sh, enrich-context.sh, and update-graph.sh had
+ * drifted from their live .claude/hooks/ counterparts — some cosmetically
+ * (comment rewording), some substantively (enrich-context.sh's docs copy
+ * still called the now-removed `codegraph deps` instead of `codegraph
+ * brief`; update-graph.sh's docs copy was missing three tracked bug fixes:
+ * #2134's project-dir-from-edited-file derivation, and #2074/#2302's
+ * build-failure diagnostics).
+ *
+ * Mirrors the byte-identity enforcement `hook-guard-git-clean.test.ts` added
+ * for guard-git.sh under #2105 — a prose note alone already failed to
+ * prevent drift once before, so this asserts identity directly instead of
+ * documenting-and-hoping.
+ *
+ * pre-commit.sh and enrich-context.sh are enforced as fully byte-identical.
+ * post-git-ops.sh and update-graph.sh each have exactly one genuinely
+ * necessary, intentional line-level difference — this repo's own copy
+ * prefers its local `dist/cli.js` build over `npx`, since this repo IS
+ * codegraph's own source and a stale npm-published fallback would silently
+ * downgrade dogfooding; the docs template's copy has no local build to
+ * prefer and falls back to `npx` instead, which is the only sensible choice
+ * for an external consumer. Both sides carry a comment explaining this.
+ * Those two files are compared with the known-different lines excluded
+ * rather than skipped outright, so any OTHER drift still fails the test.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const LIVE_DIR = path.join(REPO_ROOT, '.claude', 'hooks');
+const DOCS_DIR = path.join(REPO_ROOT, 'docs', 'examples', 'claude-code-hooks');
+
+const FULLY_IDENTICAL_HOOKS = ['pre-commit.sh', 'enrich-context.sh'];
+
+describe('claude-code-hooks docs examples stay in sync (#2330)', () => {
+  it.each(FULLY_IDENTICAL_HOOKS)('%s is byte-identical to its docs/examples copy', (name) => {
+    const live = fs.readFileSync(path.join(LIVE_DIR, name), 'utf8');
+    const docs = fs.readFileSync(path.join(DOCS_DIR, name), 'utf8');
+    expect(docs).toBe(live);
+  });
+
+  it('post-git-ops.sh differs from its docs copy only on the one documented, intentional line', () => {
+    const live = fs.readFileSync(path.join(LIVE_DIR, 'post-git-ops.sh'), 'utf8').split('\n');
+    const docs = fs.readFileSync(path.join(DOCS_DIR, 'post-git-ops.sh'), 'utf8').split('\n');
+
+    const liveBuildLine = live.findIndex((l) => l.includes('node "${CLAUDE_PROJECT_DIR'));
+    const docsBuildLine = docs.findIndex((l) => l.includes('npx --yes @optave/codegraph build'));
+    expect(liveBuildLine).toBeGreaterThan(-1);
+    expect(docsBuildLine).toBeGreaterThan(-1);
+
+    // Strip each side's own explanatory comment block (differs by design —
+    // each explains why ITS OWN choice differs from the other file) plus the
+    // one intentionally-different invocation line, then require everything
+    // else to match exactly.
+    const stripComment = (lines: string[], buildLineIdx: number) => {
+      let start = buildLineIdx;
+      while (start > 0 && lines[start - 1].trim().startsWith('#')) start--;
+      return [...lines.slice(0, start), ...lines.slice(buildLineIdx + 1)];
+    };
+    expect(stripComment(docs, docsBuildLine)).toEqual(stripComment(live, liveBuildLine));
+  });
+
+  it('update-graph.sh differs from its docs copy only on the two documented, intentional sections', () => {
+    const live = fs.readFileSync(path.join(LIVE_DIR, 'update-graph.sh'), 'utf8');
+    const docs = fs.readFileSync(path.join(DOCS_DIR, 'update-graph.sh'), 'utf8');
+
+    // Section 1: the extension-allowlist source (generated snapshot + grep
+    // vs. a static case statement) — genuinely can't be identical, since the
+    // generated snapshot is this repo's own build artifact.
+    expect(live).toContain('GENERATED_EXT_LIST="$PROJECT_DIR/dist/hook-extensions.txt"');
+    expect(docs).not.toContain('GENERATED_EXT_LIST');
+
+    // Section 2: the build invocation — this repo prefers its local
+    // dist/cli.js; the docs template falls back to npx (see file header).
+    expect(live).toContain('CLI_ENTRY="$PROJECT_DIR/dist/cli.js"');
+    expect(docs).toContain('npx --yes @optave/codegraph build');
+    expect(docs).not.toContain('CLI_ENTRY');
+
+    // Everything else — the shebang/header, JSON parsing, the fixture skip,
+    // the staleness-marker logic, and the final exit — must still match.
+    const SHARED_PREFIX = [
+      '#!/usr/bin/env bash',
+      '# update-graph.sh — PostToolUse hook for Edit and Write tools',
+    ];
+    for (const line of SHARED_PREFIX) {
+      expect(live).toContain(line);
+      expect(docs).toContain(line);
+    }
+    expect(live).toContain('# --- Staleness check ---');
+    expect(docs).toContain('# --- Staleness check ---');
+    expect(live.trimEnd().endsWith('exit 0')).toBe(true);
+    expect(docs.trimEnd().endsWith('exit 0')).toBe(true);
+  });
+});

--- a/tests/unit/hooks-docs-sync-2330.test.ts
+++ b/tests/unit/hooks-docs-sync-2330.test.ts
@@ -14,15 +14,19 @@
  * documenting-and-hoping.
  *
  * pre-commit.sh and enrich-context.sh are enforced as fully byte-identical.
- * post-git-ops.sh and update-graph.sh each have exactly one genuinely
- * necessary, intentional line-level difference — this repo's own copy
- * prefers its local `dist/cli.js` build over `npx`, since this repo IS
- * codegraph's own source and a stale npm-published fallback would silently
- * downgrade dogfooding; the docs template's copy has no local build to
- * prefer and falls back to `npx` instead, which is the only sensible choice
- * for an external consumer. Both sides carry a comment explaining this.
- * Those two files are compared with the known-different lines excluded
- * rather than skipped outright, so any OTHER drift still fails the test.
+ * post-git-ops.sh and update-graph.sh each have a small number of
+ * genuinely necessary, intentional differences, all stemming from the same
+ * root cause: this repo's own copy prefers its local `dist/cli.js` build
+ * over `npx`, since this repo IS codegraph's own source and a stale
+ * npm-published fallback would silently downgrade dogfooding, whereas the
+ * docs template's copy has no local build to prefer and correctly falls
+ * back to `npx` for an external consumer. update-graph.sh additionally
+ * keeps its own static extension allowlist (docs has no
+ * dist/hook-extensions.txt build artifact to read) and a failure message
+ * that doesn't reference this repo's own `npm run doctor` script. Both
+ * sides carry a comment explaining each split. These files are compared
+ * with the known-different regions excluded rather than skipped outright,
+ * so any OTHER drift still fails the test.
  */
 import fs from 'node:fs';
 import path from 'node:path';
@@ -65,34 +69,50 @@ describe('claude-code-hooks docs examples stay in sync (#2330)', () => {
   });
 
   it('update-graph.sh differs from its docs copy only on the two documented, intentional sections', () => {
-    const live = fs.readFileSync(path.join(LIVE_DIR, 'update-graph.sh'), 'utf8');
-    const docs = fs.readFileSync(path.join(DOCS_DIR, 'update-graph.sh'), 'utf8');
+    const live = fs.readFileSync(path.join(LIVE_DIR, 'update-graph.sh'), 'utf8').split('\n');
+    const docs = fs.readFileSync(path.join(DOCS_DIR, 'update-graph.sh'), 'utf8').split('\n');
+
+    // Removes everything strictly between two anchor lines that are
+    // required (via the expects below) to be identical text on both sides
+    // — keeping both anchors themselves, so the two calls compose without
+    // needing to track shifted offsets between them.
+    const stripBetween = (lines: string[], startAnchor: string, endAnchor: string): string[] => {
+      const startIdx = lines.findIndex((l) => l.trim() === startAnchor);
+      const endIdx = lines.findIndex((l) => l.trim() === endAnchor);
+      expect(startIdx).toBeGreaterThan(-1);
+      expect(endIdx).toBeGreaterThan(startIdx);
+      return [...lines.slice(0, startIdx + 1), ...lines.slice(endIdx)];
+    };
 
     // Section 1: the extension-allowlist source (generated snapshot + grep
     // vs. a static case statement) — genuinely can't be identical, since the
-    // generated snapshot is this repo's own build artifact.
-    expect(live).toContain('GENERATED_EXT_LIST="$PROJECT_DIR/dist/hook-extensions.txt"');
-    expect(docs).not.toContain('GENERATED_EXT_LIST');
+    // generated snapshot is this repo's own build artifact the docs template
+    // has no equivalent of.
+    const EXT_SECTION_START = '# Skip docs, configs, test fixtures, and non-code files.';
+    const EXT_SECTION_END = "# Skip test fixtures — they're copied to tmp dirs anyway";
+
+    const afterExt = {
+      live: stripBetween(live, EXT_SECTION_START, EXT_SECTION_END),
+      docs: stripBetween(docs, EXT_SECTION_START, EXT_SECTION_END),
+    };
 
     // Section 2: the build invocation — this repo prefers its local
     // dist/cli.js; the docs template falls back to npx (see file header).
-    expect(live).toContain('CLI_ENTRY="$PROJECT_DIR/dist/cli.js"');
-    expect(docs).toContain('npx --yes @optave/codegraph build');
-    expect(docs).not.toContain('CLI_ENTRY');
+    // Also swallows the failure-diagnostic message right after: live's
+    // points at `npm run doctor`, this repo's own script — meaningless (and
+    // absent) in a copied project, so docs keeps the plain message instead.
+    const BUILD_SECTION_START =
+      '# Run the build. Stderr is captured (not discarded) so a failure has a';
+    const BUILD_SECTION_END = '# Update marker only if we did a full rebuild AND it succeeded';
 
-    // Everything else — the shebang/header, JSON parsing, the fixture skip,
-    // the staleness-marker logic, and the final exit — must still match.
-    const SHARED_PREFIX = [
-      '#!/usr/bin/env bash',
-      '# update-graph.sh — PostToolUse hook for Edit and Write tools',
-    ];
-    for (const line of SHARED_PREFIX) {
-      expect(live).toContain(line);
-      expect(docs).toContain(line);
-    }
-    expect(live).toContain('# --- Staleness check ---');
-    expect(docs).toContain('# --- Staleness check ---');
-    expect(live.trimEnd().endsWith('exit 0')).toBe(true);
-    expect(docs.trimEnd().endsWith('exit 0')).toBe(true);
+    const afterBuild = {
+      live: stripBetween(afterExt.live, BUILD_SECTION_START, BUILD_SECTION_END),
+      docs: stripBetween(afterExt.docs, BUILD_SECTION_START, BUILD_SECTION_END),
+    };
+
+    // Everything else — the shebang/header, JSON parsing, the file-path
+    // guard, PROJECT_DIR derivation, the fixture skip, the staleness-marker
+    // logic, and the final exit — must be byte-identical.
+    expect(afterBuild.docs).toEqual(afterBuild.live);
   });
 });


### PR DESCRIPTION
## Problem

Same treatment #2105 applied to `guard-git.sh`: `pre-commit.sh`, `post-git-ops.sh`, `enrich-context.sh`, and `update-graph.sh` had all drifted from their `.claude/hooks/` counterparts.

## What changed

- **enrich-context.sh**: the docs copy still called the removed `codegraph deps`, missing the upgrade to `codegraph brief` (risk level, symbols with roles/caller counts, transitive importer counts). Fully resynced — now byte-identical.
- **pre-commit.sh**: made the checks-script invocation environment-adaptive (prefer a compiled `.js` if present, else run the `.ts` source directly) so one script works for both this repo's compiled copy and the docs template's build-step-free `.ts` copy. Now genuinely byte-identical.
- **post-git-ops.sh**, **update-graph.sh**: resynced everything except one (resp. two) genuinely necessary difference — this repo prefers its own local `dist/cli.js` build over `npx`, since it IS codegraph's own source and a stale npm-published fallback would silently downgrade dogfooding; the docs template has no local build to prefer and correctly falls back to `npx` for external consumers. Both sides now carry a comment explaining the split. `update-graph.sh` also picks up two previously undocumented-in-docs live fixes: #2134's project-dir-from-edited-file derivation and the hook-extensions allowlist (docs keeps its own static extension list since it has no `dist/hook-extensions.txt` build artifact to read).
- Fixed a stale header comment in `update-graph.sh` (said "rebuild-graph.sh" — the file's actual name, and the name every `settings.json` references, is `update-graph.sh`).

`track-edits.sh` and `lint-staged.sh` were already byte-identical; not touched.

## Test plan

- [x] New `tests/unit/hooks-docs-sync-2330.test.ts`: enforces byte-identity for `pre-commit.sh`/`enrich-context.sh`, and asserts `post-git-ops.sh`/`update-graph.sh` differ only on their documented, intentional lines — mirroring `hook-guard-git-clean.test.ts`'s enforcement for `guard-git.sh` under #2105
- [x] All existing hook tests still pass (`hook-fallback-build-path`, `hook-update-graph-project-scope`, `hook-extensions`, `hook-update-graph-diagnostics`, `hook-update-graph-docs-template-diagnostics`, `hook-guard-git-clean`)
- [x] Full test suite: 5235/5235 passed (native addon rebuilt fresh)
- [x] `npm run lint` clean
- [x] `node dist/cli.js diff-impact origin/main` — no function-level impact (hook scripts + a new test file, outside codegraph's own analysis-relevant surface)

Closes #2330