### PR TITLE
fix(sweep): repo-detection fallback regex also accepts ssh:// github remotes

### DIFF
--- a/.claude/skills/sweep/SKILL.md
+++ b/.claude/skills/sweep/SKILL.md
@@ -23,7 +23,7 @@ Detect the repo slug dynamically so this skill works in any fork or renamed org 
 ```bash
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null \
   || git remote get-url origin 2>/dev/null \
-     | sed -nE 's#^(git@github\.com:|https://github\.com/)([^/]+/[^/]+)/?$#\2#p' \
+     | sed -nE 's#^(git@github\.com:|https://github\.com/|ssh://git@github\.com/)([^/]+/[^/]+)/?$#\2#p' \
      | sed -E 's/\.git$//')
 if [ -z "$REPO" ]; then
   echo "ERROR: could not detect GitHub repo slug — ensure 'gh' is authenticated or 'origin' points to GitHub"


### PR DESCRIPTION
## Problem

`/sweep`'s repo-slug-detection fallback (`.claude/skills/sweep/SKILL.md`) only matches `git@github.com:owner/repo` and `https://github.com/owner/repo` remote URL forms — it silently rejects `ssh://git@github.com/owner/repo`, a valid, real-world GitHub remote form. The OLD (buggy, `.git`-suffix-retaining) regex this replaced happened to accept it too, via a permissive `.*github\.com[:/]` prefix — so this is a genuine regression, not just a pre-existing gap.

Greptile caught this exact gap on PR #2362 (porting the same fallback pattern into `/resolve`) and it was fixed there before merge. `/sweep` — the original source of this pattern (PR #2185) — still has the unfixed version.

## Fix

Add `ssh://git@github\.com/` as a third alternative in the anchored prefix group, exactly matching `/resolve`'s already-fixed copy:

```diff
-     | sed -nE 's#^(git@github\.com:|https://github\.com/)([^/]+/[^/]+)/?$#\2#p' \
+     | sed -nE 's#^(git@github\.com:|https://github\.com/|ssh://git@github\.com/)([^/]+/[^/]+)/?$#\2#p' \
```

Closes #2363

## Test plan
- [x] Verified all 6 remote URL forms (scp-style SSH, HTTPS, `ssh://`, each with/without `.git` suffix) resolve to the correct `owner/repo` slug via the fixed regex
- [x] `lint-skill.sh` shows only pre-existing warnings/errors unrelated to this line (missing frontmatter fields, missing sections — out of scope, not introduced by this change)
- [x] No source code or test infrastructure covers this markdown-embedded pattern (confirmed by checking PR #2362, which fixed the identical gap in `/resolve` with no accompanying test) — matches existing precedent