### PR TITLE
fix(stats): stop double-counting dead symbols in the roles map (#2383)

### DIFF
--- a/src/domain/analysis/module-map.ts
+++ b/src/domain/analysis/module-map.ts
@@ -265,14 +265,13 @@ function countRoles(db: BetterSqlite3Database, noTests: boolean) {
       `SELECT role, COUNT(*) as c FROM nodes WHERE role IS NOT NULL ${testFilter} GROUP BY role`,
     )
     .all() as Array<{ role: string; c: number }>;
-  const roles: Record<string, number> & { dead?: number } = {};
+  const roles: Record<string, number> = {};
   let deadTotal = 0;
   for (const r of roleRows) {
     roles[r.role] = r.c;
     if (r.role.startsWith(DEAD_ROLE_PREFIX)) deadTotal += r.c;
   }
-  if (deadTotal > 0) roles.dead = deadTotal;
-  return roles;
+  return { roles, deadTotal };
 }
 
 function getComplexitySummary(db: BetterSqlite3Database, testFilter: string) {
@@ -424,14 +423,13 @@ function computeQualityScore(
 
 /** Aggregate role counts and derive the `dead` total. */
 function aggregateRolesFromNative(roleCounts: Array<{ role: string; count: number }>) {
-  const roles: Record<string, number> & { dead?: number } = {};
+  const roles: Record<string, number> = {};
   let deadTotal = 0;
   for (const r of roleCounts) {
     roles[r.role] = r.count;
     if (r.role.startsWith(DEAD_ROLE_PREFIX)) deadTotal += r.count;
   }
-  if (deadTotal > 0) roles.dead = deadTotal;
-  return roles;
+  return { roles, deadTotal };
 }
 
 type NativeGraphStatsFn = NonNullable<NativeDatabase['getGraphStats']>;
@@ -454,7 +452,7 @@ function buildStatsFromNative(
   for (const k of s.nodesByKind) nodesByKind[k.kind] = k.count;
   const edgesByKind: Record<string, number> = {};
   for (const k of s.edgesByKind) edgesByKind[k.kind] = k.count;
-  const roles = aggregateRolesFromNative(s.roleCounts);
+  const { roles, deadTotal } = aggregateRolesFromNative(s.roleCounts);
 
   const callerCoverage =
     s.quality.callableTotal > 0 ? s.quality.callableWithCallers / s.quality.callableTotal : 0;
@@ -508,6 +506,7 @@ function buildStatsFromNative(
       falsePositiveWarnings,
     },
     roles,
+    deadTotal: deadTotal > 0 ? deadTotal : undefined,
     complexity: s.complexity
       ? {
           analyzed: s.complexity.analyzed,
@@ -542,7 +541,7 @@ function buildStatsFromJs(
   const embeddings = getEmbeddingsInfo(db);
   const fpThreshold = config.analysis?.falsePositiveCallers ?? FALSE_POSITIVE_CALLER_THRESHOLD;
   const quality = computeQualityMetrics(db, testFilter, fpThreshold);
-  const roles = countRoles(db, noTests);
+  const { roles, deadTotal } = countRoles(db, noTests);
   const complexity = getComplexitySummary(db, testFilter);
 
   return {
@@ -554,6 +553,7 @@ function buildStatsFromJs(
     embeddings,
     quality,
     roles,
+    deadTotal: deadTotal > 0 ? deadTotal : undefined,
     complexity,
   };
 }

--- a/src/presentation/queries-cli/overview.ts
+++ b/src/presentation/queries-cli/overview.ts
@@ -9,6 +9,7 @@ import {
 import { debug } from '../../infrastructure/logger.js';
 import { outputResult } from '../../infrastructure/result-formatter.js';
 import { toErrorMessage } from '../../shared/errors.js';
+import { DEAD_ROLE_PREFIX } from '../../shared/kinds.js';
 
 interface OutputOpts {
   json?: boolean;
@@ -95,6 +96,7 @@ interface StatsData {
   embeddings?: EmbeddingsInfo;
   quality?: QualityInfo;
   roles?: Record<string, number>;
+  deadTotal?: number;
   complexity?: ComplexityInfo;
   communities?: CommunityInfo;
 }
@@ -130,7 +132,10 @@ function printCountGrid(entries: [string, number][], padWidth: number): void {
   for (let i = 0; i < parts.length; i += 3) {
     const row = parts
       .slice(i, i + 3)
-      .map((p) => p.padEnd(padWidth))
+      // A part at or beyond padWidth would otherwise run straight into the next
+      // column with no separator, since padEnd is a no-op once the string already
+      // meets the target width.
+      .map((p) => (p.length >= padWidth ? `${p} ` : p.padEnd(padWidth)))
       .join('');
     console.log(`  ${row}`);
   }
@@ -225,11 +230,22 @@ function printRoles(data: StatsData): void {
   if (data.roles && Object.keys(data.roles).length > 0) {
     const total = Object.values(data.roles).reduce((a, b) => a + b, 0);
     console.log(`\nRoles:     ${total} classified symbols`);
-    const roleEntries = Object.entries(data.roles).sort((a, b) => b[1] - a[1]) as [
-      string,
-      number,
-    ][];
-    printCountGrid(roleEntries, 18);
+    const liveEntries = Object.entries(data.roles).filter(
+      ([role]) => !role.startsWith(DEAD_ROLE_PREFIX),
+    ) as [string, number][];
+    printCountGrid(
+      liveEntries.sort((a, b) => b[1] - a[1]),
+      18,
+    );
+    if (data.deadTotal) {
+      console.log(`  dead ${data.deadTotal}`);
+      const deadEntries = Object.entries(data.roles).filter(([role]) =>
+        role.startsWith(DEAD_ROLE_PREFIX),
+      ) as [string, number][];
+      for (const [role, count] of deadEntries.sort((a, b) => b[1] - a[1])) {
+        console.log(`    ${role} ${count}`);
+      }
+    }
   }
 }
 

--- a/tests/integration/roles.test.ts
+++ b/tests/integration/roles.test.ts
@@ -455,8 +455,8 @@ describe('statsData with roles', () => {
     const data = statsData(dbPath);
     expect(data.roles).toBeDefined();
     expect(Object.keys(data.roles).length).toBeGreaterThan(0);
-    // Should have dead for the unused function
-    expect(data.roles.dead).toBeGreaterThanOrEqual(1);
+    // Should have a dead sub-role for the unused function
+    expect(data.deadTotal).toBeGreaterThanOrEqual(1);
   });
 
   test('roles distribution respects noTests filter', () => {
@@ -465,6 +465,18 @@ describe('statsData with roles', () => {
     const totalWith = Object.values(withTests.roles).reduce((a, b) => a + b, 0);
     const totalWithout = Object.values(withoutTests.roles).reduce((a, b) => a + b, 0);
     expect(totalWithout).toBeLessThanOrEqual(totalWith);
+  });
+
+  test('roles map does not carry an aggregate "dead" peer key', () => {
+    // Regression test for #2383: `dead` used to be injected into the flat
+    // roles map as the sum of its own dead-* sub-roles, double-counting
+    // every dead symbol in any total over the map.
+    const data = statsData(dbPath);
+    expect(data.roles.dead).toBeUndefined();
+    const deadSubRoleTotal = Object.entries(data.roles)
+      .filter(([role]) => role.startsWith('dead-'))
+      .reduce((sum, [, count]) => sum + count, 0);
+    expect(data.deadTotal).toBe(deadSubRoleTotal);
   });
 });
 


### PR DESCRIPTION
## Summary

`codegraph stats` double-counted every dead symbol. The `roles` map contained the four granular `dead-*` sub-roles **and** an aggregate `dead` key that was their sum, sitting as a peer in the same flat map — so any total over the map (including the printed "classified symbols" headline) counted dead symbols twice.

Root cause was in `countRoles` (SQL path) and `aggregateRolesFromNative` (native path) in `src/domain/analysis/module-map.ts` — both injected `roles.dead = deadTotal` into the same object that already held the four `dead-*` counts.

## Changes

- `countRoles`/`aggregateRolesFromNative` now return `{ roles, deadTotal }` — `deadTotal` is a sibling field in the stats result, never a peer key inside `roles`. `stats -j` now emits the shape the issue proposed: `{ "roles": {...no aggregate dead key...}, "deadTotal": N }`.
- `printRoles` (text output) now renders the dead family as an indented sub-group under a single `dead N` heading instead of interleaving it with the other roles in one sorted grid.
- Fixed an accompanying `printCountGrid` cosmetic bug: a column value at or beyond the fixed pad width ran straight into the next column with no separator (e.g. `dead-unresolved 86dead 86`).
- Confirmed no Rust-side change needed: `crates/codegraph-core`'s `fetch_role_counts` does a raw `GROUP BY role` with no aggregate injected — the double-count was purely in the JS aggregation layer that both engines' stats paths share.

## Verification

- lint: pass
- `npx vitest run tests/integration/roles.test.ts`: 22/22 pass (updated the `roles.dead` assertion to `deadTotal`, added a regression test asserting the map no longer carries an aggregate `dead` peer key)
- `codegraph diff-impact --staged`: 7 functions changed, 0 external callers affected beyond `stats()`
- Manually verified against this repo's own graph: `roles` no longer contains `dead`, `deadTotal` correctly sums the four sub-roles, and the text headline total now matches the sum of disjoint categories

Note: a full local `npm test` run in this environment (Node v26.4.0, no other version available) shows ~200 unrelated failures that also reproduce on an untouched `origin/main` checkout and do not touch any file this PR changes; CI (which pins Node 22, per `.github/workflows/ci.yml`) has been consistently green on recent `main` pushes. Filed as optave/ops-codegraph-tool#2521 for separate tracking — not blocking this fix.

Closes #2383