### PR TITLE
fix(ci): verify comment author before updating/deleting impact comment

### DIFF
--- a/.github/workflows/codegraph-impact-comment.yml
+++ b/.github/workflows/codegraph-impact-comment.yml
@@ -56,7 +56,7 @@ jobs:
               repo: context.repo.repo,
               issue_number: prNumber,
             });
-            const existing = comments.find(c => c.body.startsWith('## Codegraph Impact Analysis'));
+            const existing = comments.find(c => c.body.startsWith('## Codegraph Impact Analysis') && c.user.login === 'github-actions[bot]');
             if (existing) {
               await github.rest.issues.updateComment({
                 owner: context.repo.owner,


### PR DESCRIPTION
## Summary
- Greptile flagged (Confidence 3/5, on PR #2351) that `closing-keyword-check.yml`'s sticky-comment lookup selected an existing comment purely by `body.includes(marker)`, with no check that the comment was authored by the workflow's own bot account — a PR participant could plant the marker text in their own comment and have it silently overwritten/deleted by a later run.
- `codegraph-impact-comment.yml` has the exact same pattern, pre-dating #2351: `comments.find(c => c.body.startsWith('## Codegraph Impact Analysis'))`.
- Fix: add the same `c.user.login === 'github-actions[bot]'` check #2351's fix already applies to `closing-keyword-check.yml`.

## Test plan
- [x] YAML syntax validated
- [x] No existing tests reference this workflow file (not part of the TS/JS test suite — a `.github/workflows/*.yml` change, not application code)
- [x] Confirmed no other workflow files have the same unguarded pattern (`grep` across `.github/workflows/`)

Closes #2352