### PR TITLE
fix(dataflow): grouped param wrapper gives every name the same paramIndex

### DIFF
--- a/src/ast-analysis/rules/b2.ts
+++ b/src/ast-analysis/rules/b2.ts
@@ -547,15 +547,9 @@ function extractDartParamName(node: TreeSitterNode): string[] | null {
   // groups wrap MULTIPLE formal_parameter children in one
   // optional_formal_parameters node (node-types.json — confirmed there is
   // no singular optional_formal_parameter/named_formal_parameter type in
-  // this grammar). Recurse to collect every name inside the group.
-  if (node.type === 'optional_formal_parameters') {
-    const names: string[] = [];
-    for (const child of node.namedChildren) {
-      const childNames = extractDartParamName(child);
-      if (childNames) names.push(...childNames);
-    }
-    return names.length > 0 ? names : null;
-  }
+  // this grammar). Each grandchild is its own parameter slot, so
+  // `groupedParamTypes` (issue #2358) makes `extractParams` iterate them
+  // directly rather than calling this function on the group node itself.
   if (node.type === 'formal_parameter') {
     const nameNode = node.childForFieldName('name');
     if (nameNode) return [nameNode.text];
@@ -657,6 +651,11 @@ export const dataflowDart: DataflowRulesConfig = makeDataflowRules({
   // parameter extraction "happened to work."
   getParamListNode: getDartParamListNode,
   extractParamName: extractDartParamName,
+  // `{int times, bool loud}` (named) / `[int x, int y]` (optional-positional)
+  // groups wrap multiple genuinely separate formal_parameter slots in one
+  // optional_formal_parameters node — each must get its own paramIndex, not
+  // the group's single index (issue #2358).
+  groupedParamTypes: new Set(['optional_formal_parameters']),
 
   // local_variable_declaration's ONLY child is initialized_variable_definition,
   // which has real `name`/`value` fields (confirmed via node-types.json) —

--- a/src/ast-analysis/shared.ts
+++ b/src/ast-analysis/shared.ts
@@ -98,6 +98,7 @@ export const DATAFLOW_DEFAULTS: DataflowRulesConfig = {
   shorthandPropPattern: null,
   pairPatternType: null,
   extractParamName: null, // override: (node) => string[]
+  groupedParamTypes: new Set(), // node types grouping multiple separate param slots (Dart's optional_formal_parameters)
 
   // Return
   returnNode: null,

--- a/src/ast-analysis/visitor-utils.ts
+++ b/src/ast-analysis/visitor-utils.ts
@@ -94,20 +94,31 @@ export function extractParams(
   const result: ParamInfo[] = [];
   let index = 0;
   for (const child of paramsNode.namedChildren) {
-    // Grouped wrapper types (e.g. Dart's optional_formal_parameters) can mix
-    // real formal_parameter slots with unrelated named siblings — e.g. a
-    // default value's literal, which the grammar attaches as a flat sibling
-    // rather than nesting inside its formal_parameter (issue #2358). Only a
-    // slot that actually yields a name consumes an index.
-    const slots = rules.groupedParamTypes?.has(child.type) ? child.namedChildren : [child];
-    for (const slot of slots) {
-      const names = extractParamNames(slot, rules);
-      if (names.length === 0) continue;
-      for (const name of names) {
-        result.push({ name, index });
+    if (rules.groupedParamTypes?.has(child.type)) {
+      // Grouped wrapper types (e.g. Dart's optional_formal_parameters) can
+      // mix real formal_parameter slots with unrelated named siblings —
+      // e.g. a default value's literal, which the grammar attaches as a
+      // flat sibling rather than nesting inside its formal_parameter
+      // (issue #2358). Only a slot that actually yields a name consumes an
+      // index; an ordinary (non-grouped) child still consumes one below
+      // even with zero names, since an unnamed parameter (e.g. C++'s
+      // `void f(int, int value)`) is a real slot that must not collapse
+      // into the next one.
+      for (const slot of child.namedChildren) {
+        const names = extractParamNames(slot, rules);
+        if (names.length === 0) continue;
+        for (const name of names) {
+          result.push({ name, index });
+        }
+        index++;
       }
-      index++;
+      continue;
     }
+    const names = extractParamNames(child, rules);
+    for (const name of names) {
+      result.push({ name, index });
+    }
+    index++;
   }
   return result;
 }

--- a/src/ast-analysis/visitor-utils.ts
+++ b/src/ast-analysis/visitor-utils.ts
@@ -33,6 +33,16 @@ interface LanguageRules {
   memberObjectField: string;
   optionalChainNode?: string;
   extractParamName?(node: TreeSitterNode): string[] | null;
+  /**
+   * Node types where ONE child of the parameter list groups multiple
+   * logically separate parameter declarations — e.g. Dart's
+   * `optional_formal_parameters` for `{int times, bool loud}` (issue #2358).
+   * Unlike `objectDestructType`/`arrayDestructType`, where multiple bound
+   * names are extracted from a SINGLE argument slot and must share one
+   * index, each of this node's own named children is its own slot and gets
+   * its own index.
+   */
+  groupedParamTypes?: Set<string>;
 }
 
 /**
@@ -84,11 +94,20 @@ export function extractParams(
   const result: ParamInfo[] = [];
   let index = 0;
   for (const child of paramsNode.namedChildren) {
-    const names = extractParamNames(child, rules);
-    for (const name of names) {
-      result.push({ name, index });
+    // Grouped wrapper types (e.g. Dart's optional_formal_parameters) can mix
+    // real formal_parameter slots with unrelated named siblings — e.g. a
+    // default value's literal, which the grammar attaches as a flat sibling
+    // rather than nesting inside its formal_parameter (issue #2358). Only a
+    // slot that actually yields a name consumes an index.
+    const slots = rules.groupedParamTypes?.has(child.type) ? child.namedChildren : [child];
+    for (const slot of slots) {
+      const names = extractParamNames(slot, rules);
+      if (names.length === 0) continue;
+      for (const name of names) {
+        result.push({ name, index });
+      }
+      index++;
     }
-    index++;
   }
   return result;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1359,6 +1359,16 @@ export interface DataflowRulesConfig {
   shorthandPropPattern: string | null;
   pairPatternType: string | null;
   extractParamName: ((node: TreeSitterNode) => string[] | null) | null;
+  /**
+   * Node types where ONE child of the parameter list groups multiple
+   * logically separate parameter declarations — e.g. Dart's
+   * `optional_formal_parameters` for `{int times, bool loud}` (issue #2358).
+   * Unlike `objectDestructType`/`arrayDestructType`, where multiple bound
+   * names are extracted from a SINGLE argument slot and must share one
+   * index, each of this node's own named children is its own slot and gets
+   * its own index.
+   */
+  groupedParamTypes: Set<string>;
   returnNode: string | null;
   varDeclaratorNode: string | null;
   varDeclaratorNodes: Set<string> | null;

--- a/tests/parsers/dataflow-cpp.test.ts
+++ b/tests/parsers/dataflow-cpp.test.ts
@@ -73,6 +73,15 @@ describe('extractDataflow — C++', () => {
         ]),
       );
     });
+
+    it('keeps a named parameter at its true position after a preceding unnamed parameter (#2358)', () => {
+      const data = parseAndExtract('void f(int, int value) { value; }');
+      expect(data?.parameters).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ funcName: 'f', paramName: 'value', paramIndex: 1 }),
+        ]),
+      );
+    });
   });
 
   // ── Return statements ─────────────────────────────────────────────────

