### PR TITLE
test(docs): guard README runtime-dependency claims against package.json drift

### DIFF
--- a/tests/integration/docs-readme-dependency-drift.test.ts
+++ b/tests/integration/docs-readme-dependency-drift.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Regression test for #2417: README.md's runtime-dependency claims are
+ * hand-maintained numbers/table rows that silently drift out of sync with
+ * `package.json` — this has happened twice already (backlog #96, and again
+ * when `smol-toml` was added in c50a9919/#2376). Nothing catches it except a
+ * human reading the README closely.
+ *
+ * Guards the two places `package.json`'s `dependencies` are echoed in
+ * README.md: the "Lightweight Footprint" section's prose count + dependency
+ * table, and the competitive-comparison table's own-column count. Both must
+ * track `Object.keys(pkg.dependencies)` exactly — an added, removed, or
+ * renamed dependency breaks this test until the README is updated.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = path.join(__dirname, '../..');
+const README_PATH = path.join(REPO_ROOT, 'README.md');
+
+const pkg = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf-8'));
+const actualDeps: string[] = Object.keys(pkg.dependencies ?? {}).sort();
+
+const readme = fs.readFileSync(README_PATH, 'utf-8');
+
+describe('README.md runtime-dependency claims track package.json (#2417)', () => {
+  it('finds the "Only N runtime dependencies" prose claim', () => {
+    const match = readme.match(/Only \*\*(\d+) runtime dependencies\*\*/);
+    expect(
+      match,
+      'expected README.md to contain the "Only **N** runtime dependencies" line',
+    ).not.toBeNull();
+  });
+
+  it('the prose count matches package.json dependencies', () => {
+    const match = readme.match(/Only \*\*(\d+) runtime dependencies\*\*/);
+    const claimed = Number(match?.[1]);
+    expect(claimed).toBe(actualDeps.length);
+  });
+
+  it('the Lightweight Footprint dependency table lists exactly package.json dependencies', () => {
+    // The table's own rows: `| [name](url) | ... |`, found anywhere after the
+    // "Only **N** runtime dependencies" line and before the next blank line
+    // that follows the table (a blank line can separate the prose sentence
+    // from the table itself, so this can't stop at the FIRST blank line).
+    const afterClaim = readme.split(/Only \*\*\d+ runtime dependencies\*\*/)[1];
+    expect(afterClaim, 'could not locate text after the prose claim').toBeTruthy();
+
+    const tableStart = afterClaim!.indexOf('| Dependency ');
+    expect(tableStart, 'could not locate the dependency table header').toBeGreaterThanOrEqual(0);
+
+    const afterHeader = afterClaim!.slice(tableStart);
+    const tableBlock = afterHeader.split(/\n\n/)[0];
+    const rowNames = [...tableBlock.matchAll(/^\|\s*\[([^\]]+)\]\(/gm)].map((m) => m[1]).sort();
+
+    expect(rowNames).toEqual(actualDeps);
+  });
+
+  it('the competitive-comparison table row matches package.json dependencies', () => {
+    const match = readme.match(
+      /\|\s*Runtime dependencies \(direct packages\)[^|]*\|\s*\*\*(\d+)\*\*\s*\|/,
+    );
+    expect(
+      match,
+      'expected a "Runtime dependencies (direct packages)" row with our own bolded count',
+    ).not.toBeNull();
+    expect(Number(match?.[1])).toBe(actualDeps.length);
+  });
+});

--- a/tests/integration/docs-readme-dependency-drift.test.ts
+++ b/tests/integration/docs-readme-dependency-drift.test.ts
@@ -52,7 +52,21 @@ describe('README.md runtime-dependency claims track package.json (#2417)', () =>
 
     const afterHeader = afterClaim!.slice(tableStart);
     const tableBlock = afterHeader.split(/\n\n/)[0];
-    const rowNames = [...tableBlock.matchAll(/^\|\s*\[([^\]]+)\]\(/gm)].map((m) => m[1]).sort();
+
+    // Every data row (skip the header row and the `|---|---|` separator),
+    // normalizing a linked first cell (`[name](url)`) down to its link text —
+    // but not silently dropping a row whose first cell is plain text, which
+    // would let a stale non-linked row hide from the exact-set comparison
+    // below (Greptile review).
+    const rowNames = tableBlock
+      .split('\n')
+      .slice(2)
+      .filter((line) => line.startsWith('|'))
+      .map((line) => {
+        const firstCell = line.split('|')[1].trim();
+        return firstCell.match(/^\[([^\]]+)\]\(/)?.[1] ?? firstCell;
+      })
+      .sort();
 
     expect(rowNames).toEqual(actualDeps);
   });


### PR DESCRIPTION
## Summary

Closes #2417

`README.md`'s runtime-dependency claims are hand-maintained numbers/table rows that silently drift out of sync with `package.json` — this has happened twice already (backlog #96; again when `smol-toml` was added in c50a9919/#2376, only caught by a human reading the README closely).

Adds `tests/integration/docs-readme-dependency-drift.test.ts`, asserting three things against `Object.keys(package.json.dependencies)`:
- the "Only **N** runtime dependencies" prose count
- the "Lightweight Footprint" dependency table's row names (exact set match, not just a count — a renamed or swapped dependency is caught, not just an added/removed one)
- the competitive-comparison table's own-column count

The issue also scoped a third number (a Cargo direct-crate count previously mentioned in a "native engine is not dependency-free either" paragraph). That paragraph no longer exists in the current README — the dependency section was restructured since the issue was filed to track npm deps only — so there's nothing left to guard there. Verified by reading the current README before writing the test rather than assuming the issue's original scope still applied unchanged.

This is a plain vitest test file, so it's "wired into CI" via the existing `npm test` job already required on every PR — no separate script or workflow needed, matching the issue's own "cheapest version" suggestion.

## Test plan
- [x] New test passes against current README.md/package.json
- [x] Revert-verify: manually corrupted the README's prose count, a table row's dependency name, and the competitive-table count (one at a time) and confirmed each specific assertion fails; restored and confirmed all 4 pass again
- [x] Full suite green: `npm test` (5359 passed), `npm run lint`, `codegraph diff-impact --staged -T` (no production code changed)