### PR TITLE
fix(stats): native coupling hotspots exclude structural edges, matching map (#2388)

### DIFF
--- a/crates/codegraph-core/src/db/repository/graph_read.rs
+++ b/crates/codegraph-core/src/db/repository/graph_read.rs
@@ -597,17 +597,31 @@ fn fetch_quality_metrics(
     })
 }
 
+/// Edge kinds representing structural containment rather than cross-symbol
+/// coupling (a parent declaring a child, a function declaring its own
+/// parameter, a method's implicit receiver) — excluded from fan-in/fan-out
+/// hotspot counts so a file that merely declares many symbols doesn't
+/// outrank one with genuine cross-file dependencies. Mirrors
+/// `NON_COUPLING_EDGE_KINDS` in `src/shared/kinds.ts` (#2388) — keep both
+/// lists in sync.
+const NON_COUPLING_EDGE_KINDS: &[&str] = &["contains", "parameter_of", "receiver"];
+
 fn fetch_file_hotspots(
     conn: &rusqlite::Connection,
     tf_n_file: &str,
 ) -> napi::Result<Vec<FileHotspot>> {
+    let edge_filter = NON_COUPLING_EDGE_KINDS
+        .iter()
+        .map(|k| format!("'{k}'"))
+        .collect::<Vec<_>>()
+        .join(", ");
     let sql = format!(
         "SELECT n.file, \
-         (SELECT COUNT(*) FROM edges WHERE target_id = n.id) as fan_in, \
-         (SELECT COUNT(*) FROM edges WHERE source_id = n.id) as fan_out \
+         (SELECT COUNT(*) FROM edges WHERE target_id = n.id AND kind NOT IN ({edge_filter})) as fan_in, \
+         (SELECT COUNT(*) FROM edges WHERE source_id = n.id AND kind NOT IN ({edge_filter})) as fan_out \
          FROM nodes n WHERE n.kind = 'file' {tf_n_file} \
-         ORDER BY (SELECT COUNT(*) FROM edges WHERE target_id = n.id) \
-                + (SELECT COUNT(*) FROM edges WHERE source_id = n.id) DESC \
+         ORDER BY (SELECT COUNT(*) FROM edges WHERE target_id = n.id AND kind NOT IN ({edge_filter})) \
+                + (SELECT COUNT(*) FROM edges WHERE source_id = n.id AND kind NOT IN ({edge_filter})) DESC \
          LIMIT 5",
     );
     let mut stmt = conn

--- a/src/domain/analysis/module-map.ts
+++ b/src/domain/analysis/module-map.ts
@@ -8,10 +8,17 @@ import {
 } from '../../db/index.js';
 import { debug } from '../../infrastructure/logger.js';
 import { isTestFile } from '../../infrastructure/test-filter.js';
-import { DEAD_ROLE_PREFIX } from '../../shared/kinds.js';
+import { DEAD_ROLE_PREFIX, NON_COUPLING_EDGE_KINDS } from '../../shared/kinds.js';
 import type { BetterSqlite3Database, NativeDatabase } from '../../types.js';
 import { findCycles } from '../graph/cycles.js';
 import { LANGUAGE_REGISTRY } from '../parser.js';
+
+// SQL fragment excluding structural-containment edges from coupling counts —
+// built once from the shared NON_COUPLING_EDGE_KINDS constant so this file's
+// four fan-in/fan-out queries (findHotspots, moduleMapData) and the native
+// path (crates/codegraph-core/src/db/repository/graph_read.rs) cannot drift
+// out of sync again (#2388).
+const NON_COUPLING_EDGE_FILTER = `kind NOT IN (${NON_COUPLING_EDGE_KINDS.map((k) => `'${k}'`).join(', ')})`;
 
 export const FALSE_POSITIVE_NAMES = new Set([
   'run',
@@ -123,12 +130,12 @@ function findHotspots(db: BetterSqlite3Database, noTests: boolean, limit: number
       FROM nodes n
       LEFT JOIN (
         SELECT target_id, COUNT(*) AS cnt FROM edges
-        WHERE kind NOT IN ('contains', 'parameter_of', 'receiver')
+        WHERE ${NON_COUPLING_EDGE_FILTER}
         GROUP BY target_id
       ) fi ON fi.target_id = n.id
       LEFT JOIN (
         SELECT source_id, COUNT(*) AS cnt FROM edges
-        WHERE kind NOT IN ('contains', 'parameter_of', 'receiver')
+        WHERE ${NON_COUPLING_EDGE_FILTER}
         GROUP BY source_id
       ) fo ON fo.source_id = n.id
       WHERE n.kind = 'file' ${testFilter}
@@ -325,12 +332,12 @@ export function moduleMapData(customDbPath: string, limit = 20, opts: { noTests?
       FROM nodes n
       LEFT JOIN (
         SELECT source_id, COUNT(*) AS cnt FROM edges
-        WHERE kind NOT IN ('contains', 'parameter_of', 'receiver')
+        WHERE ${NON_COUPLING_EDGE_FILTER}
         GROUP BY source_id
       ) fo ON fo.source_id = n.id
       LEFT JOIN (
         SELECT target_id, COUNT(*) AS cnt FROM edges
-        WHERE kind NOT IN ('contains', 'parameter_of', 'receiver')
+        WHERE ${NON_COUPLING_EDGE_FILTER}
         GROUP BY target_id
       ) fi ON fi.target_id = n.id
       WHERE n.kind = 'file'

--- a/src/shared/kinds.ts
+++ b/src/shared/kinds.ts
@@ -82,6 +82,15 @@ export const STRUCTURAL_EDGE_KINDS: readonly StructuralEdgeKind[] = [
 // Full set for MCP enum and validation
 export const EVERY_EDGE_KIND: readonly EdgeKind[] = [...CORE_EDGE_KINDS, ...STRUCTURAL_EDGE_KINDS];
 
+// Edge kinds that represent structural containment rather than cross-symbol
+// coupling (a parent declaring a child, a function declaring its own
+// parameter, a method's implicit receiver) — excluded from fan-in/fan-out
+// coupling metrics (`codegraph map`, `stats`' coupling hotspots) so a file
+// that merely declares many symbols doesn't outrank one with genuine
+// cross-file dependencies (#2388). Single source of truth for both the
+// native and TypeScript aggregation paths in module-map.ts.
+export const NON_COUPLING_EDGE_KINDS: readonly EdgeKind[] = ['contains', ...STRUCTURAL_EDGE_KINDS];
+
 // Dead sub-categories — refine the coarse "dead" bucket
 export const DEAD_ROLE_PREFIX = 'dead';
 export const DEAD_SUB_ROLES: readonly DeadSubRole[] = [

--- a/tests/integration/queries.test.ts
+++ b/tests/integration/queries.test.ts
@@ -903,6 +903,28 @@ describe('expanded edge types', () => {
     expect(authNode.inEdges).toBe(2);
   });
 
+  test('statsData hotspots exclude structural edges from coupling, matching moduleMapData (#2388)', () => {
+    // Regression test for #2388: the native `stats` path counted every edge
+    // touching a file node (including contains/parameter_of/receiver), while
+    // moduleMapData's JS path correctly excluded them — same graph, two
+    // different fan-in/fan-out numbers for the same file. auth.js has a
+    // `contains` edge as its SOURCE (auth.js -> UserService) that must not
+    // inflate fanOut, exactly mirroring the moduleMapData test above.
+    const mapData = moduleMapData(dbPath);
+    const authMapNode = mapData.topNodes.find((n) => n.file === 'auth.js');
+    expect(authMapNode).toBeDefined();
+
+    const stats = statsData(dbPath);
+    const authHotspot = stats.hotspots.find((h) => h.file === 'auth.js');
+    expect(authHotspot).toBeDefined();
+    expect(authHotspot.fanIn).toBe(authMapNode.inEdges);
+    expect(authHotspot.fanOut).toBe(authMapNode.outEdges);
+    // auth.js is imported by middleware.js and auth.test.js → fanIn = 2;
+    // its only outgoing edge is the structural contains edge → fanOut = 0.
+    expect(authHotspot.fanIn).toBe(2);
+    expect(authHotspot.fanOut).toBe(0);
+  });
+
   test('queryNameData returns new edge kinds in callers/callees', () => {
     // authenticate has a parameter_of edge from userId
     const authData = queryNameData('authenticate', dbPath);


### PR DESCRIPTION
## Summary

`codegraph stats`' "coupling hotspots" fan-in/fan-out counted every edge touching a file node in the native path, including structural `contains`/`parameter_of`/`receiver` edges. The TypeScript path that powers `codegraph map` already excluded them. The two engines therefore reported different numbers for the same metric, and since native is the default, most users saw the inflated one — a file that merely declares many symbols (e.g. a pure type-declaration file) ranked as a coupling hotspot ahead of genuinely central modules.

## Root cause & fix

- Native — `fetch_file_hotspots` in `crates/codegraph-core/src/db/repository/graph_read.rs` had no edge-kind filter at all.
- TypeScript — `findHotspots` in `src/domain/analysis/module-map.ts` was already correctly filtered, but repeated the same literal `kind NOT IN ('contains', 'parameter_of', 'receiver')` four times across two functions (`findHotspots` for `stats`, and the `moduleMapData` query for `map`) with no shared source of truth — exactly the kind of duplication the issue flagged as having already drifted once (#2383's roles rollup).

Fix:
- Added `NON_COUPLING_EDGE_KINDS` to `src/shared/kinds.ts` and rebuilt module-map.ts's SQL filter fragment from it, replacing all four literal occurrences.
- Mirrored the identical filter in `graph_read.rs`'s `fetch_file_hotspots`, with a doc comment cross-referencing the TS constant so the two can't drift again.

## Verification

- `cargo fmt -- --check` / `cargo clippy --workspace --all-targets -- -D warnings`: pass
- New regression test in `tests/integration/queries.test.ts` (`statsData hotspots exclude structural edges from coupling, matching moduleMapData`) — asserts `stats`' hotspot fanIn/fanOut for a file exactly equal `map`'s inEdges/outEdges for the same file, using the existing fixture's `contains`/`parameter_of`/`receiver` edges. **Verified this test fails against the pre-fix native addon** (rebuilt via `napi build` with the Rust fix reverted: `expected 1 to be +0`) before confirming it passes with the fix restored — not tautological.
- `npx vitest run tests/integration/queries.test.ts tests/integration/roles.test.ts tests/presentation/queries-cli.test.ts tests/graph/`: 397/397 pass
- Manually reproduced the issue's exact repro against this repo's own graph (freshly built native addon via `napi build`, not the stale prebuilt one): `src/types.ts` now shows `fan-in: 227  fan-out: 0` in `stats`, matching `map`'s `inEdges: 227, outEdges: 0` exactly — previously `fan-out: 1322`. Confirmed identical between the native-built and WASM-built graphs.
- `npm run lint`: pass

Closes #2388