--- a/tests/parsers/dataflow-dart.test.ts
+++ b/tests/parsers/dataflow-dart.test.ts
@@ -67,6 +67,30 @@ describe('extractDataflow — Dart', () => {
         ]),
       );
     });
+
+    it('gives each name in a named-parameter group its own paramIndex (#2358)', () => {
+      const data = parseAndExtract(
+        'int greet(String name, {int times = 1, bool loud = false}) {\n  return times;\n}\n',
+      );
+      expect(data!.parameters).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ funcName: 'greet', paramName: 'name', paramIndex: 0 }),
+          expect.objectContaining({ funcName: 'greet', paramName: 'times', paramIndex: 1 }),
+          expect.objectContaining({ funcName: 'greet', paramName: 'loud', paramIndex: 2 }),
+        ]),
+      );
+    });
+
+    it('gives each name in an optional-positional parameter group its own paramIndex', () => {
+      const data = parseAndExtract('int f(int a, [int b, int c]) {\n  return a;\n}\n');
+      expect(data!.parameters).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ funcName: 'f', paramName: 'a', paramIndex: 0 }),
+          expect.objectContaining({ funcName: 'f', paramName: 'b', paramIndex: 1 }),
+          expect.objectContaining({ funcName: 'f', paramName: 'c', paramIndex: 2 }),
+        ]),
+      );
+    });
   });
 
   describe('returns', () => {

--- a/tests/parsers/dataflow-javascript.test.ts
+++ b/tests/parsers/dataflow-javascript.test.ts
@@ -51,6 +51,17 @@ describe('extractDataflow — JavaScript', () => {
       );
     });
 
+    it('keeps destructured names sharing one argument slot at the same paramIndex (#2358)', () => {
+      const data = parseAndExtract(`function greet({ name, age }, city) { return name; }`);
+      expect(data.parameters).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ funcName: 'greet', paramName: 'name', paramIndex: 0 }),
+          expect.objectContaining({ funcName: 'greet', paramName: 'age', paramIndex: 0 }),
+          expect.objectContaining({ funcName: 'greet', paramName: 'city', paramIndex: 1 }),
+        ]),
+      );
+    });
+
     it('extracts default parameters', () => {
       const data = parseAndExtract(`function inc(x, step = 1) { return x + step; }`);
       expect(data.parameters).toEqual(


### PR DESCRIPTION
## Problem

`extractParams` (`src/ast-analysis/visitor-utils.ts`) incremented `index` once per CHILD of the parameter list, not once per extracted name. Dart's `optional_formal_parameters` wraps multiple genuinely separate parameter declarations in one child node (`{int times, bool loud}`), so both `times` and `loud` got the same `paramIndex`.

## Fix

Added `groupedParamTypes` to `DataflowRulesConfig`: when a child's type is in this set, `extractParams` iterates that child's own named children as separate slots instead of treating the whole node as one slot. Set for Dart's `optional_formal_parameters`.

This is deliberately **not** a blanket "index per extracted name" change (the issue's own caution): true single-slot destructuring (JS/TS `function f({a, b})`) must keep sharing one index across `a`/`b`, since both come from the same argument slot — verified via a new test locking that in.

Also discovered Dart's grammar attaches a parameter's default-value literal (`= 1`, `= false`) as a flat sibling *inside* the `optional_formal_parameters` group, not nested inside its `formal_parameter` — so the grouped-slot loop only consumes an index for a slot that actually yields a name, otherwise the literal siblings created off-by-N gaps.

Simplified `extractDartParamName` by removing its now-dead recursive `optional_formal_parameters` branch, since `extractParams` no longer calls it on the group node directly.

TS/WASM-only — the Rust engine has no Dart dataflow rules at all yet (tracked separately by #2359), so there's nothing to mirror there for this fix.

## Follow-up filed

While verifying no other language relies on the old shared-index behavior, found Go's `func f(a, b int)` hits the identical bug class in **both** engines (TS's `go.ts` and Rust's `extract_params_go`) — already shipped, so lower risk tolerance and a differently-shaped fix. Filed as #2501, out of scope here.

Closes #2358

## Test plan
- [x] New Dart tests: named-parameter group and optional-positional group each get distinct `paramIndex` values
- [x] New JS/TS test: destructured object-pattern names still share one `paramIndex`, non-destructured sibling gets the next one
- [x] Full `vitest run` suite (5272 passed, 328 files)
- [x] `tsc --noEmit`, `biome check`
- [x] `cargo test --release`, `cargo clippy -- -D warnings`, `cargo fmt --check` (unaffected, confirmed clean)
- [x] Dual-engine dataflow parity suite