### PR TITLE
fix(stats): show max cyclomatic in the text complexity summary (#2384)

### DIFF
--- a/src/presentation/queries-cli/overview.ts
+++ b/src/presentation/queries-cli/overview.ts
@@ -77,6 +77,7 @@ interface ComplexityInfo {
   avgCognitive: number;
   avgCyclomatic: number;
   maxCognitive: number;
+  maxCyclomatic: number;
   avgMI?: number;
   minMI?: number;
 }
@@ -254,7 +255,7 @@ function printComplexity(data: StatsData): void {
     const cx = data.complexity;
     const miPart = cx.avgMI != null ? ` | avg MI: ${cx.avgMI} | min MI: ${cx.minMI}` : '';
     console.log(
-      `\nComplexity: ${cx.analyzed} functions | avg cognitive: ${cx.avgCognitive} | avg cyclomatic: ${cx.avgCyclomatic} | max cognitive: ${cx.maxCognitive}${miPart}`,
+      `\nComplexity: ${cx.analyzed} functions | avg cognitive: ${cx.avgCognitive} | avg cyclomatic: ${cx.avgCyclomatic} | max cognitive: ${cx.maxCognitive} | max cyclomatic: ${cx.maxCyclomatic}${miPart}`,
     );
   }
 }

--- a/tests/presentation/queries-cli.test.ts
+++ b/tests/presentation/queries-cli.test.ts
@@ -39,7 +39,7 @@ const { where, queryName, context, children, explain, implementations, interface
 );
 const { symbolPath } = await import('../../src/presentation/queries-cli/path.js');
 const { fileExports } = await import('../../src/presentation/queries-cli/exports.js');
-const { moduleMap, roles } = await import('../../src/presentation/queries-cli/overview.js');
+const { moduleMap, roles, stats } = await import('../../src/presentation/queries-cli/overview.js');
 
 // ── Helpers ────────────────────────────────────────────────────────
 let lines: any;
@@ -678,5 +678,32 @@ describe('roles', () => {
     mocks.rolesData.mockReturnValue({ count: 0, summary: {}, symbols: [] });
     roles('/db', {});
     expect(output()).toContain('No classified symbols found');
+  });
+});
+
+// ── overview.js: stats ─────────────────────────────────────────────
+
+describe('stats', () => {
+  it('prints max cyclomatic alongside max cognitive', async () => {
+    mocks.statsData.mockReturnValue({
+      nodes: { total: 1, byKind: { function: 1 } },
+      edges: { total: 0, byKind: {} },
+      files: { total: 1, languages: 1, byLanguage: { javascript: 1 } },
+      cycles: { fileLevel: 0, functionLevel: 0 },
+      hotspots: [],
+      complexity: {
+        analyzed: 4633,
+        avgCognitive: 4.1,
+        avgCyclomatic: 4,
+        maxCognitive: 74,
+        maxCyclomatic: 40,
+        avgMI: 65.1,
+        minMI: 24.7,
+      },
+    });
+    await stats('/db', {});
+    const out = output();
+    expect(out).toContain('max cognitive: 74');
+    expect(out).toContain('max cyclomatic: 40');
   });
 });


### PR DESCRIPTION
## Summary

The human-readable `codegraph stats` complexity line omitted `maxCyclomatic`, even though it's computed and present in `stats -j`. The line was internally inconsistent about which extreme it reports per metric: cognitive gets its max, MI gets its min, but cyclomatic only got its average — so a function at cyclomatic 40 was invisible in the default view while an equivalent cognitive outlier was shown.

## Changes

- Added `maxCyclomatic` to the `ComplexityInfo` interface in `src/presentation/queries-cli/overview.ts` (the value was already computed by both the native and JS `stats` paths — this was purely a presentation-layer omission).
- `printComplexity` now prints `max cyclomatic: N` right after `max cognitive: N`, matching the JSON shape.

## Verification

- lint: pass
- `npx vitest run tests/presentation/queries-cli.test.ts`: 31/31 pass (added a new `stats` test asserting both max cognitive and max cyclomatic appear in the rendered line)
- `codegraph diff-impact --staged`: 2 functions changed, 2 callers affected (`stats()` and its CLI `execute` wrapper — exactly the expected surface)
- Manually verified against this repo's own graph: `Complexity: ... | max cognitive: 102 | max cyclomatic: 51 | avg MI: ...`

Closes #2384