### PR TITLE
docs: correct stale tsup build-tool references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ npm run release:dry-run          # Preview what release would do without writing
 
 **Pipeline:** Source files → tree-sitter parse → extract symbols → resolve imports → SQLite DB → query/search
 
-Source is TypeScript in `src/`, compiled via `tsup`. The Rust native engine lives in `crates/codegraph-core/`.
+Source is TypeScript in `src/`, compiled via plain `tsc` (no bundler) — every `import` in `src/` survives into `dist/` as a real module resolution, so a package used by even one code path must be a `dependencies` entry, never a `devDependency` on the assumption a bundler would have inlined it. The Rust native engine lives in `crates/codegraph-core/`.
 
 | Path | Role |
 |------|------|

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ npm run release:dry-run          # Preview what release would do without writing
 
 **Pipeline:** Source files → tree-sitter parse → extract symbols → resolve imports → SQLite DB → query/search
 
-Source is TypeScript in `src/`, compiled via plain `tsc` (no bundler) — every `import` in `src/` survives into `dist/` as a real module resolution, so a package used by even one code path must be a `dependencies` entry, never a `devDependency` on the assumption a bundler would have inlined it. The Rust native engine lives in `crates/codegraph-core/`.
+Source is TypeScript in `src/`, compiled via plain `tsc` (no bundler) — a runtime (non-type-only) `import` in `src/` survives into `dist/` as a real module resolution, so a package a non-type-only, non-lazy-loaded code path depends on must be a `dependencies` entry, never demoted to `devDependencies` on the assumption a bundler would have inlined it (type-only imports are elided by `tsc`; some packages are deliberately kept optional and lazy-loaded instead — see `@huggingface/transformers`/`@modelcontextprotocol/sdk` below). The Rust native engine lives in `crates/codegraph-core/`.
 
 | Path | Role |
 |------|------|

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -355,7 +355,7 @@ Use [GitHub Issues](https://github.com/optave/ops-codegraph-tool/issues) with:
 
 ## Code Style
 
-- Source is TypeScript (`src/`), compiled via `tsc`/`tsup`; run `npm run typecheck` to type-check without emitting
+- Source is TypeScript (`src/`), compiled via plain `tsc` (no bundler); run `npm run typecheck` to type-check without emitting
 - [Biome](https://biomejs.dev/) is used for linting and formatting (config in `biome.json`, scoped to `src/` and `tests/`)
 - Run `npm run lint` to check and `npm run lint:fix` to auto-fix
 - The pre-commit hook runs the linter automatically


### PR DESCRIPTION
## Summary

Closes #2422.

`CLAUDE.md`'s Architecture section and `CONTRIBUTING.md`'s Code Style
section both claimed the build uses `tsup`, but `tsup` was removed.
Verified against the current repo state:

- `package.json`'s `build` script is plain `tsc && ...`, no bundler.
- `tsup` is not in `devDependencies`.
- No `tsup.config.*` anywhere in the repo.
- No other currently-active doc references `tsup` (the one hit in
  `docs/roadmap/ROADMAP.md` is a historical ADR describing a past
  migration decision, not a claim about current state, so left as-is;
  `generated/architecture/ARCHITECTURE_AUDIT_v3.4.0_2026-03-26.md` is a
  dated, generated snapshot, also left as-is).

## Why it matters beyond a stale word

With `tsc` and no bundling, every `import` in `src/` survives into
`dist/` as a real module resolution — a package used by even one code
path must be a `dependencies` entry, never demoted to `devDependencies`
on the assumption a bundler would have inlined it. An agent trusting the
old `tsup` claim could reasonably (and wrongly) propose exactly that
demotion, producing a `dist/` that crashes on import for users. Made this
consequence explicit in `CLAUDE.md` so the dependency-classification rule
is unambiguous.

## Test plan

- [x] Verified `package.json`'s build script, `devDependencies`, and a
      repo-wide search for `tsup.config.*` / `tsup` references directly
      against `main`.
- [x] Docs-only change — no source touched, no test surface to add.