### PR TITLE
fix(roles): stop emitting dead-* verdicts for declarative-only languages (#2385)

### DIFF
--- a/crates/codegraph-core/src/graph/classifiers/roles.rs
+++ b/crates/codegraph-core/src/graph/classifiers/roles.rs
@@ -217,6 +217,16 @@ fn classify_node(
     median_fan_in: f64,
     median_fan_out: f64,
 ) -> &'static str {
+    // Declarative-only language (#2385) — never subject to call-graph
+    // dead-code detection; there is no call graph for it by design (e.g.
+    // Terraform/HCL — everything is a resource/module/data/variable/output
+    // block, never invoked or invoking anything). Distinct from a language
+    // where call resolution is merely not implemented yet.
+    let declarative_exts = [".tf", ".hcl"];
+    if declarative_exts.iter().any(|ext| file.ends_with(ext)) {
+        return "leaf";
+    }
+
     // Interface/type members (#1723) — never subject to call-graph dead-code
     // detection, regardless of fan-in/fan-out/export status.
     if is_type_member {
@@ -1794,6 +1804,23 @@ mod tests {
         do_classify_full(conn).expect("do_classify_full should succeed");
 
         assert_eq!(role_of(conn, 1).as_deref(), Some("dead-unresolved"));
+    }
+
+    // ── Declarative-only language carve-out (#2385) ─────────────────────
+
+    #[test]
+    fn hcl_resource_with_zero_fan_in_is_leaf_not_dead() {
+        let db = setup_db();
+        let conn = db.conn().expect("connection should still be open");
+
+        // A Terraform resource with no incoming call edges — HCL never
+        // produces call edges by design, so fan_in == 0 carries no
+        // dead-code signal here, unlike a real function/method.
+        insert_node(conn, 1, "aws_kms_key.state", "resource", "main.tf", 0);
+
+        do_classify_full(conn).expect("do_classify_full should succeed");
+
+        assert_eq!(role_of(conn, 1).as_deref(), Some("leaf"));
     }
 
     #[test]

--- a/src/graph/classifiers/roles.ts
+++ b/src/graph/classifiers/roles.ts
@@ -30,6 +30,10 @@
  * never gain inbound call edges by construction, so call-graph reachability
  * doesn't apply to them either (#1723).
  *
+ * Every node whose file belongs to a declarative-only language (currently
+ * just Terraform/HCL) is likewise classified `leaf` unconditionally, via
+ * `isDeclarativeLanguageNode` — see its doc comment (#2385).
+ *
  * `entry` requires `kind IN ('function', 'method')` (plus the framework-prefix/
  * Commander-dispatch shortcuts, which are already kind-appropriate by
  * construction). An exported interface/type/constant/class with zero fan-in is
@@ -71,6 +75,26 @@ const LEAF_KINDS = new Set(['parameter', 'property', 'constant']);
 const TYPE_DEF_KINDS = new Set(['struct', 'enum', 'trait', 'type', 'interface', 'record']);
 
 const FFI_EXTENSIONS = new Set(['.rs', '.c', '.cpp', '.h', '.go', '.java', '.cs']);
+
+/**
+ * Extensions of declarative-only languages that have no functions, classes,
+ * or call graph by design (e.g. Terraform/HCL — everything is a
+ * resource/module/data/variable/output block; nothing is ever invoked or
+ * invokes anything). A `fanIn === 0` reading for these carries zero
+ * dead-code signal, unlike a language where call resolution is merely not
+ * implemented yet (see the resolution-benchmark's 0.0/0.0 thresholds for
+ * e.g. bash/ruby/lua, which DO have real dead code a future resolver could
+ * find). Emitting `dead-*` anyway invited destructive action on live
+ * infrastructure (#2385).
+ */
+const DECLARATIVE_EXTENSIONS = new Set(['.tf', '.hcl']);
+
+/** True when `node.file`'s extension belongs to a declarative-only language (#2385). */
+function isDeclarativeLanguageNode(node: { file?: string }): boolean {
+  if (!node.file) return false;
+  const dotIdx = node.file.lastIndexOf('.');
+  return dotIdx !== -1 && DECLARATIVE_EXTENSIONS.has(node.file.slice(dotIdx));
+}
 
 /** Path patterns indicating framework-dispatched entry points. */
 const ENTRY_PATH_PATTERNS: readonly RegExp[] = [
@@ -345,6 +369,10 @@ function classifyNodeRole(
   medFanOut: number,
   typeDefNamesByFile: Map<string, Set<string>>,
 ): Role {
+  // Declarative-only language (#2385) — never subject to call-graph dead-code
+  // detection; there is no call graph for it by design.
+  if (isDeclarativeLanguageNode(node)) return 'leaf';
+
   // Interface/type members (#1723) — never subject to call-graph dead-code
   // detection, regardless of fan-in/fan-out/export status.
   if (isTypeDeclarationMember(node, typeDefNamesByFile)) return 'leaf';

--- a/tests/graph/classifiers/roles.test.ts
+++ b/tests/graph/classifiers/roles.test.ts
@@ -213,6 +213,34 @@ describe('classifyRoles', () => {
     expect(roles.get('1')).toBe('dead-ffi');
   });
 
+  it('classifies HCL resources as leaf, never dead-* (#2385)', () => {
+    // Terraform never produces call edges by design — a fanIn === 0 reading
+    // carries zero dead-code signal here, unlike a real function/method.
+    const nodes = [
+      {
+        id: '1',
+        name: 'aws_kms_key.state',
+        kind: 'resource',
+        file: 'main.tf',
+        fanIn: 0,
+        fanOut: 0,
+        isExported: false,
+      },
+      {
+        id: '2',
+        name: 'bucket_name',
+        kind: 'output',
+        file: 'outputs.hcl',
+        fanIn: 0,
+        fanOut: 0,
+        isExported: true,
+      },
+    ];
+    const roles = classifyRoles(nodes);
+    expect(roles.get('1')).toBe('leaf');
+    expect(roles.get('2')).toBe('leaf');
+  });
+
   it('classifies execute/validate as entry (not dead-entry) in CLI command files (#1585)', () => {
     // Commander.js dispatch methods (execute, validate) in cli/commands/ are
     // confirmed entry points — promoted directly to `entry` so they don't


### PR DESCRIPTION
## Summary

For languages where call resolution is intentionally absent (Terraform/HCL), role classification emitted `dead-unresolved` for every symbol — a 100% false-positive verdict by construction, since HCL has no functions, classes, or call graph at all: every node always has `fanIn === 0` regardless of how many times a resource is actually referenced elsewhere in the same file (only reference-tracking, not call-tracking, would show that — and HCL produces no reference edges either). This invites destructive action: an agent or human reading "132 dead symbols" in a Terraform repo could try to delete live infrastructure.

This is explicitly **not** the same situation as a language where call resolution is simply not implemented yet (e.g. bash/ruby/lua carry real dead code a future resolver could find, hence their `0.0/0.0` benchmark thresholds reflect an engineering gap, not a language-capability gap). HCL's absence of call edges is by design — the README support matrix already documents it as parse-only.

## Changes

- `src/graph/classifiers/roles.ts`: added `isDeclarativeLanguageNode` (checks the node's file extension against `.tf`/`.hcl`) and gated it at the top of `classifyNodeRole`, mirroring the existing carve-out for interface/type declaration members that can never be judged by call-graph reachability either. Declarative-language nodes are now classified `leaf` unconditionally — reusing the existing role rather than introducing a new enum value, since `leaf` already carries exactly this "not judged by call-graph reachability" semantic elsewhere in this file (and gets the same low `ROLE_WEIGHTS` score, 0.2, appropriate for infra-as-code declarations).
- `crates/codegraph-core/src/graph/classifiers/roles.rs`: mirrored the identical carve-out in `classify_node`, so the native and WASM engines stay in parity.
- Added test coverage in both engines: `tests/graph/classifiers/roles.test.ts` (JS, both `.tf` and `.hcl`, including an exported node) and a new Rust unit test `hcl_resource_with_zero_fan_in_is_leaf_not_dead`.

## Verification

- lint: pass
- `cargo fmt -- --check` / `cargo clippy --workspace --all-targets -- -D warnings`: pass
- `npx vitest run tests/graph/ tests/integration/roles.test.ts tests/unit/roles.test.ts`: 300/300 pass
- `cargo test --package codegraph-core graph::classifiers::roles`: 15/15 pass (including the new test)
- `codegraph diff-impact --staged`: 2 functions changed, 5 callers affected — contained to the role-classification call chain
- Manually reproduced the issue's exact Terraform fixture (KMS key + S3 bucket + SSE config + output, all cross-referenced) against a freshly built native addon (`napi build`, not the stale prebuilt one) and the WASM engine: all 4 symbols now classify `leaf` instead of `dead-unresolved`, confirmed identical across both engines

## Also filed

- optave/ops-codegraph-tool#2524 — split out the issue's secondary observation (the HCL resolution-benchmark fixture's expected `module`-reference edges never materialize) as a separate, distinct piece of resolver work not part of this dead-code classification fix

Closes #2385