### PR TITLE
fix(native): add reflection to native's flag-only dynamic-kind sink list

### DIFF
--- a/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/build_edges.rs
@@ -1770,9 +1770,17 @@ fn process_file<'a>(
         // Sink edge: flag-only dynamic calls with no resolved target are emitted as
         // a (caller → file_node) edge at confidence=0.0 with dynamic_kind set.
         // This makes them queryable (`codegraph roles --dynamic`) instead of silent drops.
+        // Mirrors TS `FLAG_ONLY_DYNAMIC_KINDS` (shared/kinds.ts) — keep both lists in
+        // sync; a kind missing here silently drops the sink edge WASM still emits
+        // (issue #2413: `reflection` — a `.call`/`.apply`/`.bind` invocation whose
+        // wrapped function doesn't resolve — was missing from this list).
         if targets.is_empty() {
             if let Some(ref dk) = call.dynamic_kind {
-                if dk == "eval" || dk == "computed-key" || dk == "unresolved-dynamic" {
+                if dk == "eval"
+                    || dk == "computed-key"
+                    || dk == "reflection"
+                    || dk == "unresolved-dynamic"
+                {
                     let sink_key = (caller_id, fc.file_node_id, dk.clone());
                     if !seen_sink_edges.contains(&sink_key) {
                         seen_sink_edges.insert(sink_key);

--- a/tests/integration/issue-2413-reflection-sink-edge-parity.test.ts
+++ b/tests/integration/issue-2413-reflection-sink-edge-parity.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Regression test for #2413: a full build of this repo's own `src/` produced
+ * a handful of `calls` edges on WASM that native never emitted, all sharing
+ * one shape — a `.call()`/`.apply()`/`.bind()` invocation whose wrapped
+ * function doesn't resolve to any project definition (e.g.
+ * `Object.prototype.toString.call(x)`, or `obj.method.bind(x)` where `method`
+ * matches nothing in scope).
+ *
+ * Both extractors correctly tag this as a `Call` with `dynamicKind:
+ * 'reflection'` (`extractMemberExprCallInfo` / `extract_member_expr_call_info`
+ * — verified identical). The divergence was purely downstream: WASM's sink-edge
+ * step consults the shared `FLAG_ONLY_DYNAMIC_KINDS` set (`shared/kinds.ts`,
+ * which includes `'reflection'`) to decide whether an unresolved dynamic call
+ * gets a `(caller -> file)` sink edge instead of being silently dropped;
+ * native's mirror of that step (`build_edges.rs`) hardcoded a 3-member list
+ * that omitted `'reflection'`, so the same call was extracted identically but
+ * its sink edge was dropped.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { describe, expect, it } from 'vitest';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+import type { EngineMode } from '../../src/types.js';
+
+const FIXTURE = `
+class Repository {}
+
+function wrapInjectedRepo(repo: Repository): { repo: Repository; close(): void } {
+  if (!(repo instanceof Repository)) {
+    throw new TypeError(
+      \`got \${Object.prototype.toString.call(repo)}\`,
+    );
+  }
+  return { repo, close() {} };
+}
+`;
+
+interface SinkEdgeRow {
+  callerName: string;
+  targetFile: string;
+  targetKind: string;
+  dynamic: number;
+  dynamicKind: string | null;
+}
+
+function readReflectionSinkEdges(dbPath: string): SinkEdgeRow[] {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return db
+      .prepare(
+        `SELECT s.name AS callerName, t.file AS targetFile, t.kind AS targetKind,
+                e.dynamic AS dynamic, e.dynamic_kind AS dynamicKind
+         FROM edges e
+         JOIN nodes s ON s.id = e.source_id
+         JOIN nodes t ON t.id = e.target_id
+         WHERE e.kind = 'calls' AND e.dynamic_kind = 'reflection'`,
+      )
+      .all() as SinkEdgeRow[];
+  } finally {
+    db.close();
+  }
+}
+
+const ENGINES: EngineMode[] = ['wasm', 'native'];
+
+describe.each(ENGINES)(
+  'reflection-kind dynamic sink edge parity (#2413) — engine: %s',
+  (engine) => {
+    it('emits a (caller -> file) sink edge for an unresolved .call() reflection invocation', async () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2413-${engine}-`));
+      try {
+        fs.writeFileSync(path.join(dir, 'sample.ts'), FIXTURE);
+        await buildGraph(dir, { incremental: false, skipRegistry: true, engine });
+
+        const sinkEdges = readReflectionSinkEdges(path.join(dir, '.codegraph', 'graph.db'));
+        const edge = sinkEdges.find((e) => e.callerName === 'wrapInjectedRepo');
+
+        expect(edge).toBeDefined();
+        expect(edge?.targetKind).toBe('file');
+        expect(edge?.targetFile).toBe('sample.ts');
+        expect(edge?.dynamic).toBe(1);
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+  },
+);


### PR DESCRIPTION
## Summary

Closes #2413

A full build of this repo's own `src/` produced a handful of `calls` edges on WASM that native never emitted, all sharing one shape: a `.call()`/`.apply()`/`.bind()` invocation whose wrapped function doesn't resolve to any project definition (e.g. `Object.prototype.toString.call(x)`, or `obj.method.bind(x)` where `method` matches nothing in scope).

Both extractors already correctly tag this as a `Call` with `dynamicKind: 'reflection'` (`extractMemberExprCallInfo` / `extract_member_expr_call_info` — verified byte-identical logic). The divergence was purely downstream: the sink-edge step that turns an *unresolved* dynamic call into a `(caller -> file)` edge (so it's queryable via `codegraph roles --dynamic` instead of silently dropped) consults a flag-only-kinds list. TS's version (`FLAG_ONLY_DYNAMIC_KINDS` in `shared/kinds.ts`) correctly includes `'reflection'`; native's mirror in `build_edges.rs` hardcoded a 3-member list (`eval`, `computed-key`, `unresolved-dynamic`) that omitted it — so an otherwise-identical `Call` got its sink edge silently dropped on native only.

- Added `'reflection'` to the native flag-only list, with a comment pointing at the TS source of truth so the two lists don't drift again.
- The issue's third originally-reported edge (`resolveViaRepo -> getClassHierarchy`) turned out to already be fixed by unrelated CHA work landed since the issue was filed — verified by re-running the issue's own repro against current `main` before starting.
- Filed #2537 for a much larger (~180-edge), structurally different divergence around interface-typed receiver/CHA dispatch that surfaced while re-verifying this fix against the current (grown) `src/` tree — out of scope here, needs its own investigation.

## Test plan
- [x] New dual-engine integration test (`tests/integration/issue-2413-reflection-sink-edge-parity.test.ts`) reproducing the exact `wrapInjectedRepo`/`Object.prototype.toString.call(...)` shape and asserting both engines emit the sink edge
- [x] Revert-verify: confirmed the native test fails without the fix (7 edges vs wasm's 8), passes with it restored
- [x] Manually rebuilt this repo's own `src/` with both engines pre- and post-fix — confirmed both of #2413's originally-reported file-sink edges (`wrapInjectedRepo`, `addLazyFallback`) now emit identically on both engines
- [x] Full suite green: `cargo test` (1056 passed), `cargo clippy -- -D warnings`, `cargo fmt --check`, `npm test` (5355 passed), `npm run lint`, `codegraph diff-impact --staged -T`