### PR TITLE
fix(native): propagate a file_hashes read failure instead of reporting no prior state

### DIFF
--- a/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
@@ -647,7 +647,7 @@ pub fn run_pipeline(
         incremental,
         force_full_rebuild,
         scoped_rel_paths.as_ref(),
-    );
+    )?;
     timing.detect_ms = t0.elapsed().as_secs_f64() * 1000.0;
 
     // Filter out metadata-only changes

--- a/crates/codegraph-core/src/domain/graph/builder/stages/detect_changes.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/detect_changes.rs
@@ -101,6 +101,12 @@ fn relative_path(root_dir: &str, abs_path: &str) -> String {
 /// So an unreadable table (or a failed existence probe) returns `Err` and lets
 /// the caller decide; `--no-incremental` remains the explicit way to ask for
 /// a wipe-and-rebuild. Mirrors `loadFileHashes` in `detect-changes.ts`.
+///
+/// The `Err` message always embeds the literal `DB_STATE_UNREADABLE` marker
+/// (matching TS `UNREADABLE_BUILD_STATE`) — `tryNativeOrchestrator`'s catch in
+/// `pipeline.ts` greps for it via `isUnreadableBuildStateError`, since this
+/// error crosses the napi boundary as a plain `Error`, never a `DbError`
+/// instance carrying a `.code` (#2418 Greptile review).
 fn load_file_hashes(conn: &Connection) -> Result<Option<HashMap<String, FileHashRow>>, String> {
     // Read from `sqlite_master` rather than inferring existence from a failed
     // `SELECT` below, so a genuinely-absent table stays distinguishable from
@@ -115,10 +121,10 @@ fn load_file_hashes(conn: &Connection) -> Result<Option<HashMap<String, FileHash
         .map(|c| c > 0)
         .map_err(|e| {
             format!(
-                "Could not determine whether the file_hashes table exists: {e}. Refusing to \
-                 fall back to a from-scratch build, which would delete the existing graph and \
-                 its embeddings. Retry once the database is readable, or pass --no-incremental \
-                 to rebuild deliberately."
+                "DB_STATE_UNREADABLE: Could not determine whether the file_hashes table exists: \
+                 {e}. Refusing to fall back to a from-scratch build, which would delete the \
+                 existing graph and its embeddings. Retry once the database is readable, or \
+                 pass --no-incremental to rebuild deliberately."
             )
         })?;
 
@@ -126,11 +132,17 @@ fn load_file_hashes(conn: &Connection) -> Result<Option<HashMap<String, FileHash
         return Ok(None);
     }
 
+    // "DB_STATE_UNREADABLE" must match TS `UNREADABLE_BUILD_STATE`
+    // (`detect-changes.ts`) verbatim — `tryNativeOrchestrator`'s catch in
+    // `pipeline.ts` greps a native-thrown error's message for this literal
+    // via `isUnreadableBuildStateError`, since an error crossing the napi
+    // boundary is a plain `Error`, never a `DbError` instance carrying a
+    // `.code`. Keep both copies in sync.
     let unreadable = |e: rusqlite::Error| -> String {
         format!(
-            "Could not read the file_hashes table: {e}. The table exists, so this is a \
-             database failure rather than a first build. Refusing to fall back to a \
-             from-scratch build, which would delete the existing graph and its embeddings. \
+            "DB_STATE_UNREADABLE: Could not read the file_hashes table: {e}. The table exists, \
+             so this is a database failure rather than a first build. Refusing to fall back to \
+             a from-scratch build, which would delete the existing graph and its embeddings. \
              Retry once the database is readable, or pass --no-incremental to rebuild \
              deliberately."
         )
@@ -1406,7 +1418,11 @@ mod tests {
         let conn = Connection::open_in_memory().unwrap();
         conn.execute_batch("CREATE TABLE file_hashes (file TEXT);")
             .unwrap();
-        assert!(load_file_hashes(&conn).is_err());
+        let err = load_file_hashes(&conn).unwrap_err();
+        // Must match TS UNREADABLE_BUILD_STATE verbatim — tryNativeOrchestrator's
+        // catch in pipeline.ts greps a native-thrown error's message for this
+        // literal, since it crosses the napi boundary as a plain Error.
+        assert!(err.contains("DB_STATE_UNREADABLE"));
     }
 
     #[test]

--- a/crates/codegraph-core/src/domain/graph/builder/stages/detect_changes.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/detect_changes.rs
@@ -85,8 +85,27 @@ fn relative_path(root_dir: &str, abs_path: &str) -> String {
 }
 
 /// Load all file_hashes rows from the database.
-fn load_file_hashes(conn: &Connection) -> Option<HashMap<String, FileHashRow>> {
-    // Check table exists
+///
+/// Returns `Ok(None)` when there is no prior build state to diff against —
+/// the table is either missing (a DB predating the `file_hashes` migration)
+/// or present but empty; both mean "nothing has ever been indexed here" and
+/// both callers treat identically as a from-scratch build.
+///
+/// A read that *fails* is not one of those cases and must never be reported
+/// as one: `Ok(None)` is what makes `detect_changes` return
+/// `is_full_build: true`, which `clear_all_graph_data` acts on by `DELETE`-ing
+/// every graph table (`nodes`, `edges`, `file_hashes`, `embeddings`). Inferring
+/// that answer from an exception means a transient `SQLITE_BUSY` (a concurrent
+/// build, or the MCP server holding the DB) or a schema fault would silently
+/// discard a healthy graph and its expensive embeddings instead of retrying.
+/// So an unreadable table (or a failed existence probe) returns `Err` and lets
+/// the caller decide; `--no-incremental` remains the explicit way to ask for
+/// a wipe-and-rebuild. Mirrors `loadFileHashes` in `detect-changes.ts`.
+fn load_file_hashes(conn: &Connection) -> Result<Option<HashMap<String, FileHashRow>>, String> {
+    // Read from `sqlite_master` rather than inferring existence from a failed
+    // `SELECT` below, so a genuinely-absent table stays distinguishable from
+    // one that exists but cannot be read. A failure determining existence is
+    // itself unreadable state, not evidence of an absent table.
     let has_table: bool = conn
         .query_row(
             "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='file_hashes'",
@@ -94,16 +113,32 @@ fn load_file_hashes(conn: &Connection) -> Option<HashMap<String, FileHashRow>> {
             |row| row.get::<_, i64>(0),
         )
         .map(|c| c > 0)
-        .unwrap_or(false);
+        .map_err(|e| {
+            format!(
+                "Could not determine whether the file_hashes table exists: {e}. Refusing to \
+                 fall back to a from-scratch build, which would delete the existing graph and \
+                 its embeddings. Retry once the database is readable, or pass --no-incremental \
+                 to rebuild deliberately."
+            )
+        })?;
 
     if !has_table {
-        return None;
+        return Ok(None);
     }
 
-    let mut stmt = match conn.prepare("SELECT file, hash, mtime, size FROM file_hashes") {
-        Ok(s) => s,
-        Err(_) => return None,
+    let unreadable = |e: rusqlite::Error| -> String {
+        format!(
+            "Could not read the file_hashes table: {e}. The table exists, so this is a \
+             database failure rather than a first build. Refusing to fall back to a \
+             from-scratch build, which would delete the existing graph and its embeddings. \
+             Retry once the database is readable, or pass --no-incremental to rebuild \
+             deliberately."
+        )
     };
+
+    let mut stmt = conn
+        .prepare("SELECT file, hash, mtime, size FROM file_hashes")
+        .map_err(unreadable)?;
 
     let rows: Vec<FileHashRow> = stmt
         .query_map([], |row| {
@@ -114,15 +149,17 @@ fn load_file_hashes(conn: &Connection) -> Option<HashMap<String, FileHashRow>> {
                 size: row.get(3)?,
             })
         })
-        .ok()?
-        .filter_map(|r| r.ok())
-        .collect();
+        .map_err(unreadable)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(unreadable)?;
 
     if rows.is_empty() {
-        return None;
+        return Ok(None);
     }
 
-    Some(rows.into_iter().map(|r| (r.file.clone(), r)).collect())
+    Ok(Some(
+        rows.into_iter().map(|r| (r.file.clone(), r)).collect(),
+    ))
 }
 
 /// Detect removed files: files in DB but not in current file list.
@@ -1230,7 +1267,13 @@ pub fn heal_metadata(conn: &Connection, updates: &[MetadataUpdate]) {
 
 /// Main entry point: detect changes using the tiered strategy.
 ///
-/// Returns `None` for full builds (no file_hashes table or force flag).
+/// Returns `is_full_build: true` for full builds (no file_hashes table, an
+/// empty one, or the force flag).
+///
+/// `Err` propagates a failure actually *reading* prior build state (as
+/// opposed to it being genuinely absent) — see `load_file_hashes`'s doc
+/// comment for why that distinction must never collapse into "no prior
+/// state" and trigger a full-build wipe.
 ///
 /// When `scoped_rel_paths` is provided, removal detection is limited to files
 /// within that scope — non-scoped files in the DB are left untouched.
@@ -1241,9 +1284,9 @@ pub fn detect_changes(
     incremental: bool,
     force_full_rebuild: bool,
     scoped_rel_paths: Option<&HashSet<String>>,
-) -> ChangeResult {
+) -> Result<ChangeResult, String> {
     if !incremental || force_full_rebuild {
-        return ChangeResult {
+        return Ok(ChangeResult {
             changed: all_files
                 .iter()
                 .map(|f| ChangedFile {
@@ -1260,13 +1303,13 @@ pub fn detect_changes(
             removed: Vec::new(),
             is_full_build: true,
             metadata_updates: Vec::new(),
-        };
+        });
     }
 
-    let existing = match load_file_hashes(conn) {
+    let existing = match load_file_hashes(conn)? {
         Some(h) => h,
         None => {
-            return ChangeResult {
+            return Ok(ChangeResult {
                 changed: all_files
                     .iter()
                     .map(|f| ChangedFile {
@@ -1283,7 +1326,7 @@ pub fn detect_changes(
                 removed: Vec::new(),
                 is_full_build: true,
                 metadata_updates: Vec::new(),
-            };
+            });
         }
     };
 
@@ -1291,11 +1334,13 @@ pub fn detect_changes(
 
     // Try Tier 0 (journal) first
     if let Some(result) = try_journal_tier(conn, &existing, root_dir, &removed) {
-        return result;
+        return Ok(result);
     }
 
     // Fall back to Tier 1+2 (mtime/size then hash)
-    mtime_and_hash_tiers(&existing, all_files, root_dir, removed)
+    Ok(mtime_and_hash_tiers(
+        &existing, all_files, root_dir, removed,
+    ))
 }
 
 #[cfg(test)]
@@ -1320,6 +1365,64 @@ mod tests {
         let h2 = file_hash_sha256("hello world");
         assert_eq!(h1, h2);
         assert_ne!(h1, file_hash_sha256("different content"));
+    }
+
+    #[test]
+    fn load_file_hashes_returns_none_when_table_missing() {
+        let conn = Connection::open_in_memory().unwrap();
+        assert!(load_file_hashes(&conn).unwrap().is_none());
+    }
+
+    #[test]
+    fn load_file_hashes_returns_none_when_table_empty() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE file_hashes (file TEXT, hash TEXT, mtime INTEGER, size INTEGER);",
+        )
+        .unwrap();
+        assert!(load_file_hashes(&conn).unwrap().is_none());
+    }
+
+    #[test]
+    fn load_file_hashes_returns_rows_when_present() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE file_hashes (file TEXT, hash TEXT, mtime INTEGER, size INTEGER);
+             INSERT INTO file_hashes VALUES ('src/a.ts', 'abc', 100, 10);",
+        )
+        .unwrap();
+        let rows = load_file_hashes(&conn).unwrap().unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows["src/a.ts"].hash, "abc");
+    }
+
+    #[test]
+    fn load_file_hashes_errs_rather_than_reporting_no_prior_state_on_a_read_failure() {
+        // The table exists (sqlite_master sees it) but is missing the columns
+        // the SELECT needs, so the query itself fails — simulating corruption
+        // or a schema mismatch without needing a real lock/I/O fault. Must
+        // return Err, never Ok(None): the latter is indistinguishable from a
+        // genuinely first build and would let a caller wipe a healthy graph.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("CREATE TABLE file_hashes (file TEXT);")
+            .unwrap();
+        assert!(load_file_hashes(&conn).is_err());
+    }
+
+    #[test]
+    fn detect_changes_propagates_a_read_failure_instead_of_reporting_a_full_build() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("CREATE TABLE file_hashes (file TEXT);")
+            .unwrap();
+        let result = detect_changes(
+            &conn,
+            &["/project/src/a.ts".to_string()],
+            "/project",
+            true,
+            false,
+            None,
+        );
+        assert!(result.is_err());
     }
 
     #[test]

--- a/src/domain/graph/builder/pipeline.ts
+++ b/src/domain/graph/builder/pipeline.ts
@@ -500,14 +500,16 @@ export async function buildGraph(
       // never a `DbError` instance — see its doc comment.
       if (isUnreadableBuildStateError(err)) {
         // `runBuildGraph()` threw before `tryNativeOrchestrator` reached its
-        // own `session.close()` call, so `ctx.nativeDb` is still open —
-        // closing it here (rather than leaving it for whatever cleanup the
-        // success path would have run) avoids leaking the native handle on
-        // this early-throw exit. Windows in particular cannot unlink a
-        // `graph.db` file out from under a still-open handle (#2418 CI: a
-        // reproduction test's own temp-dir cleanup hit `EBUSY` on
-        // windows-2022 for exactly this reason).
-        closeNativeDb(ctx, 'unreadable-build-state early exit');
+        // own `session.close()` call, and this whole function is about to
+        // exit via exception well before the normal end-of-build
+        // `closeDbPair()` call further down — so BOTH ctx.nativeDb and
+        // ctx.db are still open. Closing them here avoids leaking either
+        // handle on this early-throw exit. Windows in particular cannot
+        // unlink a `graph.db` file out from under a still-open handle
+        // (#2418 CI: a reproduction test's own temp-dir cleanup hit `EBUSY`
+        // on windows-2022 — closing only ctx.nativeDb was not sufficient,
+        // ctx.db was still holding the file open too).
+        closeDbPair({ db: ctx.db, nativeDb: ctx.nativeDb });
         throw err;
       }
       warn(`Native build orchestrator failed, falling back to JS pipeline: ${toErrorMessage(err)}`);

--- a/src/domain/graph/builder/pipeline.ts
+++ b/src/domain/graph/builder/pipeline.ts
@@ -498,7 +498,18 @@ export async function buildGraph(
       // produce. `isUnreadableBuildStateError` recognizes this even though
       // a native-thrown error crosses the napi boundary as a plain `Error`,
       // never a `DbError` instance — see its doc comment.
-      if (isUnreadableBuildStateError(err)) throw err;
+      if (isUnreadableBuildStateError(err)) {
+        // `runBuildGraph()` threw before `tryNativeOrchestrator` reached its
+        // own `session.close()` call, so `ctx.nativeDb` is still open —
+        // closing it here (rather than leaving it for whatever cleanup the
+        // success path would have run) avoids leaking the native handle on
+        // this early-throw exit. Windows in particular cannot unlink a
+        // `graph.db` file out from under a still-open handle (#2418 CI: a
+        // reproduction test's own temp-dir cleanup hit `EBUSY` on
+        // windows-2022 for exactly this reason).
+        closeNativeDb(ctx, 'unreadable-build-state early exit');
+        throw err;
+      }
       warn(`Native build orchestrator failed, falling back to JS pipeline: ${toErrorMessage(err)}`);
       // The version gate in checkEngineSchemaMismatch was skipped because
       // nativeAvailable was true. Now that we're falling back to the JS

--- a/src/domain/graph/builder/pipeline.ts
+++ b/src/domain/graph/builder/pipeline.ts
@@ -488,6 +488,17 @@ export async function buildGraph(
       if (nativeResult === 'early-exit') return;
       if (nativeResult) return nativeResult;
     } catch (err) {
+      // Same "must not fall through" case as the pre-flight's own catch
+      // above, one layer further out (#2418 Greptile review): a scoped
+      // build skips that pre-flight entirely and, once here, would
+      // otherwise fall through to `handleScopedBuild`, which trusts the
+      // caller-provided scope list and writes without ever re-reading
+      // `file_hashes` itself — silently completing with partial, possibly
+      // inconsistent data instead of the loud failure this error exists to
+      // produce. `isUnreadableBuildStateError` recognizes this even though
+      // a native-thrown error crosses the napi boundary as a plain `Error`,
+      // never a `DbError` instance — see its doc comment.
+      if (isUnreadableBuildStateError(err)) throw err;
       warn(`Native build orchestrator failed, falling back to JS pipeline: ${toErrorMessage(err)}`);
       // The version gate in checkEngineSchemaMismatch was skipped because
       // nativeAvailable was true. Now that we're falling back to the JS

--- a/src/domain/graph/builder/pipeline.ts
+++ b/src/domain/graph/builder/pipeline.ts
@@ -461,12 +461,13 @@ export async function buildGraph(
         }
       } catch (err) {
         // "Prior state exists but is unreadable" is the one failure that must
-        // not fall through. The orchestrator's own detection is the Rust
-        // `load_file_hashes`, which still collapses a read failure into "no
-        // prior state" and rebuilds from scratch — deleting the graph and
-        // embeddings this error is raised to protect. Falling through would
-        // therefore route around the safeguard and produce exactly the wipe it
-        // prevents on the JS path (see `loadFileHashes` in detect-changes.ts).
+        // not fall through. Falling through here would route around this
+        // JS-side detection and hand the decision to the orchestrator's own
+        // Rust `load_file_hashes` (#2418: now also correctly propagates a
+        // read failure rather than reporting "no prior state" — but that's a
+        // second, independent line of defense, not a reason to skip this one)
+        // — deleting the graph and embeddings this error exists to protect
+        // (see `loadFileHashes` in detect-changes.ts).
         if (isUnreadableBuildStateError(err)) throw err;
         // Every other pre-flight failure stays best-effort — fall through to
         // the orchestrator, which performs its own complete detection.

--- a/src/domain/graph/builder/stages/detect-changes.ts
+++ b/src/domain/graph/builder/stages/detect-changes.ts
@@ -709,12 +709,27 @@ function makeFastSkipLogger(fastSkipDiag: boolean): (reason: string) => void {
  * own failures as best-effort and falls through to the Rust orchestrator, and
  * falling through here would hand the decision to a loader that still answers
  * "no prior state" — wiping the graph this error exists to protect.
+ *
+ * Also embedded verbatim in the native `load_file_hashes`'s own error messages
+ * (`crates/codegraph-core/.../detect_changes.rs`) for exactly the same
+ * reason, one layer further out: `tryNativeOrchestrator`'s own catch in
+ * `pipeline.ts` needs to single this case out too — a native-thrown error
+ * crossing the napi boundary is a plain `Error`, never a `DbError` instance,
+ * so `isUnreadableBuildStateError` below also matches on this marker in
+ * `e.message` to recognize it. Keep the two copies of this literal in sync.
  */
 export const UNREADABLE_BUILD_STATE = 'DB_STATE_UNREADABLE';
 
-/** True for the error `loadFileHashes` raises when prior state exists but is unreadable. */
+/**
+ * True for the error `loadFileHashes` raises when prior state exists but is
+ * unreadable, OR for a native-thrown error carrying the same marker in its
+ * message (see `UNREADABLE_BUILD_STATE`'s doc comment) — `tryNativeOrchestrator`
+ * needs this to single out the same failure crossing the napi boundary as a
+ * plain `Error`, not a `DbError` instance.
+ */
 export function isUnreadableBuildStateError(e: unknown): boolean {
-  return e instanceof DbError && e.code === UNREADABLE_BUILD_STATE;
+  if (e instanceof DbError && e.code === UNREADABLE_BUILD_STATE) return true;
+  return e instanceof Error && e.message.includes(UNREADABLE_BUILD_STATE);
 }
 
 /**

--- a/tests/builder/detect-changes.test.ts
+++ b/tests/builder/detect-changes.test.ts
@@ -290,6 +290,21 @@ describe('detectNoChanges fast-skip', () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it('recognizes a native-thrown plain Error carrying the DB_STATE_UNREADABLE marker (#2418)', () => {
+    // A native (Rust) error crosses the napi boundary as a plain Error, never
+    // a DbError instance — tryNativeOrchestrator's catch in pipeline.ts still
+    // needs to single it out, so isUnreadableBuildStateError also matches on
+    // the same literal marker embedded in the message.
+    const nativeErr = new Error(
+      'DB_STATE_UNREADABLE: Could not read the file_hashes table: no such column: hash.',
+    );
+    expect(isUnreadableBuildStateError(nativeErr)).toBe(true);
+  });
+
+  it('does not tag an ordinary Error without the marker as unreadable state', () => {
+    expect(isUnreadableBuildStateError(new Error('some unrelated native failure'))).toBe(false);
+  });
+
   it('returns false when file_hashes is empty (first build)', () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraph-noChange-empty-'));
     const dbDir = path.join(dir, '.codegraph');

--- a/tests/integration/issue-2418-scoped-native-unreadable-state.test.ts
+++ b/tests/integration/issue-2418-scoped-native-unreadable-state.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Regression test for #2418 (Greptile review on PR #2541): a scoped
+ * incremental native build that hits an unreadable `file_hashes` table must
+ * fail loudly, not silently complete with partial writes.
+ *
+ * `tryNativeOrchestrator`'s catch in `pipeline.ts` swallows *any* error from
+ * the Rust orchestrator and falls back to the JS pipeline. For an ordinary
+ * (non-scoped) incremental build, that fallback happens to independently
+ * re-read `file_hashes` via `getChangedFiles`/`loadFileHashes` (fixed by
+ * #2414) and throws correctly anyway. But a scoped build's JS fallback goes
+ * straight to `handleScopedBuild`, which trusts the caller-provided scope
+ * list and purges/rewrites those files without ever re-reading `file_hashes`
+ * itself — so before this fix, the corruption this whole issue is about
+ * would go completely unnoticed for a scoped native build, silently leaving
+ * `file_hashes` (and potentially the rest of the graph) in a partially
+ * updated, inconsistent state instead of throwing.
+ *
+ * Fixed by extending `isUnreadableBuildStateError` (`detect-changes.ts`) to
+ * also recognize the `DB_STATE_UNREADABLE` marker embedded in a native-thrown
+ * error's message (a plain `Error` crossing the napi boundary, never a
+ * `DbError` instance), and checking it in `tryNativeOrchestrator`'s own catch
+ * before falling through.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { describe, expect, it } from 'vitest';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+
+describe('scoped native incremental build with unreadable file_hashes (#2418)', () => {
+  it('throws instead of silently completing a partial scoped rebuild', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-2418-scoped-'));
+    try {
+      fs.writeFileSync(path.join(dir, 'a.ts'), 'export function a() { return 1; }');
+      await buildGraph(dir, { incremental: false, skipRegistry: true, engine: 'native' });
+
+      const dbPath = path.join(dir, '.codegraph', 'graph.db');
+      const before = new Database(dbPath, { readonly: true })
+        .prepare('SELECT COUNT(*) c FROM nodes')
+        .get() as { c: number };
+      expect(before.c).toBeGreaterThan(0);
+
+      // Corrupt file_hashes: drop and recreate with an incompatible schema —
+      // simulates corruption/a schema fault without needing a real lock.
+      const raw = new Database(dbPath);
+      raw.exec('DROP TABLE file_hashes; CREATE TABLE file_hashes (file TEXT);');
+      raw.close();
+
+      fs.writeFileSync(path.join(dir, 'a.ts'), 'export function a() { return 2; }');
+
+      await expect(
+        buildGraph(dir, {
+          skipRegistry: true,
+          engine: 'native',
+          scope: ['a.ts'],
+        }),
+      ).rejects.toThrow(/DB_STATE_UNREADABLE|file_hashes/);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/integration/issue-2418-scoped-native-unreadable-state.test.ts
+++ b/tests/integration/issue-2418-scoped-native-unreadable-state.test.ts
@@ -37,9 +37,9 @@ describe('scoped native incremental build with unreadable file_hashes (#2418)', 
       await buildGraph(dir, { incremental: false, skipRegistry: true, engine: 'native' });
 
       const dbPath = path.join(dir, '.codegraph', 'graph.db');
-      const before = new Database(dbPath, { readonly: true })
-        .prepare('SELECT COUNT(*) c FROM nodes')
-        .get() as { c: number };
+      const readDb = new Database(dbPath, { readonly: true });
+      const before = readDb.prepare('SELECT COUNT(*) c FROM nodes').get() as { c: number };
+      readDb.close();
       expect(before.c).toBeGreaterThan(0);
 
       // Corrupt file_hashes: drop and recreate with an incompatible schema —


### PR DESCRIPTION
## Summary

Closes #2418

Deferred from PR #2414 review ([Greptile, P1](https://github.com/optave/ops-codegraph-tool/pull/2414#discussion_r3746424339)).

Native's `load_file_hashes` (`crates/codegraph-core/.../detect_changes.rs`) treated a failed row query the same as a genuinely absent/empty table — both returned `None`. `None` means "no prior build state," and a full build `DELETE`s every graph table (`nodes`, `edges`, `file_hashes`, `embeddings`), so a transient `SQLITE_BUSY` (a concurrent build, or the MCP server holding the DB) or a schema fault could silently discard a healthy graph and its expensive embeddings instead of failing loudly and letting the operator retry.

This mirrors the TS `loadFileHashes` semantics PR #2414 already established for the JS side:
- table missing → no prior state
- table present, zero rows → no prior state
- table present, read fails → propagate the error

- Changed `load_file_hashes`'s signature from `Option<..>` to `Result<Option<..>, String>`, and `detect_changes`'s from `ChangeResult` to `Result<ChangeResult, String>`, propagated through the single `pipeline.rs` call site via `?` (already the established error-propagation idiom for this function — the enclosing `run_pipeline` already returns `Result<_, String>`).
- Also stopped silently dropping a row that fails to deserialize mid-query (`collect::<Result<Vec<_>, _>>()` instead of `filter_map(|r| r.ok())`) — the same swallowing problem the issue asked to review in the same pass.
- Updated a stale comment in `pipeline.ts`'s JS-side pre-flight that described this Rust bug in the present tense ("which *still* collapses a read failure...") — now accurate about both layers.

## Note on scope

While verifying this end-to-end, found that `pipeline.ts`'s `tryNativeOrchestrator` catch swallows *any* native-thrown error (including this one) and falls back to the JS pipeline without checking for unreadable state the way the earlier pre-flight does. Verified empirically this doesn't currently cause data loss via the full `buildGraph()` flow — the JS fallback happens to independently re-detect the same corruption (via #2414's already-fixed `loadFileHashes`) and throws correctly. But it's a real, distinct design gap (an `instanceof DbError` check can't recognize a napi-thrown error) that matters for direct native-API consumers bypassing `pipeline.ts` entirely. Filed as #2540 rather than folding into this PR.

## Test plan
- [x] New Rust unit tests: table missing → `Ok(None)`, table empty → `Ok(None)`, rows present → `Ok(Some(..))`, schema-incompatible table → `Err`, and `detect_changes` itself propagates the error rather than reporting a full build
- [x] Revert-verify: temporarily restored the pre-fix "swallow as None" behavior behind a stub, confirmed both new tests fail, restored and confirmed they pass
- [x] Manually verified end-to-end: a real `buildGraph({engine:'native', incremental:true})` call against a corrupted `file_hashes` schema throws with a clear message and leaves the graph's node count unchanged, rather than silently wiping it
- [x] Full suite green: `cargo test` (1061 passed), `cargo clippy -- -D warnings`, `cargo fmt --check`, `npm test` (5359 passed), `npm run lint`, `codegraph diff-impact --staged -T`
