### PR TITLE
fix(hooks): guard-git.sh branch validation uses the real push target, not the hook's own cwd (#2386)

### DIFF
--- a/.claude/hooks/guard-git.sh
+++ b/.claude/hooks/guard-git.sh
@@ -21,6 +21,20 @@ if [ -z "$COMMAND" ]; then
   exit 0
 fi
 
+# The actual directory the Bash tool will run this command in — a top-level
+# field on every PreToolUse payload, independent of whatever cd/-C text
+# happens to appear in $COMMAND. This is what a bare `git push` (relying on
+# the Bash tool's persistent cwd from an earlier, separate tool call) must
+# resolve against; the hook's own process cwd is unrelated to it (#2386).
+HOOK_CWD=$(echo "$INPUT" | node -e "
+  let d='';
+  process.stdin.on('data',c=>d+=c);
+  process.stdin.on('end',()=>{
+    const p=JSON.parse(d).cwd||'';
+    if(p)process.stdout.write(p);
+  });
+" 2>/dev/null) || true
+
 # Act on git and gh commands (may appear after cd "..." &&, inside a quoted
 # nested-shell invocation like `bash -c "git clean -fd"`, or inside a command
 # substitution like `"message $(git clean -fd)"` — #2099 Greptile review).
@@ -169,7 +183,8 @@ fi
 # Resolve the working directory a git command targets:
 # - `git -C "<dir>" ...`   → the -C target (takes precedence — explicit git-level override)
 # - `cd "<dir>" && git ...` → the cd target
-# Falls back to empty string (caller uses cwd).
+# Falls back to empty string when neither appears in the command text —
+# callers then fall back further to the hook's own $HOOK_CWD (#2386).
 #
 # Optional arg: target subcommand hint (e.g. `push`, `commit`). When given,
 # narrows the search to the `&&`-separated segment whose git invocation runs
@@ -220,18 +235,33 @@ validate_branch_name() {
   local work_dir
   work_dir=$(detect_work_dir "$subcmd")
 
+  # No explicit -C/cd in the command text — fall back to the Bash tool's
+  # actual cwd for this call (reported by the harness on every PreToolUse
+  # payload), NOT the hook process's own ambient cwd. A bare `git push`
+  # relying on a `cd` from an earlier, separate tool call has no directory
+  # hint in $COMMAND at all; substituting the hook's own cwd there validates
+  # a completely unrelated repo's branch (#2386).
+  if [ -z "$work_dir" ] && [ -n "$HOOK_CWD" ] && [ -d "$HOOK_CWD" ]; then
+    work_dir="$HOOK_CWD"
+  fi
+
   local BRANCH=""
   if [ -n "$work_dir" ] && [ -d "$work_dir" ]; then
     BRANCH=$(git -C "$work_dir" rev-parse --abbrev-ref HEAD 2>/dev/null) || true
   fi
+
+  # Still unresolved — we genuinely don't know which repo this command
+  # targets. A false deny on valid work (validating an unrelated repo's
+  # branch, as happened in #2386) is worse than a missed check here: decline
+  # to validate rather than guessing.
   if [ -z "$BRANCH" ]; then
-    BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || true
+    return 0
   fi
 
-  if [ -n "$BRANCH" ] && [ "$BRANCH" != "main" ] && [ "$BRANCH" != "HEAD" ]; then
+  if [ "$BRANCH" != "main" ] && [ "$BRANCH" != "HEAD" ]; then
     local PATTERN="^(feat|fix|docs|refactor|test|chore|ci|perf|build|release|dependabot|revert)/"
     if [[ ! "$BRANCH" =~ $PATTERN ]]; then
-      deny "BLOCKED: Branch '$BRANCH' does not match required pattern. Branch names must start with: feat/, fix/, docs/, refactor/, test/, chore/, ci/, perf/, build/, release/, revert/"
+      deny "BLOCKED: Branch '$BRANCH' (resolved from $work_dir) does not match required pattern. Branch names must start with: feat/, fix/, docs/, refactor/, test/, chore/, ci/, perf/, build/, release/, dependabot/, revert/"
     fi
   fi
 }

--- a/docs/examples/claude-code-hooks/guard-git.sh
+++ b/docs/examples/claude-code-hooks/guard-git.sh
@@ -21,6 +21,20 @@ if [ -z "$COMMAND" ]; then
   exit 0
 fi
 
+# The actual directory the Bash tool will run this command in — a top-level
+# field on every PreToolUse payload, independent of whatever cd/-C text
+# happens to appear in $COMMAND. This is what a bare `git push` (relying on
+# the Bash tool's persistent cwd from an earlier, separate tool call) must
+# resolve against; the hook's own process cwd is unrelated to it (#2386).
+HOOK_CWD=$(echo "$INPUT" | node -e "
+  let d='';
+  process.stdin.on('data',c=>d+=c);
+  process.stdin.on('end',()=>{
+    const p=JSON.parse(d).cwd||'';
+    if(p)process.stdout.write(p);
+  });
+" 2>/dev/null) || true
+
 # Act on git and gh commands (may appear after cd "..." &&, inside a quoted
 # nested-shell invocation like `bash -c "git clean -fd"`, or inside a command
 # substitution like `"message $(git clean -fd)"` — #2099 Greptile review).
@@ -169,7 +183,8 @@ fi
 # Resolve the working directory a git command targets:
 # - `git -C "<dir>" ...`   → the -C target (takes precedence — explicit git-level override)
 # - `cd "<dir>" && git ...` → the cd target
-# Falls back to empty string (caller uses cwd).
+# Falls back to empty string when neither appears in the command text —
+# callers then fall back further to the hook's own $HOOK_CWD (#2386).
 #
 # Optional arg: target subcommand hint (e.g. `push`, `commit`). When given,
 # narrows the search to the `&&`-separated segment whose git invocation runs
@@ -220,18 +235,33 @@ validate_branch_name() {
   local work_dir
   work_dir=$(detect_work_dir "$subcmd")
 
+  # No explicit -C/cd in the command text — fall back to the Bash tool's
+  # actual cwd for this call (reported by the harness on every PreToolUse
+  # payload), NOT the hook process's own ambient cwd. A bare `git push`
+  # relying on a `cd` from an earlier, separate tool call has no directory
+  # hint in $COMMAND at all; substituting the hook's own cwd there validates
+  # a completely unrelated repo's branch (#2386).
+  if [ -z "$work_dir" ] && [ -n "$HOOK_CWD" ] && [ -d "$HOOK_CWD" ]; then
+    work_dir="$HOOK_CWD"
+  fi
+
   local BRANCH=""
   if [ -n "$work_dir" ] && [ -d "$work_dir" ]; then
     BRANCH=$(git -C "$work_dir" rev-parse --abbrev-ref HEAD 2>/dev/null) || true
   fi
+
+  # Still unresolved — we genuinely don't know which repo this command
+  # targets. A false deny on valid work (validating an unrelated repo's
+  # branch, as happened in #2386) is worse than a missed check here: decline
+  # to validate rather than guessing.
   if [ -z "$BRANCH" ]; then
-    BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || true
+    return 0
   fi
 
-  if [ -n "$BRANCH" ] && [ "$BRANCH" != "main" ] && [ "$BRANCH" != "HEAD" ]; then
+  if [ "$BRANCH" != "main" ] && [ "$BRANCH" != "HEAD" ]; then
     local PATTERN="^(feat|fix|docs|refactor|test|chore|ci|perf|build|release|dependabot|revert)/"
     if [[ ! "$BRANCH" =~ $PATTERN ]]; then
-      deny "BLOCKED: Branch '$BRANCH' does not match required pattern. Branch names must start with: feat/, fix/, docs/, refactor/, test/, chore/, ci/, perf/, build/, release/, revert/"
+      deny "BLOCKED: Branch '$BRANCH' (resolved from $work_dir) does not match required pattern. Branch names must start with: feat/, fix/, docs/, refactor/, test/, chore/, ci/, perf/, build/, release/, dependabot/, revert/"
     fi
   fi
 }

--- a/tests/unit/hook-guard-git-branch-validation.test.ts
+++ b/tests/unit/hook-guard-git-branch-validation.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Regression guard for issue #2386: `.claude/hooks/guard-git.sh`'s branch
+ * validation fell back to the hook process's own ambient cwd whenever it
+ * couldn't parse a `-C <dir>` / `cd <dir> &&` prefix out of the command
+ * text — which is exactly what happens for a bare `git push` relying on
+ * the Bash tool's persistent cwd from an EARLIER, separate tool call. For a
+ * subagent pushing to a different repository, that validated the wrong
+ * repo's branch entirely and denied a perfectly valid push.
+ *
+ * The fix: read the hook's own top-level `cwd` field (the Bash tool's
+ * actual cwd for this call, reported on every PreToolUse payload) as the
+ * fallback instead, and decline to validate at all (allow) rather than
+ * guess when even that isn't available.
+ */
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const HOOK_PATH = path.join(REPO_ROOT, '.claude', 'hooks', 'guard-git.sh');
+
+interface HookDecision {
+  hookSpecificOutput?: {
+    permissionDecision?: string;
+    permissionDecisionReason?: string;
+  };
+}
+
+function runHook(command: string, opts: { cwd?: string; hookCwd?: string } = {}): HookDecision {
+  const payload: Record<string, unknown> = { tool_input: { command } };
+  if (opts.hookCwd) payload.cwd = opts.hookCwd;
+  const stdout = execFileSync('bash', [HOOK_PATH], {
+    input: JSON.stringify(payload),
+    encoding: 'utf8',
+    cwd: opts.cwd,
+  });
+  return stdout.trim() ? JSON.parse(stdout) : {};
+}
+
+function initRepo(dir: string, branch: string): void {
+  fs.mkdirSync(dir, { recursive: true });
+  execFileSync('git', ['init', '-q', '-b', branch], { cwd: dir });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+  execFileSync('git', ['config', 'user.name', 'Test'], { cwd: dir });
+  fs.writeFileSync(path.join(dir, 'README.md'), 'test\n');
+  execFileSync('git', ['add', 'README.md'], { cwd: dir });
+  execFileSync('git', ['commit', '-q', '-m', 'init'], { cwd: dir });
+}
+
+describe('guard-git.sh branch validation resolves the actual push target (#2386)', () => {
+  let base: string;
+  let sessionRepo: string;
+  let otherRepo: string;
+
+  beforeEach(() => {
+    base = fs.mkdtempSync(path.join(os.tmpdir(), 'guard-git-branch-'));
+    sessionRepo = path.join(base, 'session-repo');
+    otherRepo = path.join(base, 'other-repo');
+    // The orchestrator's own worktree branch — invalid pattern, matching the
+    // repro in #2386 (a branch name that appears nowhere in the command the
+    // subagent actually ran).
+    initRepo(sessionRepo, 'claude/optave-project-rollout-420503');
+    // The subagent's actual target repo, on a valid branch.
+    initRepo(otherRepo, 'chore/codegraph-onboarding');
+  });
+
+  afterEach(() => {
+    fs.rmSync(base, { recursive: true, force: true });
+  });
+
+  it('uses the hook payload cwd for a bare git push with no -C/cd, not the hook process ambient cwd', () => {
+    const result = runHook('git push -u origin chore/codegraph-onboarding', {
+      cwd: sessionRepo, // hook process's own ambient cwd — the WRONG repo
+      hookCwd: otherRepo, // reported cwd on the PreToolUse payload — the RIGHT repo
+    });
+    expect(result.hookSpecificOutput?.permissionDecision).not.toBe('deny');
+  });
+
+  it('still denies when the payload cwd itself resolves to an invalid branch, and names it', () => {
+    const result = runHook('git push -u origin claude/optave-project-rollout-420503', {
+      cwd: otherRepo,
+      hookCwd: sessionRepo,
+    });
+    expect(result.hookSpecificOutput?.permissionDecision).toBe('deny');
+    expect(result.hookSpecificOutput?.permissionDecisionReason).toContain(sessionRepo);
+  });
+
+  it('still prefers an explicit git -C over the payload cwd', () => {
+    const result = runHook(`git -C "${otherRepo}" push -u origin chore/codegraph-onboarding`, {
+      cwd: sessionRepo,
+      hookCwd: sessionRepo,
+    });
+    expect(result.hookSpecificOutput?.permissionDecision).not.toBe('deny');
+  });
+
+  it('declines to validate (allows) rather than guess when no payload cwd is available either', () => {
+    const result = runHook('git push -u origin chore/codegraph-onboarding', {
+      cwd: sessionRepo, // ambient cwd is the wrong repo and must never be consulted
+    });
+    expect(result.hookSpecificOutput?.permissionDecision).not.toBe('deny');
+  });
+
+  it('validates gh pr create the same way as git push', () => {
+    const result = runHook('gh pr create --title "x" --body "y"', {
+      cwd: sessionRepo,
+      hookCwd: otherRepo,
+    });
+    expect(result.hookSpecificOutput?.permissionDecision).not.toBe('deny');
+  });
+});


### PR DESCRIPTION
## Summary

`guard-git.sh`'s branch-name validator fell back to the **hook process's own ambient cwd** whenever it couldn't parse a working directory out of the command string (`git -C <dir>` or `cd <dir> &&`). A bare `git push` that relies on the Bash tool's persistent cwd from an earlier, separate tool call matches neither shape, so `work_dir` was empty and the code substituted the hook's own cwd — the session project root, not the repo actually being pushed to. For a subagent pushing to a different repository, this validated an unrelated repo's branch and denied a perfectly valid push, showing the operator a branch name that appeared nowhere in the command they ran.

## Root cause & fix

Every PreToolUse hook payload carries a top-level `cwd` field — the Bash tool's actual working directory for that specific call — completely independent of whatever `cd`/`-C` text happens to appear in the command string. `guard-git.sh` was never reading it.

- `guard-git.sh` now extracts this field as `HOOK_CWD` and uses it as `validate_branch_name`'s fallback (after the existing `-C`/`cd` detection, which still takes precedence when present).
- When even `HOOK_CWD` isn't usable (missing or not a directory), the hook now **declines to validate** (allows) rather than guessing against its own ambient cwd — a false deny on valid work is worse than a missed check here, per the issue's own reasoning.
- The deny message now names the resolved working directory alongside the branch, so a wrong resolution is obvious immediately.
- The error text's pattern list now includes `dependabot/`, matching what the regex already permitted (a display-only inconsistency the issue flagged).
- Kept `.claude/hooks/guard-git.sh` and `docs/examples/claude-code-hooks/guard-git.sh` byte-identical, as enforced by the existing `tests/unit/hook-guard-git-clean.test.ts` sync check.

## Verification

- `bash -n` / `shellcheck`: clean
- New test file `tests/unit/hook-guard-git-branch-validation.test.ts` (5 tests) reproduces the issue's exact scenario — two real temp git repos, one on an invalid-pattern branch (simulating the orchestrator's own worktree branch) and one on a valid branch (the subagent's actual target), with the hook's payload `cwd` and its actual process cwd set independently to prove the fix reads the right one. **Verified these tests fail against the pre-fix hook** (4/5 failed) before confirming they pass against the fix (5/5), and re-ran with the fix restored (5/5 pass) — not tautological.
- `npx vitest run tests/unit/hook-guard-git-branch-validation.test.ts tests/unit/hook-guard-git-clean.test.ts`: 47/47 pass (including the byte-identical docs-sync check)
- `npm run lint`: pass

## Also filed

- optave/ops-codegraph-tool#2526 — the commit-validation section (edit-log check) further down in the same file uses the identical `detect_work_dir` helper and has a milder version of the same gap (silently skips rather than falsely denies); split out as a separate, distinct fix rather than bundled here

Closes #2386