### PR TITLE
fix(roles): distinguish wrapper calls from the real entrypoint target (#2420)

### DIFF
--- a/crates/codegraph-core/src/db/connection.rs
+++ b/crates/codegraph-core/src/db/connection.rs
@@ -979,6 +979,13 @@ impl NativeDatabase {
             let _ = conn.execute_batch(
                 "CREATE INDEX IF NOT EXISTS idx_nodes_entrypoint_source_file ON nodes(entrypoint_source_file)",
             );
+            // #2420: narrower than `entrypoint` — see TS `ensureNodeColumns`'s
+            // mirrored comment (migrations.ts) for the full rationale.
+            if !has_column(conn, "nodes", "entrypoint_role") {
+                let _ = conn.execute_batch(
+                    "ALTER TABLE nodes ADD COLUMN entrypoint_role INTEGER DEFAULT 0",
+                );
+            }
             let _ = conn.execute_batch(
                 "UPDATE nodes SET qualified_name = name WHERE qualified_name IS NULL",
             );
@@ -1024,6 +1031,18 @@ impl NativeDatabase {
             let _ = conn.execute_batch(
                 "CREATE INDEX IF NOT EXISTS idx_edges_dynamic_kind ON edges(dynamic_kind) WHERE dynamic_kind IS NOT NULL",
             );
+        }
+
+        // #2420: bare name of the call this evidence row's call is nested
+        // inside, or NULL for a top-level entrypoint call. Mirrors TS
+        // `ensureEntrypointCallsColumns` (migrations.ts) — see that
+        // function's doc comment for why this is an idempotent ALTER rather
+        // than a numbered migration. Guarded on the table existing since a
+        // pre-v31 database reaches this before migration v31 has run.
+        if has_table(conn, "entrypoint_calls")
+            && !has_column(conn, "entrypoint_calls", "wrapped_by")
+        {
+            let _ = conn.execute_batch("ALTER TABLE entrypoint_calls ADD COLUMN wrapped_by TEXT");
         }
 
         // #2428: seed `entrypoint_calls` from attribution a pre-v31 build

--- a/crates/codegraph-core/src/domain/graph/builder/entrypoints.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/entrypoints.rs
@@ -71,9 +71,9 @@ fn persist_entrypoint_calls(conn: &Connection, file_symbols: &BTreeMap<String, F
         let Ok(mut delete) = tx.prepare("DELETE FROM entrypoint_calls WHERE file = ?1") else {
             return;
         };
-        let Ok(mut insert) =
-            tx.prepare("INSERT OR IGNORE INTO entrypoint_calls (file, name) VALUES (?1, ?2)")
-        else {
+        let Ok(mut insert) = tx.prepare(
+            "INSERT OR IGNORE INTO entrypoint_calls (file, name, wrapped_by) VALUES (?1, ?2, ?3)",
+        ) else {
             return;
         };
 
@@ -82,12 +82,19 @@ fn persist_entrypoint_calls(conn: &Connection, file_symbols: &BTreeMap<String, F
                 continue;
             }
             let _ = delete.execute(rusqlite::params![rel_path]);
-            let mut seen: HashSet<&str> = HashSet::new();
+            // First occurrence per name wins (matches TS's dedup behavior) —
+            // see persistEntrypointCalls's doc comment for the rare-edge-case
+            // rationale.
+            let mut seen: HashMap<&str, Option<&str>> = HashMap::new();
             for call in &symbols.calls {
-                if !call.entrypoint.unwrap_or(false) || !seen.insert(call.name.as_str()) {
+                if !call.entrypoint.unwrap_or(false) {
                     continue;
                 }
-                let _ = insert.execute(rusqlite::params![rel_path, call.name]);
+                seen.entry(call.name.as_str())
+                    .or_insert(call.entrypoint_wrapped_by.as_deref());
+            }
+            for (name, wrapped_by) in seen {
+                let _ = insert.execute(rusqlite::params![rel_path, name, wrapped_by]);
             }
         }
     }
@@ -98,12 +105,14 @@ fn persist_entrypoint_calls(conn: &Connection, file_symbols: &BTreeMap<String, F
 struct DesiredRow {
     file: String,
     source_file: String,
+    name: String,
+    wrapped_by: Option<String>,
 }
 
-/// Recompute `nodes.entrypoint` / `nodes.entrypoint_source_file` from the
-/// persisted evidence and the committed `calls` edges, returning the files
-/// whose flag set actually changed so the caller can seed incremental role
-/// reclassification for them.
+/// Recompute `nodes.entrypoint` / `nodes.entrypoint_source_file` /
+/// `nodes.entrypoint_role` from the persisted evidence and the committed
+/// `calls` edges, returning the files whose flag set actually changed so the
+/// caller can seed incremental role reclassification for them.
 ///
 /// Must run after every edge-insert path for the build has completed — it
 /// identifies targets from committed edges, not by re-resolving. An
@@ -122,7 +131,36 @@ struct DesiredRow {
 /// two files both call the same target as their entrypoint, the
 /// lexicographically first wins deterministically (rather than "whichever
 /// marked last", as in #2411) and the target stays correctly flagged while
-/// either survives. Tracked as #2419.
+/// either survives (#2419).
+///
+/// ## `entrypoint_role`: which of several calls sharing a line gets `role: 'entry'`
+///
+/// `entrypoint` alone answers "is the runtime the caller" — set on every call
+/// inside a qualifying guard, including one nested inside another
+/// (`main(configure())` flags both `main` and `configure`, correctly: both
+/// really do run at module load and need the same dead-code-downgrade
+/// protection). But only one should be the *label* role classification
+/// promotes to `'entry'` — a helper like `configure` should keep whatever
+/// role its own fan-in/fan-out shape implies, not misleadingly appear in
+/// `codegraph roles --role entry` next to the real entrypoint (#2420).
+///
+/// The rule: a call not nested inside another call on the same qualifying
+/// line always wins the label. A nested call (`Call.entrypoint_wrapped_by`
+/// set at extraction time) only wins the label if its wrapper does NOT
+/// resolve to an in-repo target from the same source file — e.g.
+/// `sys.exit(main())`, where `sys.exit` is an unresolvable stdlib
+/// passthrough, so `main` gets the label instead of being silently skipped.
+/// This can only be decided here, once resolution is known: extraction (only
+/// sees syntax) cannot tell `main(configure())` (wrapper resolves in-repo)
+/// from `sys.exit(main())` (wrapper does not) without the graph's `calls`
+/// edges — the same reason `desired` itself waits until here.
+///
+/// An `entrypoint_role` value change is role-classification-visible even
+/// when `entrypoint`/`entrypoint_source_file` stay the same — e.g. a wrapper
+/// that used to resolve stops resolving on a later rebuild that doesn't
+/// touch the wrapped target's own file at all — so it is checked and
+/// `touched_files`-seeded independently of the existing source-file-change
+/// check.
 fn project_entrypoint_attribution(conn: &Connection) -> HashSet<String> {
     let mut touched_files: HashSet<String> = HashSet::new();
 
@@ -158,7 +196,7 @@ fn project_entrypoint_attribution(conn: &Connection) -> HashSet<String> {
     // over a changed-file set.
     let mut desired: HashMap<i64, DesiredRow> = HashMap::new();
     if let Ok(mut stmt) = conn.prepare(
-        "SELECT e.target_id, tgt.file, ec.file
+        "SELECT e.target_id, tgt.file, ec.file, ec.name, ec.wrapped_by
          FROM entrypoint_calls ec
          JOIN nodes src ON src.kind = 'file' AND src.file = ec.file
          JOIN edges e ON e.source_id = src.id AND e.kind = 'calls'
@@ -173,25 +211,47 @@ fn project_entrypoint_attribution(conn: &Connection) -> HashSet<String> {
                 row.get::<_, i64>(0)?,
                 row.get::<_, String>(1)?,
                 row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, Option<String>>(4)?,
             ))
         }) {
-            for (id, file, source_file) in rows.flatten() {
-                desired
-                    .entry(id)
-                    .or_insert(DesiredRow { file, source_file });
+            for (id, file, source_file, name, wrapped_by) in rows.flatten() {
+                desired.entry(id).or_insert(DesiredRow {
+                    file,
+                    source_file,
+                    name,
+                    wrapped_by,
+                });
             }
         }
     }
 
-    let mut current: Vec<(i64, String, Option<String>)> = Vec::new();
-    if let Ok(mut stmt) =
-        conn.prepare("SELECT id, file, entrypoint_source_file FROM nodes WHERE entrypoint = 1")
-    {
+    // Which (source_file, name) pairs resolved to SOME in-repo target — used
+    // below to test whether a wrapped call's own wrapper resolved. Built from
+    // `desired` rather than a separate query since it needs exactly the same
+    // "did ec.name resolve via a calls edge from ec.file" answer `desired`
+    // itself already computed.
+    let mut resolved_names: HashSet<String> = HashSet::new();
+    for row in desired.values() {
+        resolved_names.insert(format!("{} {}", row.source_file, row.name));
+    }
+    let is_role_eligible = |row: &DesiredRow| -> bool {
+        match &row.wrapped_by {
+            None => true,
+            Some(wrapper) => !resolved_names.contains(&format!("{} {}", row.source_file, wrapper)),
+        }
+    };
+
+    let mut current: Vec<(i64, String, Option<String>, i64)> = Vec::new();
+    if let Ok(mut stmt) = conn.prepare(
+        "SELECT id, file, entrypoint_source_file, entrypoint_role FROM nodes WHERE entrypoint = 1",
+    ) {
         if let Ok(rows) = stmt.query_map([], |row| {
             Ok((
                 row.get::<_, i64>(0)?,
                 row.get::<_, String>(1)?,
                 row.get::<_, Option<String>>(2)?,
+                row.get::<_, i64>(3)?,
             ))
         }) {
             current.extend(rows.flatten());
@@ -206,38 +266,46 @@ fn project_entrypoint_attribution(conn: &Connection) -> HashSet<String> {
     };
     {
         let Ok(mut clear) = tx.prepare(
-            "UPDATE nodes SET entrypoint = 0, entrypoint_source_file = NULL WHERE id = ?1",
+            "UPDATE nodes SET entrypoint = 0, entrypoint_source_file = NULL, entrypoint_role = 0 WHERE id = ?1",
         ) else {
             return touched_files;
         };
-        let Ok(mut mark) = tx
-            .prepare("UPDATE nodes SET entrypoint = 1, entrypoint_source_file = ?1 WHERE id = ?2")
-        else {
+        let Ok(mut mark) = tx.prepare(
+            "UPDATE nodes SET entrypoint = 1, entrypoint_source_file = ?1, entrypoint_role = ?2 WHERE id = ?3",
+        ) else {
             return touched_files;
         };
 
         let mut current_ids: HashSet<i64> = HashSet::new();
-        for (id, file, source_file) in &current {
+        for (id, file, source_file, role) in &current {
             current_ids.insert(*id);
             match desired.get(id) {
                 None => {
                     let _ = clear.execute(rusqlite::params![id]);
                     touched_files.insert(file.clone());
                 }
-                // Still an entrypoint, only the attributing file changed. The
-                // role is `entry` either way, so this needs no role
-                // reclassification.
-                Some(want) if Some(&want.source_file) != source_file.as_ref() => {
-                    let _ = mark.execute(rusqlite::params![want.source_file, id]);
+                Some(want) => {
+                    let want_role = i64::from(is_role_eligible(want));
+                    if Some(&want.source_file) == source_file.as_ref() && want_role == *role {
+                        continue;
+                    }
+                    let _ = mark.execute(rusqlite::params![want.source_file, want_role, id]);
+                    // A source-file-only change needs no reclassification
+                    // (the role is `entry` either way), but an
+                    // entrypoint_role VALUE change does — it is exactly what
+                    // role classification's `'entry'` early-return reads.
+                    if want_role != *role {
+                        touched_files.insert(file.clone());
+                    }
                 }
-                Some(_) => {}
             }
         }
         for (id, want) in &desired {
             if current_ids.contains(id) {
                 continue;
             }
-            let _ = mark.execute(rusqlite::params![want.source_file, id]);
+            let want_role = i64::from(is_role_eligible(want));
+            let _ = mark.execute(rusqlite::params![want.source_file, want_role, id]);
             touched_files.insert(want.file.clone());
         }
     }
@@ -299,7 +367,7 @@ pub fn apply_pyproject_script_attribution(
             return touched_files;
         };
         let Ok(mut mark_stmt) = tx.prepare(
-            "UPDATE nodes SET entrypoint = 1, entrypoint_source_file = 'pyproject.toml' WHERE id = ?1",
+            "UPDATE nodes SET entrypoint = 1, entrypoint_source_file = 'pyproject.toml', entrypoint_role = 1 WHERE id = ?1",
         ) else {
             return touched_files;
         };
@@ -329,7 +397,7 @@ pub fn apply_pyproject_script_attribution(
     }
     {
         let Ok(mut clear_stmt) = tx.prepare(
-            "UPDATE nodes SET entrypoint = 0, entrypoint_source_file = NULL WHERE id = ?1",
+            "UPDATE nodes SET entrypoint = 0, entrypoint_source_file = NULL, entrypoint_role = 0 WHERE id = ?1",
         ) else {
             return touched_files;
         };
@@ -357,14 +425,15 @@ mod tests {
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 name TEXT, kind TEXT, file TEXT, line INTEGER,
                 entrypoint INTEGER DEFAULT 0,
-                entrypoint_source_file TEXT
+                entrypoint_source_file TEXT,
+                entrypoint_role INTEGER DEFAULT 0
              );
              CREATE TABLE edges (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 source_id INTEGER, target_id INTEGER, kind TEXT
              );
              CREATE TABLE entrypoint_calls (
-                file TEXT NOT NULL, name TEXT NOT NULL, PRIMARY KEY (file, name)
+                file TEXT NOT NULL, name TEXT NOT NULL, wrapped_by TEXT, PRIMARY KEY (file, name)
              );",
         )
         .unwrap();
@@ -408,6 +477,122 @@ mod tests {
             |row| Ok((row.get(0)?, row.get(1)?)),
         )
         .unwrap()
+    }
+
+    fn role_of(conn: &Connection, id: i64) -> i64 {
+        conn.query_row(
+            "SELECT entrypoint_role FROM nodes WHERE id = ?1",
+            rusqlite::params![id],
+            |row| row.get(0),
+        )
+        .unwrap()
+    }
+
+    /// Like `seed`, but records `wrapped_by` evidence and reuses the same
+    /// `run.py` file node across repeated calls — needed to model several
+    /// calls sharing one qualifying line (`main(configure())`).
+    fn seed_wrapped(
+        conn: &Connection,
+        target_name: &str,
+        call_name: &str,
+        wrapped_by: Option<&str>,
+    ) -> i64 {
+        let src_id = match conn.query_row(
+            "SELECT id FROM nodes WHERE kind = 'file' AND file = 'run.py'",
+            [],
+            |row| row.get::<_, i64>(0),
+        ) {
+            Ok(id) => id,
+            Err(_) => {
+                conn.execute(
+                    "INSERT INTO nodes (name, kind, file, line) VALUES ('run.py', 'file', 'run.py', 0)",
+                    [],
+                )
+                .unwrap();
+                conn.last_insert_rowid()
+            }
+        };
+        conn.execute(
+            "INSERT INTO nodes (name, kind, file, line) VALUES (?1, 'function', 'lib.py', 1)",
+            rusqlite::params![target_name],
+        )
+        .unwrap();
+        let tgt_id = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO edges (source_id, target_id, kind) VALUES (?1, ?2, 'calls')",
+            rusqlite::params![src_id, tgt_id],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO entrypoint_calls (file, name, wrapped_by) VALUES ('run.py', ?1, ?2)",
+            rusqlite::params![call_name, wrapped_by],
+        )
+        .unwrap();
+        tgt_id
+    }
+
+    #[test]
+    fn defers_the_entry_role_to_the_wrapper_when_the_wrapper_call_resolves_in_repo() {
+        // `main(configure())` — both calls are recorded as entrypoint
+        // evidence (both really run at import time), but only the unwrapped
+        // outer call should carry the `'entry'` label.
+        let conn = test_conn();
+        let main_tgt = seed_wrapped(&conn, "main", "main", None);
+        let configure_tgt = seed_wrapped(&conn, "configure", "configure", Some("main"));
+
+        project_entrypoint_attribution(&conn);
+
+        assert_eq!(flag_of(&conn, main_tgt).0, 1);
+        assert_eq!(role_of(&conn, main_tgt), 1);
+        assert_eq!(flag_of(&conn, configure_tgt).0, 1);
+        assert_eq!(role_of(&conn, configure_tgt), 0);
+    }
+
+    #[test]
+    fn a_wrapper_that_does_not_resolve_in_repo_does_not_block_the_entry_role() {
+        // `sys.exit(main())` — `exit` is recorded as entrypoint evidence too
+        // (it's the outer call on the line), but it never resolves to an
+        // in-repo target, so no `calls` edge names it and it never enters
+        // `desired`. `main`'s wrapper lookup must not find it there and must
+        // still grant the label rather than silently dropping it.
+        let conn = test_conn();
+        conn.execute(
+            "INSERT INTO entrypoint_calls (file, name, wrapped_by) VALUES ('run.py', 'exit', NULL)",
+            [],
+        )
+        .unwrap();
+        let main_tgt = seed_wrapped(&conn, "main", "main", Some("exit"));
+
+        project_entrypoint_attribution(&conn);
+
+        assert_eq!(role_of(&conn, main_tgt), 1);
+    }
+
+    #[test]
+    fn a_role_only_change_touches_the_file_even_when_the_source_file_is_unchanged() {
+        // First build: `main` resolves unwrapped and gets the label. A later
+        // rebuild discovers `main` is now nested inside a wrapper that
+        // itself resolves — `entrypoint_source_file` doesn't change (`main`
+        // is still attributed to `run.py`), but the role must flip to 0, and
+        // that flip alone — independent of the source-file check — must
+        // surface the file for role reclassification.
+        let conn = test_conn();
+        let tgt = seed_wrapped(&conn, "main", "main", None);
+        project_entrypoint_attribution(&conn);
+        assert_eq!(role_of(&conn, tgt), 1);
+
+        seed_wrapped(&conn, "wrapper", "wrapper", None);
+        conn.execute(
+            "UPDATE entrypoint_calls SET wrapped_by = 'wrapper' WHERE file = 'run.py' AND name = 'main'",
+            [],
+        )
+        .unwrap();
+
+        let touched = project_entrypoint_attribution(&conn);
+
+        assert_eq!(role_of(&conn, tgt), 0);
+        assert_eq!(flag_of(&conn, tgt).1, Some("run.py".to_string()));
+        assert!(touched.contains("lib.py"));
     }
 
     #[test]

--- a/crates/codegraph-core/src/extractors/python.rs
+++ b/crates/codegraph-core/src/extractors/python.rs
@@ -29,6 +29,14 @@ impl SymbolExtractor for PythonExtractor {
     }
 }
 
+/// Stdlib modules whose attribute calls are the "process launcher
+/// passthrough" idiom #2420 exists to protect (`sys.exit(main())`,
+/// `asyncio.run(main())`, `os._exit(main())`) — deliberately narrow and
+/// non-exhaustive, mirrors TS `STDLIB_PROCESS_LAUNCHER_MODULES`. See that
+/// constant's doc comment for why it's scoped this narrowly rather than
+/// attempting a general external-vs-local import classification.
+const STDLIB_PROCESS_LAUNCHER_MODULES: [&str; 3] = ["sys", "os", "asyncio"];
+
 /// Flag every call that starts the program rather than being invoked by other
 /// code in the repo, covering Python's two canonical conventions (#2392):
 ///
@@ -42,21 +50,23 @@ impl SymbolExtractor for PythonExtractor {
 /// the same AST and mark the same calls, leaving no room to disagree about a
 /// given call site.
 fn mark_entrypoint_calls(root: &Node, source: &[u8], file_path: &str, symbols: &mut FileSymbols) {
-    // Plain `import X` / `import X as Y` bindings only (`handle_py_import`'s
-    // `namespace_bindings`) — never a `from X import Y` binding, which names
-    // a symbol pulled out of a module, not the module namespace itself. Runs
-    // after `walk_tree`, so `symbols.imports` is already fully populated by
-    // the time this reads it (see `PythonExtractor::extract`'s call order).
-    let mut module_bound_names = std::collections::HashSet::new();
+    // Maps each plain `import X` / `import X as Y` local binding name
+    // (`handle_py_import`'s `namespace_bindings`) to the module it actually
+    // imports (`imp.source`), so an alias like `import os as o` still maps
+    // "o" to "os" — never a `from X import Y` binding, which names a symbol
+    // pulled out of a module, not the module namespace itself. Runs after
+    // `walk_tree`, so `symbols.imports` is already fully populated by the
+    // time this reads it (see `PythonExtractor::extract`'s call order).
+    let mut import_source_by_local_name = std::collections::HashMap::new();
     for imp in &symbols.imports {
         if let Some(bindings) = &imp.namespace_bindings {
             for name in bindings {
-                module_bound_names.insert(name.clone());
+                import_source_by_local_name.insert(name.clone(), imp.source.clone());
             }
         }
     }
     let (lines, wrapped_by) =
-        collect_entrypoint_call_lines(root, source, file_path, &module_bound_names);
+        collect_entrypoint_call_lines(root, source, file_path, &import_source_by_local_name);
     if lines.is_empty() {
         return;
     }
@@ -116,24 +126,25 @@ type EntrypointWrappedBy = std::collections::HashMap<(u32, String), String>;
 
 /// Read-only context threaded through the recursive entrypoint-call scan —
 /// bundled into one struct purely to keep `visit_entrypoint_calls` under
-/// clippy's argument-count limit; `source` and `module_bound_names` never
-/// change across the recursion, unlike `guarded`/`at_module_level`, which do.
+/// clippy's argument-count limit; `source` and `import_source_by_local_name`
+/// never change across the recursion, unlike `guarded`/`at_module_level`,
+/// which do.
 struct EntrypointScanCtx<'a> {
     source: &'a [u8],
-    module_bound_names: &'a std::collections::HashSet<String>,
+    import_source_by_local_name: &'a std::collections::HashMap<String, String>,
 }
 
 fn collect_entrypoint_call_lines(
     root: &Node,
     source: &[u8],
     file_path: &str,
-    module_bound_names: &std::collections::HashSet<String>,
+    import_source_by_local_name: &std::collections::HashMap<String, String>,
 ) -> (std::collections::HashSet<u32>, EntrypointWrappedBy) {
     let mut lines = std::collections::HashSet::new();
     let mut wrapped_by = EntrypointWrappedBy::new();
     let ctx = EntrypointScanCtx {
         source,
-        module_bound_names,
+        import_source_by_local_name,
     };
     visit_entrypoint_calls(
         root,
@@ -166,27 +177,31 @@ fn get_call_name(node: &Node, source: &[u8]) -> Option<String> {
 /// `findEnclosingCallName` — see that function's doc comment for why the
 /// walk stops at a statement boundary.
 ///
-/// A wrapper whose receiver is bound by a plain `import X` / `import X as Y`
-/// statement (`module_bound_names`) — e.g. `sys.exit(...)`, `asyncio.run(...)`
-/// — returns `None` here, same as no wrapper, rather than its bare attribute
-/// name: `sys`/`asyncio` are external modules, so such a call can never
-/// resolve to a same-file symbol, yet its bare attribute name (`exit`, `run`)
-/// is too likely to coincidentally collide with an unrelated same-named
-/// in-repo symbol for the file-wide bare-name lookup in
+/// A wrapper whose receiver resolves (via `import_source_by_local_name`,
+/// honoring `import X as Y` aliasing) to one of
+/// `STDLIB_PROCESS_LAUNCHER_MODULES` — `sys.exit(...)`, `asyncio.run(...)`,
+/// `os._exit(...)` — returns `None` here, same as no wrapper, rather than
+/// its bare attribute name. This is exactly the stdlib-passthrough idiom
+/// #2420 exists to protect: these specific modules are never resolvable to
+/// a same-file symbol, yet the bare attribute name (`exit`, `run`) is too
+/// likely to coincidentally collide with an unrelated same-named in-repo
+/// symbol for the file-wide bare-name lookup in
 /// `project_entrypoint_attribution` to trust (#2420 review — Greptile,
-/// first round).
+/// round 1).
 ///
-/// A wrapper whose receiver is NOT a recognized module import — a plain
-/// identifier call, or a dotted call on a local object/instance
-/// (`runner.run(...)`) — reports its bare name as usual: unlike a module
-/// attribute, `runner.run` plausibly IS a same-file method, and
-/// unconditionally treating every dotted wrapper as unresolvable regresses
-/// to the original bug for exactly this case (#2420 review — Greptile,
-/// second round). See TS's doc comment for the full rationale.
+/// Every OTHER wrapper — a plain identifier call, a dotted call on a local
+/// object/instance (`runner.run(...)`), or a dotted call on an import that
+/// isn't one of those specific stdlib modules (`import runner;
+/// runner.run(...)`, a same-repo module) — reports its bare name as usual:
+/// unlike `sys`/`asyncio`, any of these plausibly resolve to a same-repo
+/// symbol, and excluding either "every dotted wrapper" or "every
+/// import-bound wrapper" regresses to the original bug for these cases
+/// (#2420 review — Greptile, rounds 2 and 3). See TS's doc comment for the
+/// full rationale.
 fn find_enclosing_call_name(
     node: &Node,
     source: &[u8],
-    module_bound_names: &std::collections::HashSet<String>,
+    import_source_by_local_name: &std::collections::HashMap<String, String>,
 ) -> Option<String> {
     let mut parent = node.parent();
     let mut hops = 0;
@@ -199,7 +214,13 @@ fn find_enclosing_call_name(
                 let fn_node = p.child_by_field_name("function")?;
                 if fn_node.kind() == "attribute" {
                     if let Some(receiver) = fn_node.child_by_field_name("object") {
-                        if module_bound_names.contains(node_text(&receiver, source)) {
+                        let receiver_text = node_text(&receiver, source);
+                        if import_source_by_local_name
+                            .get(receiver_text)
+                            .is_some_and(|src| {
+                                STDLIB_PROCESS_LAUNCHER_MODULES.contains(&src.as_str())
+                            })
+                        {
                             return None;
                         }
                     }
@@ -232,7 +253,7 @@ fn visit_entrypoint_calls(
         lines.insert(line);
         if let Some(name) = get_call_name(node, ctx.source) {
             if let Some(wrapper) =
-                find_enclosing_call_name(node, ctx.source, ctx.module_bound_names)
+                find_enclosing_call_name(node, ctx.source, ctx.import_source_by_local_name)
             {
                 wrapped_by.insert((line, name), wrapper);
             }
@@ -1003,6 +1024,24 @@ mod tests {
         // run's.
         let s = parse_py(
             "class Runner:\n    def run(self, x):\n        return x\n\ndef main():\n    return 1\n\nrunner = Runner()\n\nif __name__ == \"__main__\":\n    runner.run(main())\n",
+        );
+        let main_call = s.calls.iter().find(|c| c.name == "main").unwrap();
+        assert_eq!(main_call.entrypoint, Some(true));
+        assert_eq!(main_call.entrypoint_wrapped_by, Some("run".to_string()));
+    }
+
+    #[test]
+    fn records_the_wrapper_name_for_a_dotted_wrapper_on_a_non_stdlib_module_import() {
+        // #2420 review (Greptile, third round): `import runner;
+        // runner.run(main())` — "runner" IS a plain module import (unlike
+        // the previous test's local instance), but it is not one of the
+        // curated stdlib process-launcher modules, so it is not treated as
+        // definitely-external the way `sys`/`asyncio` are. The wrapper name
+        // ("run") is still reported and resolves normally at projection
+        // time, correctly suppressing main's entry role in favor of run's —
+        // exactly like a same-repo module should.
+        let s = parse_py(
+            "import runner\n\ndef main():\n    return 1\n\nif __name__ == \"__main__\":\n    runner.run(main())\n",
         );
         let main_call = s.calls.iter().find(|c| c.name == "main").unwrap();
         assert_eq!(main_call.entrypoint, Some(true));

--- a/crates/codegraph-core/src/extractors/python.rs
+++ b/crates/codegraph-core/src/extractors/python.rs
@@ -137,6 +137,13 @@ fn get_call_name(node: &Node, source: &[u8]) -> Option<String> {
 /// another call within the same statement (#2420). Mirrors TS
 /// `findEnclosingCallName` — see that function's doc comment for why the
 /// walk stops at a statement boundary.
+///
+/// Only a bare-identifier wrapper is reported at all — an attribute/dotted
+/// wrapper (`sys.exit(...)`, `asyncio.run(...)`) returns `None` here, same as
+/// no wrapper, since its bare attribute name is too likely to coincidentally
+/// collide with an unrelated same-named in-repo symbol for the file-wide
+/// bare-name lookup in `project_entrypoint_attribution` to trust (#2420
+/// review — Greptile). See TS's doc comment for the full rationale.
 fn find_enclosing_call_name(node: &Node, source: &[u8]) -> Option<String> {
     let mut parent = node.parent();
     let mut hops = 0;
@@ -145,7 +152,14 @@ fn find_enclosing_call_name(node: &Node, source: &[u8]) -> Option<String> {
             return None;
         }
         match p.kind() {
-            "call" => return get_call_name(&p, source),
+            "call" => {
+                let fn_node = p.child_by_field_name("function")?;
+                return if fn_node.kind() == "identifier" {
+                    get_call_name(&p, source)
+                } else {
+                    None
+                };
+            }
             "expression_statement" | "block" | "module" => return None,
             _ => {}
         }
@@ -911,10 +925,15 @@ mod tests {
     }
 
     #[test]
-    fn records_the_wrapper_name_through_an_unresolvable_stdlib_passthrough() {
-        // #2420: sys.exit(main()) — the outer call is a bare-name-extracted
-        // "exit" (receiver "sys"), an external stdlib passthrough; main is
-        // still the call that matters and still gets a wrapper recorded.
+    fn does_not_record_a_wrapper_for_a_dotted_stdlib_passthrough_call() {
+        // #2420 review (Greptile): sys.exit(main()) — the outer call is a
+        // bare-name-extracted "exit" (receiver "sys"), an external stdlib
+        // passthrough. Its bare attribute name is too likely to
+        // coincidentally collide with an unrelated same-named in-repo symbol
+        // elsewhere in the file for the projection's file-wide bare-name
+        // lookup to trust, so no wrapper is recorded at all here — main is
+        // extracted as if unwrapped, which is always eligible for the entry
+        // role regardless of anything else in the file.
         let s = parse_py(
             "import sys\n\ndef main():\n    return 1\n\nif __name__ == \"__main__\":\n    sys.exit(main())\n",
         );
@@ -923,7 +942,7 @@ mod tests {
         assert_eq!(exit_call.entrypoint_wrapped_by, None);
         let main_call = s.calls.iter().find(|c| c.name == "main").unwrap();
         assert_eq!(main_call.entrypoint, Some(true));
-        assert_eq!(main_call.entrypoint_wrapped_by, Some("exit".to_string()));
+        assert_eq!(main_call.entrypoint_wrapped_by, None);
     }
 
     #[test]

--- a/crates/codegraph-core/src/extractors/python.rs
+++ b/crates/codegraph-core/src/extractors/python.rs
@@ -34,7 +34,9 @@ impl SymbolExtractor for PythonExtractor {
 /// `asyncio.run(main())`, `os._exit(main())`) — deliberately narrow and
 /// non-exhaustive, mirrors TS `STDLIB_PROCESS_LAUNCHER_MODULES`. See that
 /// constant's doc comment for why it's scoped this narrowly rather than
-/// attempting a general external-vs-local import classification.
+/// attempting a general external-vs-local import classification, and for
+/// the known residual gap (#2543, deliberately not fixed here) when a
+/// repository shadows one of these module names with its own file.
 const STDLIB_PROCESS_LAUNCHER_MODULES: [&str; 3] = ["sys", "os", "asyncio"];
 
 /// Flag every call that starts the program rather than being invoked by other

--- a/crates/codegraph-core/src/extractors/python.rs
+++ b/crates/codegraph-core/src/extractors/python.rs
@@ -42,7 +42,21 @@ impl SymbolExtractor for PythonExtractor {
 /// the same AST and mark the same calls, leaving no room to disagree about a
 /// given call site.
 fn mark_entrypoint_calls(root: &Node, source: &[u8], file_path: &str, symbols: &mut FileSymbols) {
-    let (lines, wrapped_by) = collect_entrypoint_call_lines(root, source, file_path);
+    // Plain `import X` / `import X as Y` bindings only (`handle_py_import`'s
+    // `namespace_bindings`) — never a `from X import Y` binding, which names
+    // a symbol pulled out of a module, not the module namespace itself. Runs
+    // after `walk_tree`, so `symbols.imports` is already fully populated by
+    // the time this reads it (see `PythonExtractor::extract`'s call order).
+    let mut module_bound_names = std::collections::HashSet::new();
+    for imp in &symbols.imports {
+        if let Some(bindings) = &imp.namespace_bindings {
+            for name in bindings {
+                module_bound_names.insert(name.clone());
+            }
+        }
+    }
+    let (lines, wrapped_by) =
+        collect_entrypoint_call_lines(root, source, file_path, &module_bound_names);
     if lines.is_empty() {
         return;
     }
@@ -100,16 +114,30 @@ fn is_main_guard_condition(condition: Option<Node>, source: &[u8]) -> bool {
 /// either, for the same immediate-execution reason.
 type EntrypointWrappedBy = std::collections::HashMap<(u32, String), String>;
 
+/// Read-only context threaded through the recursive entrypoint-call scan —
+/// bundled into one struct purely to keep `visit_entrypoint_calls` under
+/// clippy's argument-count limit; `source` and `module_bound_names` never
+/// change across the recursion, unlike `guarded`/`at_module_level`, which do.
+struct EntrypointScanCtx<'a> {
+    source: &'a [u8],
+    module_bound_names: &'a std::collections::HashSet<String>,
+}
+
 fn collect_entrypoint_call_lines(
     root: &Node,
     source: &[u8],
     file_path: &str,
+    module_bound_names: &std::collections::HashSet<String>,
 ) -> (std::collections::HashSet<u32>, EntrypointWrappedBy) {
     let mut lines = std::collections::HashSet::new();
     let mut wrapped_by = EntrypointWrappedBy::new();
+    let ctx = EntrypointScanCtx {
+        source,
+        module_bound_names,
+    };
     visit_entrypoint_calls(
         root,
-        source,
+        &ctx,
         0,
         file_path.ends_with("__main__.py"),
         true,
@@ -138,13 +166,28 @@ fn get_call_name(node: &Node, source: &[u8]) -> Option<String> {
 /// `findEnclosingCallName` — see that function's doc comment for why the
 /// walk stops at a statement boundary.
 ///
-/// Only a bare-identifier wrapper is reported at all — an attribute/dotted
-/// wrapper (`sys.exit(...)`, `asyncio.run(...)`) returns `None` here, same as
-/// no wrapper, since its bare attribute name is too likely to coincidentally
-/// collide with an unrelated same-named in-repo symbol for the file-wide
-/// bare-name lookup in `project_entrypoint_attribution` to trust (#2420
-/// review — Greptile). See TS's doc comment for the full rationale.
-fn find_enclosing_call_name(node: &Node, source: &[u8]) -> Option<String> {
+/// A wrapper whose receiver is bound by a plain `import X` / `import X as Y`
+/// statement (`module_bound_names`) — e.g. `sys.exit(...)`, `asyncio.run(...)`
+/// — returns `None` here, same as no wrapper, rather than its bare attribute
+/// name: `sys`/`asyncio` are external modules, so such a call can never
+/// resolve to a same-file symbol, yet its bare attribute name (`exit`, `run`)
+/// is too likely to coincidentally collide with an unrelated same-named
+/// in-repo symbol for the file-wide bare-name lookup in
+/// `project_entrypoint_attribution` to trust (#2420 review — Greptile,
+/// first round).
+///
+/// A wrapper whose receiver is NOT a recognized module import — a plain
+/// identifier call, or a dotted call on a local object/instance
+/// (`runner.run(...)`) — reports its bare name as usual: unlike a module
+/// attribute, `runner.run` plausibly IS a same-file method, and
+/// unconditionally treating every dotted wrapper as unresolvable regresses
+/// to the original bug for exactly this case (#2420 review — Greptile,
+/// second round). See TS's doc comment for the full rationale.
+fn find_enclosing_call_name(
+    node: &Node,
+    source: &[u8],
+    module_bound_names: &std::collections::HashSet<String>,
+) -> Option<String> {
     let mut parent = node.parent();
     let mut hops = 0;
     while let Some(p) = parent {
@@ -154,11 +197,14 @@ fn find_enclosing_call_name(node: &Node, source: &[u8]) -> Option<String> {
         match p.kind() {
             "call" => {
                 let fn_node = p.child_by_field_name("function")?;
-                return if fn_node.kind() == "identifier" {
-                    get_call_name(&p, source)
-                } else {
-                    None
-                };
+                if fn_node.kind() == "attribute" {
+                    if let Some(receiver) = fn_node.child_by_field_name("object") {
+                        if module_bound_names.contains(node_text(&receiver, source)) {
+                            return None;
+                        }
+                    }
+                }
+                return get_call_name(&p, source);
             }
             "expression_statement" | "block" | "module" => return None,
             _ => {}
@@ -171,7 +217,7 @@ fn find_enclosing_call_name(node: &Node, source: &[u8]) -> Option<String> {
 
 fn visit_entrypoint_calls(
     node: &Node,
-    source: &[u8],
+    ctx: &EntrypointScanCtx,
     depth: usize,
     guarded: bool,
     at_module_level: bool,
@@ -184,8 +230,10 @@ fn visit_entrypoint_calls(
     if node.kind() == "call" && guarded {
         let line = start_line(node);
         lines.insert(line);
-        if let Some(name) = get_call_name(node, source) {
-            if let Some(wrapper) = find_enclosing_call_name(node, source) {
+        if let Some(name) = get_call_name(node, ctx.source) {
+            if let Some(wrapper) =
+                find_enclosing_call_name(node, ctx.source, ctx.module_bound_names)
+            {
                 wrapped_by.insert((line, name), wrapper);
             }
         }
@@ -203,7 +251,7 @@ fn visit_entrypoint_calls(
     let child_at_module_level = at_module_level && !leaves_runtime_scope;
     let guard_consequence = if at_module_level
         && node.kind() == "if_statement"
-        && is_main_guard_condition(node.child_by_field_name("condition"), source)
+        && is_main_guard_condition(node.child_by_field_name("condition"), ctx.source)
     {
         node.child_by_field_name("consequence")
             .or_else(|| find_child(node, "block"))
@@ -217,7 +265,7 @@ fn visit_entrypoint_calls(
         let is_guard_body = guard_start.is_some_and(|p| child.start_position() == p);
         visit_entrypoint_calls(
             &child,
-            source,
+            ctx,
             depth + 1,
             if is_guard_body { true } else { child_guarded },
             child_at_module_level,
@@ -943,6 +991,22 @@ mod tests {
         let main_call = s.calls.iter().find(|c| c.name == "main").unwrap();
         assert_eq!(main_call.entrypoint, Some(true));
         assert_eq!(main_call.entrypoint_wrapped_by, None);
+    }
+
+    #[test]
+    fn records_the_wrapper_name_for_a_dotted_wrapper_whose_receiver_is_not_a_module_import() {
+        // #2420 review (Greptile, second round): runner.run(main()) — "runner"
+        // is a local instance, not bound via `import`, so unlike sys.exit its
+        // dotted wrapper name ("run") is still reported and can go through
+        // the normal bare-name resolution check at projection time, where it
+        // correctly resolves and suppresses main's entry role in favor of
+        // run's.
+        let s = parse_py(
+            "class Runner:\n    def run(self, x):\n        return x\n\ndef main():\n    return 1\n\nrunner = Runner()\n\nif __name__ == \"__main__\":\n    runner.run(main())\n",
+        );
+        let main_call = s.calls.iter().find(|c| c.name == "main").unwrap();
+        assert_eq!(main_call.entrypoint, Some(true));
+        assert_eq!(main_call.entrypoint_wrapped_by, Some("run".to_string()));
     }
 
     #[test]

--- a/crates/codegraph-core/src/extractors/python.rs
+++ b/crates/codegraph-core/src/extractors/python.rs
@@ -42,13 +42,17 @@ impl SymbolExtractor for PythonExtractor {
 /// the same AST and mark the same calls, leaving no room to disagree about a
 /// given call site.
 fn mark_entrypoint_calls(root: &Node, source: &[u8], file_path: &str, symbols: &mut FileSymbols) {
-    let lines = collect_entrypoint_call_lines(root, source, file_path);
+    let (lines, wrapped_by) = collect_entrypoint_call_lines(root, source, file_path);
     if lines.is_empty() {
         return;
     }
     for call in &mut symbols.calls {
-        if lines.contains(&call.line) {
-            call.entrypoint = Some(true);
+        if !lines.contains(&call.line) {
+            continue;
+        }
+        call.entrypoint = Some(true);
+        if let Some(wrapper) = wrapped_by.get(&(call.line, call.name.clone())) {
+            call.entrypoint_wrapped_by = Some(wrapper.clone());
         }
     }
 }
@@ -94,12 +98,15 @@ fn is_main_guard_condition(condition: Option<Node>, source: &[u8]) -> bool {
 /// `false` too") are indistinguishable without this separate flag (review
 /// finding on #2411). Like `guarded`, entering a class does not turn this off
 /// either, for the same immediate-execution reason.
+type EntrypointWrappedBy = std::collections::HashMap<(u32, String), String>;
+
 fn collect_entrypoint_call_lines(
     root: &Node,
     source: &[u8],
     file_path: &str,
-) -> std::collections::HashSet<u32> {
+) -> (std::collections::HashSet<u32>, EntrypointWrappedBy) {
     let mut lines = std::collections::HashSet::new();
+    let mut wrapped_by = EntrypointWrappedBy::new();
     visit_entrypoint_calls(
         root,
         source,
@@ -107,8 +114,45 @@ fn collect_entrypoint_call_lines(
         file_path.ends_with("__main__.py"),
         true,
         &mut lines,
+        &mut wrapped_by,
     );
-    lines
+    (lines, wrapped_by)
+}
+
+/// The bare callee name of a `call` node, matching `handle_call`'s own naming
+/// exactly — so a wrapper name recorded here matches what `entrypoint_calls`/
+/// projection later look up by the same bare-name convention.
+fn get_call_name(node: &Node, source: &[u8]) -> Option<String> {
+    let fn_node = node.child_by_field_name("function")?;
+    match fn_node.kind() {
+        "identifier" => Some(node_text(&fn_node, source).to_string()),
+        "attribute" => named_child_text(&fn_node, "attribute", source).map(|s| s.to_string()),
+        _ => None,
+    }
+}
+
+/// The name of the nearest enclosing `call` whose arguments directly or
+/// transitively contain `node` — e.g. `main` for the `configure()` call
+/// inside `main(configure())` — or `None` if `node` is not nested inside
+/// another call within the same statement (#2420). Mirrors TS
+/// `findEnclosingCallName` — see that function's doc comment for why the
+/// walk stops at a statement boundary.
+fn find_enclosing_call_name(node: &Node, source: &[u8]) -> Option<String> {
+    let mut parent = node.parent();
+    let mut hops = 0;
+    while let Some(p) = parent {
+        if hops >= MAX_WALK_DEPTH {
+            return None;
+        }
+        match p.kind() {
+            "call" => return get_call_name(&p, source),
+            "expression_statement" | "block" | "module" => return None,
+            _ => {}
+        }
+        parent = p.parent();
+        hops += 1;
+    }
+    None
 }
 
 fn visit_entrypoint_calls(
@@ -118,12 +162,19 @@ fn visit_entrypoint_calls(
     guarded: bool,
     at_module_level: bool,
     lines: &mut std::collections::HashSet<u32>,
+    wrapped_by: &mut EntrypointWrappedBy,
 ) {
     if depth >= MAX_WALK_DEPTH {
         return;
     }
     if node.kind() == "call" && guarded {
-        lines.insert(start_line(node));
+        let line = start_line(node);
+        lines.insert(line);
+        if let Some(name) = get_call_name(node, source) {
+            if let Some(wrapper) = find_enclosing_call_name(node, source) {
+                wrapped_by.insert((line, name), wrapper);
+            }
+        }
     }
 
     // Only a function defers its body — a class body is a normal statement
@@ -157,6 +208,7 @@ fn visit_entrypoint_calls(
             if is_guard_body { true } else { child_guarded },
             child_at_module_level,
             lines,
+            wrapped_by,
         );
     }
 }
@@ -838,6 +890,40 @@ mod tests {
             .find(|c| c.name == "main")
             .expect("main() call should be extracted");
         assert_eq!(main_call.entrypoint, Some(true));
+    }
+
+    #[test]
+    fn records_the_wrapper_name_for_a_nested_entrypoint_call() {
+        // #2420: main(configure()) — configure is an argument to main, not a
+        // standalone top-level entrypoint call.
+        let s = parse_py(
+            "def configure():\n    return 1\n\ndef main(x):\n    return x\n\nif __name__ == \"__main__\":\n    main(configure())\n",
+        );
+        let main_call = s.calls.iter().find(|c| c.name == "main").unwrap();
+        assert_eq!(main_call.entrypoint, Some(true));
+        assert_eq!(main_call.entrypoint_wrapped_by, None);
+        let configure_call = s.calls.iter().find(|c| c.name == "configure").unwrap();
+        assert_eq!(configure_call.entrypoint, Some(true));
+        assert_eq!(
+            configure_call.entrypoint_wrapped_by,
+            Some("main".to_string())
+        );
+    }
+
+    #[test]
+    fn records_the_wrapper_name_through_an_unresolvable_stdlib_passthrough() {
+        // #2420: sys.exit(main()) — the outer call is a bare-name-extracted
+        // "exit" (receiver "sys"), an external stdlib passthrough; main is
+        // still the call that matters and still gets a wrapper recorded.
+        let s = parse_py(
+            "import sys\n\ndef main():\n    return 1\n\nif __name__ == \"__main__\":\n    sys.exit(main())\n",
+        );
+        let exit_call = s.calls.iter().find(|c| c.name == "exit").unwrap();
+        assert_eq!(exit_call.entrypoint, Some(true));
+        assert_eq!(exit_call.entrypoint_wrapped_by, None);
+        let main_call = s.calls.iter().find(|c| c.name == "main").unwrap();
+        assert_eq!(main_call.entrypoint, Some(true));
+        assert_eq!(main_call.entrypoint_wrapped_by, Some("exit".to_string()));
     }
 
     #[test]

--- a/crates/codegraph-core/src/types.rs
+++ b/crates/codegraph-core/src/types.rs
@@ -148,6 +148,14 @@ pub struct Call {
     /// the guard frequently invokes a `main` imported from another module.
     /// Mirrors TS `Call.entrypoint` (#2392).
     pub entrypoint: Option<bool>,
+    /// Bare name of the immediately enclosing call, when this entrypoint call
+    /// is itself an argument to another call within the same qualifying
+    /// statement — e.g. `configure` in `main(configure())` carries `Some("main")`.
+    /// `None` for a call that is not nested inside another call, or that is
+    /// not `entrypoint` at all. Mirrors TS `Call.entrypointWrappedBy` (#2420)
+    /// — see that field's doc comment for the full rationale.
+    #[napi(js_name = "entrypointWrappedBy")]
+    pub entrypoint_wrapped_by: Option<String>,
 }
 
 /// `import { X as Y }`: the local binding name (Y) paired with the original

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -683,6 +683,7 @@ function ensureLegacyColumns(db: BetterSqlite3Database): void {
   if (hasTable(db, 'edges')) {
     ensureEdgeColumns(db);
   }
+  ensureEntrypointCallsColumns(db);
 }
 
 function ensureNodeColumns(db: BetterSqlite3Database): void {
@@ -724,6 +725,19 @@ function ensureNodeColumns(db: BetterSqlite3Database): void {
   db.exec(
     'CREATE INDEX IF NOT EXISTS idx_nodes_entrypoint_source_file ON nodes(entrypoint_source_file)',
   );
+  // #2420: narrower than `entrypoint` — a target can be a live root
+  // (`entrypoint = 1`, seeding reachability so it isn't downgraded as dead)
+  // without also being the *label-worthy* program entrypoint for role
+  // classification. `main(configure())` flags both `main` and `configure` as
+  // `entrypoint` (neither should be silently treated as dead code — the
+  // reachability side has no bug), but only `main` — the outermost call
+  // whose target actually resolves in-repo — should classify as
+  // `role: 'entry'`; `configure` keeps whatever role its own fan-in/fan-out
+  // shape would otherwise give it. See `projectEntrypointAttribution`'s doc
+  // comment for the wrapper-chain rule this column is set from. Mirrored in
+  // crates/codegraph-core/src/db/connection.rs.
+  if (missing('entrypoint_role'))
+    db.exec('ALTER TABLE nodes ADD COLUMN entrypoint_role INTEGER DEFAULT 0');
   db.exec('UPDATE nodes SET qualified_name = name WHERE qualified_name IS NULL');
   db.exec('CREATE INDEX IF NOT EXISTS idx_nodes_qualified_name ON nodes(qualified_name)');
   db.exec('CREATE INDEX IF NOT EXISTS idx_nodes_scope ON nodes(scope)');
@@ -734,6 +748,24 @@ function ensureEdgeColumns(db: BetterSqlite3Database): void {
     db.exec('ALTER TABLE edges ADD COLUMN confidence REAL DEFAULT 1.0');
   if (!hasColumn(db, 'edges', 'dynamic'))
     db.exec('ALTER TABLE edges ADD COLUMN dynamic INTEGER DEFAULT 0');
+}
+
+/**
+ * #2420: the bare name of the call this evidence row's call is nested inside
+ * (e.g. `'main'` for the `configure` evidence row from `main(configure())`),
+ * or `NULL` for a top-level (unwrapped) entrypoint call. Added the same way
+ * `entrypoint`/`entrypoint_source_file` were — an idempotent `ALTER TABLE`
+ * here rather than a numbered migration, since `entrypoint_calls` itself was
+ * only ever created via one (v31) and a bare `ALTER` is not replay-safe
+ * against a schema_version already stamped past that point. Guarded on the
+ * table existing for the same reason `backfillEntrypointEvidence` is: a
+ * pre-v31 database reaches this function before migration v31 has run.
+ * Mirrored in crates/codegraph-core/src/db/connection.rs.
+ */
+function ensureEntrypointCallsColumns(db: BetterSqlite3Database): void {
+  if (!hasTable(db, 'entrypoint_calls')) return;
+  if (!hasColumn(db, 'entrypoint_calls', 'wrapped_by'))
+    db.exec('ALTER TABLE entrypoint_calls ADD COLUMN wrapped_by TEXT');
 }
 
 /**

--- a/src/domain/graph/builder/entrypoints.ts
+++ b/src/domain/graph/builder/entrypoints.ts
@@ -50,6 +50,7 @@ import { resolvePyprojectScriptEntrypoints } from '../resolve.js';
 interface EntrypointCall {
   name: string;
   entrypoint?: boolean;
+  entrypointWrappedBy?: string;
 }
 
 /**
@@ -78,19 +79,25 @@ export function persistEntrypointCalls(
 ): void {
   const deleteStmt = db.prepare('DELETE FROM entrypoint_calls WHERE file = ?');
   const insertStmt = db.prepare(
-    'INSERT OR IGNORE INTO entrypoint_calls (file, name) VALUES (?, ?)',
+    'INSERT OR IGNORE INTO entrypoint_calls (file, name, wrapped_by) VALUES (?, ?, ?)',
   );
 
   const tx = db.transaction(() => {
     for (const [file, calls] of entries) {
       if (!file.endsWith('.py')) continue;
       deleteStmt.run(file);
-      const names = new Set<string>();
+      // First occurrence per name wins (matches the existing "seen" dedup
+      // behavior) — the rare case of the same name appearing both wrapped
+      // and unwrapped as separate entrypoint calls within one file isn't
+      // otherwise representable by this (file, name) primary key.
+      const names = new Map<string, string | null>();
       for (const call of calls) {
-        if (call.entrypoint) names.add(call.name);
+        if (call.entrypoint && !names.has(call.name)) {
+          names.set(call.name, call.entrypointWrappedBy ?? null);
+        }
       }
-      for (const name of names) {
-        insertStmt.run(file, name);
+      for (const [name, wrappedBy] of names) {
+        insertStmt.run(file, name, wrappedBy);
       }
     }
   });
@@ -102,13 +109,15 @@ interface DesiredRow {
   id: number;
   file: string;
   sourceFile: string;
+  name: string;
+  wrappedBy: string | null;
 }
 
 /**
- * Recompute `nodes.entrypoint` / `nodes.entrypoint_source_file` from the
- * persisted evidence and the committed `calls` edges, and return the files
- * whose flag set actually changed, so the caller can seed incremental role
- * reclassification for them.
+ * Recompute `nodes.entrypoint` / `nodes.entrypoint_source_file` /
+ * `nodes.entrypoint_role` from the persisted evidence and the committed
+ * `calls` edges, and return the files whose flag set actually changed, so the
+ * caller can seed incremental role reclassification for them.
  *
  * Must run after every edge-insert path for the build has completed — it
  * identifies targets from committed edges, not by re-resolving. An entrypoint
@@ -129,7 +138,37 @@ interface DesiredRow {
  * files both call the same target as their entrypoint, the one that sorts
  * first wins deterministically (rather than "whichever marked last", as in
  * #2411) and the target stays correctly flagged while either survives —
- * removing one no longer clears it. Tracked as #2419.
+ * removing one no longer clears it (#2419).
+ *
+ * ## `entrypoint_role`: which of several calls sharing a line gets `role: 'entry'`
+ *
+ * `entrypoint` alone answers "is the runtime the caller" — set on EVERY call
+ * inside a qualifying guard, including one nested inside another
+ * (`main(configure())` flags both `main` and `configure`, and correctly so:
+ * `configure` really does run at module load and needs the same
+ * dead-code-downgrade protection `main` does). But only one of them should be
+ * the *label* role classification promotes to `'entry'` — a helper like
+ * `configure` should keep whatever role its own fan-in/fan-out shape implies,
+ * not misleadingly appear in `codegraph roles --role entry` next to the real
+ * entrypoint (#2420).
+ *
+ * The rule: a call that is not nested inside another call on the same
+ * qualifying line is always the label winner. A nested call
+ * (`entrypointWrappedBy` set at extraction time, see `Call`'s doc comment)
+ * only wins the label if its wrapper does NOT resolve to an in-repo target
+ * from the same source file — e.g. `sys.exit(main())`, where `sys.exit` is
+ * an unresolvable stdlib passthrough, so `main` — the call that actually
+ * matters — gets the label instead of being silently skipped. This can only
+ * be decided here, once resolution is known: extraction (which only sees
+ * syntax) cannot tell `main(configure())` (wrapper resolves in-repo) from
+ * `sys.exit(main())` (wrapper does not) without knowing the graph's `calls`
+ * edges — the same reason `desired` itself waits until here.
+ *
+ * A `entrypoint_role` value change is a role-classification-visible change
+ * even when `entrypoint`/`entrypoint_source_file` stay the same — e.g. a
+ * wrapper that used to resolve stops resolving on a later rebuild that
+ * doesn't touch the wrapped target's own file at all — so it is checked and
+ * `touchedFiles`-seeded independently of the existing sourceFile-change check.
  */
 export function projectEntrypointAttribution(db: BetterSqlite3Database): string[] {
   // Cheap exit for the overwhelmingly common case — no Python entrypoint
@@ -150,7 +189,8 @@ export function projectEntrypointAttribution(db: BetterSqlite3Database): string[
   // `Owner.start`, hence the qualified form at all.
   const desiredRows = db
     .prepare(
-      `SELECT e.target_id AS id, tgt.file AS file, ec.file AS sourceFile
+      `SELECT e.target_id AS id, tgt.file AS file, ec.file AS sourceFile,
+              ec.name AS name, ec.wrapped_by AS wrappedBy
        FROM entrypoint_calls ec
        JOIN nodes src ON src.kind = 'file' AND src.file = ec.file
        JOIN edges e ON e.source_id = src.id AND e.kind = 'calls'
@@ -170,18 +210,30 @@ export function projectEntrypointAttribution(db: BetterSqlite3Database): string[
     if (!desired.has(row.id)) desired.set(row.id, row);
   }
 
+  // Which (sourceFile, name) pairs resolved to SOME in-repo target — used
+  // below to test whether a wrapped call's own wrapper resolved. Built from
+  // `desired` rather than a separate query since it needs exactly the same
+  // "did ec.name resolve via a calls edge from ec.file" answer `desired`
+  // itself already computed.
+  const resolvedNames = new Set<string>();
+  for (const row of desired.values()) {
+    resolvedNames.add(`${row.sourceFile} ${row.name}`);
+  }
+  const isRoleEligible = (row: DesiredRow): boolean =>
+    row.wrappedBy === null || !resolvedNames.has(`${row.sourceFile} ${row.wrappedBy}`);
+
   const current = db
     .prepare(
-      `SELECT id, file, entrypoint_source_file AS sourceFile
+      `SELECT id, file, entrypoint_source_file AS sourceFile, entrypoint_role AS role
        FROM nodes WHERE entrypoint = 1`,
     )
-    .all() as Array<{ id: number; file: string; sourceFile: string | null }>;
+    .all() as Array<{ id: number; file: string; sourceFile: string | null; role: number }>;
 
   const clearStmt = db.prepare(
-    'UPDATE nodes SET entrypoint = 0, entrypoint_source_file = NULL WHERE id = ?',
+    'UPDATE nodes SET entrypoint = 0, entrypoint_source_file = NULL, entrypoint_role = 0 WHERE id = ?',
   );
   const markStmt = db.prepare(
-    'UPDATE nodes SET entrypoint = 1, entrypoint_source_file = ? WHERE id = ?',
+    'UPDATE nodes SET entrypoint = 1, entrypoint_source_file = ?, entrypoint_role = ? WHERE id = ?',
   );
 
   const touchedFiles = new Set<string>();
@@ -193,15 +245,19 @@ export function projectEntrypointAttribution(db: BetterSqlite3Database): string[
       if (!want) {
         clearStmt.run(row.id);
         touchedFiles.add(row.file);
-      } else if (want.sourceFile !== row.sourceFile) {
-        // Still an entrypoint, only the attributing file changed. The role is
-        // `entry` either way, so this needs no role reclassification.
-        markStmt.run(want.sourceFile, row.id);
+        continue;
       }
+      const wantRole = isRoleEligible(want) ? 1 : 0;
+      if (want.sourceFile === row.sourceFile && wantRole === row.role) continue;
+      markStmt.run(want.sourceFile, wantRole, row.id);
+      // A sourceFile-only change needs no reclassification (the role is
+      // `entry` either way), but an entrypoint_role VALUE change does — it
+      // is exactly what role classification's `'entry'` early-return reads.
+      if (wantRole !== row.role) touchedFiles.add(row.file);
     }
     for (const [id, want] of desired) {
       if (currentIds.has(id)) continue;
-      markStmt.run(want.sourceFile, id);
+      markStmt.run(want.sourceFile, isRoleEligible(want) ? 1 : 0, id);
       touchedFiles.add(want.file);
     }
   });
@@ -249,10 +305,14 @@ export function applyPyprojectScriptAttribution(
   if (desired.length === 0 && current.length === 0) return [];
 
   const clearStmt = db.prepare(
-    'UPDATE nodes SET entrypoint = 0, entrypoint_source_file = NULL WHERE id = ?',
+    'UPDATE nodes SET entrypoint = 0, entrypoint_source_file = NULL, entrypoint_role = 0 WHERE id = ?',
   );
+  // entrypoint_role is unconditionally 1 here (#2420): an explicit
+  // `[project.scripts]`-style declaration has no "nested call" ambiguity to
+  // resolve — there is exactly one target per script name, always the
+  // label-worthy one.
   const markStmt = db.prepare(
-    "UPDATE nodes SET entrypoint = 1, entrypoint_source_file = 'pyproject.toml' WHERE id = ?",
+    "UPDATE nodes SET entrypoint = 1, entrypoint_source_file = 'pyproject.toml', entrypoint_role = 1 WHERE id = ?",
   );
   const findCandidates = db.prepare(
     `SELECT id, name FROM nodes WHERE file = ? AND kind IN ('function', 'method')`,

--- a/src/extractors/python.ts
+++ b/src/extractors/python.ts
@@ -222,12 +222,31 @@ function getCallName(node: TreeSitterNode): string | null {
  * walking past a statement boundary would find an unrelated, merely
  * lexically-outer call (e.g. the `if __name__ == "__main__":` guard's own
  * body statement list is a `block`, not a call, and must stop the walk).
+ *
+ * Only a bare-identifier wrapper (`main(...)`) is reported at all — an
+ * attribute/dotted wrapper (`sys.exit(...)`, `asyncio.run(...)`,
+ * `os._exit(...)`) returns `null` here, same as no wrapper. This is exactly
+ * the stdlib-passthrough idiom #2420 exists to protect, and its bare
+ * attribute name (`exit`, `run`) is a plain identifier stripped of its
+ * qualifier — far too likely to coincidentally match an unrelated same-named
+ * symbol elsewhere in the file for `projectEntrypointAttribution`'s
+ * file-wide bare-name lookup to trust (#2420 review — Greptile: a second,
+ * unrelated `exit`-named call elsewhere in the file that DOES resolve
+ * in-repo would otherwise make this wrapper look "resolved" and wrongly
+ * suppress the real entrypoint's role). Treating it as unwrapped is always
+ * the safe default: silently losing a real entrypoint's role is worse than
+ * an over-inclusive label on its wrapper, which is the same trade-off the
+ * feature already accepts for reachability (see this file's `Call`-marking
+ * doc comment).
  */
 function findEnclosingCallName(node: TreeSitterNode): string | null {
   let parent = node.parent;
   let hops = 0;
   while (parent && hops < MAX_WALK_DEPTH) {
-    if (parent.type === 'call') return getCallName(parent);
+    if (parent.type === 'call') {
+      const fn = parent.childForFieldName('function');
+      return fn?.type === 'identifier' ? getCallName(parent) : null;
+    }
     if (
       parent.type === 'expression_statement' ||
       parent.type === 'block' ||

--- a/src/extractors/python.ts
+++ b/src/extractors/python.ts
@@ -97,10 +97,13 @@ export function extractPythonSymbols(tree: TreeSitterTree, filePath: string): Ex
  * leaving no room for the two engines to disagree about a given call site.
  */
 function markEntrypointCalls(root: TreeSitterNode, filePath: string, ctx: ExtractorOutput): void {
-  const lines = collectEntrypointCallLines(root, filePath);
+  const { lines, wrappedBy } = collectEntrypointCallLines(root, filePath);
   if (lines.size === 0) return;
   for (const call of ctx.calls) {
-    if (lines.has(call.line)) call.entrypoint = true;
+    if (!lines.has(call.line)) continue;
+    call.entrypoint = true;
+    const wrapper = wrappedBy.get(`${call.line}:${call.name}`);
+    if (wrapper) call.entrypointWrappedBy = wrapper;
   }
 }
 
@@ -132,8 +135,12 @@ function markEntrypointCalls(root: TreeSitterNode, filePath: string, ctx: Extrac
  * Like `guarded`, entering a class does not turn this off either, for the
  * same immediate-execution reason.
  */
-function collectEntrypointCallLines(root: TreeSitterNode, filePath: string): Set<number> {
+function collectEntrypointCallLines(
+  root: TreeSitterNode,
+  filePath: string,
+): { lines: Set<number>; wrappedBy: Map<string, string> } {
   const lines = new Set<number>();
+  const wrappedBy = new Map<string, string>();
 
   const visit = (
     node: TreeSitterNode,
@@ -142,7 +149,13 @@ function collectEntrypointCallLines(root: TreeSitterNode, filePath: string): Set
     atModuleLevel: boolean,
   ): void => {
     if (depth >= MAX_WALK_DEPTH) return;
-    if (node.type === 'call' && guarded) lines.add(node.startPosition.row + 1);
+    if (node.type === 'call' && guarded) {
+      const line = node.startPosition.row + 1;
+      lines.add(line);
+      const name = getCallName(node);
+      const wrapper = name ? findEnclosingCallName(node) : null;
+      if (name && wrapper) wrappedBy.set(`${line}:${name}`, wrapper);
+    }
 
     // Only a function defers its body — a class body is executed immediately
     // while evaluating the `class` statement, so it must not be treated the
@@ -176,7 +189,56 @@ function collectEntrypointCallLines(root: TreeSitterNode, filePath: string): Set
   };
 
   visit(root, 0, filePath.endsWith('__main__.py'), true);
-  return lines;
+  return { lines, wrappedBy };
+}
+
+/**
+ * The bare callee name of a `call` node, matching `handlePyCall`'s own naming
+ * exactly (identifier, or an attribute call's `.attribute` half) — so a
+ * wrapper name recorded here matches what `entrypoint_calls`/projection
+ * later look up by the same bare-name convention. Returns `null` for a
+ * shape `handlePyCall` itself would skip (e.g. a computed/subscript callee).
+ */
+function getCallName(node: TreeSitterNode): string | null {
+  const fn = node.childForFieldName('function');
+  if (!fn) return null;
+  if (fn.type === 'identifier') return fn.text;
+  if (fn.type === 'attribute') {
+    const attr = fn.childForFieldName('attribute');
+    return attr ? attr.text : null;
+  }
+  return null;
+}
+
+/**
+ * The name of the nearest enclosing `call` whose arguments directly or
+ * transitively contain `node` — e.g. `main` for the `configure()` call
+ * inside `main(configure())` — or `null` if `node` is not nested inside
+ * another call within the same statement (#2420).
+ *
+ * Bounded to the current statement: stops (returns `null`) at the first
+ * `expression_statement`/`block`/`module` ancestor, since a call can only be
+ * "wrapped" by another call textually enclosing it in the same expression —
+ * walking past a statement boundary would find an unrelated, merely
+ * lexically-outer call (e.g. the `if __name__ == "__main__":` guard's own
+ * body statement list is a `block`, not a call, and must stop the walk).
+ */
+function findEnclosingCallName(node: TreeSitterNode): string | null {
+  let parent = node.parent;
+  let hops = 0;
+  while (parent && hops < MAX_WALK_DEPTH) {
+    if (parent.type === 'call') return getCallName(parent);
+    if (
+      parent.type === 'expression_statement' ||
+      parent.type === 'block' ||
+      parent.type === 'module'
+    ) {
+      return null;
+    }
+    parent = parent.parent;
+    hops++;
+  }
+  return null;
 }
 
 /** True for the `__name__ == "__main__"` test of an `if` statement. */

--- a/src/extractors/python.ts
+++ b/src/extractors/python.ts
@@ -59,6 +59,19 @@ const BUILTIN_GLOBALS_PY: Set<string> = new Set([
 ]);
 
 /**
+ * Stdlib modules whose attribute calls are the "process launcher
+ * passthrough" idiom #2420 exists to protect (`sys.exit(main())`,
+ * `asyncio.run(main())`, `os._exit(main())`) — deliberately narrow and
+ * non-exhaustive. This is NOT an attempt to classify every import as
+ * external vs. local (real import resolution, needed to do that precisely,
+ * isn't available at extraction time); it only names the specific handful
+ * of modules this exact idiom uses. See `findEnclosingCallName`'s doc
+ * comment for why a wrapper resolving to any OTHER module (or no import at
+ * all) takes a different path.
+ */
+const STDLIB_PROCESS_LAUNCHER_MODULES: ReadonlySet<string> = new Set(['sys', 'os', 'asyncio']);
+
+/**
  * Extract symbols from Python files.
  */
 export function extractPythonSymbols(tree: TreeSitterTree, filePath: string): ExtractorOutput {
@@ -97,16 +110,18 @@ export function extractPythonSymbols(tree: TreeSitterTree, filePath: string): Ex
  * leaving no room for the two engines to disagree about a given call site.
  */
 function markEntrypointCalls(root: TreeSitterNode, filePath: string, ctx: ExtractorOutput): void {
-  // Plain `import X` / `import X as Y` bindings only (`handlePyImport`'s
-  // `namespaceBindings`) — never a `from X import Y` binding, which names a
-  // symbol pulled out of a module, not the module namespace itself. Runs
-  // after `walkPythonNode`, so `ctx.imports` is already fully populated by
-  // the time this reads it (see `extractPythonSymbols`'s call order).
-  const moduleBoundNames = new Set<string>();
+  // Maps each plain `import X` / `import X as Y` local binding name
+  // (`handlePyImport`'s `namespaceBindings`) to the module it actually
+  // imports (`imp.source`), so an alias like `import os as o` still maps
+  // "o" to "os" — never a `from X import Y` binding, which names a symbol
+  // pulled out of a module, not the module namespace itself. Runs after
+  // `walkPythonNode`, so `ctx.imports` is already fully populated by the
+  // time this reads it (see `extractPythonSymbols`'s call order).
+  const importSourceByLocalName = new Map<string, string>();
   for (const imp of ctx.imports) {
-    for (const name of imp.namespaceBindings ?? []) moduleBoundNames.add(name);
+    for (const name of imp.namespaceBindings ?? []) importSourceByLocalName.set(name, imp.source);
   }
-  const { lines, wrappedBy } = collectEntrypointCallLines(root, filePath, moduleBoundNames);
+  const { lines, wrappedBy } = collectEntrypointCallLines(root, filePath, importSourceByLocalName);
   if (lines.size === 0) return;
   for (const call of ctx.calls) {
     if (!lines.has(call.line)) continue;
@@ -147,7 +162,7 @@ function markEntrypointCalls(root: TreeSitterNode, filePath: string, ctx: Extrac
 function collectEntrypointCallLines(
   root: TreeSitterNode,
   filePath: string,
-  moduleBoundNames: ReadonlySet<string>,
+  importSourceByLocalName: ReadonlyMap<string, string>,
 ): { lines: Set<number>; wrappedBy: Map<string, string> } {
   const lines = new Set<number>();
   const wrappedBy = new Map<string, string>();
@@ -163,7 +178,7 @@ function collectEntrypointCallLines(
       const line = node.startPosition.row + 1;
       lines.add(line);
       const name = getCallName(node);
-      const wrapper = name ? findEnclosingCallName(node, moduleBoundNames) : null;
+      const wrapper = name ? findEnclosingCallName(node, importSourceByLocalName) : null;
       if (name && wrapper) wrappedBy.set(`${line}:${name}`, wrapper);
     }
 
@@ -233,36 +248,42 @@ function getCallName(node: TreeSitterNode): string | null {
  * lexically-outer call (e.g. the `if __name__ == "__main__":` guard's own
  * body statement list is a `block`, not a call, and must stop the walk).
  *
- * A wrapper whose receiver is bound by a plain `import X` / `import X as Y`
- * statement (`moduleBoundNames`) — e.g. `sys.exit(...)`, `asyncio.run(...)`
- * — is reported as `null` here, same as no wrapper, rather than its bare
- * attribute name. This is exactly the stdlib-passthrough idiom #2420 exists
- * to protect: `sys`/`asyncio` are external modules, so `sys.exit`/`asyncio.run`
- * can never resolve to a same-file symbol, yet their bare attribute name
- * (`exit`, `run`) is a plain identifier stripped of its module qualifier —
- * far too likely to coincidentally match an unrelated same-named in-repo
- * symbol for `projectEntrypointAttribution`'s file-wide bare-name lookup to
- * trust (#2420 review — Greptile: a second, unrelated `exit`-named call
- * elsewhere in the file that DOES resolve in-repo would otherwise make this
- * wrapper look "resolved" and wrongly suppress the real entrypoint's role).
- * Treating it as unwrapped is always the safe default here: silently losing
- * a real entrypoint's role is worse than an over-inclusive label on its
- * wrapper, the same trade-off the feature already accepts for reachability
- * (see this file's `Call`-marking doc comment).
+ * A wrapper whose receiver resolves (via `importSourceByLocalName`, honoring
+ * `import X as Y` aliasing) to one of `STDLIB_PROCESS_LAUNCHER_MODULES` —
+ * `sys.exit(...)`, `asyncio.run(...)`, `os._exit(...)` — is reported as
+ * `null` here, same as no wrapper, rather than its bare attribute name. This
+ * is exactly the stdlib-passthrough idiom #2420 exists to protect: these
+ * specific modules are never resolvable to a same-file symbol, yet the bare
+ * attribute name (`exit`, `run`) is a plain identifier stripped of its
+ * module qualifier — far too likely to coincidentally match an unrelated
+ * same-named in-repo symbol for `projectEntrypointAttribution`'s file-wide
+ * bare-name lookup to trust (#2420 review — Greptile, round 1: a second,
+ * unrelated `exit`-named call elsewhere in the file that DOES resolve
+ * in-repo would otherwise make this wrapper look "resolved" and wrongly
+ * suppress the real entrypoint's role). Treating it as unwrapped is always
+ * the safe default here: silently losing a real entrypoint's role is worse
+ * than an over-inclusive label on its wrapper, the same trade-off the
+ * feature already accepts for reachability (see this file's `Call`-marking
+ * doc comment).
  *
- * A wrapper whose receiver is NOT a recognized module import — a plain
- * identifier call (`main(...)`), or a dotted call on a local
- * object/instance (`runner.run(...)`) — reports its bare name as usual and
- * goes through the normal bare-name resolution check instead: unlike a
- * module attribute, `runner.run` plausibly IS a same-file (or same-repo)
- * method, and #2420 review (Greptile, second round) confirmed that
- * unconditionally treating every dotted wrapper as unresolvable regresses
- * to the original bug for exactly this case — both `run` and `main` would
- * wrongly receive the entry label.
+ * Every OTHER wrapper — a plain identifier call (`main(...)`), a dotted
+ * call on a local object/instance (`runner.run(...)`), or a dotted call on
+ * an import that ISN'T one of those specific stdlib modules (`import
+ * runner; runner.run(...)`, a same-repo module) — reports its bare name as
+ * usual and goes through the normal bare-name resolution check instead:
+ * unlike `sys`/`asyncio`, any of these plausibly resolve to a same-repo
+ * symbol. #2420 review (Greptile, rounds 2 and 3) confirmed that excluding
+ * either "every dotted wrapper" or "every import-bound wrapper" regresses
+ * to the original bug for these cases — both the wrapper and the wrapped
+ * call would wrongly receive the entry label. `STDLIB_PROCESS_LAUNCHER_MODULES`
+ * is deliberately narrow rather than an attempt to classify every import as
+ * external vs. local (which needs real import resolution, unavailable at
+ * extraction time) — it only needs to name the specific handful of modules
+ * this exact idiom uses.
  */
 function findEnclosingCallName(
   node: TreeSitterNode,
-  moduleBoundNames: ReadonlySet<string>,
+  importSourceByLocalName: ReadonlyMap<string, string>,
 ): string | null {
   let parent = node.parent;
   let hops = 0;
@@ -271,7 +292,8 @@ function findEnclosingCallName(
       const fn = parent.childForFieldName('function');
       if (fn?.type === 'attribute') {
         const receiver = fn.childForFieldName('object')?.text;
-        if (receiver && moduleBoundNames.has(receiver)) return null;
+        const source = receiver ? importSourceByLocalName.get(receiver) : undefined;
+        if (source && STDLIB_PROCESS_LAUNCHER_MODULES.has(source)) return null;
       }
       return getCallName(parent);
     }

--- a/src/extractors/python.ts
+++ b/src/extractors/python.ts
@@ -97,7 +97,16 @@ export function extractPythonSymbols(tree: TreeSitterTree, filePath: string): Ex
  * leaving no room for the two engines to disagree about a given call site.
  */
 function markEntrypointCalls(root: TreeSitterNode, filePath: string, ctx: ExtractorOutput): void {
-  const { lines, wrappedBy } = collectEntrypointCallLines(root, filePath);
+  // Plain `import X` / `import X as Y` bindings only (`handlePyImport`'s
+  // `namespaceBindings`) — never a `from X import Y` binding, which names a
+  // symbol pulled out of a module, not the module namespace itself. Runs
+  // after `walkPythonNode`, so `ctx.imports` is already fully populated by
+  // the time this reads it (see `extractPythonSymbols`'s call order).
+  const moduleBoundNames = new Set<string>();
+  for (const imp of ctx.imports) {
+    for (const name of imp.namespaceBindings ?? []) moduleBoundNames.add(name);
+  }
+  const { lines, wrappedBy } = collectEntrypointCallLines(root, filePath, moduleBoundNames);
   if (lines.size === 0) return;
   for (const call of ctx.calls) {
     if (!lines.has(call.line)) continue;
@@ -138,6 +147,7 @@ function markEntrypointCalls(root: TreeSitterNode, filePath: string, ctx: Extrac
 function collectEntrypointCallLines(
   root: TreeSitterNode,
   filePath: string,
+  moduleBoundNames: ReadonlySet<string>,
 ): { lines: Set<number>; wrappedBy: Map<string, string> } {
   const lines = new Set<number>();
   const wrappedBy = new Map<string, string>();
@@ -153,7 +163,7 @@ function collectEntrypointCallLines(
       const line = node.startPosition.row + 1;
       lines.add(line);
       const name = getCallName(node);
-      const wrapper = name ? findEnclosingCallName(node) : null;
+      const wrapper = name ? findEnclosingCallName(node, moduleBoundNames) : null;
       if (name && wrapper) wrappedBy.set(`${line}:${name}`, wrapper);
     }
 
@@ -223,29 +233,47 @@ function getCallName(node: TreeSitterNode): string | null {
  * lexically-outer call (e.g. the `if __name__ == "__main__":` guard's own
  * body statement list is a `block`, not a call, and must stop the walk).
  *
- * Only a bare-identifier wrapper (`main(...)`) is reported at all — an
- * attribute/dotted wrapper (`sys.exit(...)`, `asyncio.run(...)`,
- * `os._exit(...)`) returns `null` here, same as no wrapper. This is exactly
- * the stdlib-passthrough idiom #2420 exists to protect, and its bare
- * attribute name (`exit`, `run`) is a plain identifier stripped of its
- * qualifier — far too likely to coincidentally match an unrelated same-named
- * symbol elsewhere in the file for `projectEntrypointAttribution`'s
- * file-wide bare-name lookup to trust (#2420 review — Greptile: a second,
- * unrelated `exit`-named call elsewhere in the file that DOES resolve
- * in-repo would otherwise make this wrapper look "resolved" and wrongly
- * suppress the real entrypoint's role). Treating it as unwrapped is always
- * the safe default: silently losing a real entrypoint's role is worse than
- * an over-inclusive label on its wrapper, which is the same trade-off the
- * feature already accepts for reachability (see this file's `Call`-marking
- * doc comment).
+ * A wrapper whose receiver is bound by a plain `import X` / `import X as Y`
+ * statement (`moduleBoundNames`) — e.g. `sys.exit(...)`, `asyncio.run(...)`
+ * — is reported as `null` here, same as no wrapper, rather than its bare
+ * attribute name. This is exactly the stdlib-passthrough idiom #2420 exists
+ * to protect: `sys`/`asyncio` are external modules, so `sys.exit`/`asyncio.run`
+ * can never resolve to a same-file symbol, yet their bare attribute name
+ * (`exit`, `run`) is a plain identifier stripped of its module qualifier —
+ * far too likely to coincidentally match an unrelated same-named in-repo
+ * symbol for `projectEntrypointAttribution`'s file-wide bare-name lookup to
+ * trust (#2420 review — Greptile: a second, unrelated `exit`-named call
+ * elsewhere in the file that DOES resolve in-repo would otherwise make this
+ * wrapper look "resolved" and wrongly suppress the real entrypoint's role).
+ * Treating it as unwrapped is always the safe default here: silently losing
+ * a real entrypoint's role is worse than an over-inclusive label on its
+ * wrapper, the same trade-off the feature already accepts for reachability
+ * (see this file's `Call`-marking doc comment).
+ *
+ * A wrapper whose receiver is NOT a recognized module import — a plain
+ * identifier call (`main(...)`), or a dotted call on a local
+ * object/instance (`runner.run(...)`) — reports its bare name as usual and
+ * goes through the normal bare-name resolution check instead: unlike a
+ * module attribute, `runner.run` plausibly IS a same-file (or same-repo)
+ * method, and #2420 review (Greptile, second round) confirmed that
+ * unconditionally treating every dotted wrapper as unresolvable regresses
+ * to the original bug for exactly this case — both `run` and `main` would
+ * wrongly receive the entry label.
  */
-function findEnclosingCallName(node: TreeSitterNode): string | null {
+function findEnclosingCallName(
+  node: TreeSitterNode,
+  moduleBoundNames: ReadonlySet<string>,
+): string | null {
   let parent = node.parent;
   let hops = 0;
   while (parent && hops < MAX_WALK_DEPTH) {
     if (parent.type === 'call') {
       const fn = parent.childForFieldName('function');
-      return fn?.type === 'identifier' ? getCallName(parent) : null;
+      if (fn?.type === 'attribute') {
+        const receiver = fn.childForFieldName('object')?.text;
+        if (receiver && moduleBoundNames.has(receiver)) return null;
+      }
+      return getCallName(parent);
     }
     if (
       parent.type === 'expression_statement' ||

--- a/src/extractors/python.ts
+++ b/src/extractors/python.ts
@@ -68,6 +68,17 @@ const BUILTIN_GLOBALS_PY: Set<string> = new Set([
  * of modules this exact idiom uses. See `findEnclosingCallName`'s doc
  * comment for why a wrapper resolving to any OTHER module (or no import at
  * all) takes a different path.
+ *
+ * Known residual gap (#2543, deliberately not fixed here): this matches by
+ * import *source name* only, not by whether the import actually resolved to
+ * a stdlib module. A repository that defines its own top-level module
+ * literally named `sys.py`/`os.py`/`asyncio.py` would have a call like
+ * `asyncio.run(main())` still treated as the external passthrough even
+ * though it resolves in-repo. Closing that gap needs real resolved-import
+ * data (an `imports` edge), only available after the build's import
+ * resolution phase — i.e. in `projectEntrypointAttribution`, not here at
+ * extraction time. Left for #2543 given a repository shadowing a stdlib
+ * module name this way is already unusual, independent of this tool.
  */
 const STDLIB_PROCESS_LAUNCHER_MODULES: ReadonlySet<string> = new Set(['sys', 'os', 'asyncio']);
 

--- a/src/features/structure.ts
+++ b/src/features/structure.ts
@@ -631,6 +631,14 @@ interface CallableNodeRow {
   fan_out: number;
   /** 1 when a program-entrypoint call resolves here (#2392). */
   entrypoint: number;
+  /**
+   * 1 when this specific target should carry the `role: 'entry'` label,
+   * narrower than `entrypoint` — a nested call sharing a line with another
+   * (unresolved) call gets `entrypoint = 1` for reachability but not
+   * necessarily this (#2420). See `projectEntrypointAttribution`'s doc
+   * comment for the full rule.
+   */
+  entrypoint_role: number;
 }
 
 /**
@@ -699,6 +707,7 @@ function buildClassifierInput(
   hasActiveFileSiblings: boolean | undefined;
   isPublicSurface: boolean;
   isEntrypoint: boolean;
+  isEntrypointRole: boolean;
 }> {
   return rows.map((r) => ({
     id: String(r.id),
@@ -709,6 +718,7 @@ function buildClassifierInput(
     fanOut: r.fan_out,
     isExported: exportedIds.has(r.id),
     isEntrypoint: r.entrypoint === 1,
+    isEntrypointRole: r.entrypoint_role === 1,
     productionFanIn: prodFanInMap.get(r.id) || 0,
     // Set hasActiveFileSiblings for annotation-only kinds (constants, type defs)
     // AND for method/function — the latter two can have fanIn === 0 due to
@@ -877,6 +887,7 @@ function classifyNodeRolesFull(db: BetterSqlite3Database, emptySummary: RoleSumm
     .prepare(
       `SELECT n.id, n.name, n.kind, n.file,
         COALESCE(n.entrypoint, 0) AS entrypoint,
+        COALESCE(n.entrypoint_role, 0) AS entrypoint_role,
         COALESCE(fi.cnt, 0) AS fan_in,
         COALESCE(fo.cnt, 0) AS fan_out
       FROM nodes n
@@ -1219,6 +1230,7 @@ function runIncrementalReachabilityDowngrade(
     .prepare(
       `SELECT n.id, n.name, n.kind, n.file, n.exported,
         COALESCE(n.entrypoint, 0) AS entrypoint,
+        COALESCE(n.entrypoint_role, 0) AS entrypoint_role,
         COALESCE(fi.cnt, 0) AS fan_in,
         COALESCE(fo.cnt, 0) AS fan_out
       FROM nodes n
@@ -1238,6 +1250,7 @@ function runIncrementalReachabilityDowngrade(
     file: string;
     exported: number;
     entrypoint: number;
+    entrypoint_role: number;
     fan_in: number;
     fan_out: number;
   }>;
@@ -1252,6 +1265,7 @@ function runIncrementalReachabilityDowngrade(
     isExported: r.exported === 1,
     isPublicSurface: r.exported === 1,
     isEntrypoint: r.entrypoint === 1,
+    isEntrypointRole: r.entrypoint_role === 1,
     hasActiveFileSiblings: true,
   }));
 
@@ -1360,6 +1374,7 @@ function classifyNodeRolesIncremental(
     .prepare(
       `SELECT n.id, n.name, n.kind, n.file,
         COALESCE(n.entrypoint, 0) AS entrypoint,
+        COALESCE(n.entrypoint_role, 0) AS entrypoint_role,
         (SELECT COUNT(*) FROM edges WHERE kind IN ('calls', 'imports-type') AND target_id = n.id) AS fan_in,
         (SELECT COUNT(*) FROM edges WHERE kind = 'calls' AND source_id = n.id) AS fan_out
       FROM nodes n

--- a/src/graph/classifiers/roles.ts
+++ b/src/graph/classifiers/roles.ts
@@ -268,13 +268,33 @@ export interface RoleClassificationNode {
    * extractor-flagged call site (Python's `if __name__ == "__main__":` guard
    * and `__main__.py` module level).
    *
+   * Consumed ONLY by `isLiveRoot` (reachability seeding) — NOT by role
+   * classification's `'entry'` label, which reads `isEntrypointRole` instead
+   * (#2420). `main(configure())` sets `isEntrypoint` on both `main` and
+   * `configure`: both genuinely run at module load and both need the same
+   * dead-code-downgrade protection, so reachability treats them identically.
+   * But only one of them should visibly appear as `role: 'entry'` — see
+   * `isEntrypointRole`'s own doc comment for which one and why.
+   */
+  isEntrypoint?: boolean;
+  /**
+   * True when this node is not merely reachable via a program-entrypoint call
+   * (`isEntrypoint`) but is specifically the one classification should label
+   * `role: 'entry'` (#2420). Sourced from the `nodes.entrypoint_role` column,
+   * which `projectEntrypointAttribution` computes from the wrapper-chain rule
+   * documented there: the outermost call on a qualifying line always wins;
+   * a nested call only wins if its wrapper does NOT resolve to an in-repo
+   * target (e.g. `sys.exit(main())`, where `sys.exit` never resolves, so
+   * `main` — the call that matters — gets the label instead of `configure`
+   * silently winning in `main(configure())`, where `main` DOES resolve).
+   *
    * Checked before the `fanIn === 0` gate, unlike the export-based `entry`
    * rule: an entrypoint invoked from its own module's guard *does* have an
    * inbound call edge (the module-level call, attributed to the file node),
    * so a zero-fan-in requirement would never fire for the very convention
    * this exists to recognize.
    */
-  isEntrypoint?: boolean;
+  isEntrypointRole?: boolean;
 }
 
 /**
@@ -380,8 +400,12 @@ function classifyNodeRole(
   if (FRAMEWORK_ENTRY_PREFIXES.some((p) => node.name.startsWith(p))) return 'entry';
 
   // A confirmed program entrypoint (#2392) — the runtime invokes it, so its
-  // in-repo fan-in shape says nothing about how it is reached.
-  if (node.isEntrypoint) return 'entry';
+  // in-repo fan-in shape says nothing about how it is reached. Narrower than
+  // `isEntrypoint` (#2420): a call nested inside another on the same
+  // qualifying line (`main(configure())`'s `configure`) is still reachable
+  // via `isLiveRoot`, but doesn't win this label unless it's the one call on
+  // the line that actually matters — see `isEntrypointRole`'s doc comment.
+  if (node.isEntrypointRole) return 'entry';
 
   if (node.fanIn === 0) {
     if (!node.isExported) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -630,6 +630,28 @@ export interface Call {
    * into the `nodes.entrypoint` flag the role classifier reads.
    */
   entrypoint?: boolean;
+  /**
+   * Bare name of the *immediately* enclosing call, when this entrypoint call
+   * is itself an argument to another call within the same qualifying
+   * statement — e.g. `configure` in `main(configure())`, where this field
+   * would read `'main'`. `undefined` for a call that is not nested inside
+   * another call (the top-level `main` in that same example), or for a call
+   * that is not `entrypoint` at all.
+   *
+   * Exists because `entrypoint` alone cannot distinguish two shapes that look
+   * identical from inside `markEntrypointCalls` (#2420): `main(configure())`,
+   * where `configure` is a helper that merely happens to run at module load
+   * and should NOT itself be classified `role: 'entry'`, versus
+   * `sys.exit(main())`, where the outer call is an unresolvable stdlib
+   * passthrough and the *inner* `main` is the one that matters. Both share a
+   * line and both calls get `entrypoint: true` (reachability has no bug to
+   * fix here — see the field's own projection-side consumer's doc comment) —
+   * but only the outermost call whose target actually resolves to an in-repo
+   * definition should win the `role: 'entry'` label. `projectEntrypointAttribution`
+   * (`domain/graph/builder/entrypoints.ts`) walks this chain at build end,
+   * once resolution is known, to decide which target that is.
+   */
+  entrypointWrappedBy?: string;
   dynamicKind?: DynamicKind;
   /** Raw key/arg text — used for diagnostics and future RES-1 const-string resolution. */
   keyExpr?: string;

--- a/tests/integration/issue-2420-entrypoint-wrapper-role.test.ts
+++ b/tests/integration/issue-2420-entrypoint-wrapper-role.test.ts
@@ -212,6 +212,41 @@ if __name__ == "__main__":
       }
     });
 
+    it('import runner; runner.run(main()) still suppresses the wrapped call for an in-repo module import (Greptile review, round 3)', async () => {
+      // Unlike sys/asyncio, "runner" here is a plain `import runner` of a
+      // SAME-REPO module, not a curated stdlib process-launcher module —
+      // its dotted wrapper ("run") must still resolve normally and win the
+      // label over main, same as the local-instance case above.
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2420-local-module-import-${engine}-`));
+      try {
+        writeFixture(dir, {
+          'runner.py': `
+def run(x):
+    return x
+`,
+          'run.py': `
+import runner
+
+def main():
+    return 0
+
+if __name__ == "__main__":
+    runner.run(main())
+`,
+        });
+        await buildGraph(dir, { incremental: false, skipRegistry: true, engine });
+        const nodes = readFunctionNodes(path.join(dir, '.codegraph', 'graph.db'));
+        const mainRow = nodes.find((n) => n.name === 'main');
+        const runRow = nodes.find((n) => n.name === 'run');
+        expect(mainRow?.entrypoint).toBe(1);
+        expect(mainRow?.role).not.toBe('entry');
+        expect(runRow?.entrypoint).toBe(1);
+        expect(runRow?.role).toBe('entry');
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
     it('an entrypoint with no wrapping ambiguity is unaffected', async () => {
       const dir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2420-plain-${engine}-`));
       try {

--- a/tests/integration/issue-2420-entrypoint-wrapper-role.test.ts
+++ b/tests/integration/issue-2420-entrypoint-wrapper-role.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Regression test for #2420: entrypoint-call detection (#2392) is keyed on
+ * source line, not AST-node identity, so when a qualifying statement
+ * contains more than one call on the same line — `main(configure())` — every
+ * call sharing that line was flagged `role: 'entry'`, not just the real
+ * target. `configure` genuinely does run at module load and must keep
+ * `entrypoint = 1` (reachability seeding has no bug here — see
+ * `isLiveRoot`), but it should not carry the `'entry'` role label alongside
+ * `main`.
+ *
+ * The opposite idiom — `sys.exit(main())` — must keep working: there the
+ * *outer* call (`sys.exit`) is an unresolvable stdlib passthrough and the
+ * *inner* call (`main`) is the one that matters, so `main` must still get
+ * the `'entry'` label despite being nested.
+ *
+ * The rule (`isRoleEligible` in `projectEntrypointAttribution` /
+ * `is_role_eligible` in `project_entrypoint_attribution`): a call not nested
+ * inside another call on the same line always wins the label; a nested call
+ * only wins it if its wrapper does not itself resolve to an in-repo target
+ * from the same source file.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+import type { EngineMode } from '../../src/types.js';
+
+function writeFixture(dir: string, files: Record<string, string>) {
+  for (const [rel, content] of Object.entries(files)) {
+    const abs = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, content);
+  }
+}
+
+interface NodeRow {
+  name: string;
+  file: string;
+  entrypoint: number;
+  role: string | null;
+}
+
+function readFunctionNodes(dbPath: string): NodeRow[] {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return db
+      .prepare(
+        `SELECT name, file, COALESCE(entrypoint, 0) AS entrypoint, role
+         FROM nodes WHERE kind IN ('function', 'method') ORDER BY file, name`,
+      )
+      .all() as NodeRow[];
+  } finally {
+    db.close();
+  }
+}
+
+const ENGINES: EngineMode[] = ['wasm', 'native'];
+
+describe.each(ENGINES)(
+  'entrypoint wrapper vs. target role classification (#2420) — engine: %s',
+  (engine) => {
+    describe('main(configure()) — a call wrapping another that resolves in-repo', () => {
+      let dir: string;
+      let nodes: NodeRow[];
+
+      const byName = (name: string): NodeRow => {
+        const row = nodes.find((n) => n.name === name);
+        if (!row)
+          throw new Error(`no node named ${name} (have: ${nodes.map((n) => n.name).join(', ')})`);
+        return row;
+      };
+
+      beforeAll(async () => {
+        dir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2420-nested-${engine}-`));
+        writeFixture(dir, {
+          'run.py': `
+def configure():
+    return {}
+
+def main(settings):
+    return settings
+
+if __name__ == "__main__":
+    main(configure())
+`,
+        });
+        await buildGraph(dir, { incremental: false, skipRegistry: true, engine });
+        nodes = readFunctionNodes(path.join(dir, '.codegraph', 'graph.db'));
+      });
+
+      afterAll(() => {
+        if (dir) fs.rmSync(dir, { recursive: true, force: true });
+      });
+
+      it('gives the unwrapped outer call the entry role', () => {
+        expect(byName('main').entrypoint).toBe(1);
+        expect(byName('main').role).toBe('entry');
+      });
+
+      it('still flags the nested call as reachable, but not as the entry label', () => {
+        expect(byName('configure').entrypoint).toBe(1);
+        expect(byName('configure').role).not.toBe('entry');
+      });
+    });
+
+    describe('sys.exit(main()) — a wrapper that does not resolve in-repo', () => {
+      let dir: string;
+      let nodes: NodeRow[];
+
+      beforeAll(async () => {
+        dir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2420-passthrough-${engine}-`));
+        writeFixture(dir, {
+          'run.py': `
+import sys
+
+def main():
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())
+`,
+        });
+        await buildGraph(dir, { incremental: false, skipRegistry: true, engine });
+        nodes = readFunctionNodes(path.join(dir, '.codegraph', 'graph.db'));
+      });
+
+      afterAll(() => {
+        if (dir) fs.rmSync(dir, { recursive: true, force: true });
+      });
+
+      it('still gives the nested call the entry role, since its wrapper never resolves', () => {
+        const row = nodes.find((n) => n.name === 'main');
+        expect(row?.entrypoint).toBe(1);
+        expect(row?.role).toBe('entry');
+      });
+    });
+
+    it('an entrypoint with no wrapping ambiguity is unaffected', async () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2420-plain-${engine}-`));
+      try {
+        writeFixture(dir, {
+          'run.py': `
+def main():
+    return 0
+
+if __name__ == "__main__":
+    main()
+`,
+        });
+        await buildGraph(dir, { incremental: false, skipRegistry: true, engine });
+        const row = readFunctionNodes(path.join(dir, '.codegraph', 'graph.db')).find(
+          (n) => n.name === 'main',
+        );
+        expect(row?.entrypoint).toBe(1);
+        expect(row?.role).toBe('entry');
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+  },
+);

--- a/tests/integration/issue-2420-entrypoint-wrapper-role.test.ts
+++ b/tests/integration/issue-2420-entrypoint-wrapper-role.test.ts
@@ -138,6 +138,43 @@ if __name__ == "__main__":
       });
     });
 
+    it('sys.exit(main()) keeps the entry role even when an unrelated local "exit" resolves in the same file (Greptile review)', async () => {
+      // A same-file namesake collision: `sys.exit` is an attribute call, so
+      // its bare attribute name ("exit") is stripped of the "sys" qualifier
+      // before any resolution is attempted. Without the dotted-wrapper
+      // exclusion, a file-wide bare-name lookup for "exit" would find this
+      // unrelated local `exit` function (called here entirely independently
+      // of the guard) and wrongly conclude the sys.exit wrapper "resolved
+      // in-repo," suppressing main's entry role.
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2420-collision-${engine}-`));
+      try {
+        writeFixture(dir, {
+          'run.py': `
+import sys
+
+def exit(status):
+    print(status)
+
+exit(0)
+
+def main():
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())
+`,
+        });
+        await buildGraph(dir, { incremental: false, skipRegistry: true, engine });
+        const row = readFunctionNodes(path.join(dir, '.codegraph', 'graph.db')).find(
+          (n) => n.name === 'main',
+        );
+        expect(row?.entrypoint).toBe(1);
+        expect(row?.role).toBe('entry');
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
     it('an entrypoint with no wrapping ambiguity is unaffected', async () => {
       const dir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2420-plain-${engine}-`));
       try {

--- a/tests/integration/issue-2420-entrypoint-wrapper-role.test.ts
+++ b/tests/integration/issue-2420-entrypoint-wrapper-role.test.ts
@@ -175,6 +175,43 @@ if __name__ == "__main__":
       }
     });
 
+    it('runner.run(main()) still suppresses the wrapped call in favor of a resolvable dotted wrapper (Greptile review, round 2)', async () => {
+      // Unlike sys.exit, "runner" here is a local instance, not a module
+      // import — its dotted wrapper ("run") really does resolve to an
+      // in-repo method, so main must NOT get the entry label, same as the
+      // plain-identifier main(configure()) case. Treating every dotted
+      // wrapper as always-unresolvable would regress to the original #2420
+      // bug for exactly this shape.
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2420-dotted-resolves-${engine}-`));
+      try {
+        writeFixture(dir, {
+          'run.py': `
+class Runner:
+    def run(self, x):
+        return x
+
+def main():
+    return 0
+
+runner = Runner()
+
+if __name__ == "__main__":
+    runner.run(main())
+`,
+        });
+        await buildGraph(dir, { incremental: false, skipRegistry: true, engine });
+        const nodes = readFunctionNodes(path.join(dir, '.codegraph', 'graph.db'));
+        const mainRow = nodes.find((n) => n.name === 'main');
+        const runRow = nodes.find((n) => n.name.endsWith('.run'));
+        expect(mainRow?.entrypoint).toBe(1);
+        expect(mainRow?.role).not.toBe('entry');
+        expect(runRow?.entrypoint).toBe(1);
+        expect(runRow?.role).toBe('entry');
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
     it('an entrypoint with no wrapping ambiguity is unaffected', async () => {
       const dir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2420-plain-${engine}-`));
       try {


### PR DESCRIPTION
## Summary

Closes #2420.

`markEntrypointCalls` (#2392) flags every call sharing a qualifying guard
line — `if __name__ == "__main__": main(configure())` — as an entrypoint
call, since the convention is keyed on source line rather than AST-node
identity (deliberate, for engine-parity reasons documented on that
function). When more than one call shares such a line, every one of them
was classified role `'entry'`, not just the real target: `configure` would
wrongly show up in `codegraph roles --role entry` next to the actual
program entrypoint, `main`.

The reachability side (`isLiveRoot`) has no bug here — `configure` really
does run at module load and needs the same dead-code-downgrade protection
`main` does, so it must keep `entrypoint = 1`. Only the *role label* needed
narrowing.

## Fix

- A call not nested inside another call on a qualifying line always wins
  the `'entry'` label.
- A nested call only wins the label if its own wrapper does **not** resolve
  to an in-repo target from the same source file — preserving the (more
  common) `sys.exit(main())` / `asyncio.run(main())` idiom, where the outer
  call is an unresolvable stdlib passthrough and the inner call is the one
  that actually matters.
- This can only be decided once the graph's `calls` edges are known
  (extraction only sees syntax), so a new `nodes.entrypoint_role` column is
  computed in `projectEntrypointAttribution` / `project_entrypoint_attribution`,
  independent of the existing reachability-only `nodes.entrypoint` flag.
  `classifyNode`'s `'entry'` early-return now reads `isEntrypointRole`
  instead of `isEntrypoint`; `isLiveRoot` is untouched.

Mirrored in both engines per the dual-engine architecture:
- extraction (`python.ts` / `python.rs`) records `entrypointWrappedBy` per
  call by walking the call's parent chain within the existing
  Python-specific entrypoint pass;
- persisted per-file evidence (`entrypoint_calls.wrapped_by`) carries it
  across rebuilds that don't touch the guard's own file;
- projection resolves eligibility from the evidence plus the committed
  `calls` edges.

## Test plan

- [x] New dual-engine integration test
      (`tests/integration/issue-2420-entrypoint-wrapper-role.test.ts`)
      covering: `main(configure())` (wrapper resolves → outer wins),
      `sys.exit(main())` (wrapper doesn't resolve → inner still wins), and
      an unwrapped baseline — asserting `role` directly from the DB on both
      `wasm` and `native` engines.
- [x] New Rust unit tests for the role-eligibility reconciliation logic,
      including a role-only-change-without-source-file-change case.
- [x] Revert-verified: temporarily disabled the eligibility check on both
      engines and confirmed the new tests fail with the exact pre-fix
      symptom (`configure` classified `'entry'`), then restored.
- [x] `npm test` (5370 passed), `cargo test --lib` (1066 passed),
      `cargo clippy -- -D warnings`, `cargo fmt --check`, `npm run lint`,
      `npx tsc --noEmit` all clean.
- [x] `codegraph diff-impact --staged -T` reviewed — blast radius scoped to
      the entrypoint-attribution pipeline and role classification, as
      expected.
