### PR TITLE
fix(js/ts): resolve JSX elements and call-arg identifiers as references (#2389)

### DIFF
--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -1756,6 +1756,9 @@ fn match_js_node(
         "enum_declaration" => handle_enum_decl(node, source, symbols),
         "lexical_declaration" | "variable_declaration" => handle_var_decl(node, source, symbols),
         "call_expression" => handle_call_expr(node, source, symbols, callback_param_shapes),
+        "jsx_opening_element" | "jsx_self_closing_element" => {
+            handle_jsx_element_ref(node, source, &mut symbols.calls)
+        }
         "new_expression" => handle_new_expr(node, source, symbols),
         "decorator" => handle_decorator(node, source, symbols),
         "import_statement" => handle_import_stmt(node, source, symbols),
@@ -2874,6 +2877,9 @@ fn handle_call_expr(
                 callback_param_shapes,
                 &mut symbols.calls,
             );
+            symbols
+                .calls
+                .extend(extract_call_argument_identifier_refs(node, source));
             return;
         }
     }
@@ -2884,6 +2890,9 @@ fn handle_call_expr(
         symbols.definitions.push(cb_def);
     }
     extract_callback_reference_calls(node, source, callback_param_shapes, &mut symbols.calls);
+    symbols
+        .calls
+        .extend(extract_call_argument_identifier_refs(node, source));
 }
 
 fn handle_new_expr(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
@@ -4357,6 +4366,118 @@ fn handle_object_literal_shorthand_value_ref(node: &Node, source: &[u8], calls: 
 /// `build_edges.rs` accepts `class`-kind targets in addition to
 /// function/method for this reason.
 ///
+/// A JSX element's opening/self-closing tag name is a reference to the
+/// component it renders — `<Header />` is exactly as much a use of `Header`
+/// as `Header()` would be, but produces no call edge by construction since
+/// it's not a `call_expression` (issue #2389). Emitted as a `value-ref`
+/// dynamic call, the same mechanism already used for object-literal
+/// property values, `instanceof` operands, and logical-or/ternary fallbacks.
+///
+/// Only a capitalized bare identifier is treated as a component reference,
+/// matching JSX's own convention: a lowercase-first tag name (`<div>`,
+/// `<span>`) compiles to a DOM/intrinsic element (not an identifier
+/// reference) and must not be credited as a symbol use. A `member_expression`
+/// name (`<Namespace.Component />`) credits the base object identifier.
+///
+/// Mirrors `handleJsxElementRef` in `src/extractors/javascript.ts`.
+fn handle_jsx_element_ref(node: &Node, source: &[u8], calls: &mut Vec<Call>) {
+    let Some(name_node) = node.child_by_field_name("name") else {
+        return;
+    };
+    let line = start_line(node);
+    match name_node.kind() {
+        "identifier" => {
+            let text = node_text(&name_node, source);
+            if !text.starts_with(|c: char| c.is_ascii_uppercase())
+                || JS_BUILTIN_GLOBALS.contains(&text)
+            {
+                return;
+            }
+            calls.push(Call {
+                name: text.to_string(),
+                line,
+                dynamic: Some(true),
+                dynamic_kind: Some("value-ref".to_string()),
+                ..Default::default()
+            });
+        }
+        "member_expression" => {
+            let Some(obj_node) = name_node.child_by_field_name("object") else {
+                return;
+            };
+            if obj_node.kind() != "identifier" {
+                return;
+            }
+            let text = node_text(&obj_node, source);
+            if JS_BUILTIN_GLOBALS.contains(&text) {
+                return;
+            }
+            calls.push(Call {
+                name: text.to_string(),
+                line,
+                dynamic: Some(true),
+                dynamic_kind: Some("value-ref".to_string()),
+                ..Default::default()
+            });
+        }
+        _ => {}
+    }
+}
+
+/// A capitalized bare identifier passed as a call argument is a value
+/// reference to whatever it names — `Factory.create(AppModule)` is a
+/// genuine use of `AppModule` (issue #2389; the NestJS module/controller
+/// registration idiom, `NestFactory.create(AppModule)`, relies on exactly
+/// this pattern).
+///
+/// Restricted to capitalized identifiers — the same class/component-naming
+/// convention already used to gate JSX element references
+/// (`handle_jsx_element_ref`) — deliberately, not merely for style: issue
+/// #1741 is a regression guard proving that crediting an arbitrary
+/// lowercase DATA argument (e.g. `analyzeDrift(communities, communityDirs)`)
+/// as any kind of reference risks the global-fallback resolver binding it
+/// to an unrelated same-named function elsewhere in the repo, fabricating a
+/// call edge and, transitively, a phantom cycle. A class/component
+/// reference passed by value is overwhelmingly PascalCase in JS/TS
+/// convention, so this restriction captures the pattern #2389 asks for
+/// while leaving #1741's already-diagnosed false-positive risk exactly as
+/// closed as it was.
+///
+/// Restricted to direct-child bare identifiers of the arguments list,
+/// mirroring this file's "restrict to the simplest syntactic shape"
+/// precedent (#1771/#1784).
+///
+/// Mirrors `extractCallArgumentIdentifierRefs` in `src/extractors/javascript.ts`.
+fn extract_call_argument_identifier_refs(call_node: &Node, source: &[u8]) -> Vec<Call> {
+    let mut result = Vec::new();
+    let Some(args) = call_node
+        .child_by_field_name("arguments")
+        .or_else(|| find_child(call_node, "arguments"))
+    else {
+        return result;
+    };
+    let line = start_line(call_node);
+    for i in 0..args.child_count() {
+        let Some(child) = args.child(i) else { continue };
+        if child.kind() != "identifier" {
+            continue;
+        }
+        let text = node_text(&child, source);
+        if !text.starts_with(|c: char| c.is_ascii_uppercase()) || JS_BUILTIN_GLOBALS.contains(&text)
+        {
+            continue;
+        }
+        result.push(Call {
+            name: text.to_string(),
+            line,
+            dynamic: Some(true),
+            dynamic_kind: Some("value-ref".to_string()),
+            ..Default::default()
+        });
+    }
+    result
+}
+
 /// Mirrors `collectInstanceofValueRefCall` in `src/extractors/javascript.ts`.
 fn handle_instanceof_value_ref(node: &Node, source: &[u8], calls: &mut Vec<Call>) {
     let Some(operator_n) = node.child_by_field_name("operator") else {
@@ -8463,6 +8584,74 @@ mod tests {
             .filter(|c| c.dynamic_kind.as_deref() == Some("value-ref"))
             .collect();
         assert!(value_refs.iter().any(|c| c.name == "someFunction"));
+    }
+
+    // ── #2389: JSX element value-ref extraction ──────────────────────────────
+
+    #[test]
+    fn extracts_value_ref_call_for_self_closing_jsx_component() {
+        let s = parse_js("function App() { return <Header title=\"x\" />; }");
+        assert!(s
+            .calls
+            .iter()
+            .any(|c| c.name == "Header" && c.dynamic_kind.as_deref() == Some("value-ref")));
+    }
+
+    #[test]
+    fn extracts_value_ref_call_for_jsx_component_with_children() {
+        let s = parse_js("function App() { return <Wrapper><span /></Wrapper>; }");
+        assert!(s
+            .calls
+            .iter()
+            .any(|c| c.name == "Wrapper" && c.dynamic_kind.as_deref() == Some("value-ref")));
+    }
+
+    #[test]
+    fn does_not_extract_value_ref_call_for_lowercase_intrinsic_jsx_tag() {
+        let s = parse_js("function App() { return <div className=\"x\"><span /></div>; }");
+        assert!(!s
+            .calls
+            .iter()
+            .any(|c| c.dynamic_kind.as_deref() == Some("value-ref")));
+    }
+
+    #[test]
+    fn credits_base_identifier_for_namespaced_jsx_component() {
+        let s = parse_js("function App() { return <NS.Header />; }");
+        assert!(s
+            .calls
+            .iter()
+            .any(|c| c.name == "NS" && c.dynamic_kind.as_deref() == Some("value-ref")));
+    }
+
+    // ── #2389: call-argument identifier value-ref extraction ────────────────
+
+    #[test]
+    fn extracts_value_ref_call_for_capitalized_call_argument() {
+        let s = parse_js("Factory.create(AppModule);");
+        assert!(s
+            .calls
+            .iter()
+            .any(|c| c.name == "AppModule" && c.dynamic_kind.as_deref() == Some("value-ref")));
+    }
+
+    #[test]
+    fn does_not_extract_value_ref_call_for_lowercase_data_argument_regression_1741() {
+        // Regression guard mirroring #1741: a lowercase DATA argument must
+        // never be credited as any kind of reference, or the global-fallback
+        // resolver can bind it to an unrelated same-named function elsewhere
+        // in the repo, fabricating a call edge and a phantom cycle.
+        let s = parse_js("analyzeDrift(communities, communityDirs);");
+        assert!(!s.calls.iter().any(|c| c.dynamic == Some(true)));
+    }
+
+    #[test]
+    fn does_not_extract_value_ref_call_for_builtin_global_argument() {
+        let s = parse_js("register(console);");
+        assert!(!s
+            .calls
+            .iter()
+            .any(|c| c.dynamic_kind.as_deref() == Some("value-ref")));
     }
 
     // ── #2257: logical-or/nullish-coalescing/ternary value-ref extraction ───

--- a/src/domain/parser.ts
+++ b/src/domain/parser.ts
@@ -203,6 +203,18 @@ const TS_EXTRA_PATTERNS: string[] = [
   '(type_alias_declaration name: (type_identifier) @type_name) @type_node',
 ];
 
+// JSX element tag names — only javascript and tsx grammars define these node
+// types; plain typescript (.ts, no JSX) does not, so this must never be
+// folded into COMMON_QUERY_PATTERNS or TS_EXTRA_PATTERNS (shared with plain
+// typescript) — Query() compilation throws on an unknown node type, which
+// would break all .ts parsing (#2389).
+const JSX_QUERY_PATTERNS: string[] = [
+  '(jsx_opening_element name: (identifier) @jsxid_name) @jsxid_node',
+  '(jsx_self_closing_element name: (identifier) @jsxid_name) @jsxid_node',
+  '(jsx_opening_element name: (member_expression) @jsxmem_name) @jsxmem_node',
+  '(jsx_self_closing_element name: (member_expression) @jsxmem_name) @jsxmem_node',
+];
+
 /**
  * Load a single language grammar and cache the parser + language + query.
  * Uses in-flight deduplication so concurrent callers awaiting the same grammar
@@ -227,9 +239,12 @@ async function doLoadLanguage(entry: LanguageRegistryEntry): Promise<void> {
     _cachedLanguages!.set(entry.id, lang);
     if (entry.extractor === extractSymbols && !_queryCache.has(entry.id)) {
       const isTS = entry.id === 'typescript' || entry.id === 'tsx';
-      const patterns = isTS
-        ? [...COMMON_QUERY_PATTERNS, ...TS_EXTRA_PATTERNS]
-        : [...COMMON_QUERY_PATTERNS, ...JS_CLASS_PATTERNS];
+      const supportsJsx = entry.id === 'javascript' || entry.id === 'tsx';
+      const patterns = [
+        ...COMMON_QUERY_PATTERNS,
+        ...(isTS ? TS_EXTRA_PATTERNS : JS_CLASS_PATTERNS),
+        ...(supportsJsx ? JSX_QUERY_PATTERNS : []),
+      ];
       _queryCache.set(entry.id, new Query(lang, patterns.join('\n')));
     }
   } catch (e: unknown) {

--- a/src/domain/parser.ts
+++ b/src/domain/parser.ts
@@ -180,6 +180,13 @@ const COMMON_QUERY_PATTERNS: string[] = [
   '(call_expression function: (member_expression) @callmem_fn) @callmem_node',
   '(call_expression function: (subscript_expression) @callsub_fn) @callsub_node',
   '(call_expression function: (super) @callsuper_fn) @callsuper_node',
+  // Generic capture for call-argument identifier value-ref extraction (#2389) —
+  // matches every call_expression regardless of the callee's shape (chained,
+  // curried, or parenthesized callees like `getFactory()(AppModule)`), mirroring
+  // the walk path's unconditional `case 'call_expression'` dispatch. Named-call
+  // resolution stays on the shape-specific patterns above; this one only feeds
+  // dispatchQueryMatch's `callarg_node` branch.
+  '(call_expression) @callarg_node',
   '(new_expression constructor: (identifier) @newfn_name) @newfn_node',
   '(new_expression constructor: (member_expression) @newmem_fn) @newmem_node',
   '(expression_statement (assignment_expression left: (member_expression) @assign_left right: (_) @assign_right)) @assign_node',

--- a/src/domain/wasm-worker-entry.ts
+++ b/src/domain/wasm-worker-entry.ts
@@ -125,6 +125,13 @@ const COMMON_QUERY_PATTERNS: string[] = [
   '(call_expression function: (member_expression) @callmem_fn) @callmem_node',
   '(call_expression function: (subscript_expression) @callsub_fn) @callsub_node',
   '(call_expression function: (super) @callsuper_fn) @callsuper_node',
+  // Generic capture for call-argument identifier value-ref extraction (#2389) —
+  // matches every call_expression regardless of the callee's shape (chained,
+  // curried, or parenthesized callees like `getFactory()(AppModule)`), mirroring
+  // the walk path's unconditional `case 'call_expression'` dispatch. Named-call
+  // resolution stays on the shape-specific patterns above; this one only feeds
+  // dispatchQueryMatch's `callarg_node` branch.
+  '(call_expression) @callarg_node',
   '(new_expression constructor: (identifier) @newfn_name) @newfn_node',
   '(new_expression constructor: (member_expression) @newmem_fn) @newmem_node',
   '(expression_statement (assignment_expression left: (member_expression) @assign_left right: (_) @assign_right)) @assign_node',

--- a/src/domain/wasm-worker-entry.ts
+++ b/src/domain/wasm-worker-entry.ts
@@ -145,6 +145,18 @@ const TS_EXTRA_PATTERNS: string[] = [
   '(type_alias_declaration name: (type_identifier) @type_name) @type_node',
 ];
 
+// JSX element tag names — only javascript and tsx grammars define these node
+// types; plain typescript (.ts, no JSX) does not, so this must never be
+// folded into COMMON_QUERY_PATTERNS or TS_EXTRA_PATTERNS (shared with plain
+// typescript) — Query() compilation throws on an unknown node type, which
+// would break all .ts parsing (#2389).
+const JSX_QUERY_PATTERNS: string[] = [
+  '(jsx_opening_element name: (identifier) @jsxid_name) @jsxid_node',
+  '(jsx_self_closing_element name: (identifier) @jsxid_name) @jsxid_node',
+  '(jsx_opening_element name: (member_expression) @jsxmem_name) @jsxmem_node',
+  '(jsx_self_closing_element name: (member_expression) @jsxmem_name) @jsxmem_node',
+];
+
 // ── Local language registry ─────────────────────────────────────────────────
 // Local copy — re-using parser.ts's registry would drag in its process-wide
 // parser/grammar caches, which are not safe to share across worker threads.
@@ -444,9 +456,12 @@ async function loadLanguageLazy(entry: LanguageRegistryEntry): Promise<Parser | 
     // Build the JS/TS/TSX query (mirrors parser.ts::doLoadLanguage)
     if (entry.extractor === extractSymbols && !_queries.has(entry.id)) {
       const isTS = entry.id === 'typescript' || entry.id === 'tsx';
-      const patterns = isTS
-        ? [...COMMON_QUERY_PATTERNS, ...TS_EXTRA_PATTERNS]
-        : [...COMMON_QUERY_PATTERNS, ...JS_CLASS_PATTERNS];
+      const supportsJsx = entry.id === 'javascript' || entry.id === 'tsx';
+      const patterns = [
+        ...COMMON_QUERY_PATTERNS,
+        ...(isTS ? TS_EXTRA_PATTERNS : JS_CLASS_PATTERNS),
+        ...(supportsJsx ? JSX_QUERY_PATTERNS : []),
+      ];
       _queries.set(entry.id, new Query(lang, patterns.join('\n')));
     }
     return parser;

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -399,6 +399,7 @@ function dispatchQueryMatch(
     const callfnInfo = extractCallInfo(c.callfn_name!, c.callfn_node);
     if (callfnInfo) calls.push(callfnInfo);
     calls.push(...extractCallbackReferenceCalls(c.callfn_node, callbackParamShapes));
+    calls.push(...extractCallArgumentIdentifierRefs(c.callfn_node));
   } else if (c.callmem_node) {
     // extractCallInfo → extractMemberExprCallInfo tags .call/.apply/.bind (e.g. `fn.call(ctx)`)
     // as dynamic/reflection regardless of receiver shape, matching the walk path and native
@@ -410,10 +411,16 @@ function dispatchQueryMatch(
     const cbDef = extractCallbackDefinition(c.callmem_node, c.callmem_fn);
     if (cbDef) definitions.push(cbDef);
     calls.push(...extractCallbackReferenceCalls(c.callmem_node, callbackParamShapes));
+    calls.push(...extractCallArgumentIdentifierRefs(c.callmem_node));
   } else if (c.callsub_node) {
     const callInfo = extractCallInfo(c.callsub_fn!, c.callsub_node, arrayElemBindings);
     if (callInfo) calls.push(callInfo);
     calls.push(...extractCallbackReferenceCalls(c.callsub_node, callbackParamShapes));
+    calls.push(...extractCallArgumentIdentifierRefs(c.callsub_node));
+  } else if (c.jsxid_node) {
+    handleJsxElementRef(c.jsxid_node, calls);
+  } else if (c.jsxmem_node) {
+    handleJsxElementRef(c.jsxmem_node, calls);
   } else if (c.newfn_node) {
     if (c.newfn_name!.text === 'Function') {
       // new Function(body) — dynamic code execution; classify as eval kind
@@ -1507,6 +1514,10 @@ function walkJavaScriptNode(
     case 'call_expression':
       handleCallExpr(node, ctx, callbackParamShapes);
       break;
+    case 'jsx_opening_element':
+    case 'jsx_self_closing_element':
+      handleJsxElementRef(node, ctx.calls);
+      break;
     case 'new_expression':
       handleNewExpr(node, ctx);
       break;
@@ -2225,7 +2236,83 @@ function handleCallExpr(
       }
     }
     ctx.calls.push(...extractCallbackReferenceCalls(node, callbackParamShapes));
+    ctx.calls.push(...extractCallArgumentIdentifierRefs(node));
   }
+}
+
+/**
+ * A JSX element's opening/self-closing tag name is a reference to the
+ * component it renders — `<Header />` is exactly as much a use of `Header`
+ * as `Header()` would be, but produces no call edge by construction since
+ * it's not a `call_expression` (issue #2389). Emitted as a `value-ref`
+ * dynamic call, the same mechanism already used for object-literal
+ * property values, `instanceof` operands, and logical-or/ternary fallbacks
+ * (#1771/#1895/#2257).
+ *
+ * Only a capitalized bare identifier is treated as a component reference,
+ * matching JSX's own convention: a lowercase-first tag name (`<div>`,
+ * `<span>`) compiles to a DOM/intrinsic element (a string, not an
+ * identifier reference) and must not be credited as a symbol use. A
+ * `member_expression` name (`<Namespace.Component />`) credits the base
+ * object identifier, mirroring `extractReceiverName`'s handling of
+ * member-expression receivers elsewhere in this file.
+ */
+function handleJsxElementRef(node: TreeSitterNode, calls: Call[]): void {
+  const nameNode = node.childForFieldName('name');
+  if (!nameNode) return;
+  const line = nodeStartLine(node);
+  if (nameNode.type === 'identifier') {
+    const name = nameNode.text;
+    if (!name || !/^[A-Z]/.test(name) || BUILTIN_GLOBALS.has(name)) return;
+    calls.push({ name, line, dynamic: true, dynamicKind: 'value-ref' });
+  } else if (nameNode.type === 'member_expression') {
+    const objNode = nameNode.childForFieldName('object');
+    if (objNode?.type === 'identifier' && !BUILTIN_GLOBALS.has(objNode.text)) {
+      calls.push({ name: objNode.text, line, dynamic: true, dynamicKind: 'value-ref' });
+    }
+  }
+}
+
+/**
+ * A capitalized bare identifier passed as a call argument is a value
+ * reference to whatever it names — `Factory.create(AppModule)` is a
+ * genuine use of `AppModule`, the same as an object-literal property value
+ * or a logical-or fallback (#1771/#2257), but arguments in ordinary call
+ * position produce no edge at all today (issue #2389; the NestJS
+ * module/controller registration idiom, `NestFactory.create(AppModule)`,
+ * relies on exactly this pattern).
+ *
+ * Restricted to capitalized identifiers — the same class/component-naming
+ * convention already used to gate JSX element references
+ * (`handleJsxElementRef`) — deliberately, not merely for style: issue
+ * #1741 is a regression guard proving that crediting an arbitrary
+ * lowercase DATA argument (e.g. `analyzeDrift(communities, communityDirs)`)
+ * as any kind of reference risks the global-fallback resolver binding it
+ * to an unrelated same-named function elsewhere in the repo, fabricating a
+ * call edge and, transitively, a phantom cycle. A class/component
+ * reference passed by value is overwhelmingly PascalCase in JS/TS
+ * convention, so this restriction captures the pattern #2389 asks for
+ * while leaving #1741's already-diagnosed false-positive risk exactly as
+ * closed as it was.
+ *
+ * Restricted to direct-child bare identifiers of the arguments list (not
+ * nested inside member/call expressions), matching this file's established
+ * "restrict to the simplest syntactic shape" precedent (#1771/#1784).
+ */
+function extractCallArgumentIdentifierRefs(callNode: TreeSitterNode): Call[] {
+  const args = callNode.childForFieldName('arguments') || findChild(callNode, 'arguments');
+  if (!args) return [];
+  const result: Call[] = [];
+  const line = nodeStartLine(callNode);
+  for (let i = 0; i < args.childCount; i++) {
+    const child = args.child(i);
+    if (!child) continue;
+    if (child.type !== 'identifier') continue;
+    const name = child.text;
+    if (!name || !/^[A-Z]/.test(name) || BUILTIN_GLOBALS.has(name)) continue;
+    result.push({ name, line, dynamic: true, dynamicKind: 'value-ref' });
+  }
+  return result;
 }
 
 function handleNewExpr(node: TreeSitterNode, ctx: ExtractorOutput): void {

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -399,7 +399,6 @@ function dispatchQueryMatch(
     const callfnInfo = extractCallInfo(c.callfn_name!, c.callfn_node);
     if (callfnInfo) calls.push(callfnInfo);
     calls.push(...extractCallbackReferenceCalls(c.callfn_node, callbackParamShapes));
-    calls.push(...extractCallArgumentIdentifierRefs(c.callfn_node));
   } else if (c.callmem_node) {
     // extractCallInfo → extractMemberExprCallInfo tags .call/.apply/.bind (e.g. `fn.call(ctx)`)
     // as dynamic/reflection regardless of receiver shape, matching the walk path and native
@@ -411,12 +410,10 @@ function dispatchQueryMatch(
     const cbDef = extractCallbackDefinition(c.callmem_node, c.callmem_fn);
     if (cbDef) definitions.push(cbDef);
     calls.push(...extractCallbackReferenceCalls(c.callmem_node, callbackParamShapes));
-    calls.push(...extractCallArgumentIdentifierRefs(c.callmem_node));
   } else if (c.callsub_node) {
     const callInfo = extractCallInfo(c.callsub_fn!, c.callsub_node, arrayElemBindings);
     if (callInfo) calls.push(callInfo);
     calls.push(...extractCallbackReferenceCalls(c.callsub_node, callbackParamShapes));
-    calls.push(...extractCallArgumentIdentifierRefs(c.callsub_node));
   } else if (c.jsxid_node) {
     handleJsxElementRef(c.jsxid_node, calls);
   } else if (c.jsxmem_node) {
@@ -446,6 +443,17 @@ function dispatchQueryMatch(
     // scope. Mirrors the explicit early return in the Rust handle_call_expr super branch.
     const callInfo = extractCallInfo(c.callsuper_fn!, c.callsuper_node);
     if (callInfo) calls.push(callInfo);
+  } else if (c.callarg_node) {
+    // Generic call_expression capture (#2389) — fires for every call regardless
+    // of the callee's shape, so chained/curried/parenthesized callees like
+    // `getFactory()(AppModule)` still get call-argument identifier value-ref
+    // extraction, matching the walk path's unconditional `handleCallExpr` dispatch.
+    // `super(...)`/`this(...)` are excluded to mirror handleCallExpr's early
+    // returns for those two shapes.
+    const fn = c.callarg_node.childForFieldName('function');
+    if (fn?.type !== 'super' && fn?.type !== 'this') {
+      calls.push(...extractCallArgumentIdentifierRefs(c.callarg_node));
+    }
   } else if (c.assign_node) {
     handleCommonJSAssignment(c.assign_left!, c.assign_right!, c.assign_node, imports);
     handleFuncPropAssignment(c.assign_left!, c.assign_right!, definitions);

--- a/tests/engines/query-walk-parity.test.ts
+++ b/tests/engines/query-walk-parity.test.ts
@@ -366,6 +366,38 @@ export function useIt(): number {
 }
 `,
   },
+  // Issue #2389: JSX component references and call-argument identifiers
+  {
+    name: 'JSX self-closing component reference (#2389)',
+    file: 'test.jsx',
+    code: `
+import { Header } from './comp.jsx';
+export function App() {
+  return <Header title="x" />;
+}
+`,
+  },
+  {
+    name: 'JSX component with children and a namespaced reference (#2389)',
+    file: 'test.tsx',
+    code: `
+import * as NS from './comp';
+export function App() {
+  return <Wrapper><NS.Header /><span /></Wrapper>;
+}
+`,
+  },
+  {
+    name: 'call-argument identifier value reference (#2389)',
+    file: 'test.ts',
+    code: `
+class AppModule {}
+const Factory = { create(m: unknown) { return m; } };
+export function bootstrap() {
+  return Factory.create(AppModule);
+}
+`,
+  },
 ];
 
 describe('Query vs Walk parity', () => {

--- a/tests/engines/query-walk-parity.test.ts
+++ b/tests/engines/query-walk-parity.test.ts
@@ -398,6 +398,23 @@ export function bootstrap() {
 }
 `,
   },
+  {
+    // Regression guard for Greptile's #2389 review finding: a call whose callee
+    // is itself an expression (not a bare identifier/member/subscript) has no
+    // dedicated query capture, so the value-ref extraction must be routed
+    // through a shape-agnostic capture rather than the shape-specific ones.
+    name: 'call-argument identifier value reference with expression-based callee (#2389)',
+    file: 'test.ts',
+    code: `
+class AppModule {}
+function getFactory() {
+  return (m: unknown) => m;
+}
+export function bootstrap() {
+  return getFactory()(AppModule);
+}
+`,
+  },
 ];
 
 describe('Query vs Walk parity', () => {

--- a/tests/parsers/javascript.test.ts
+++ b/tests/parsers/javascript.test.ts
@@ -2034,6 +2034,62 @@ function runDemo(reporter: Reporter, users: string[]): void {
     });
   });
 
+  describe('JSX element value-ref extraction (#2389)', () => {
+    it('extracts a value-ref call for a self-closing component reference', () => {
+      const symbols = parseJS(`function App() { return <Header title="x" />; }`);
+      expect(symbols.calls).toContainEqual(
+        expect.objectContaining({ name: 'Header', dynamic: true, dynamicKind: 'value-ref' }),
+      );
+    });
+
+    it('extracts a value-ref call for a component with children', () => {
+      const symbols = parseJS(`function App() { return <Wrapper><span /></Wrapper>; }`);
+      expect(symbols.calls).toContainEqual(
+        expect.objectContaining({ name: 'Wrapper', dynamic: true, dynamicKind: 'value-ref' }),
+      );
+    });
+
+    it('does not extract a value-ref call for a lowercase intrinsic HTML tag', () => {
+      const symbols = parseJS(`function App() { return <div className="x"><span /></div>; }`);
+      expect(symbols.calls.filter((c) => c.dynamicKind === 'value-ref')).toHaveLength(0);
+    });
+
+    it('credits the base object identifier for a namespaced component reference', () => {
+      const symbols = parseJS(`function App() { return <NS.Header />; }`);
+      expect(symbols.calls).toContainEqual(
+        expect.objectContaining({ name: 'NS', dynamic: true, dynamicKind: 'value-ref' }),
+      );
+    });
+  });
+
+  describe('call-argument identifier value-ref extraction (#2389)', () => {
+    it('extracts a value-ref call for a bare identifier passed as a call argument', () => {
+      const symbols = parseJS(`Factory.create(AppModule);`);
+      expect(symbols.calls).toContainEqual(
+        expect.objectContaining({ name: 'AppModule', dynamic: true, dynamicKind: 'value-ref' }),
+      );
+    });
+
+    it('extracts a value-ref call for every bare identifier argument', () => {
+      const symbols = parseJS(`register(ModuleA, ModuleB);`);
+      for (const name of ['ModuleA', 'ModuleB']) {
+        expect(symbols.calls).toContainEqual(
+          expect.objectContaining({ name, dynamic: true, dynamicKind: 'value-ref' }),
+        );
+      }
+    });
+
+    it('does not extract a value-ref call for undefined/null/builtin-global arguments', () => {
+      const symbols = parseJS(`register(undefined, null, console);`);
+      expect(symbols.calls.filter((c) => c.dynamicKind === 'value-ref')).toHaveLength(0);
+    });
+
+    it('does not extract a value-ref call for a member-expression or call-expression argument', () => {
+      const symbols = parseJS(`register(obj.Module, makeModule());`);
+      expect(symbols.calls.filter((c) => c.dynamicKind === 'value-ref')).toHaveLength(0);
+    });
+  });
+
   describe('object-literal value-ref keyExpr capture (#1895)', () => {
     it('captures the property key, distinct from the referenced value name', () => {
       const symbols = parseJS(`const table = { resolve: someFunction };`);


### PR DESCRIPTION
## Summary

Two members of the "value-position reference produces no edge" family (#2257, #2260):

1. **A JSX element is not a reference to its component.** `<Header />` produced no edge to `Header`.
2. **An identifier passed as a call argument is not a use.** `Factory.create(AppModule)` produced no edge to `AppModule`.

Both are structural, not edge cases: every React component used only as JSX read as dead, and NestJS's module/controller registration pattern (`NestFactory.create(AppModule)`) relies entirely on the second pattern — depressing caller coverage and inflating dead-code counts across every React/NestJS repo in the org rollout.

## Changes

Both patterns are extracted as `value-ref` dynamic calls — the existing mechanism already used for object-literal property values, `instanceof` operands, and logical-or/ternary fallbacks (#1771/#1895/#2257):

- **JSX element reference** (`handleJsxElementRef`): a JSX opening/self-closing element's tag name is credited as a reference to the component it renders, gated on JSX's own capitalization convention — lowercase (`<div>`, `<span>`) is an intrinsic DOM element, never a symbol reference; a `member_expression` name (`<Namespace.Component />`) credits the base object identifier.
- **Call-argument identifier reference** (`extractCallArgumentIdentifierRefs`): a **capitalized** bare identifier passed as a call argument is credited as a reference to whatever it names.

### Why capitalized-only for call arguments

This restriction isn't stylistic — it's load-bearing. Issue **#1741** is an existing regression guard proving that crediting an arbitrary lowercase DATA argument (e.g. `analyzeDrift(communities, communityDirs)`) as any kind of reference risks the global-fallback resolver binding it to an unrelated same-named function elsewhere in the repo, fabricating a call edge and, transitively, a phantom cycle. My first pass at this fix did exactly that and broke 13 existing tests locally before I caught it. A class/component reference passed by value is overwhelmingly PascalCase in JS/TS convention, so restricting to capitalized identifiers satisfies #2389's request without reopening #1741 — verified all 13 previously-broken tests pass again with this restriction in place.

### Engine parity

Mirrored in `crates/codegraph-core/src/extractors/javascript.rs`.

The WASM query-based extraction path required new tree-sitter query patterns scoped to *only* the `javascript`/`tsx` grammars — plain `.ts` (no JSX) has no JSX node types at all, so folding them into the shared TypeScript pattern set would throw at `Query()` compile time and break all `.ts` parsing. These patterns are duplicated in both `src/domain/parser.ts` and the isolated `wasm-worker-entry.ts` (which intentionally keeps its own copy to avoid importing `parser.ts`'s non-worker-safe process-global caches) — I initially only updated `parser.ts` and the fix silently didn't work through the real WASM worker pool. A new query-vs-walk parity test case for a capitalized JSX tag catches exactly this class of omission; verified it fails against the pre-fix `wasm-worker-entry.ts` before confirming it passes with the fix.

## Verification

- `cargo fmt -- --check` / `cargo clippy --workspace --all-targets -- -D warnings`: pass
- `npx vitest run tests/parsers/javascript.test.ts`: 382/382 pass (8 new tests added, all 13 previously-regressed callback-extraction tests still pass with the capitalization restriction)
- `npx vitest run tests/engines/query-walk-parity.test.ts`: 25/25 pass (3 new JSX/call-argument parity cases added; verified they fail against the pre-fix `wasm-worker-entry.ts` and pass against the fix)
- `cargo test --package codegraph-core extractors::javascript`: 299/299 pass (6 new Rust tests added, including a regression guard mirroring #1741)
- `npx vitest run tests/parsers/ tests/engines/`: 1120/1128 pass (8 skipped, pre-existing)
- `npx vitest run tests/integration/`: 1483/1487 pass (2 skipped, 2 todo, pre-existing)
- `npm run lint`: pass
- Manually reproduced both of the issue's exact fixtures against a freshly built native addon (`napi build`) and the WASM engine: `Header`/`AppModule` now both show "Used in: ..." on both engines, with identical node/edge counts

Closes #2389