### PR TITLE
fix(journal): incremental-build journal follows dbPath, not rootDir

### DIFF
--- a/crates/codegraph-core/src/db/connection.rs
+++ b/crates/codegraph-core/src/db/connection.rs
@@ -1869,9 +1869,11 @@ impl NativeDatabase {
     ) -> napi::Result<String> {
         let conn = self.conn()?;
         let workspaces_json = workspaces_json.unwrap_or_default();
+        let db_path = self.db_path();
         let result = crate::domain::graph::builder::pipeline::run_pipeline(
             conn,
             &root_dir,
+            &db_path,
             &config_json,
             &aliases_json,
             &opts_json,

--- a/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/pipeline.rs
@@ -198,11 +198,11 @@ fn early_exit_result(
     file_count: usize,
     timing: PipelineTiming,
     conn: &Connection,
-    root_dir: &str,
+    journal_dir: &str,
     metadata_updates: &[detect_changes::MetadataUpdate],
 ) -> BuildPipelineResult {
     detect_changes::heal_metadata(conn, metadata_updates);
-    journal::write_journal_header(root_dir, now_ms());
+    journal::write_journal_header(journal_dir, now_ms());
     BuildPipelineResult {
         phases: timing,
         node_count: 0,
@@ -593,10 +593,18 @@ fn run_analysis_persistence(
 
 /// Run the full build pipeline in Rust.
 ///
-/// Called from `NativeDatabase.build_graph()` via napi.
+/// Called from `NativeDatabase.build_graph()` via napi. `db_path` is the
+/// database's actual on-disk path — `self.db_path()` on the caller, already
+/// resolved from a caller-supplied `dbPath` override or the
+/// `root_dir/.codegraph/graph.db` default. The incremental-build journal
+/// must live alongside the database (`Path::new(db_path).parent()`), never
+/// unconditionally under `root_dir` — otherwise a build targeting a custom
+/// `dbPath` writes a stray `.codegraph/` into `root_dir` that the actual
+/// database never uses (#2426).
 pub fn run_pipeline(
     conn: &Connection,
     root_dir: &str,
+    db_path: &str,
     config_json: &str,
     aliases_json: &str,
     opts_json: &str,
@@ -604,6 +612,13 @@ pub fn run_pipeline(
 ) -> Result<BuildPipelineResult, String> {
     let total_start = Instant::now();
     let mut timing = PipelineTiming::default();
+
+    // The journal always travels with the database, not root_dir — see this
+    // function's doc comment (#2426).
+    let journal_dir = Path::new(db_path)
+        .parent()
+        .and_then(|p| p.to_str())
+        .unwrap_or(root_dir);
 
     // ── Stage 1: Deserialize config ────────────────────────────────────
     let t0 = Instant::now();
@@ -635,6 +650,7 @@ pub fn run_pipeline(
         &opts,
         incremental,
         force_full_rebuild,
+        journal_dir,
     );
     timing.collect_ms = t0.elapsed().as_secs_f64() * 1000.0;
 
@@ -647,6 +663,7 @@ pub fn run_pipeline(
         incremental,
         force_full_rebuild,
         scoped_rel_paths.as_ref(),
+        journal_dir,
     )?;
     timing.detect_ms = t0.elapsed().as_secs_f64() * 1000.0;
 
@@ -664,7 +681,7 @@ pub fn run_pipeline(
             collect_result.files.len(),
             timing,
             conn,
-            root_dir,
+            journal_dir,
             &change_result.metadata_updates,
         ));
     }
@@ -880,7 +897,7 @@ pub fn run_pipeline(
 
     // ── Stage 9: Finalize ──────────────────────────────────────────────
     let t0 = Instant::now();
-    let (node_count, edge_count) = finalize_build(conn, root_dir);
+    let (node_count, edge_count) = finalize_build(conn, root_dir, journal_dir);
     timing.finalize_ms = t0.elapsed().as_secs_f64() * 1000.0;
 
     // Include total time in setup for overhead accounting.
@@ -924,6 +941,7 @@ fn collect_source_files(
     opts: &BuildOpts,
     incremental: bool,
     force_full_rebuild: bool,
+    journal_dir: &str,
 ) -> collect_files::CollectResult {
     if let Some(ref scope) = opts.scope {
         // Scoped rebuild
@@ -948,7 +966,7 @@ fn collect_source_files(
         }
     } else if incremental && !force_full_rebuild {
         // Try fast collect from DB + journal
-        let journal = journal::read_journal(root_dir);
+        let journal = journal::read_journal(journal_dir);
         let has_entries =
             journal.valid && (!journal.changed.is_empty() || !journal.removed.is_empty());
 
@@ -1221,7 +1239,7 @@ fn collect_reexport_from_barrels(
 }
 
 /// Stage 9: Finalize build — persist metadata, write journal, return counts.
-fn finalize_build(conn: &Connection, root_dir: &str) -> (i64, i64) {
+fn finalize_build(conn: &Connection, root_dir: &str, journal_dir: &str) -> (i64, i64) {
     let node_count = conn
         .query_row("SELECT COUNT(*) FROM nodes", [], |row| row.get::<_, i64>(0))
         .unwrap_or(0);
@@ -1249,7 +1267,7 @@ fn finalize_build(conn: &Connection, root_dir: &str) -> (i64, i64) {
     }
 
     // Write journal header
-    journal::write_journal_header(root_dir, now_ms());
+    journal::write_journal_header(journal_dir, now_ms());
     (node_count, edge_count)
 }
 

--- a/crates/codegraph-core/src/domain/graph/builder/stages/detect_changes.rs
+++ b/crates/codegraph-core/src/domain/graph/builder/stages/detect_changes.rs
@@ -221,8 +221,9 @@ fn try_journal_tier(
     existing: &HashMap<String, FileHashRow>,
     root_dir: &str,
     removed: &[String],
+    journal_dir: &str,
 ) -> Option<ChangeResult> {
-    let journal = journal::read_journal(root_dir);
+    let journal = journal::read_journal(journal_dir);
     if !journal.valid {
         return None;
     }
@@ -1296,6 +1297,7 @@ pub fn detect_changes(
     incremental: bool,
     force_full_rebuild: bool,
     scoped_rel_paths: Option<&HashSet<String>>,
+    journal_dir: &str,
 ) -> Result<ChangeResult, String> {
     if !incremental || force_full_rebuild {
         return Ok(ChangeResult {
@@ -1345,7 +1347,7 @@ pub fn detect_changes(
     let removed = detect_removed_files(&existing, all_files, root_dir, scoped_rel_paths);
 
     // Try Tier 0 (journal) first
-    if let Some(result) = try_journal_tier(conn, &existing, root_dir, &removed) {
+    if let Some(result) = try_journal_tier(conn, &existing, root_dir, &removed, journal_dir) {
         return Ok(result);
     }
 
@@ -1377,6 +1379,49 @@ mod tests {
         let h2 = file_hash_sha256("hello world");
         assert_eq!(h1, h2);
         assert_ne!(h1, file_hash_sha256("different content"));
+    }
+
+    #[test]
+    fn try_journal_tier_reads_from_journal_dir_not_root_dir() {
+        // #2426: the journal must be read from wherever the database actually
+        // lives (journal_dir), not unconditionally from root_dir/.codegraph —
+        // this is exactly the case a caller-supplied dbPath override hits.
+        // root_dir/.codegraph is never created here, so this can only pass if
+        // try_journal_tier genuinely reads from journal_dir.
+        let root_tmp = std::env::temp_dir().join("codegraph_tjt_root");
+        let journal_tmp = std::env::temp_dir().join("codegraph_tjt_journal_elsewhere");
+        fs::create_dir_all(&root_tmp).unwrap();
+        fs::create_dir_all(&journal_tmp).unwrap();
+        fs::write(root_tmp.join("a.ts"), "hello").unwrap();
+
+        journal::write_journal_header(journal_tmp.to_str().unwrap(), 9_999_999_999_999.0);
+        let journal_file = journal_tmp.join("changes.journal");
+        let mut content = fs::read_to_string(&journal_file).unwrap();
+        content.push_str("a.ts\n");
+        fs::write(&journal_file, content).unwrap();
+
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE file_hashes (file TEXT, hash TEXT, mtime INTEGER, size INTEGER);",
+        )
+        .unwrap();
+        let existing = HashMap::new();
+
+        let result = try_journal_tier(
+            &conn,
+            &existing,
+            root_tmp.to_str().unwrap(),
+            &[],
+            journal_tmp.to_str().unwrap(),
+        );
+
+        assert!(result.is_some());
+        let result = result.unwrap();
+        assert_eq!(result.changed.len(), 1);
+        assert_eq!(result.changed[0].rel_path, "a.ts");
+
+        let _ = fs::remove_dir_all(&root_tmp);
+        let _ = fs::remove_dir_all(&journal_tmp);
     }
 
     #[test]
@@ -1437,6 +1482,7 @@ mod tests {
             true,
             false,
             None,
+            "/project/.codegraph",
         );
         assert!(result.is_err());
     }

--- a/crates/codegraph-core/src/domain/graph/journal.rs
+++ b/crates/codegraph-core/src/domain/graph/journal.rs
@@ -21,15 +21,22 @@ pub struct JournalResult {
     pub removed: Vec<String>,
 }
 
-fn journal_path(root_dir: &str) -> PathBuf {
-    Path::new(root_dir)
-        .join(".codegraph")
-        .join("changes.journal")
+fn journal_path(journal_dir: &str) -> PathBuf {
+    Path::new(journal_dir).join("changes.journal")
 }
 
 /// Read and parse the changes journal.
-pub fn read_journal(root_dir: &str) -> JournalResult {
-    let path = journal_path(root_dir);
+///
+/// `journal_dir` is the directory the journal lives in directly — normally
+/// the database's own directory (`Path::new(db_path).parent()`), NOT
+/// `root_dir`. `db_path` defaults to `root_dir/.codegraph/graph.db`, so the
+/// common case is unchanged (`root_dir/.codegraph`), but a caller-supplied
+/// `dbPath` override relocates the database — and the journal must follow
+/// it, or a build targeting a custom `dbPath` writes a stray `.codegraph/`
+/// into `root_dir` that the actual database never uses (#2426). Mirrors TS
+/// `readJournal` in `src/domain/graph/journal.ts`.
+pub fn read_journal(journal_dir: &str) -> JournalResult {
+    let path = journal_path(journal_dir);
     let content = match fs::read_to_string(&path) {
         Ok(c) => c,
         Err(_) => return JournalResult::default(),
@@ -74,13 +81,16 @@ pub fn read_journal(root_dir: &str) -> JournalResult {
 }
 
 /// Write a fresh journal header, atomically replacing the old journal.
-pub fn write_journal_header(root_dir: &str, timestamp: f64) {
-    let dir = Path::new(root_dir).join(".codegraph");
+///
+/// `journal_dir` — see `read_journal`'s doc comment: the database's own
+/// directory, not `root_dir`.
+pub fn write_journal_header(journal_dir: &str, timestamp: f64) {
+    let dir = Path::new(journal_dir);
     let path = dir.join("changes.journal");
     let tmp = dir.join("changes.journal.tmp");
 
-    if let Err(e) = fs::create_dir_all(&dir) {
-        eprintln!("Warning: failed to create .codegraph dir: {e}");
+    if let Err(e) = fs::create_dir_all(dir) {
+        eprintln!("Warning: failed to create journal dir: {e}");
         return;
     }
 
@@ -98,12 +108,12 @@ mod tests {
     #[test]
     fn round_trip_journal() {
         let tmp = std::env::temp_dir().join("codegraph_journal_test");
-        let root = tmp.to_str().unwrap();
         let dir = tmp.join(".codegraph");
+        let journal_dir = dir.to_str().unwrap();
         fs::create_dir_all(&dir).unwrap();
 
         // Write header
-        write_journal_header(root, 1700000000000.0);
+        write_journal_header(journal_dir, 1700000000000.0);
 
         // Append some entries manually
         let journal_file = dir.join("changes.journal");
@@ -113,7 +123,7 @@ mod tests {
         content.push_str("src/foo.ts\n"); // duplicate
         fs::write(&journal_file, &content).unwrap();
 
-        let result = read_journal(root);
+        let result = read_journal(journal_dir);
         assert!(result.valid);
         assert_eq!(result.timestamp, 1700000000000.0);
         assert_eq!(result.changed, vec!["src/foo.ts"]);
@@ -124,14 +134,34 @@ mod tests {
     }
 
     #[test]
+    fn round_trip_journal_in_a_dir_not_named_dot_codegraph() {
+        // #2426: a caller-supplied `dbPath` need not live under a
+        // `.codegraph`-named directory at all — the journal must follow
+        // whatever directory actually holds the database, verbatim.
+        let tmp = std::env::temp_dir().join("codegraph_journal_custom_dbpath");
+        let journal_dir = tmp.to_str().unwrap();
+        fs::create_dir_all(&tmp).unwrap();
+
+        write_journal_header(journal_dir, 1700000000000.0);
+        let journal_file = tmp.join("changes.journal");
+        assert!(journal_file.exists());
+
+        let result = read_journal(journal_dir);
+        assert!(result.valid);
+        assert_eq!(result.timestamp, 1700000000000.0);
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
     fn invalid_journal() {
         let tmp = std::env::temp_dir().join("codegraph_journal_invalid");
-        let root = tmp.to_str().unwrap();
         let dir = tmp.join(".codegraph");
+        let journal_dir = dir.to_str().unwrap();
         fs::create_dir_all(&dir).unwrap();
         fs::write(dir.join("changes.journal"), "garbage\n").unwrap();
 
-        let result = read_journal(root);
+        let result = read_journal(journal_dir);
         assert!(!result.valid);
 
         let _ = fs::remove_dir_all(&tmp);

--- a/src/domain/graph/builder/pipeline.ts
+++ b/src/domain/graph/builder/pipeline.ts
@@ -455,7 +455,10 @@ export async function buildGraph(
           )
         ) {
           info('No changes detected. Graph is up to date.');
-          writeJournalHeader(ctx.rootDir, Date.now());
+          // Alongside the database (dbPath's directory), not unconditionally
+          // under rootDir — a caller-supplied dbPath override relocates both
+          // together (#2426).
+          writeJournalHeader(path.dirname(ctx.dbPath), Date.now());
           closeDb(ctx.db);
           return;
         }

--- a/src/domain/graph/builder/stages/collect-files.ts
+++ b/src/domain/graph/builder/stages/collect-files.ts
@@ -26,7 +26,7 @@ import {
 function tryFastCollect(
   ctx: PipelineContext,
 ): { files: string[]; directories: Set<string> } | null {
-  const { db, rootDir, config } = ctx;
+  const { db, rootDir, dbPath, config } = ctx;
   const useNative = ctx.engineName === 'native' && !!ctx.nativeDb?.getCollectFilesData;
 
   // 1. Check that file_hashes table exists and has entries
@@ -48,8 +48,10 @@ function tryFastCollect(
 
   // 2. Read the journal — only use fast path when journal has entries,
   // proving the watcher was active and tracking changes. An empty-but-valid
-  // journal (no watcher) could miss file deletions.
-  const journal = readJournal(rootDir);
+  // journal (no watcher) could miss file deletions. The journal lives
+  // alongside the database (dbPath's directory), not unconditionally under
+  // rootDir — a caller-supplied dbPath override relocates both together (#2426).
+  const journal = readJournal(path.dirname(dbPath));
   if (!journal.valid) return null;
   const hasEntries =
     (journal.changed && journal.changed.length > 0) ||

--- a/src/domain/graph/builder/stages/detect-changes.ts
+++ b/src/domain/graph/builder/stages/detect-changes.ts
@@ -64,6 +64,7 @@ function getChangedFiles(
   db: BetterSqlite3Database,
   allFiles: string[],
   rootDir: string,
+  journalDir: string,
 ): ChangeResult {
   // NativeDatabase is not open during change detection (deferred to after
   // early-exit check). All queries use better-sqlite3 here.
@@ -80,7 +81,7 @@ function getChangedFiles(
   }
 
   const removed = detectRemovedFiles(existing, allFiles, rootDir);
-  const journalResult = tryJournalTier(db, existing, rootDir, removed);
+  const journalResult = tryJournalTier(db, existing, rootDir, removed, journalDir);
   if (journalResult) return journalResult;
   return mtimeAndHashTiers(existing, allFiles, rootDir, removed);
 }
@@ -108,9 +109,10 @@ function tryJournalTier(
   existing: Map<string, FileHashRow>,
   rootDir: string,
   removed: string[],
+  journalDir: string,
   precomputedMaxMtime?: number,
 ): ChangeResult | null {
-  const journal = readJournal(rootDir);
+  const journal = readJournal(journalDir);
   if (!journal.valid) return null;
 
   const latestDbMtime =
@@ -981,14 +983,17 @@ function hasEmptyAnalysisTable(db: BetterSqlite3Database, table: string): boolea
 export async function detectChanges(ctx: PipelineContext): Promise<void> {
   const start = performance.now();
   try {
-    const { db, allFiles, rootDir, incremental, forceFullRebuild, opts } = ctx;
+    const { db, allFiles, rootDir, dbPath, incremental, forceFullRebuild, opts } = ctx;
     if ((opts as Record<string, unknown>).scope) {
       handleScopedBuild(ctx);
       return;
     }
+    // The journal always travels with the database, not rootDir — see
+    // journal.ts's `readJournal` doc comment (#2426).
+    const journalDir = path.dirname(dbPath);
     const increResult =
       incremental && !forceFullRebuild
-        ? getChangedFiles(db, allFiles, rootDir)
+        ? getChangedFiles(db, allFiles, rootDir, journalDir)
         : {
             changed: allFiles.map((f): ChangedFile => ({ file: f })),
             removed: [] as string[],
@@ -1020,14 +1025,14 @@ export async function detectChanges(ctx: PipelineContext): Promise<void> {
       const ranAnalysis = await runPendingAnalysis(ctx);
       if (ranAnalysis) {
         closeDb(db);
-        writeJournalHeader(rootDir, Date.now());
+        writeJournalHeader(journalDir, Date.now());
         ctx.earlyExit = true;
         return;
       }
       healMetadata(ctx);
       info('No changes detected. Graph is up to date.');
       closeDb(db);
-      writeJournalHeader(rootDir, Date.now());
+      writeJournalHeader(journalDir, Date.now());
       ctx.earlyExit = true;
       return;
     }

--- a/src/domain/graph/builder/stages/finalize.ts
+++ b/src/domain/graph/builder/stages/finalize.ts
@@ -311,7 +311,7 @@ function runAdvisoryChecks(ctx: PipelineContext, hasEmbeddings: boolean, buildNo
 }
 
 export async function finalize(ctx: PipelineContext): Promise<void> {
-  const { allSymbols, rootDir, isFullBuild, hasEmbeddings, opts } = ctx;
+  const { allSymbols, rootDir, dbPath, isFullBuild, hasEmbeddings, opts } = ctx;
 
   const t0 = performance.now();
 
@@ -367,8 +367,9 @@ export async function finalize(ctx: PipelineContext): Promise<void> {
     closeDbPair(pair);
   }
 
-  // Write journal header after successful build
-  writeJournalHeader(rootDir, Date.now());
+  // Write journal header after successful build — alongside the database
+  // (dbPath's directory), not unconditionally under rootDir (#2426).
+  writeJournalHeader(path.dirname(dbPath), Date.now());
 
   // Skip auto-registration for incremental builds — the repo was already
   // registered during the initial full build. The dynamic import + file I/O

--- a/src/domain/graph/journal.ts
+++ b/src/domain/graph/journal.ts
@@ -204,11 +204,10 @@ function sweepStaleTmpFiles(dir: string): void {
   }
 }
 
-function withJournalLock<T>(rootDir: string, fn: () => T): T {
-  const dir = path.join(rootDir, '.codegraph');
-  fs.mkdirSync(dir, { recursive: true });
-  sweepStaleTmpFiles(dir);
-  const lockPath = path.join(dir, `${JOURNAL_FILENAME}${LOCK_SUFFIX}`);
+function withJournalLock<T>(journalDir: string, fn: () => T): T {
+  fs.mkdirSync(journalDir, { recursive: true });
+  sweepStaleTmpFiles(journalDir);
+  const lockPath = path.join(journalDir, `${JOURNAL_FILENAME}${LOCK_SUFFIX}`);
   const lock = acquireJournalLock(lockPath);
   try {
     return fn();
@@ -262,8 +261,17 @@ function parseJournalBody(lines: string[]): { changed: string[]; removed: string
   return { changed, removed };
 }
 
-export function readJournal(rootDir: string): JournalResult {
-  const journalPath = path.join(rootDir, '.codegraph', JOURNAL_FILENAME);
+/**
+ * `journalDir` is the directory the journal lives in directly — normally the
+ * database's own directory (`path.dirname(dbPath)`), NOT `rootDir`. `dbPath`
+ * defaults to `rootDir/.codegraph/graph.db`, so the common case is unchanged
+ * (`rootDir/.codegraph`), but a caller-supplied `dbPath` override relocates
+ * the database — and the journal must follow it, or a build targeting a
+ * custom `dbPath` writes a stray `.codegraph/` into `rootDir` that the
+ * actual database never uses (#2426).
+ */
+export function readJournal(journalDir: string): JournalResult {
+  const journalPath = path.join(journalDir, JOURNAL_FILENAME);
   let content: string;
   try {
     content = fs.readFileSync(journalPath, 'utf-8');
@@ -279,12 +287,13 @@ export function readJournal(rootDir: string): JournalResult {
   return { valid: true, timestamp, changed, removed };
 }
 
+/** `journalDir` — see `readJournal`'s doc comment: the database's own directory, not `rootDir`. */
 export function appendJournalEntries(
-  rootDir: string,
+  journalDir: string,
   entries: Array<{ file: string; deleted?: boolean }>,
 ): void {
-  withJournalLock(rootDir, () => {
-    const journalPath = path.join(rootDir, '.codegraph', JOURNAL_FILENAME);
+  withJournalLock(journalDir, () => {
+    const journalPath = path.join(journalDir, JOURNAL_FILENAME);
 
     if (!fs.existsSync(journalPath)) {
       fs.writeFileSync(journalPath, `${HEADER_PREFIX}0\n`);
@@ -299,9 +308,10 @@ export function appendJournalEntries(
   });
 }
 
-export function writeJournalHeader(rootDir: string, timestamp: number): void {
-  withJournalLock(rootDir, () => {
-    const journalPath = path.join(rootDir, '.codegraph', JOURNAL_FILENAME);
+/** `journalDir` — see `readJournal`'s doc comment: the database's own directory, not `rootDir`. */
+export function writeJournalHeader(journalDir: string, timestamp: number): void {
+  withJournalLock(journalDir, () => {
+    const journalPath = path.join(journalDir, JOURNAL_FILENAME);
     const tmpPath = `${journalPath}.tmp`;
 
     try {
@@ -328,14 +338,17 @@ export function writeJournalHeader(rootDir: string, timestamp: number): void {
  *
  * Writes a tmp file then renames — a crash mid-rename leaves the previous
  * journal state intact.
+ *
+ * `journalDir` — see `readJournal`'s doc comment: the database's own
+ * directory, not `rootDir`.
  */
 export function appendJournalEntriesAndStampHeader(
-  rootDir: string,
+  journalDir: string,
   entries: Array<{ file: string; deleted?: boolean }>,
   timestamp: number,
 ): void {
-  withJournalLock(rootDir, () => {
-    const journalPath = path.join(rootDir, '.codegraph', JOURNAL_FILENAME);
+  withJournalLock(journalDir, () => {
+    const journalPath = path.join(journalDir, JOURNAL_FILENAME);
     const tmpPath = `${journalPath}.tmp`;
 
     let existingBody = '';

--- a/src/domain/graph/watcher.ts
+++ b/src/domain/graph/watcher.ts
@@ -105,6 +105,7 @@ async function processPendingFiles(
   stmts: IncrementalStmts,
   engineOpts: import('../../types.js').EngineOpts,
   cache: ReturnType<typeof createParseTreeCache>,
+  journalDir: string,
 ): Promise<void> {
   const results: RebuildResult[] = [];
   for (const filePath of files) {
@@ -128,20 +129,30 @@ async function processPendingFiles(
   }
 
   if (results.length > 0) {
-    writeJournalAndChangeEvents(rootDir, results);
+    writeJournalAndChangeEvents(rootDir, journalDir, results);
   }
 
   logRebuildResults(results);
 }
 
-/** Write journal entries and change events for processed files. */
-function writeJournalAndChangeEvents(rootDir: string, updates: RebuildResult[]): void {
+/**
+ * Write incremental-build journal entries and change events for processed
+ * files. `journalDir` (the database's own directory, `path.dirname(dbPath)`,
+ * #2426) is for the incremental-build journal only — `rootDir` is still used
+ * as-is for `appendChangeEvents`' own NDJSON change-event log, an unrelated
+ * feature (`change-journal.ts`) this issue does not touch.
+ */
+function writeJournalAndChangeEvents(
+  rootDir: string,
+  journalDir: string,
+  updates: RebuildResult[],
+): void {
   const entries = updates.map((r) => ({
     file: r.file,
     deleted: r.deleted || false,
   }));
   try {
-    appendJournalEntriesAndStampHeader(rootDir, entries, Date.now());
+    appendJournalEntriesAndStampHeader(journalDir, entries, Date.now());
   } catch (e: unknown) {
     debug(`Journal write failed (non-fatal): ${(e as Error).message}`);
   }
@@ -211,6 +222,10 @@ function collectTrackedFiles(
 /** Shared watcher state passed between setup and watcher sub-functions. */
 interface WatcherContext {
   rootDir: string;
+  /** The database's actual on-disk path — the journal must live alongside
+   * it (`path.dirname(dbPath)`), not unconditionally under `rootDir`,
+   * since a caller-supplied `dbPath` override relocates both together (#2426). */
+  dbPath: string;
   db: ReturnType<typeof openDb>;
   stmts: IncrementalStmts;
   engineOpts: import('../../types.js').EngineOpts;
@@ -309,6 +324,7 @@ function setupWatcher(rootDir: string, opts: { engine?: string; dbPath?: string 
 
   return {
     rootDir,
+    dbPath,
     db,
     stmts,
     engineOpts,
@@ -333,7 +349,15 @@ function scheduleDebouncedProcess(ctx: WatcherContext): void {
       ctx.workspaceRefreshPending = false;
       refreshWorkspaceAndExportsCaches(ctx.rootDir);
     }
-    await processPendingFiles(files, ctx.db, ctx.rootDir, ctx.stmts, ctx.engineOpts, ctx.cache);
+    await processPendingFiles(
+      files,
+      ctx.db,
+      ctx.rootDir,
+      ctx.stmts,
+      ctx.engineOpts,
+      ctx.cache,
+      path.dirname(ctx.dbPath),
+    );
   }, ctx.debounceMs);
 }
 
@@ -474,7 +498,7 @@ function setupShutdownHandler(ctx: WatcherContext, cleanup: () => void): void {
     if (ctx.pending.size > 0) {
       const entries = buildFlushEntriesFromPending(ctx.rootDir, ctx.pending);
       try {
-        appendJournalEntriesAndStampHeader(ctx.rootDir, entries, Date.now());
+        appendJournalEntriesAndStampHeader(path.dirname(ctx.dbPath), entries, Date.now());
       } catch (e: unknown) {
         debug(`Journal flush on exit failed (non-fatal): ${(e as Error).message}`);
       }

--- a/tests/builder/detect-changes.test.ts
+++ b/tests/builder/detect-changes.test.ts
@@ -35,6 +35,7 @@ describe('detectChanges stage', () => {
 
     const ctx = new PipelineContext();
     ctx.rootDir = tmpDir;
+    ctx.dbPath = path.join(dbDir, 'graph.db');
     ctx.db = db;
     ctx.allFiles = [path.join(tmpDir, 'a.js')];
     ctx.opts = {};
@@ -85,6 +86,7 @@ describe('detectChanges stage', () => {
 
     const ctx = new PipelineContext();
     ctx.rootDir = dir;
+    ctx.dbPath = path.join(dbDir, 'graph.db');
     ctx.db = db;
     ctx.allFiles = [path.join(dir, 'a.js')];
     ctx.opts = {};
@@ -126,11 +128,13 @@ describe('detectChanges stage', () => {
       stat.size,
     );
 
-    // Write journal header so journal check doesn't confuse things
-    writeJournalHeader(dir, Date.now());
+    // Write journal header so journal check doesn't confuse things — the
+    // journal lives alongside the database (dbDir), not rootDir (#2426).
+    writeJournalHeader(dbDir, Date.now());
 
     const ctx = new PipelineContext();
     ctx.rootDir = dir;
+    ctx.dbPath = path.join(dbDir, 'graph.db');
     ctx.db = db;
     ctx.allFiles = [path.join(dir, 'a.js')];
     ctx.opts = {};
@@ -156,6 +160,7 @@ describe('detectChanges stage', () => {
 
     const ctx = new PipelineContext();
     ctx.rootDir = dir;
+    ctx.dbPath = path.join(dbDir, 'graph.db');
     ctx.db = db;
     ctx.allFiles = [path.join(dir, 'a.js')];
     ctx.opts = { scope: ['a.js'] };
@@ -186,6 +191,7 @@ describe('detectChanges stage', () => {
 
     const ctx = new PipelineContext();
     ctx.rootDir = dir;
+    ctx.dbPath = path.join(dbDir, 'graph.db');
     ctx.db = db;
     ctx.allFiles = [path.join(dir, 'a.js')];
     ctx.opts = {};

--- a/tests/integration/issue-2426-journal-follows-dbpath.test.ts
+++ b/tests/integration/issue-2426-journal-follows-dbpath.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Regression test for #2426: the incremental-build journal
+ * (`domain/graph/journal.ts`'s `changes.journal`) always wrote into
+ * `rootDir/.codegraph`, ignoring `buildGraph`'s `dbPath` override — so a
+ * build targeting a custom `dbPath` (e.g. a temp dir, to keep the DB out of
+ * a tracked fixture tree) still left a stray `.codegraph/` directory
+ * (containing `changes.journal` + its `.lock` file) inside `rootDir`,
+ * regardless of where the actual database ended up. This is the exact
+ * mechanism behind the stray fixture-directory `.codegraph/` dirs reported
+ * in #2415.
+ *
+ * The journal must always travel with the database: `path.dirname(dbPath)`,
+ * not unconditionally `rootDir/.codegraph`. Default behavior (no `dbPath`
+ * override) is unchanged, since `dbPath` itself defaults to
+ * `rootDir/.codegraph/graph.db`.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildGraph } from '../../src/domain/graph/builder.js';
+import type { EngineMode } from '../../src/types.js';
+
+const ENGINES: EngineMode[] = ['wasm', 'native'];
+
+function writeFixture(dir: string, files: Record<string, string>) {
+  for (const [rel, content] of Object.entries(files)) {
+    const abs = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, content);
+  }
+}
+
+describe.each(ENGINES)(
+  'incremental-build journal follows dbPath (#2426) — engine: %s',
+  (engine) => {
+    let rootDir: string;
+    let dbDir: string;
+
+    beforeAll(() => {
+      rootDir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2426-root-${engine}-`));
+      dbDir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2426-dbdir-${engine}-`));
+      writeFixture(rootDir, { 'a.ts': 'export function a() { return 1; }\n' });
+    });
+
+    afterAll(() => {
+      fs.rmSync(rootDir, { recursive: true, force: true });
+      fs.rmSync(dbDir, { recursive: true, force: true });
+    });
+
+    it('writes the journal alongside a custom dbPath, not into rootDir/.codegraph', async () => {
+      const dbPath = path.join(dbDir, 'graph.db');
+      await buildGraph(rootDir, { dbPath, incremental: true, skipRegistry: true, engine });
+
+      expect(fs.existsSync(path.join(dbDir, 'changes.journal'))).toBe(true);
+      expect(fs.existsSync(path.join(rootDir, '.codegraph'))).toBe(false);
+    });
+
+    it('an incremental no-change rebuild keeps writing the journal to the same custom directory', async () => {
+      const dbPath = path.join(dbDir, 'graph.db');
+      // Re-run with no source changes — exercises the early-exit path, which
+      // also stamps the journal header.
+      await buildGraph(rootDir, { dbPath, incremental: true, skipRegistry: true, engine });
+
+      expect(fs.existsSync(path.join(dbDir, 'changes.journal'))).toBe(true);
+      expect(fs.existsSync(path.join(rootDir, '.codegraph'))).toBe(false);
+    });
+  },
+);
+
+describe.each(ENGINES)(
+  'incremental-build journal default location is unchanged (#2426) — engine: %s',
+  (engine) => {
+    it('writes the journal under rootDir/.codegraph when dbPath is not overridden', async () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2426-default-${engine}-`));
+      try {
+        writeFixture(dir, { 'a.ts': 'export function a() { return 1; }\n' });
+        await buildGraph(dir, { incremental: true, skipRegistry: true, engine });
+
+        expect(fs.existsSync(path.join(dir, '.codegraph', 'changes.journal'))).toBe(true);
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+  },
+);

--- a/tests/unit/journal.test.ts
+++ b/tests/unit/journal.test.ts
@@ -24,49 +24,56 @@ afterAll(() => {
   if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
-function makeRoot() {
+/**
+ * Returns the directory the journal lives in directly — normally the
+ * database's own directory (`.codegraph` under a repo root by default, but
+ * every journal function takes this directory itself now, not the repo
+ * root — see #2426).
+ */
+function makeJournalDir() {
   const root = fs.mkdtempSync(path.join(tmpDir, 'root-'));
-  fs.mkdirSync(path.join(root, '.codegraph'), { recursive: true });
-  return root;
+  const journalDir = path.join(root, '.codegraph');
+  fs.mkdirSync(journalDir, { recursive: true });
+  return journalDir;
 }
 
-function journalPath(root) {
-  return path.join(root, '.codegraph', JOURNAL_FILENAME);
+function journalPath(journalDir: string) {
+  return path.join(journalDir, JOURNAL_FILENAME);
 }
 
 describe('readJournal', () => {
   it('returns { valid: false } when journal does not exist', () => {
-    const root = makeRoot();
-    const result = readJournal(root);
+    const journalDir = makeJournalDir();
+    const result = readJournal(journalDir);
     expect(result.valid).toBe(false);
   });
 
   it('returns { valid: false } for empty file', () => {
-    const root = makeRoot();
-    fs.writeFileSync(journalPath(root), '');
-    expect(readJournal(root).valid).toBe(false);
+    const journalDir = makeJournalDir();
+    fs.writeFileSync(journalPath(journalDir), '');
+    expect(readJournal(journalDir).valid).toBe(false);
   });
 
   it('returns { valid: false } for malformed header', () => {
-    const root = makeRoot();
-    fs.writeFileSync(journalPath(root), 'garbage header\nsrc/foo.js\n');
-    expect(readJournal(root).valid).toBe(false);
+    const journalDir = makeJournalDir();
+    fs.writeFileSync(journalPath(journalDir), 'garbage header\nsrc/foo.js\n');
+    expect(readJournal(journalDir).valid).toBe(false);
   });
 
   it('returns { valid: false } for invalid timestamp', () => {
-    const root = makeRoot();
-    fs.writeFileSync(journalPath(root), '# codegraph-journal v1 not-a-number\n');
-    expect(readJournal(root).valid).toBe(false);
+    const journalDir = makeJournalDir();
+    fs.writeFileSync(journalPath(journalDir), '# codegraph-journal v1 not-a-number\n');
+    expect(readJournal(journalDir).valid).toBe(false);
   });
 
   it('returns { valid: false } for zero timestamp', () => {
-    const root = makeRoot();
-    fs.writeFileSync(journalPath(root), '# codegraph-journal v1 0\n');
-    expect(readJournal(root).valid).toBe(false);
+    const journalDir = makeJournalDir();
+    fs.writeFileSync(journalPath(journalDir), '# codegraph-journal v1 0\n');
+    expect(readJournal(journalDir).valid).toBe(false);
   });
 
   it('parses valid journal with changed and removed files', () => {
-    const root = makeRoot();
+    const journalDir = makeJournalDir();
     const content = [
       '# codegraph-journal v1 1700000000000',
       'src/builder.js',
@@ -74,9 +81,9 @@ describe('readJournal', () => {
       'DELETED src/old-file.js',
       '',
     ].join('\n');
-    fs.writeFileSync(journalPath(root), content);
+    fs.writeFileSync(journalPath(journalDir), content);
 
-    const result = readJournal(root);
+    const result = readJournal(journalDir);
     expect(result.valid).toBe(true);
     expect(result.timestamp).toBe(1700000000000);
     expect(result.changed).toEqual(['src/builder.js', 'src/db.js']);
@@ -84,7 +91,7 @@ describe('readJournal', () => {
   });
 
   it('deduplicates repeated paths', () => {
-    const root = makeRoot();
+    const journalDir = makeJournalDir();
     const content = [
       '# codegraph-journal v1 1700000000000',
       'src/foo.js',
@@ -94,15 +101,15 @@ describe('readJournal', () => {
       'DELETED src/old.js',
       '',
     ].join('\n');
-    fs.writeFileSync(journalPath(root), content);
+    fs.writeFileSync(journalPath(journalDir), content);
 
-    const result = readJournal(root);
+    const result = readJournal(journalDir);
     expect(result.changed).toEqual(['src/foo.js', 'src/bar.js']);
     expect(result.removed).toEqual(['src/old.js']);
   });
 
   it('skips blank lines and comment lines', () => {
-    const root = makeRoot();
+    const journalDir = makeJournalDir();
     const content = [
       '# codegraph-journal v1 1700000000000',
       '',
@@ -111,18 +118,18 @@ describe('readJournal', () => {
       '   ',
       '',
     ].join('\n');
-    fs.writeFileSync(journalPath(root), content);
+    fs.writeFileSync(journalPath(journalDir), content);
 
-    const result = readJournal(root);
+    const result = readJournal(journalDir);
     expect(result.changed).toEqual(['src/foo.js']);
     expect(result.removed).toEqual([]);
   });
 
   it('handles file with no trailing newline', () => {
-    const root = makeRoot();
-    fs.writeFileSync(journalPath(root), '# codegraph-journal v1 1700000000000\nsrc/a.js');
+    const journalDir = makeJournalDir();
+    fs.writeFileSync(journalPath(journalDir), '# codegraph-journal v1 1700000000000\nsrc/a.js');
 
-    const result = readJournal(root);
+    const result = readJournal(journalDir);
     expect(result.valid).toBe(true);
     expect(result.changed).toEqual(['src/a.js']);
   });
@@ -130,96 +137,100 @@ describe('readJournal', () => {
 
 describe('writeJournalHeader', () => {
   it('creates journal with header only', () => {
-    const root = makeRoot();
-    writeJournalHeader(root, 1700000000000);
+    const journalDir = makeJournalDir();
+    writeJournalHeader(journalDir, 1700000000000);
 
-    const content = fs.readFileSync(journalPath(root), 'utf-8');
+    const content = fs.readFileSync(journalPath(journalDir), 'utf-8');
     expect(content).toBe('# codegraph-journal v1 1700000000000\n');
   });
 
   it('overwrites existing journal content', () => {
-    const root = makeRoot();
-    fs.writeFileSync(journalPath(root), '# codegraph-journal v1 100\nsrc/old.js\n');
-    writeJournalHeader(root, 200);
+    const journalDir = makeJournalDir();
+    fs.writeFileSync(journalPath(journalDir), '# codegraph-journal v1 100\nsrc/old.js\n');
+    writeJournalHeader(journalDir, 200);
 
-    const content = fs.readFileSync(journalPath(root), 'utf-8');
+    const content = fs.readFileSync(journalPath(journalDir), 'utf-8');
     expect(content).toBe('# codegraph-journal v1 200\n');
   });
 
-  it('creates .codegraph directory if missing', () => {
-    const root = fs.mkdtempSync(path.join(tmpDir, 'nodir-'));
-    writeJournalHeader(root, 1700000000000);
-    expect(fs.existsSync(journalPath(root))).toBe(true);
+  it('creates the journal directory if missing', () => {
+    // #2426: the passed directory need not be named `.codegraph` at all —
+    // a caller-supplied dbPath can relocate the database (and therefore the
+    // journal) anywhere.
+    const journalDir = fs.mkdtempSync(path.join(tmpDir, 'nodir-custom-dbpath-'));
+    fs.rmSync(journalDir, { recursive: true, force: true });
+    writeJournalHeader(journalDir, 1700000000000);
+    expect(fs.existsSync(journalPath(journalDir))).toBe(true);
   });
 });
 
 describe('appendJournalEntries', () => {
   it('appends changed file entries', () => {
-    const root = makeRoot();
-    writeJournalHeader(root, 1700000000000);
-    appendJournalEntries(root, [{ file: 'src/a.js' }, { file: 'src/b.js' }]);
+    const journalDir = makeJournalDir();
+    writeJournalHeader(journalDir, 1700000000000);
+    appendJournalEntries(journalDir, [{ file: 'src/a.js' }, { file: 'src/b.js' }]);
 
-    const result = readJournal(root);
+    const result = readJournal(journalDir);
     expect(result.valid).toBe(true);
     expect(result.changed).toEqual(['src/a.js', 'src/b.js']);
   });
 
   it('appends deleted file entries with DELETED prefix', () => {
-    const root = makeRoot();
-    writeJournalHeader(root, 1700000000000);
-    appendJournalEntries(root, [{ file: 'src/removed.js', deleted: true }]);
+    const journalDir = makeJournalDir();
+    writeJournalHeader(journalDir, 1700000000000);
+    appendJournalEntries(journalDir, [{ file: 'src/removed.js', deleted: true }]);
 
-    const result = readJournal(root);
+    const result = readJournal(journalDir);
     expect(result.removed).toEqual(['src/removed.js']);
   });
 
   it('creates journal with placeholder header if missing', () => {
-    const root = makeRoot();
-    appendJournalEntries(root, [{ file: 'src/a.js' }]);
+    const journalDir = makeJournalDir();
+    appendJournalEntries(journalDir, [{ file: 'src/a.js' }]);
 
     // Placeholder header has timestamp 0 → readJournal returns invalid
-    const result = readJournal(root);
+    const result = readJournal(journalDir);
     expect(result.valid).toBe(false);
 
     // But the file exists and has the entry
-    const content = fs.readFileSync(journalPath(root), 'utf-8');
+    const content = fs.readFileSync(journalPath(journalDir), 'utf-8');
     expect(content).toContain('src/a.js');
   });
 
   it('appends multiple batches', () => {
-    const root = makeRoot();
-    writeJournalHeader(root, 1700000000000);
-    appendJournalEntries(root, [{ file: 'src/a.js' }]);
-    appendJournalEntries(root, [{ file: 'src/b.js' }]);
+    const journalDir = makeJournalDir();
+    writeJournalHeader(journalDir, 1700000000000);
+    appendJournalEntries(journalDir, [{ file: 'src/a.js' }]);
+    appendJournalEntries(journalDir, [{ file: 'src/b.js' }]);
 
-    const result = readJournal(root);
+    const result = readJournal(journalDir);
     expect(result.changed).toEqual(['src/a.js', 'src/b.js']);
   });
 });
 
 describe('concurrent-append safety', () => {
   it('cleans up the .lock file after a successful append', () => {
-    const root = makeRoot();
-    writeJournalHeader(root, 1700000000000);
-    appendJournalEntries(root, [{ file: 'src/a.js' }]);
+    const journalDir = makeJournalDir();
+    writeJournalHeader(journalDir, 1700000000000);
+    appendJournalEntries(journalDir, [{ file: 'src/a.js' }]);
 
-    const lockPath = path.join(root, '.codegraph', `${JOURNAL_FILENAME}.lock`);
+    const lockPath = path.join(journalDir, `${JOURNAL_FILENAME}.lock`);
     expect(fs.existsSync(lockPath)).toBe(false);
   });
 
   it('steals a stale lock whose holder PID is dead', () => {
-    const root = makeRoot();
-    writeJournalHeader(root, 1700000000000);
+    const journalDir = makeJournalDir();
+    writeJournalHeader(journalDir, 1700000000000);
 
     // Pre-stage a lockfile with a PID that is guaranteed not to exist
     // (max 32-bit value; well above any real process).
-    const lockPath = path.join(root, '.codegraph', `${JOURNAL_FILENAME}.lock`);
+    const lockPath = path.join(journalDir, `${JOURNAL_FILENAME}.lock`);
     fs.writeFileSync(lockPath, '2147483646\n');
 
-    expect(() => appendJournalEntries(root, [{ file: 'src/a.js' }])).not.toThrow();
+    expect(() => appendJournalEntries(journalDir, [{ file: 'src/a.js' }])).not.toThrow();
     expect(fs.existsSync(lockPath)).toBe(false);
 
-    const result = readJournal(root);
+    const result = readJournal(journalDir);
     expect(result.changed).toEqual(['src/a.js']);
   });
 
@@ -232,16 +243,16 @@ describe('concurrent-append safety', () => {
     // and release it), then (3) staging a *live* lockfile that pretends to
     // belong to a different winner, and (4) making sure the previous release
     // path does not retroactively unlink it.
-    const root = makeRoot();
-    writeJournalHeader(root, 1700000000000);
+    const journalDir = makeJournalDir();
+    writeJournalHeader(journalDir, 1700000000000);
 
-    const lockPath = path.join(root, '.codegraph', `${JOURNAL_FILENAME}.lock`);
+    const lockPath = path.join(journalDir, `${JOURNAL_FILENAME}.lock`);
 
     // Stage a stale lock held by a dead PID.
     fs.writeFileSync(lockPath, '2147483646\n');
 
     // Run the real acquire/steal/release cycle.
-    appendJournalEntries(root, [{ file: 'src/a.js' }]);
+    appendJournalEntries(journalDir, [{ file: 'src/a.js' }]);
 
     // Lock should be fully released (no residual lockfile).
     expect(fs.existsSync(lockPath)).toBe(false);
@@ -258,19 +269,19 @@ describe('concurrent-append safety', () => {
   });
 
   it('produces no interleaved lines under repeated appends', () => {
-    const root = makeRoot();
-    writeJournalHeader(root, 1700000000000);
+    const journalDir = makeJournalDir();
+    writeJournalHeader(journalDir, 1700000000000);
 
     // Many small appends — every emitted line must be a complete,
     // well-formed entry (no truncated "DELETED " prefixes, no split paths).
     for (let i = 0; i < 200; i++) {
-      appendJournalEntries(root, [
+      appendJournalEntries(journalDir, [
         { file: `src/changed-${i}.js` },
         { file: `src/gone-${i}.js`, deleted: true },
       ]);
     }
 
-    const content = fs.readFileSync(path.join(root, '.codegraph', JOURNAL_FILENAME), 'utf-8');
+    const content = fs.readFileSync(path.join(journalDir, JOURNAL_FILENAME), 'utf-8');
     for (const line of content.split('\n')) {
       if (!line || line.startsWith('#')) continue;
       expect(line).toMatch(/^(DELETED src\/gone-\d+\.js|src\/changed-\d+\.js)$/);
@@ -280,12 +291,11 @@ describe('concurrent-append safety', () => {
   it('sweeps orphaned .tmp files older than the stale threshold', () => {
     // Regression for Greptile P2: crash-mid-steal leaves .codegraph/changes.journal.lock.<nonce>.tmp
     // files behind. withJournalLock should clean up stale ones (> LOCK_STALE_MS old) on entry.
-    const root = makeRoot();
-    writeJournalHeader(root, 1700000000000);
+    const journalDir = makeJournalDir();
+    writeJournalHeader(journalDir, 1700000000000);
 
-    const dir = path.join(root, '.codegraph');
-    const freshTmp = path.join(dir, `${JOURNAL_FILENAME}.lock.fresh-nonce.tmp`);
-    const staleTmp = path.join(dir, `${JOURNAL_FILENAME}.lock.stale-nonce.tmp`);
+    const freshTmp = path.join(journalDir, `${JOURNAL_FILENAME}.lock.fresh-nonce.tmp`);
+    const staleTmp = path.join(journalDir, `${JOURNAL_FILENAME}.lock.stale-nonce.tmp`);
     fs.writeFileSync(freshTmp, 'fresh');
     fs.writeFileSync(staleTmp, 'stale');
 
@@ -295,35 +305,35 @@ describe('concurrent-append safety', () => {
     fs.utimesSync(staleTmp, past, past);
 
     // Any journal write enters withJournalLock which triggers the sweep.
-    appendJournalEntries(root, [{ file: 'src/a.js' }]);
+    appendJournalEntries(journalDir, [{ file: 'src/a.js' }]);
 
     expect(fs.existsSync(staleTmp)).toBe(false);
     expect(fs.existsSync(freshTmp)).toBe(true);
 
-    // Clean up the fresh tmp so makeRoot's temp dir removal stays clean.
+    // Clean up the fresh tmp so makeJournalDir's temp dir removal stays clean.
     fs.unlinkSync(freshTmp);
   });
 });
 
 describe('appendJournalEntriesAndStampHeader', () => {
   it('creates journal with header + entries when none exists', () => {
-    const root = makeRoot();
-    appendJournalEntriesAndStampHeader(root, [{ file: 'src/a.js' }], 1700000000000);
+    const journalDir = makeJournalDir();
+    appendJournalEntriesAndStampHeader(journalDir, [{ file: 'src/a.js' }], 1700000000000);
 
-    const result = readJournal(root);
+    const result = readJournal(journalDir);
     expect(result.valid).toBe(true);
     expect(result.timestamp).toBe(1700000000000);
     expect(result.changed).toEqual(['src/a.js']);
   });
 
   it('advances the header timestamp while preserving prior entries', () => {
-    const root = makeRoot();
-    writeJournalHeader(root, 1000);
-    appendJournalEntries(root, [{ file: 'src/a.js' }, { file: 'src/b.js', deleted: true }]);
+    const journalDir = makeJournalDir();
+    writeJournalHeader(journalDir, 1000);
+    appendJournalEntries(journalDir, [{ file: 'src/a.js' }, { file: 'src/b.js', deleted: true }]);
 
-    appendJournalEntriesAndStampHeader(root, [{ file: 'src/c.js' }], 2000);
+    appendJournalEntriesAndStampHeader(journalDir, [{ file: 'src/c.js' }], 2000);
 
-    const result = readJournal(root);
+    const result = readJournal(journalDir);
     expect(result.valid).toBe(true);
     expect(result.timestamp).toBe(2000);
     expect(result.changed).toEqual(['src/a.js', 'src/c.js']);
@@ -331,27 +341,27 @@ describe('appendJournalEntriesAndStampHeader', () => {
   });
 
   it('advances the header even when no new entries are supplied', () => {
-    const root = makeRoot();
-    writeJournalHeader(root, 1000);
-    appendJournalEntries(root, [{ file: 'src/a.js' }]);
+    const journalDir = makeJournalDir();
+    writeJournalHeader(journalDir, 1000);
+    appendJournalEntries(journalDir, [{ file: 'src/a.js' }]);
 
-    appendJournalEntriesAndStampHeader(root, [], 2000);
+    appendJournalEntriesAndStampHeader(journalDir, [], 2000);
 
-    const result = readJournal(root);
+    const result = readJournal(journalDir);
     expect(result.timestamp).toBe(2000);
     expect(result.changed).toEqual(['src/a.js']);
   });
 
   it('is atomic: interleaved reads see either old or new state, never a truncated header', () => {
-    const root = makeRoot();
-    writeJournalHeader(root, 1000);
-    appendJournalEntries(root, [{ file: 'src/a.js' }]);
+    const journalDir = makeJournalDir();
+    writeJournalHeader(journalDir, 1000);
+    appendJournalEntries(journalDir, [{ file: 'src/a.js' }]);
 
-    appendJournalEntriesAndStampHeader(root, [{ file: 'src/b.js' }], 2000);
+    appendJournalEntriesAndStampHeader(journalDir, [{ file: 'src/b.js' }], 2000);
 
     // No leftover .tmp file after the rename
-    expect(fs.existsSync(`${journalPath(root)}.tmp`)).toBe(false);
-    const content = fs.readFileSync(journalPath(root), 'utf-8');
+    expect(fs.existsSync(`${journalPath(journalDir)}.tmp`)).toBe(false);
+    const content = fs.readFileSync(journalPath(journalDir), 'utf-8');
     expect(content.startsWith('# codegraph-journal v1 2000\n')).toBe(true);
   });
 });
@@ -362,15 +372,15 @@ describe('regression: watch session keeps header ahead of DB mtime', () => {
     // at T0, the watcher appends entries at T1 > T0. A later build's Tier 0
     // check compares journal.timestamp against MAX(file_hashes.mtime).
     // If the header stays at T0, Tier 0 bails out and the fast path is lost.
-    const root = makeRoot();
+    const journalDir = makeJournalDir();
 
     const buildFinalizedAt = 1000;
-    writeJournalHeader(root, buildFinalizedAt);
+    writeJournalHeader(journalDir, buildFinalizedAt);
 
     const watcherAppendAt = 2500;
-    appendJournalEntriesAndStampHeader(root, [{ file: 'src/a.js' }], watcherAppendAt);
+    appendJournalEntriesAndStampHeader(journalDir, [{ file: 'src/a.js' }], watcherAppendAt);
 
-    const journal = readJournal(root);
+    const journal = readJournal(journalDir);
     expect(journal.valid).toBe(true);
     expect(journal.timestamp).toBeGreaterThanOrEqual(watcherAppendAt);
     // latestDbMtime can never exceed the timestamp of the most recent append
@@ -382,24 +392,27 @@ describe('regression: watch session keeps header ahead of DB mtime', () => {
 
 describe('read/write/append lifecycle', () => {
   it('full lifecycle: header → append → read → new header', () => {
-    const root = makeRoot();
+    const journalDir = makeJournalDir();
 
     // Simulate build completion
-    writeJournalHeader(root, 1000);
+    writeJournalHeader(journalDir, 1000);
 
     // Simulate watcher appending changes
-    appendJournalEntries(root, [{ file: 'src/foo.js' }, { file: 'src/bar.js', deleted: true }]);
+    appendJournalEntries(journalDir, [
+      { file: 'src/foo.js' },
+      { file: 'src/bar.js', deleted: true },
+    ]);
 
     // Simulate next build reading journal
-    const journal = readJournal(root);
+    const journal = readJournal(journalDir);
     expect(journal.valid).toBe(true);
     expect(journal.timestamp).toBe(1000);
     expect(journal.changed).toEqual(['src/foo.js']);
     expect(journal.removed).toEqual(['src/bar.js']);
 
     // Build completes, reset journal
-    writeJournalHeader(root, 2000);
-    const fresh = readJournal(root);
+    writeJournalHeader(journalDir, 2000);
+    const fresh = readJournal(journalDir);
     expect(fresh.valid).toBe(true);
     expect(fresh.changed).toEqual([]);
     expect(fresh.removed).toEqual([]);


### PR DESCRIPTION
## Summary

Closes #2426.

`buildGraph(rootDir, opts)` lets callers redirect the SQLite database to an
arbitrary location via `opts.dbPath`. Only the database followed `dbPath` —
the incremental-build journal (`domain/graph/journal.ts`'s
`changes.journal` + its `.lock` file) always wrote into
`rootDir/.codegraph` regardless, since every journal function derived its
path from `rootDir` rather than `dbPath`'s directory.

This is the exact mechanism behind the stray fixture-directory
`.codegraph/` dirs reported in #2415 — the gitignore fix there hid the
symptom, but the underlying coupling was unchanged. A latent correctness
risk followed from the same gap: if the same `rootDir` were ever built
against two different non-empty `dbPath` targets across separate
invocations, an incremental build would consult a journal written in the
context of a different build's `dbPath` lineage, with no association
between the two.

## Fix

Threaded the journal's directory from `dbPath`'s directory
(`path.dirname(dbPath)` / `Path::new(db_path).parent()`) at every call
site instead of hardcoding `rootDir`, in both engines:

- `journal.ts` / `journal.rs`: functions no longer append `.codegraph`
  internally — the caller now passes the directory that should directly
  hold the journal, so a custom `dbPath` need not even live under a
  `.codegraph`-named directory.
- `collect-files.ts`, `detect-changes.ts` (×3 call sites), `finalize.ts`,
  `pipeline.ts`, `watcher.ts` (×2 call sites) — all updated to compute and
  pass the journal directory from `ctx.dbPath` instead of `ctx.rootDir`.
- Rust mirror: `pipeline.rs`'s `run_pipeline` now takes `db_path` (already
  available on `NativeDatabase` via `self.db_path()` — no new NAPI
  parameter needed), threaded to `collect_source_files`,
  `detect_changes::detect_changes` → `try_journal_tier`,
  `early_exit_result`, and `finalize_build`.

Default behavior is unchanged, since `dbPath` itself defaults to
`rootDir/.codegraph/graph.db`.

## Test plan

- [x] New dual-engine integration test
      (`tests/integration/issue-2426-journal-follows-dbpath.test.ts`)
      proving: a custom `dbPath` gets the journal alongside it (both a
      first full build and a no-change incremental rebuild), no stray
      `.codegraph/` appears in `rootDir`, and the default (no override)
      location is unchanged.
- [x] Updated `tests/unit/journal.test.ts` (27 tests) for the new
      `journalDir`-is-the-directory-itself contract, plus a new test
      proving a directory not named `.codegraph` at all still works.
- [x] Updated `tests/builder/detect-changes.test.ts`'s hand-built
      `PipelineContext` fixtures to set `ctx.dbPath` (now required to
      compute the journal directory).
- [x] New Rust unit test (`try_journal_tier_reads_from_journal_dir_not_root_dir`)
      proving the native tier reads from the database's directory, not
      `root_dir`, plus a `journal.rs` test for a non-`.codegraph`-named
      directory.
- [x] Revert-verified: temporarily reverted the fix in both engines and
      confirmed the new tests fail with the reported symptom, then
      restored.
- [x] `npm test` (5382 passed), `cargo test --lib` (1070 passed),
      `cargo clippy -- -D warnings`, `cargo fmt --check`, `npm run lint`,
      `npx tsc --noEmit` all clean.
- [x] `codegraph diff-impact --staged -T` reviewed — scope matches exactly
      the functions touched (18 functions across 9 files), no surprises.
