### PR TITLE
fix: ignore Rust target/ build directory during file collection (#2374)

### DIFF
--- a/crates/codegraph-core/src/domain/graph/builder/stages/collect_files.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/collect_files.rs
@@ -28,6 +28,7 @@ pub(crate) const DEFAULT_IGNORE_DIRS: &[&str] = &[
     "venv",
     "env",
     ".env",
+    "target",
 ];
 
 /// All supported file extensions (mirrors the JS `EXTENSIONS` set).
@@ -469,6 +470,24 @@ mod tests {
         let result = collect_files(tmp.to_str().unwrap(), &[], &[], &[]);
         assert_eq!(result.files.len(), 1);
         assert!(result.files[0].contains("app.ts"));
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn collect_skips_target_dir() {
+        let tmp = std::env::temp_dir().join("codegraph_collect_target_test");
+        let _ = fs::remove_dir_all(&tmp);
+        let build_out = tmp.join("target").join("debug");
+        fs::create_dir_all(&build_out).unwrap();
+        fs::write(build_out.join("build.rs"), "").unwrap();
+        let src = tmp.join("src");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(src.join("app.rs"), "").unwrap();
+
+        let result = collect_files(tmp.to_str().unwrap(), &[], &[], &[]);
+        assert_eq!(result.files.len(), 1);
+        assert!(result.files[0].contains("app.rs"));
 
         let _ = fs::remove_dir_all(&tmp);
     }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -31,6 +31,7 @@ export const IGNORE_DIRS: ArrayCompatSet<string> = withArrayCompat(
     'venv',
     'env',
     '.env',
+    'target',
   ]),
 );
 

--- a/tests/unit/builder.test.ts
+++ b/tests/unit/builder.test.ts
@@ -32,12 +32,15 @@ beforeAll(() => {
   //     secret.js        (hidden dir, ignored)
   //   vendor/
   //     third.js         (in IGNORE_DIRS)
+  //   target/
+  //     debug/build.rs   (Rust build output, in IGNORE_DIRS)
   fs.mkdirSync(path.join(tmpDir, 'src'), { recursive: true });
   fs.mkdirSync(path.join(tmpDir, 'lib'), { recursive: true });
   fs.mkdirSync(path.join(tmpDir, 'node_modules', 'pkg'), { recursive: true });
   fs.mkdirSync(path.join(tmpDir, '.git'), { recursive: true });
   fs.mkdirSync(path.join(tmpDir, '.hidden'), { recursive: true });
   fs.mkdirSync(path.join(tmpDir, 'vendor'), { recursive: true });
+  fs.mkdirSync(path.join(tmpDir, 'target', 'debug'), { recursive: true });
 
   fs.writeFileSync(path.join(tmpDir, 'src', 'app.js'), 'export default {}');
   fs.writeFileSync(path.join(tmpDir, 'src', 'utils.ts'), 'export const x = 1;');
@@ -48,6 +51,7 @@ beforeAll(() => {
   fs.writeFileSync(path.join(tmpDir, '.git', 'config'), '[core]');
   fs.writeFileSync(path.join(tmpDir, '.hidden', 'secret.js'), 'export const s = 1;');
   fs.writeFileSync(path.join(tmpDir, 'vendor', 'third.js'), 'export const t = 1;');
+  fs.writeFileSync(path.join(tmpDir, 'target', 'debug', 'build.rs'), 'fn main() {}');
 });
 
 afterAll(() => {
@@ -95,6 +99,12 @@ describe('collectFiles', () => {
     const files = collectFiles(tmpDir);
     const inVendor = files.filter((f) => f.includes('vendor'));
     expect(inVendor).toHaveLength(0);
+  });
+
+  it('skips target directory (Rust build output)', () => {
+    const files = collectFiles(tmpDir);
+    const inTarget = files.filter((f) => f.includes('target'));
+    expect(inTarget).toHaveLength(0);
   });
 
   it('respects config.ignoreDirs', () => {

--- a/tests/unit/constants.test.ts
+++ b/tests/unit/constants.test.ts
@@ -47,7 +47,16 @@ describe('EXTENSIONS', () => {
 
 describe('IGNORE_DIRS', () => {
   it('contains expected directory names', () => {
-    const expected = ['node_modules', '.git', 'dist', 'build', 'coverage', '__pycache__', 'vendor'];
+    const expected = [
+      'node_modules',
+      '.git',
+      'dist',
+      'build',
+      'coverage',
+      '__pycache__',
+      'vendor',
+      'target',
+    ];
     for (const dir of expected) {
       expect(IGNORE_DIRS.has(dir)).toBe(true);
     }
@@ -91,6 +100,10 @@ describe('shouldIgnore', () => {
 
   it('returns true for .git', () => {
     expect(shouldIgnore('.git')).toBe(true);
+  });
+
+  it('returns true for target (Rust build output)', () => {
+    expect(shouldIgnore('target')).toBe(true);
   });
 
   it('returns true for hidden directories (dot prefix)', () => {


### PR DESCRIPTION
## Summary
Neither `IGNORE_DIRS` (TypeScript, `src/shared/constants.ts`) nor its mirror `DEFAULT_IGNORE_DIRS` (Rust, `crates/codegraph-core/src/domain/graph/builder/stages/collect_files.rs`) skipped Cargo's `target/` build output directory. For any non-trivial Rust project this directory can be enormous, and codegen tools (`bindgen`, `prost`, `tonic-build`, etc.) emit real, syntactically valid `.rs` files into `OUT_DIR` under `target/` — codegraph's file walk was parsing these as hand-written project source, polluting the graph and adding real walk-time cost.

Added `"target"` to both lists, keeping the dual-engine mirroring convention intact.

## Verification
- lint: pass
- tests: pass (full JS suite: 328 files / 5287 tests; full Rust suite: 1024 tests)
- Added unit coverage: `shouldIgnore('target')` + `IGNORE_DIRS` membership (TS), an end-to-end `collectFiles()` walk test with a `target/debug/build.rs` fixture (TS), and a `collect_skips_target_dir` test mirroring the existing `collect_skips_ignored_dirs` pattern (Rust)

Closes #2374