### PR TITLE
test(hub-selection): raise windows-flaky beforeAll/test timeouts to 60s

### DIFF
--- a/tests/unit/hub-selection.test.ts
+++ b/tests/unit/hub-selection.test.ts
@@ -80,7 +80,7 @@ beforeAll(() => {
   insertEdge(db, orchestrator, leafHelper, 'calls');
 
   db.close();
-});
+}, 60_000); // Windows CI runners have hit the default 30s hook timeout on slow tmpdir I/O (#2368)
 
 afterAll(() => {
   if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -126,7 +126,11 @@ describe('selectHubTargets', () => {
     expect(second).toEqual(first);
   });
 
-  it('throws when the graph has no qualifying nodes with edges', () => {
+  // Windows CI runners have hit the default 30s test timeout here on slow
+  // tmpdir/DB-file I/O (#2368) — this test does its own mkdtempSync + a
+  // fresh better-sqlite3 file, unlike the other tests in this file which
+  // reuse the single DB `beforeAll` already built.
+  it('throws when the graph has no qualifying nodes with edges', { timeout: 60_000 }, () => {
     const emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-hub-selection-empty-'));
     const emptyDbPath = path.join(emptyDir, 'graph.db');
     const db = new Database(emptyDbPath);


### PR DESCRIPTION
## Problem

`tests/unit/hub-selection.test.ts` has now hit the default 30s hook/test timeout on `Test Node 22 (windows-2022)` across **multiple** independent, otherwise-unrelated PRs this session (a docs-only README badge change, a lockfile-only chore, and two of my own earlier PRs in this /fixer run) — always the same two spots:

- The `beforeAll` hook (`fs.mkdtempSync` + a fresh `better-sqlite3` file + schema init).
- The `'throws when the graph has no qualifying nodes with edges'` test, which does its own separate `mkdtempSync` + DB file (unlike every other test in the file, which reuses the single DB `beforeAll` already built).

Every occurrence reran cleanly on retry — this is Windows-runner I/O slowness (the full Windows suite run is consistently ~470-500s, close to whatever margin exists before hitting the 30s per-hook/per-test ceiling), not a real regression in this file or whatever the triggering PR happened to touch.

## Fix

Raised both to a 60s timeout via vitest's per-hook/per-test override — mirrors the identical fix already applied to a different Windows-flaky test in this repo (`tests/unit/lint-skill-read-binding-2344.test.ts`, PR #2490).

Did not pursue the issue's other two suggested options:
- The I/O itself (`mkdtempSync` + a small sqlite init) isn't doing anything unusually slow — nothing to speed up algorithmically; the slowness is Windows-runner-environmental.
- A "known-flaky" allowlist would still require someone to notice and rerun the failure each time — the timeout increase actually prevents the failure from happening in the first place.

Closes #2368

## Test plan
- [x] `vitest run tests/unit/hub-selection.test.ts` — all 6 tests pass
- [x] Full `vitest run` suite (5283 passed, 328 files) after rebuilding the native addon (stale in the fresh worktree, unrelated to this test-only change)
- [x] `tsc --noEmit`, `biome check` clean