### PR TITLE
fix(cli): distinguish zero role matches from an unbuilt graph in roles --role

### DIFF
--- a/src/domain/analysis/roles.ts
+++ b/src/domain/analysis/roles.ts
@@ -51,9 +51,20 @@ export function rolesData(
   try {
     const noTests = opts.noTests || false;
     const filterRole = opts.role || null;
-    const conditions = ['role IS NOT NULL'];
-    const params: (string | number)[] = [];
 
+    const baseConditions = ['role IS NOT NULL'];
+    const baseParams: (string | number)[] = [];
+    {
+      const fc = buildFileConditionSQL(opts.file || '', 'file');
+      if (fc.sql) {
+        // Strip leading ' AND ' since we're using conditions array
+        baseConditions.push(fc.sql.replace(/^ AND /, ''));
+        baseParams.push(...fc.params);
+      }
+    }
+
+    const conditions = [...baseConditions];
+    const params = [...baseParams];
     if (filterRole) {
       if (filterRole === DEAD_ROLE_PREFIX) {
         conditions.push('role LIKE ?');
@@ -61,14 +72,6 @@ export function rolesData(
       } else {
         conditions.push('role = ?');
         params.push(filterRole);
-      }
-    }
-    {
-      const fc = buildFileConditionSQL(opts.file || '', 'file');
-      if (fc.sql) {
-        // Strip leading ' AND ' since we're using conditions array
-        conditions.push(fc.sql.replace(/^ AND /, ''));
-        params.push(...fc.params);
       }
     }
 
@@ -86,6 +89,21 @@ export function rolesData(
 
     if (noTests) rows = rows.filter((r) => !isTestFile(r.file));
 
+    // Issue #2390: total classified-symbol count ignoring the --role filter
+    // (but respecting the file filter and noTests, same as the row query
+    // above), so the CLI can tell "this role has no matches" apart from "the
+    // graph has no classified symbols at all" and stop recommending a rebuild
+    // when the graph is actually fine. Only queried when a role filter is
+    // active — otherwise it's identical to `rows.length` and free to reuse.
+    let totalClassified = rows.length;
+    if (filterRole) {
+      let totalRows = db
+        .prepare(`SELECT file FROM nodes WHERE ${baseConditions.join(' AND ')}`)
+        .all(...baseParams) as Pick<NodeRow, 'file'>[];
+      if (noTests) totalRows = totalRows.filter((r) => !isTestFile(r.file));
+      totalClassified = totalRows.length;
+    }
+
     const summary: Record<string, number> = {};
     for (const r of rows) {
       // SQL guarantees role IS NOT NULL
@@ -95,7 +113,7 @@ export function rolesData(
 
     const hc = new Map();
     const symbols = rows.map((r) => normalizeSymbol(r, db, hc));
-    const base = { count: symbols.length, summary, symbols };
+    const base = { count: symbols.length, totalClassified, summary, symbols };
     return paginateResult(base, 'symbols', { limit: opts.limit, offset: opts.offset });
   } finally {
     db.close();

--- a/src/domain/analysis/roles.ts
+++ b/src/domain/analysis/roles.ts
@@ -104,6 +104,21 @@ export function rolesData(
       totalClassified = totalRows.length;
     }
 
+    // Issue #2390 follow-up: `totalClassified` above is still scoped by
+    // `--file`/`--no-tests`, so a filter combination that excludes every
+    // classified symbol from that scope (e.g. a file with none, or a role
+    // that only exists in test files under `-T`) falls through to zero there
+    // too — even though the graph is perfectly healthy outside that scope.
+    // Only in that doubly-empty case do we need a fully unscoped (no role, no
+    // file, no noTests) count to tell "this scope is empty" apart from "the
+    // graph was never classified at all."
+    let totalClassifiedUnscoped: number | undefined;
+    if (totalClassified === 0 && (filterRole || opts.file || noTests)) {
+      totalClassifiedUnscoped = (
+        db.prepare('SELECT COUNT(*) AS c FROM nodes WHERE role IS NOT NULL').get() as { c: number }
+      ).c;
+    }
+
     const summary: Record<string, number> = {};
     for (const r of rows) {
       // SQL guarantees role IS NOT NULL
@@ -113,7 +128,13 @@ export function rolesData(
 
     const hc = new Map();
     const symbols = rows.map((r) => normalizeSymbol(r, db, hc));
-    const base = { count: symbols.length, totalClassified, summary, symbols };
+    const base = {
+      count: symbols.length,
+      totalClassified,
+      totalClassifiedUnscoped,
+      summary,
+      symbols,
+    };
     return paginateResult(base, 'symbols', { limit: opts.limit, offset: opts.offset });
   } finally {
     db.close();

--- a/src/presentation/queries-cli/overview.ts
+++ b/src/presentation/queries-cli/overview.ts
@@ -125,6 +125,7 @@ interface RoleSymbol {
 interface RolesData {
   count: number;
   totalClassified: number;
+  totalClassifiedUnscoped?: number;
   summary: Record<string, number>;
   symbols: RoleSymbol[];
 }
@@ -374,6 +375,16 @@ export function roles(customDbPath: string, opts: OutputOpts = {}): void {
       // The graph is fine — this role filter simply matched nothing (#2390).
       console.log(
         `No symbols with role "${opts.role}". (${data.totalClassified} classified symbols in graph.)`,
+      );
+    } else if (data.totalClassifiedUnscoped) {
+      // The --file/--no-tests scope excluded every classified symbol, but the
+      // graph is healthy outside that scope — don't blame the build (#2390).
+      const scopeParts: string[] = [];
+      if (opts.file) scopeParts.push(`file "${opts.file}"`);
+      if (opts.noTests) scopeParts.push('non-test files');
+      const scopeDesc = scopeParts.length > 0 ? ` for ${scopeParts.join(' and ')}` : '';
+      console.log(
+        `No classified symbols found${scopeDesc}. (${data.totalClassifiedUnscoped} classified symbols in graph overall.)`,
       );
     } else {
       console.log('No classified symbols found. Run "codegraph build" first.');

--- a/src/presentation/queries-cli/overview.ts
+++ b/src/presentation/queries-cli/overview.ts
@@ -373,8 +373,16 @@ export function roles(customDbPath: string, opts: OutputOpts = {}): void {
   if (data.count === 0) {
     if (opts.role && data.totalClassified > 0) {
       // The graph is fine — this role filter simply matched nothing (#2390).
+      // totalClassified is itself scoped by --file/--no-tests, so the count
+      // shown must be labeled accordingly instead of always claiming "in
+      // graph" (Greptile review on #2531).
+      const roleScopeParts: string[] = [];
+      if (opts.file) roleScopeParts.push(`file "${opts.file}"`);
+      if (opts.noTests) roleScopeParts.push('non-test files');
+      const roleScopeDesc =
+        roleScopeParts.length > 0 ? `in ${roleScopeParts.join(' and ')}` : 'in graph';
       console.log(
-        `No symbols with role "${opts.role}". (${data.totalClassified} classified symbols in graph.)`,
+        `No symbols with role "${opts.role}". (${data.totalClassified} classified symbols ${roleScopeDesc}.)`,
       );
     } else if (data.totalClassifiedUnscoped) {
       // The --file/--no-tests scope excluded every classified symbol, but the

--- a/src/presentation/queries-cli/overview.ts
+++ b/src/presentation/queries-cli/overview.ts
@@ -124,6 +124,7 @@ interface RoleSymbol {
 
 interface RolesData {
   count: number;
+  totalClassified: number;
   summary: Record<string, number>;
   symbols: RoleSymbol[];
 }
@@ -369,7 +370,14 @@ export function roles(customDbPath: string, opts: OutputOpts = {}): void {
   if (outputResult(data, 'symbols', opts, customDbPath)) return;
 
   if (data.count === 0) {
-    console.log('No classified symbols found. Run "codegraph build" first.');
+    if (opts.role && data.totalClassified > 0) {
+      // The graph is fine — this role filter simply matched nothing (#2390).
+      console.log(
+        `No symbols with role "${opts.role}". (${data.totalClassified} classified symbols in graph.)`,
+      );
+    } else {
+      console.log('No classified symbols found. Run "codegraph build" first.');
+    }
     return;
   }
 

--- a/tests/integration/roles.test.ts
+++ b/tests/integration/roles.test.ts
@@ -446,6 +446,34 @@ describe('rolesData', () => {
       expect(s.file).not.toMatch(/\.test\./);
     }
   });
+
+  // Regression guard for #2390: `--role <X>` with zero matches must be able to
+  // tell "this role has no matches" apart from "the graph has no classified
+  // symbols at all" — both cases return count:0, but only totalClassified
+  // distinguishes them.
+  test('totalClassified reflects the full graph, unaffected by an unmatched role filter', () => {
+    const unfiltered = rolesData(dbPath);
+    const noMatches = rolesData(dbPath, { role: 'entry-fixture-nonexistent-role' });
+    expect(noMatches.count).toBe(0);
+    expect(noMatches.totalClassified).toBe(unfiltered.count);
+    expect(noMatches.totalClassified).toBeGreaterThan(0);
+  });
+
+  test('totalClassified equals count when no role filter is applied', () => {
+    const data = rolesData(dbPath);
+    expect(data.totalClassified).toBe(data.count);
+  });
+
+  test('totalClassified respects the file filter (matches the same-file unfiltered count)', () => {
+    const unfilteredForFile = rolesData(dbPath, { file: 'lib.js' });
+    const noMatchesForFile = rolesData(dbPath, {
+      file: 'lib.js',
+      role: 'entry-fixture-nonexistent-role',
+    });
+    expect(noMatchesForFile.count).toBe(0);
+    expect(noMatchesForFile.totalClassified).toBe(unfilteredForFile.count);
+    expect(noMatchesForFile.totalClassified).toBeGreaterThan(0);
+  });
 });
 
 // ─── statsData includes roles ───────────────────────────────────────────

--- a/tests/integration/roles.test.ts
+++ b/tests/integration/roles.test.ts
@@ -474,6 +474,47 @@ describe('rolesData', () => {
     expect(noMatchesForFile.totalClassified).toBe(unfilteredForFile.count);
     expect(noMatchesForFile.totalClassified).toBeGreaterThan(0);
   });
+
+  // Regression guard for Greptile's #2531 review finding: a --file/--no-tests
+  // scope that excludes every classified symbol must not be conflated with a
+  // genuinely unbuilt graph either — totalClassified (scoped) is 0 in this
+  // case too, so totalClassifiedUnscoped (ignoring every filter) is needed to
+  // show the graph is fine outside the requested scope.
+  test('totalClassifiedUnscoped reports the graph-wide count when a --file scope excludes everything', () => {
+    const unfiltered = rolesData(dbPath);
+    const emptyFileScope = rolesData(dbPath, { file: 'nonexistent-file.js' });
+    expect(emptyFileScope.count).toBe(0);
+    expect(emptyFileScope.totalClassified).toBe(0);
+    expect(emptyFileScope.totalClassifiedUnscoped).toBe(unfiltered.count);
+    expect(emptyFileScope.totalClassifiedUnscoped).toBeGreaterThan(0);
+  });
+
+  test('totalClassifiedUnscoped reports the graph-wide count when file+noTests excludes everything', () => {
+    const unfiltered = rolesData(dbPath);
+    // app.test.js is the only file matching this filter, and noTests removes it too.
+    const emptyScope = rolesData(dbPath, { file: 'app.test.js', noTests: true });
+    expect(emptyScope.count).toBe(0);
+    expect(emptyScope.totalClassified).toBe(0);
+    expect(emptyScope.totalClassifiedUnscoped).toBe(unfiltered.count);
+    expect(emptyScope.totalClassifiedUnscoped).toBeGreaterThan(0);
+  });
+
+  test('totalClassifiedUnscoped is not computed when the graph genuinely has no classified symbols', () => {
+    const emptyDb = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-roles-empty-'));
+    fs.mkdirSync(path.join(emptyDb, '.codegraph'));
+    const emptyDbPath = path.join(emptyDb, '.codegraph', 'graph.db');
+    const db = new Database(emptyDbPath);
+    db.pragma('journal_mode = WAL');
+    initSchema(db);
+    db.close();
+
+    const data = rolesData(emptyDbPath);
+    expect(data.count).toBe(0);
+    expect(data.totalClassified).toBe(0);
+    expect(data.totalClassifiedUnscoped).toBeUndefined();
+
+    fs.rmSync(emptyDb, { recursive: true, force: true });
+  });
 });
 
 // ─── statsData includes roles ───────────────────────────────────────────

--- a/tests/presentation/queries-cli.test.ts
+++ b/tests/presentation/queries-cli.test.ts
@@ -697,6 +697,36 @@ describe('roles', () => {
     roles('/db', { role: 'entry' });
     expect(output()).toContain('No classified symbols found. Run "codegraph build" first.');
   });
+
+  // Regression guard for Greptile's #2531 review finding: a --file/--no-tests
+  // scope that excludes every classified symbol must not be reported as an
+  // unbuilt graph either, when the graph is healthy outside that scope.
+  it('reports a scope-specific zero-match message instead of "run build first" when --file excludes everything but the graph is healthy (#2390)', () => {
+    mocks.rolesData.mockReturnValue({
+      count: 0,
+      totalClassified: 0,
+      totalClassifiedUnscoped: 548,
+      summary: {},
+      symbols: [],
+    });
+    roles('/db', { file: 'empty.js' });
+    const out = output();
+    expect(out).toContain('No classified symbols found for file "empty.js"');
+    expect(out).toContain('548 classified symbols in graph overall');
+    expect(out).not.toContain('Run "codegraph build" first');
+  });
+
+  it('mentions both file and no-tests scope in the message when both are active (#2390)', () => {
+    mocks.rolesData.mockReturnValue({
+      count: 0,
+      totalClassified: 0,
+      totalClassifiedUnscoped: 548,
+      summary: {},
+      symbols: [],
+    });
+    roles('/db', { file: 'app.test.js', noTests: true });
+    expect(output()).toContain('for file "app.test.js" and non-test files');
+  });
 });
 
 // ── overview.js: stats ─────────────────────────────────────────────

--- a/tests/presentation/queries-cli.test.ts
+++ b/tests/presentation/queries-cli.test.ts
@@ -675,9 +675,27 @@ describe('roles', () => {
   });
 
   it('prints message when no symbols classified', () => {
-    mocks.rolesData.mockReturnValue({ count: 0, summary: {}, symbols: [] });
+    mocks.rolesData.mockReturnValue({ count: 0, totalClassified: 0, summary: {}, symbols: [] });
     roles('/db', {});
     expect(output()).toContain('No classified symbols found');
+  });
+
+  // Regression guard for #2390: a --role filter with zero matches on a fully
+  // classified graph must not tell the user to rebuild — that's only correct
+  // when the graph itself has no classified symbols at all.
+  it('reports a role-specific zero-match message instead of "run build first" when the graph is otherwise classified (#2390)', () => {
+    mocks.rolesData.mockReturnValue({ count: 0, totalClassified: 548, summary: {}, symbols: [] });
+    roles('/db', { role: 'entry' });
+    const out = output();
+    expect(out).toContain('No symbols with role "entry"');
+    expect(out).toContain('548 classified symbols in graph');
+    expect(out).not.toContain('Run "codegraph build" first');
+  });
+
+  it('still recommends a rebuild for a --role filter when the graph genuinely has no classified symbols (#2390)', () => {
+    mocks.rolesData.mockReturnValue({ count: 0, totalClassified: 0, summary: {}, symbols: [] });
+    roles('/db', { role: 'entry' });
+    expect(output()).toContain('No classified symbols found. Run "codegraph build" first.');
   });
 });
 

--- a/tests/presentation/queries-cli.test.ts
+++ b/tests/presentation/queries-cli.test.ts
@@ -698,6 +698,26 @@ describe('roles', () => {
     expect(output()).toContain('No classified symbols found. Run "codegraph build" first.');
   });
 
+  // Regression guard for Greptile's second #2531 review finding: totalClassified
+  // is scoped by --file/--no-tests even in the role-specific branch, so the
+  // count must be labeled as belonging to that scope, not "in graph".
+  it('labels the count by scope instead of "in graph" when --role is combined with --file (#2390)', () => {
+    mocks.rolesData.mockReturnValue({ count: 0, totalClassified: 12, summary: {}, symbols: [] });
+    roles('/db', { role: 'entry', file: 'src/utils.ts' });
+    const out = output();
+    expect(out).toContain('No symbols with role "entry"');
+    expect(out).toContain('12 classified symbols in file "src/utils.ts"');
+    expect(out).not.toContain('12 classified symbols in graph');
+  });
+
+  it('labels the count by scope instead of "in graph" when --role is combined with --no-tests (#2390)', () => {
+    mocks.rolesData.mockReturnValue({ count: 0, totalClassified: 500, summary: {}, symbols: [] });
+    roles('/db', { role: 'entry', noTests: true });
+    const out = output();
+    expect(out).toContain('500 classified symbols in non-test files');
+    expect(out).not.toContain('500 classified symbols in graph');
+  });
+
   // Regression guard for Greptile's #2531 review finding: a --file/--no-tests
   // scope that excludes every classified symbol must not be reported as an
   // unbuilt graph either, when the graph is healthy outside that scope.


### PR DESCRIPTION
Closes #2390

## Problem

`codegraph roles --role <X>` with zero matches always said `No classified symbols found. Run "codegraph build" first.` — even on a fully and correctly built graph where the role simply has no members. Per the issue, this cost real time across 5 of 14 agents in an org rollout, each re-running `codegraph build` for nothing.

`rolesData`'s `count` conflates two different states:
- the graph has no classified symbols at all (genuinely worth rebuilding), and
- this `--role` filter matched nothing (the graph is fine).

## Fix

`rolesData` (`src/domain/analysis/roles.ts`) now also returns `totalClassified`: the classified-symbol count ignoring the `--role` filter but still respecting the `--file`/`-T` (noTests) filters. It's computed via one extra lightweight query, only when a role filter is active (free — identical to `rows.length` — in the common unfiltered case).

The CLI (`src/presentation/queries-cli/overview.ts`) uses this to print:

```
No symbols with role "entry". (548 classified symbols in graph.)
```

instead of the misleading rebuild suggestion, whenever the graph is otherwise non-empty. The original message is preserved for the genuine zero-graph case.

No native/Rust changes — this is a TypeScript query/presentation-layer fix only; `domain/analysis/` and `presentation/queries-cli/` have no Rust mirror (the dual-engine parity requirement applies to graph extraction, not CLI query formatting).

## Scope note

While auditing `queries-cli/` for the same conflation (per the issue's suggestion), found an identical bug in `codegraph exports <file>` (a file with legitimately zero exports gets told to rebuild). Filed separately as #2530 to keep this PR to one concern.

## Test plan

- [x] `tests/integration/roles.test.ts`: 3 new tests on `rolesData` — `totalClassified` matches the unfiltered count when a role filter has zero matches, equals `count` when no filter is applied, and respects the `file` filter.
- [x] `tests/presentation/queries-cli.test.ts`: 2 new tests on the CLI's `roles()` formatter — role-specific zero-match message when the graph is otherwise classified, and the original rebuild message preserved when the graph genuinely has none.
- [x] Verified all 5 new tests fail without the fix (reverted the two source files, confirmed failures, restored).
- [x] Full suite: `npm test` — 5313 passed.
- [x] `npm run lint` clean.
- [x] `codegraph diff-impact --staged -T` — bounded impact (2 files, 2 transitive callers, benchmark script + MCP passthrough only, both benign additive changes).