### PR TITLE
fix(bench): give Full build the same warmup as the other incremental metrics

### DIFF
--- a/scripts/incremental-benchmark.ts
+++ b/scripts/incremental-benchmark.ts
@@ -160,12 +160,17 @@ console.log = (...args) => console.error(...args);
 const RUNS = 5;
 const PROBE_FILE = path.join(root, 'src', 'domain', 'queries.ts');
 
-// First 1–2 incremental rebuilds per process pay a cold-start cost (rusqlite
+// First 1–2 builds/rebuilds per process pay a cold-start cost (rusqlite
 // statement-cache warmup, OS page cache for the DB file, NAPI-side static
 // init from tree-sitter's transitive crates linked into the .node binary).
 // Mirrors the WARMUP_RUNS used in scripts/query-benchmark.ts since #1077 —
 // without this, a 3-sample median includes cold-start outliers and shows
 // CI-amplified false regressions on sub-30ms metrics like No-op rebuild.
+// Full build is the FIRST buildGraph call in this worker's process lifetime,
+// so it's the metric MOST exposed to this cost (the one-time NAPI static
+// init can only ever land on a build's very first call) — #2436 traced part
+// of the gate's reported non-determinism to Full build being the one metric
+// that measured without this warmup.
 const WARMUP_RUNS = 2;
 
 // Resolution-benchmark fixtures (`BENCHMARK_EXCLUDES` in scripts/lib/bench-config.ts)
@@ -180,6 +185,10 @@ const BUILD_OPTS = { engine, exclude: [...resolveBenchmarkExcludes()] };
 console.error(`Benchmarking ${engine} engine...`);
 
 // Full build (delete DB first)
+for (let i = 0; i < WARMUP_RUNS; i++) {
+	if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
+	await buildGraph(root, { ...BUILD_OPTS, incremental: false });
+}
 const fullBuildMs = Math.round(
 	await timeMedian(async () => {
 		if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);


### PR DESCRIPTION
## Summary

Progresses #2436 (does not close it — see "What this does and doesn't
fix" below). Filed #2549 and #2550 as follow-ups for the parts of #2436
this PR doesn't address.

`scripts/incremental-benchmark.ts`'s `fullBuildMs` measured a plain median
of 5 samples with no warmup, unlike `noopRebuildMs`/`oneFileRebuildMs`,
which both run 2 warmup iterations first specifically to absorb
per-process cold-start cost (rusqlite statement-cache warmup, OS page
cache, NAPI-side static init from tree-sitter's transitive crates) before
the timed samples — see that file's own pre-existing `WARMUP_RUNS` doc
comment.

Full build is the *first* `buildGraph` call in the whole worker process's
lifetime, so it's the metric **most** exposed to this cost, not least —
the one-time NAPI static init can only ever land on a build's very first
call, and without warmup it lands inside the measured median instead of
being absorbed beforehand.

## What this does and doesn't fix

Investigating #2436 confirmed:
- Each metric already computes a median of 5 in-process samples per CI
  job — this asymmetry (`fullBuildMs` alone lacking warmup) was a real,
  confirmed, mechanical gap with a well-established fix pattern already
  used elsewhere in the same file.
- The deeper, harder problem — cross-invocation (runner-to-runner) CI
  variance, not smoothable by any in-process median however large — is
  **not** addressed by this fix. #2436's own report shows the *already
  warmed-up* 1-file-rebuild metric swinging +103% on a re-run of the exact
  same commit, which this PR cannot change.
- `scripts/benchmark.ts` (a separate benchmark surface,
  `BUILD-BENCHMARKS.md`) has an even less-protected instance of the same
  class of bug (no median, no warmup at all) — filed as #2549 rather than
  bundled in here, since it's a distinct file/surface with its own
  history/thresholds.
- The cross-invocation noise itself, and the CI-vs-local ~3x gap on
  1-file-rebuild #2436 also flags, need either infrastructure changes
  (dedicated runner) or empirical CI experimentation I can't do from a
  single local investigative pass — filed as #2550.

`tests/benchmarks/regression-guard.test.ts`'s existing `3.16.0:Full build`
/ `3.16.0:1-file rebuild` `KNOWN_REGRESSIONS` allowlist entries are left
untouched — they're tied to already-recorded (and, for Full build, now
known-unreliable) 3.16.0 baseline numbers, not to future runs.

## Test plan

- [x] Ran `scripts/incremental-benchmark.ts --version dev --dist` directly
      (both engines) end-to-end — completes cleanly, warmup runs execute
      before the measured runs as expected, output shape unchanged.
- [x] `tests/benchmarks/regression-guard.test.ts` (11 passed, 17 skipped —
      the skipped ones are gated behind `RUN_REGRESSION_GUARD=1`, CI-only)
      — unaffected, since it doesn't invoke this script directly.
- [x] `scripts/` isn't covered by `tsconfig.json`'s `include` or
      `biome.json`'s lint scope (both explicitly scoped to `src/`/`tests/`
      per this repo's own convention), so there's no separate
      typecheck/lint step for this file beyond running it directly.
