### PR TITLE
docs: fix stale references to retired entrypoint-attribution functions

### DIFF
--- a/crates/codegraph-core/src/graph/classifiers/roles.rs
+++ b/crates/codegraph-core/src/graph/classifiers/roles.rs
@@ -451,7 +451,7 @@ pub(crate) fn do_classify_full(conn: &Connection) -> rusqlite::Result<RoleSummar
         return Ok(summary);
     }
 
-    // 2b. Program-entrypoint IDs (#2392) — set by `mark_entrypoint_targets`
+    // 2b. Program-entrypoint IDs (#2392) — set by `apply_entrypoint_attribution`
     // from an extractor-flagged call site (Python's `__main__` guard and
     // `__main__.py` module level). Mirrors the `entrypoint` column read by
     // `buildClassifierInput` in features/structure.ts.

--- a/tests/integration/issue-2392-python-entrypoints.test.ts
+++ b/tests/integration/issue-2392-python-entrypoints.test.ts
@@ -245,9 +245,11 @@ describe.each(ENGINES)(
       // Greptile finding on this PR's own fix (#2425): deleting the guard's
       // *file* is a different code path than editing it — the removed file
       // is never a member of fileSymbols (the reparsed-files set
-      // markEntrypointTargets iterates), so only the detect-changes stage's
-      // pre-purge capture (clearEntrypointAttributionForRemovedFiles /
-      // clear_entrypoint_attribution_for_removed_files) can catch this.
+      // persistEntrypointCalls iterates), so its entrypoint_calls evidence
+      // row can only be cleared via the generic per-file purge
+      // (preparePurgeStmts's entrypointCalls statement, the same path every
+      // other per-file table uses for a deleted file) — projectEntrypointAttribution
+      // then re-derives the flag from whatever evidence remains, clearing it.
       const dir = fs.mkdtempSync(path.join(os.tmpdir(), `cg-2425-stale-${engine}-`));
       try {
         const guardFile = path.join(dir, 'run.py');


### PR DESCRIPTION
## Summary

Closes #2437.

#2434 retired `markEntrypointTargets`/`mark_entrypoint_targets` and
`clearEntrypointAttributionForRemovedFiles`/`clear_entrypoint_attribution_for_removed_files`
in favor of `persistEntrypointCalls` + `projectEntrypointAttribution`
(`apply_entrypoint_attribution` on the Rust side), but left two comments
pointing readers at the removed names. Verified via `grep -rn` across
`src/`, `crates/codegraph-core/src/`, `tests/` that no other references
remain besides the one in `issue-2428-watch-python-entrypoints.test.ts`'s
header, which the issue itself correctly identifies as intentional
historical context (describing the bug #2428 fixed, at the time it used
those names) and should stay as-is — left untouched.

## Fix

- `crates/codegraph-core/src/graph/classifiers/roles.rs:454` — swapped the
  retired name for the current one (`apply_entrypoint_attribution`).
- `tests/integration/issue-2392-python-entrypoints.test.ts:245-250` —
  needed more than a name swap: the comment described a dedicated
  "pre-purge capture" step for deleted guard files that the current
  evidence+projection design doesn't have. Deletion is now handled by the
  same generic per-file purge every other per-file table uses
  (`preparePurgeStmts`'s `entrypointCalls` statement), with
  `projectEntrypointAttribution` re-deriving the flag afterward. Rewrote
  the comment to describe the actual current mechanism.

## Test plan

- [x] `grep -rn` sweep across `src/`, `crates/codegraph-core/src/`,
      `tests/` confirms zero remaining references to the retired names
      outside the one intentionally-preserved historical comment.
- [x] `cargo build --lib`, `cargo fmt --check` clean.
- [x] `npx tsc --noEmit`, `npm run lint` clean.
- [x] `tests/integration/issue-2392-python-entrypoints.test.ts` (22 tests,
      both engines) still passes — comment-only change, no behavior touched.