### PR TITLE
fix(hooks): normalize $IFS/${IFS} before any guard-git.sh verb-detection check

### DIFF
--- a/.claude/hooks/guard-git.sh
+++ b/.claude/hooks/guard-git.sh
@@ -21,6 +21,8 @@ if [ -z "$COMMAND" ]; then
   exit 0
 fi
 
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 # The actual directory the Bash tool will run this command in — a top-level
 # field on every PreToolUse payload, independent of whatever cd/-C text
 # happens to appear in $COMMAND. This is what a bare `git push` (relying on
@@ -35,6 +37,25 @@ HOOK_CWD=$(echo "$INPUT" | node -e "
   });
 " 2>/dev/null) || true
 
+# Replace every $IFS/${IFS} reference with a literal space (#2451) BEFORE
+# even the fast-path filter below runs. `$IFS`/`${IFS}` (bash's own
+# whitespace field-separator variable) supplies a token boundary bash
+# expands at execution time that the command TEXT itself has no literal
+# whitespace for — `git${IFS}checkout` looks like a single token to every
+# regex in this file, including the fast-path filter's own
+# `(git|gh)[[:space:]]+` check, but bash expands the unquoted `${IFS}` to
+# whitespace before Git ever runs, so Git actually receives `checkout` as a
+# separate argument. Without this, the fast-path filter doesn't recognize
+# such a command as git/gh at all and exits 0 immediately, skipping EVERY
+# check below, not just whichever one the attacker was targeting. See
+# normalize-ifs.mjs for why this can run without any quote-awareness of its
+# own. Extraction logic below (detect_work_dir, MSG_FILE, the AI-attribution
+# scan) deliberately keeps reading the raw, unnormalized $COMMAND.
+IFS_NORM_COMMAND=$(echo "$COMMAND" | node "$HOOK_DIR/normalize-ifs.mjs" 2>/dev/null) || true
+if [ -z "$IFS_NORM_COMMAND" ]; then
+  IFS_NORM_COMMAND="$COMMAND"
+fi
+
 # Act on git and gh commands (may appear after cd "..." &&, inside a quoted
 # nested-shell invocation like `bash -c "git clean -fd"`, or inside a command
 # substitution like `"message $(git clean -fd)"` — #2099 Greptile review).
@@ -43,7 +64,7 @@ HOOK_CWD=$(echo "$INPUT" | node -e "
 # rather than exact: a false "yes" here just means the rest of the script
 # runs its checks anyway, while a false "no" would exit before ever reaching
 # them.
-if ! echo "$COMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*|["'"'"'`(])(git|gh)[[:space:]]+'; then
+if ! echo "$IFS_NORM_COMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*|["'"'"'`(])(git|gh)[[:space:]]+'; then
   exit 0
 fi
 
@@ -53,13 +74,17 @@ fi
 # awareness of shell quoting — so text that merely APPEARS inside a quoted
 # argument (e.g. `gh issue create --body "...git clean -fd..."`) matched the
 # same pattern as a real invocation and got blocked. See mask-quoted-text.mjs
-# for the masking rules. Extraction logic below (detect_work_dir, MSG_FILE,
-# the AI-attribution scan) deliberately keeps reading the raw, unmasked
-# $COMMAND — masking only feeds the verb-detection checks that use $NCOMMAND.
-HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
-MASKED_COMMAND=$(echo "$COMMAND" | node "$HOOK_DIR/mask-quoted-text.mjs" 2>/dev/null) || true
+# for the masking rules. Fed from $IFS_NORM_COMMAND (not raw $COMMAND) so
+# every downstream verb-detection check also benefits from IFS normalization
+# (#2451) without needing its own IFS-awareness — a $IFS/${IFS} that landed
+# inside a quoted span gets replaced with a space here, then blanked out
+# (along with everything else in that span) by masking anyway. Extraction
+# logic below (detect_work_dir, MSG_FILE, the AI-attribution scan)
+# deliberately keeps reading the raw, unmasked $COMMAND — masking only feeds
+# the verb-detection checks that use $NCOMMAND.
+MASKED_COMMAND=$(echo "$IFS_NORM_COMMAND" | node "$HOOK_DIR/mask-quoted-text.mjs" 2>/dev/null) || true
 if [ -z "$MASKED_COMMAND" ]; then
-  MASKED_COMMAND="$COMMAND"
+  MASKED_COMMAND="$IFS_NORM_COMMAND"
 fi
 
 # Normalize: strip `git -C "<path>"` / `git -C <path>` so downstream subcommand

--- a/.claude/hooks/normalize-ifs.mjs
+++ b/.claude/hooks/normalize-ifs.mjs
@@ -29,12 +29,35 @@
 // literal text. Bash variable-name continuation characters are
 // `[A-Za-z0-9_]`; the braced form (`${IFS}`) has no such ambiguity, since
 // `}` unambiguously ends it.
+//
+// `${IFS:0:1}`/`${IFS:1:1}`/etc. (substring expansion — Greptile review):
+// bash's field-splitting applies to the RESULT of any unquoted parameter
+// expansion, not just a bare variable reference, so `${IFS:0:1}` (which
+// extracts a single whitespace character from IFS's default value) creates
+// exactly the same token boundary as the whole-variable form. Matched
+// generically as "any `${IFS` followed by a parameter-expansion operator up
+// to the closing `}`" — `[^}]*` — rather than enumerating every specific
+// bash operator (substring `:`, pattern-trim `#`/`%`, substitution `/`,
+// case-conversion `^`/`,`, …), so this also covers forms not spelled out
+// here. Assumes IFS still holds its default value (space/tab/newline) at
+// expansion time, the same implicit assumption the whole-variable form
+// already makes — a prior `IFS=...` reassignment earlier in the same
+// command line is a materially harder problem (tracking shell state across
+// the whole line) that this regex-based heuristic guard does not attempt,
+// matching the tolerance for edge cases already accepted by
+// mask-quoted-text.mjs and guard-git.sh's other checks. Does not handle a
+// nested `${...}` inside the offset/length (`${IFS:0:${N}}`) — `[^}]*`
+// stops at the first `}` — an exotic construction with no known real-world
+// motivation for this specific bypass.
 
 let input = '';
 process.stdin.on('data', (chunk) => {
   input += chunk;
 });
 process.stdin.on('end', () => {
-  const normalized = input.replace(/\$\{IFS\}/g, ' ').replace(/\$IFS(?![A-Za-z0-9_])/g, ' ');
+  const normalized = input
+    .replace(/\$\{IFS\}/g, ' ')
+    .replace(/\$\{IFS[^A-Za-z0-9_}][^}]*\}/g, ' ')
+    .replace(/\$IFS(?![A-Za-z0-9_])/g, ' ');
   process.stdout.write(normalized);
 });

--- a/.claude/hooks/normalize-ifs.mjs
+++ b/.claude/hooks/normalize-ifs.mjs
@@ -50,16 +50,29 @@
 //   `git reset`. This also protects the WITH-length form the same way:
 //   `${IFS:5:1}` is empty too (bash returns nothing once offset alone is
 //   out of range, regardless of the requested length).
-// - LENGTH, when present, must be a non-zero digit sequence (Greptile
-//   review): `${IFS:0:0}` extracts zero characters — an EMPTY string,
-//   which an unquoted expansion contributes NOTHING from (not even a
-//   separator) — `echo git${IFS:0:0}reset` really expands to the single
-//   harmless token `gitreset`. Once OFFSET is validated as in-range, ANY
-//   non-zero LENGTH is safe to accept without also bounding its upper
-//   value: bash clamps a length that exceeds what's actually available
-//   from OFFSET to the end of the string, rather than erroring or
-//   producing something unexpected, so a too-large length still yields a
-//   non-empty (if shorter than requested) whitespace-only result.
+// - LENGTH, when present, must be a digit sequence that isn't all zeros
+//   (Greptile review): `${IFS:0:0}` extracts zero characters — an EMPTY
+//   string, which an unquoted expansion contributes NOTHING from (not
+//   even a separator) — `echo git${IFS:0:0}reset` really expands to the
+//   single harmless token `gitreset`. Once OFFSET is validated as
+//   in-range, ANY non-zero LENGTH is safe to accept without also bounding
+//   its upper value: bash clamps a length that exceeds what's actually
+//   available from OFFSET to the end of the string, rather than erroring
+//   or producing something unexpected, so a too-large length still yields
+//   a non-empty (if shorter than requested) whitespace-only result.
+//
+// OFFSET and LENGTH both tolerate leading zeros (Greptile review):
+// bash evaluates both as arithmetic expressions, so `${IFS:00}` and
+// `${IFS:0:01}` are exactly as valid as `${IFS:0}` and `${IFS:0:1}` — an
+// earlier version's exact single-digit patterns (`[0-2]`, `[1-9]\d*`)
+// missed these zero-padded spellings entirely, leaving them unnormalized
+// even though bash evaluates them identically. `0*[0-2]`/`-0*[1-3]` for
+// OFFSET and `0*[1-9]\d*` for LENGTH accept any number of leading zeros
+// (including none) ahead of the same significant digit(s) validated
+// above. This does not attempt full arithmetic-expression support (hex,
+// operators, nested expansions, `$((...))`) — a genuinely open-ended
+// problem, the same class already tracked in #2558, not a bounded,
+// concretely-named gap like leading zeros.
 //
 // `${IFS:+ }`/`${IFS+ }` (alternate-value expansion, restricted to
 // ALL-whitespace content — Greptile review): unlike substring, this
@@ -114,7 +127,7 @@ process.stdin.on('data', (chunk) => {
 process.stdin.on('end', () => {
   const normalized = input
     .replace(/\$\{IFS\}/g, ' ')
-    .replace(/\$\{IFS: *(?:[0-2]|-[1-3])(?::[1-9]\d*)?\}/g, ' ')
+    .replace(/\$\{IFS: *(?:0*[0-2]|-0*[1-3])(?::0*[1-9]\d*)?\}/g, ' ')
     .replace(/\$\{IFS:?\+[ \t]+\}/g, ' ')
     .replace(/\$IFS(?![A-Za-z0-9_])/g, ' ');
   process.stdout.write(normalized);

--- a/.claude/hooks/normalize-ifs.mjs
+++ b/.claude/hooks/normalize-ifs.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+// normalize-ifs.mjs — reads a shell command line from stdin and writes it
+// back with every $IFS/${IFS} reference replaced by a single literal space
+// (#2451). Bash's own field-splitting on an unquoted $IFS/${IFS} expansion
+// produces exactly this effect at execution time — `git${IFS}checkout`
+// looks like one token as command TEXT, but Git actually receives
+// `checkout` as a separate argument once bash expands it. Every
+// verb-detection regex in guard-git.sh (including its own top-level "is
+// this even a git/gh command" fast-path filter, which the unnormalized
+// form bypasses entirely, exiting 0 before any check runs) assumes a
+// literal space between a command verb and its arguments — this
+// normalization runs upstream of all of them so none needs its own
+// IFS-awareness.
+//
+// Deliberately not quote-aware: this runs BEFORE mask-quoted-text.mjs in
+// guard-git.sh's pipeline, so a $IFS/${IFS} that happens to sit inside a
+// quoted, inert string gets replaced with a space here but is then blanked
+// out (along with everything else in that quoted span) by masking anyway —
+// the two passes compose correctly without this script needing its own
+// quote-tracking. A $IFS/${IFS} inside a command-substitution span
+// (`$(...)`/backticks) is left exactly as normalized here, since masking
+// deliberately copies those spans through verbatim — they execute
+// unconditionally in real bash, so IFS-driven splitting genuinely applies
+// there too.
+//
+// The bare `$IFS` form must not swallow the start of a longer variable
+// name — `$IFSOMETHING` references a completely different (and almost
+// certainly unset, hence empty-expanding) variable, not `$IFS` followed by
+// literal text. Bash variable-name continuation characters are
+// `[A-Za-z0-9_]`; the braced form (`${IFS}`) has no such ambiguity, since
+// `}` unambiguously ends it.
+
+let input = '';
+process.stdin.on('data', (chunk) => {
+  input += chunk;
+});
+process.stdin.on('end', () => {
+  const normalized = input.replace(/\$\{IFS\}/g, ' ').replace(/\$IFS(?![A-Za-z0-9_])/g, ' ');
+  process.stdout.write(normalized);
+});

--- a/.claude/hooks/normalize-ifs.mjs
+++ b/.claude/hooks/normalize-ifs.mjs
@@ -74,6 +74,14 @@
 // problem, the same class already tracked in #2558, not a bounded,
 // concretely-named gap like leading zeros.
 //
+// `-0`/`-00`/etc. (negative zero — Greptile review): integers have no
+// signed zero, so bash evaluates `-0` to the same value as `0` — offset
+// `-0` is offset `0` FROM THE START (valid, non-empty), NOT "0 characters
+// before the end" the way `-1`/`-2`/`-3` are. `-0*[1-3]` requires a
+// non-zero digit after the leading zeros, so it correctly does not match
+// a run of ALL zeros after the minus sign — matched separately here via
+// `-0+` (a literal minus followed by one or more zeros and nothing else).
+//
 // `${IFS:+ }`/`${IFS+ }` (alternate-value expansion, restricted to
 // ALL-whitespace content — Greptile review): unlike substring, this
 // operator does NOT extract from IFS's own value at all — it substitutes
@@ -127,7 +135,7 @@ process.stdin.on('data', (chunk) => {
 process.stdin.on('end', () => {
   const normalized = input
     .replace(/\$\{IFS\}/g, ' ')
-    .replace(/\$\{IFS: *(?:0*[0-2]|-0*[1-3])(?::0*[1-9]\d*)?\}/g, ' ')
+    .replace(/\$\{IFS: *(?:0*[0-2]|-0*[1-3]|-0+)(?::0*[1-9]\d*)?\}/g, ' ')
     .replace(/\$\{IFS:?\+[ \t]+\}/g, ' ')
     .replace(/\$IFS(?![A-Za-z0-9_])/g, ' ');
   process.stdout.write(normalized);

--- a/.claude/hooks/normalize-ifs.mjs
+++ b/.claude/hooks/normalize-ifs.mjs
@@ -34,36 +34,61 @@
 // bash's field-splitting applies to the RESULT of any unquoted parameter
 // expansion, not just a bare variable reference, so `${IFS:0:1}` (which
 // extracts a single whitespace character from IFS's default value) creates
-// exactly the same token boundary as the whole-variable form.
+// exactly the same token boundary as the whole-variable form. The LENGTH
+// portion must be a non-zero digit sequence (Greptile review):
+// `${IFS:0:0}` extracts zero characters — an EMPTY string, which an
+// unquoted expansion contributes NOTHING from (not even a separator) —
+// `echo git${IFS:0:0}reset` really expands to the single harmless token
+// `gitreset`, not `git reset`.
 //
-// Deliberately scoped to ONLY the substring form (`${IFS:offset}` /
-// `${IFS:offset:length}`, offset/length optionally negative, digits only —
-// not general arithmetic expressions), not "any `${IFS<operator>...}`"
-// generically: an earlier version of this normalizer tried the generic
-// form and was wrong (Greptile review) — several other bash operators that
-// also start with `${IFS` do NOT extract a value derived from IFS's own
-// characters at all, they use IFS's set/unset/null STATE as a condition and
-// substitute a completely arbitrary, attacker-chosen alternate string
-// instead: `${IFS:+word}`/`${IFS+word}` (substitute `word` when IFS IS set
-// and non-null — the normally-true case, so `word` is what actually comes
-// out), `${IFS/pattern/replacement}` (substitutes `replacement` wherever
-// `pattern` matches within IFS's value), and the bash 4.4+ `${IFS@Q}`-style
+// `${IFS:+ }`/`${IFS+ }` (alternate-value expansion, restricted to
+// ALL-whitespace content — Greptile review): unlike substring, this
+// operator does NOT extract from IFS's own value at all — it substitutes
+// an entirely separate, attacker-chosen string `word` whenever IFS IS set
+// and non-null (`:+`) or merely set (`+`), which normally means `word` is
+// what actually comes out, not IFS's value. Because of that, this is
+// matched ONLY when `word` consists of one or more spaces/tabs and
+// NOTHING else — `${IFS:+ }` really does expand to a literal space
+// (`word` itself, not derived from IFS), so it's exactly as safe to
+// normalize as the whole-variable form; `${IFS:+x}` is not touched, since
+// `x` is not whitespace and substituting a space for it would fabricate a
+// token boundary bash never produces (an earlier version of this
+// normalizer treated the operator as unconditionally unsafe and missed
+// this whitespace-content special case — Greptile review).
+//
+// Deliberately does NOT generalize to "any `${IFS<operator>...}`": an
+// earlier version tried that and was wrong (Greptile review) —
+// `${IFS/pattern/replacement}` (substitutes `replacement` wherever
+// `pattern` matches within IFS's value) and the bash 4.4+ `${IFS@Q}`-style
 // transformation operators (e.g. `@Q` shell-quotes the value, producing
-// `$' \t\n'`-shaped text, not plain whitespace). `echo git${IFS:+x}reset`
-// really expands to the single harmless token `gitxreset` in real bash, but
-// the generic form wrongly rewrote it to `git reset`, fabricating a git
-// invocation out of an `echo` argument. Rather than trying to enumerate
-// every operator that IS safe (`:-`, `-`, `:=`, `=`, `:?`, `?`, `#`, `##`,
-// `%`, `%%`, `^`, `^^`, `,`, `,,` all still yield IFS's own characters,
-// assuming it wasn't reassigned first — see below) and risk missing
-// another unsafe one, this stays narrowly scoped to the ONE form that's
-// been concretely demonstrated as exploitable and is provably always
-// whitespace-only: a substring of IFS's own value can never contain a
-// character IFS's value didn't already have.
+// `$' \t\n'`-shaped text) can ALSO produce arbitrary non-whitespace text,
+// the same class of problem `:+`/`+` have — and unlike `:+`/`+`, there is
+// no simple "restrict to all-whitespace content" fix for them, since
+// `pattern`/`replacement ` are two separate, differently-shaped fields.
+// Left unhandled rather than risk another incorrect generalization; a
+// determined obfuscator using one of these is a known, accepted gap in
+// this heuristic guard (see #2558 for tracking the closely related,
+// broader problem that `:+`/`+` with all-whitespace content isn't even
+// unique to the `IFS` name — `${HOME:+ }`/`${PWD:+ }`/any other normally-set
+// variable works identically, which a per-variable-name normalizer like
+// this one can never fully close).
+//
+// Also does not attempt to detect an out-of-range substring OFFSET with no
+// explicit length (`${IFS:3}` — offset 3 is at the end of the 3-character
+// default IFS value, so this is ALSO empty, the same problem as an
+// explicit zero length) — narrower and easier to get precisely right than
+// modeling every offset/length combination against IFS's exact default
+// length, and not the concrete form named in review.
+//
+// The bare `$IFS` form must not swallow the start of a longer variable
+// name — `$IFSOMETHING` references a completely different (and almost
+// certainly unset, hence empty-expanding) variable, not `$IFS` followed by
+// literal text. Bash variable-name continuation characters are
+// `[A-Za-z0-9_]`; the braced forms have no such ambiguity, since a
+// non-identifier operator character or `}` unambiguously ends the name.
 //
 // Assumes IFS still holds its default value (space/tab/newline) at
-// expansion time, the same implicit assumption the whole-variable form
-// already makes — a prior `IFS=...` reassignment earlier in the same
+// expansion time — a prior `IFS=...` reassignment earlier in the same
 // command line is a materially harder problem (tracking shell state across
 // the whole line) that this regex-based heuristic guard does not attempt,
 // matching the tolerance for edge cases already accepted by
@@ -76,7 +101,8 @@ process.stdin.on('data', (chunk) => {
 process.stdin.on('end', () => {
   const normalized = input
     .replace(/\$\{IFS\}/g, ' ')
-    .replace(/\$\{IFS: *-?\d+(: *-?\d+)?\}/g, ' ')
+    .replace(/\$\{IFS: *-?\d+(: *-?[1-9]\d*)?\}/g, ' ')
+    .replace(/\$\{IFS:?\+[ \t]+\}/g, ' ')
     .replace(/\$IFS(?![A-Za-z0-9_])/g, ' ');
   process.stdout.write(normalized);
 });

--- a/.claude/hooks/normalize-ifs.mjs
+++ b/.claude/hooks/normalize-ifs.mjs
@@ -34,21 +34,40 @@
 // bash's field-splitting applies to the RESULT of any unquoted parameter
 // expansion, not just a bare variable reference, so `${IFS:0:1}` (which
 // extracts a single whitespace character from IFS's default value) creates
-// exactly the same token boundary as the whole-variable form. Matched
-// generically as "any `${IFS` followed by a parameter-expansion operator up
-// to the closing `}`" — `[^}]*` — rather than enumerating every specific
-// bash operator (substring `:`, pattern-trim `#`/`%`, substitution `/`,
-// case-conversion `^`/`,`, …), so this also covers forms not spelled out
-// here. Assumes IFS still holds its default value (space/tab/newline) at
+// exactly the same token boundary as the whole-variable form.
+//
+// Deliberately scoped to ONLY the substring form (`${IFS:offset}` /
+// `${IFS:offset:length}`, offset/length optionally negative, digits only —
+// not general arithmetic expressions), not "any `${IFS<operator>...}`"
+// generically: an earlier version of this normalizer tried the generic
+// form and was wrong (Greptile review) — several other bash operators that
+// also start with `${IFS` do NOT extract a value derived from IFS's own
+// characters at all, they use IFS's set/unset/null STATE as a condition and
+// substitute a completely arbitrary, attacker-chosen alternate string
+// instead: `${IFS:+word}`/`${IFS+word}` (substitute `word` when IFS IS set
+// and non-null — the normally-true case, so `word` is what actually comes
+// out), `${IFS/pattern/replacement}` (substitutes `replacement` wherever
+// `pattern` matches within IFS's value), and the bash 4.4+ `${IFS@Q}`-style
+// transformation operators (e.g. `@Q` shell-quotes the value, producing
+// `$' \t\n'`-shaped text, not plain whitespace). `echo git${IFS:+x}reset`
+// really expands to the single harmless token `gitxreset` in real bash, but
+// the generic form wrongly rewrote it to `git reset`, fabricating a git
+// invocation out of an `echo` argument. Rather than trying to enumerate
+// every operator that IS safe (`:-`, `-`, `:=`, `=`, `:?`, `?`, `#`, `##`,
+// `%`, `%%`, `^`, `^^`, `,`, `,,` all still yield IFS's own characters,
+// assuming it wasn't reassigned first — see below) and risk missing
+// another unsafe one, this stays narrowly scoped to the ONE form that's
+// been concretely demonstrated as exploitable and is provably always
+// whitespace-only: a substring of IFS's own value can never contain a
+// character IFS's value didn't already have.
+//
+// Assumes IFS still holds its default value (space/tab/newline) at
 // expansion time, the same implicit assumption the whole-variable form
 // already makes — a prior `IFS=...` reassignment earlier in the same
 // command line is a materially harder problem (tracking shell state across
 // the whole line) that this regex-based heuristic guard does not attempt,
 // matching the tolerance for edge cases already accepted by
-// mask-quoted-text.mjs and guard-git.sh's other checks. Does not handle a
-// nested `${...}` inside the offset/length (`${IFS:0:${N}}`) — `[^}]*`
-// stops at the first `}` — an exotic construction with no known real-world
-// motivation for this specific bypass.
+// mask-quoted-text.mjs and guard-git.sh's other checks.
 
 let input = '';
 process.stdin.on('data', (chunk) => {
@@ -57,7 +76,7 @@ process.stdin.on('data', (chunk) => {
 process.stdin.on('end', () => {
   const normalized = input
     .replace(/\$\{IFS\}/g, ' ')
-    .replace(/\$\{IFS[^A-Za-z0-9_}][^}]*\}/g, ' ')
+    .replace(/\$\{IFS: *-?\d+(: *-?\d+)?\}/g, ' ')
     .replace(/\$IFS(?![A-Za-z0-9_])/g, ' ');
   process.stdout.write(normalized);
 });

--- a/.claude/hooks/normalize-ifs.mjs
+++ b/.claude/hooks/normalize-ifs.mjs
@@ -34,12 +34,32 @@
 // bash's field-splitting applies to the RESULT of any unquoted parameter
 // expansion, not just a bare variable reference, so `${IFS:0:1}` (which
 // extracts a single whitespace character from IFS's default value) creates
-// exactly the same token boundary as the whole-variable form. The LENGTH
-// portion must be a non-zero digit sequence (Greptile review):
-// `${IFS:0:0}` extracts zero characters — an EMPTY string, which an
-// unquoted expansion contributes NOTHING from (not even a separator) —
-// `echo git${IFS:0:0}reset` really expands to the single harmless token
-// `gitreset`, not `git reset`.
+// exactly the same token boundary as the whole-variable form.
+//
+// Both OFFSET and LENGTH are constrained to the exact values that are
+// PROVABLY non-empty against IFS's 3-character default value
+// (space/tab/newline), rather than accepting any digit sequence:
+//
+// - OFFSET is restricted to `0`/`1`/`2` (from the start) or `-1`/`-2`/`-3`
+//   (from the end) — the only positions that exist within a 3-character
+//   string. `${IFS:3}` (Greptile review) starts extraction AT the end of
+//   the string — bash's substring expansion returns EMPTY once offset is
+//   at or past the string's length, the same "empty, not whitespace"
+//   problem as an explicit zero length below — `echo git${IFS:3}reset`
+//   really expands to the single harmless token `gitreset`, not
+//   `git reset`. This also protects the WITH-length form the same way:
+//   `${IFS:5:1}` is empty too (bash returns nothing once offset alone is
+//   out of range, regardless of the requested length).
+// - LENGTH, when present, must be a non-zero digit sequence (Greptile
+//   review): `${IFS:0:0}` extracts zero characters — an EMPTY string,
+//   which an unquoted expansion contributes NOTHING from (not even a
+//   separator) — `echo git${IFS:0:0}reset` really expands to the single
+//   harmless token `gitreset`. Once OFFSET is validated as in-range, ANY
+//   non-zero LENGTH is safe to accept without also bounding its upper
+//   value: bash clamps a length that exceeds what's actually available
+//   from OFFSET to the end of the string, rather than erroring or
+//   producing something unexpected, so a too-large length still yields a
+//   non-empty (if shorter than requested) whitespace-only result.
 //
 // `${IFS:+ }`/`${IFS+ }` (alternate-value expansion, restricted to
 // ALL-whitespace content — Greptile review): unlike substring, this
@@ -73,13 +93,6 @@
 // variable works identically, which a per-variable-name normalizer like
 // this one can never fully close).
 //
-// Also does not attempt to detect an out-of-range substring OFFSET with no
-// explicit length (`${IFS:3}` — offset 3 is at the end of the 3-character
-// default IFS value, so this is ALSO empty, the same problem as an
-// explicit zero length) — narrower and easier to get precisely right than
-// modeling every offset/length combination against IFS's exact default
-// length, and not the concrete form named in review.
-//
 // The bare `$IFS` form must not swallow the start of a longer variable
 // name — `$IFSOMETHING` references a completely different (and almost
 // certainly unset, hence empty-expanding) variable, not `$IFS` followed by
@@ -101,7 +114,7 @@ process.stdin.on('data', (chunk) => {
 process.stdin.on('end', () => {
   const normalized = input
     .replace(/\$\{IFS\}/g, ' ')
-    .replace(/\$\{IFS: *-?\d+(: *-?[1-9]\d*)?\}/g, ' ')
+    .replace(/\$\{IFS: *(?:[0-2]|-[1-3])(?::[1-9]\d*)?\}/g, ' ')
     .replace(/\$\{IFS:?\+[ \t]+\}/g, ' ')
     .replace(/\$IFS(?![A-Za-z0-9_])/g, ' ');
   process.stdout.write(normalized);

--- a/docs/examples/claude-code-hooks/README.md
+++ b/docs/examples/claude-code-hooks/README.md
@@ -9,6 +9,7 @@ Ready-to-use [Claude Code hooks](https://docs.anthropic.com/en/docs/claude-code/
 mkdir -p .claude/hooks
 cp docs/examples/claude-code-hooks/*.sh .claude/hooks/
 cp docs/examples/claude-code-hooks/*.js .claude/hooks/
+cp docs/examples/claude-code-hooks/*.mjs .claude/hooks/
 chmod +x .claude/hooks/*.sh
 
 # 2. Copy settings (or merge into your existing .claude/settings.json)

--- a/docs/examples/claude-code-hooks/README.md
+++ b/docs/examples/claude-code-hooks/README.md
@@ -46,7 +46,7 @@ If an instruction matters, make it a blocking hook. If it's in CLAUDE.md but not
 
 | Hook | Trigger | What it does |
 |------|---------|-------------|
-| `guard-git.sh` (+ `mask-quoted-text.mjs`, `check-git-clean-force.mjs`) | PreToolUse on Bash | Blocks `git add .`, `git reset`, `git restore`, a force-deleting `git clean` (dry-run is allowed), `git stash`; blocks AI attribution in commit messages; validates branch names and that commits only include files the session actually edited |
+| `guard-git.sh` (+ `mask-quoted-text.mjs`, `check-git-clean-force.mjs`, `normalize-ifs.mjs`) | PreToolUse on Bash | Blocks `git add .`, `git reset`, `git restore`, a force-deleting `git clean` (dry-run is allowed), `git stash`; blocks AI attribution in commit messages; validates branch names and that commits only include files the session actually edited |
 | `track-edits.sh` | PostToolUse on Edit/Write | Logs every file edited to `.claude/session-edits.log` — required by guard-git.sh and pre-commit.sh |
 | `track-moves.sh` | PostToolUse on Bash | Logs files affected by `mv`/`git mv`/`cp` to the edit log |
 
@@ -80,7 +80,7 @@ All session-local state files (`session-edits.log`) use `git rev-parse --show-to
 
 **Branch name validation:** `guard-git.sh` validates branch names against conventional prefixes (`feat/`, `fix/`, etc.) on `git push` and `gh pr create`. Adjust the `PATTERN` in `validate_branch_name` if your project uses different conventions.
 
-**Kept in sync automatically:** `guard-git.sh` and its two companion scripts (`mask-quoted-text.mjs`, `check-git-clean-force.mjs`) here are exact copies of this repo's own `.claude/hooks/` — a test (`tests/unit/hook-guard-git-clean.test.ts`) fails CI if they ever diverge, so this example always reflects the live hook's actual behavior instead of drifting into a stale, partial snapshot (#2105).
+**Kept in sync automatically:** `guard-git.sh` and its companion scripts (`mask-quoted-text.mjs`, `check-git-clean-force.mjs`, `normalize-ifs.mjs`) here are exact copies of this repo's own `.claude/hooks/` — a test (`tests/unit/hook-guard-git-clean.test.ts`) fails CI if they ever diverge, so this example always reflects the live hook's actual behavior instead of drifting into a stale, partial snapshot (#2105).
 
 ## Incremental build freshness
 

--- a/docs/examples/claude-code-hooks/guard-git.sh
+++ b/docs/examples/claude-code-hooks/guard-git.sh
@@ -21,6 +21,8 @@ if [ -z "$COMMAND" ]; then
   exit 0
 fi
 
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 # The actual directory the Bash tool will run this command in — a top-level
 # field on every PreToolUse payload, independent of whatever cd/-C text
 # happens to appear in $COMMAND. This is what a bare `git push` (relying on
@@ -35,6 +37,25 @@ HOOK_CWD=$(echo "$INPUT" | node -e "
   });
 " 2>/dev/null) || true
 
+# Replace every $IFS/${IFS} reference with a literal space (#2451) BEFORE
+# even the fast-path filter below runs. `$IFS`/`${IFS}` (bash's own
+# whitespace field-separator variable) supplies a token boundary bash
+# expands at execution time that the command TEXT itself has no literal
+# whitespace for — `git${IFS}checkout` looks like a single token to every
+# regex in this file, including the fast-path filter's own
+# `(git|gh)[[:space:]]+` check, but bash expands the unquoted `${IFS}` to
+# whitespace before Git ever runs, so Git actually receives `checkout` as a
+# separate argument. Without this, the fast-path filter doesn't recognize
+# such a command as git/gh at all and exits 0 immediately, skipping EVERY
+# check below, not just whichever one the attacker was targeting. See
+# normalize-ifs.mjs for why this can run without any quote-awareness of its
+# own. Extraction logic below (detect_work_dir, MSG_FILE, the AI-attribution
+# scan) deliberately keeps reading the raw, unnormalized $COMMAND.
+IFS_NORM_COMMAND=$(echo "$COMMAND" | node "$HOOK_DIR/normalize-ifs.mjs" 2>/dev/null) || true
+if [ -z "$IFS_NORM_COMMAND" ]; then
+  IFS_NORM_COMMAND="$COMMAND"
+fi
+
 # Act on git and gh commands (may appear after cd "..." &&, inside a quoted
 # nested-shell invocation like `bash -c "git clean -fd"`, or inside a command
 # substitution like `"message $(git clean -fd)"` — #2099 Greptile review).
@@ -43,7 +64,7 @@ HOOK_CWD=$(echo "$INPUT" | node -e "
 # rather than exact: a false "yes" here just means the rest of the script
 # runs its checks anyway, while a false "no" would exit before ever reaching
 # them.
-if ! echo "$COMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*|["'"'"'`(])(git|gh)[[:space:]]+'; then
+if ! echo "$IFS_NORM_COMMAND" | grep -qE '(^|[[:space:]]|&&[[:space:]]*|["'"'"'`(])(git|gh)[[:space:]]+'; then
   exit 0
 fi
 
@@ -53,13 +74,17 @@ fi
 # awareness of shell quoting — so text that merely APPEARS inside a quoted
 # argument (e.g. `gh issue create --body "...git clean -fd..."`) matched the
 # same pattern as a real invocation and got blocked. See mask-quoted-text.mjs
-# for the masking rules. Extraction logic below (detect_work_dir, MSG_FILE,
-# the AI-attribution scan) deliberately keeps reading the raw, unmasked
-# $COMMAND — masking only feeds the verb-detection checks that use $NCOMMAND.
-HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
-MASKED_COMMAND=$(echo "$COMMAND" | node "$HOOK_DIR/mask-quoted-text.mjs" 2>/dev/null) || true
+# for the masking rules. Fed from $IFS_NORM_COMMAND (not raw $COMMAND) so
+# every downstream verb-detection check also benefits from IFS normalization
+# (#2451) without needing its own IFS-awareness — a $IFS/${IFS} that landed
+# inside a quoted span gets replaced with a space here, then blanked out
+# (along with everything else in that span) by masking anyway. Extraction
+# logic below (detect_work_dir, MSG_FILE, the AI-attribution scan)
+# deliberately keeps reading the raw, unmasked $COMMAND — masking only feeds
+# the verb-detection checks that use $NCOMMAND.
+MASKED_COMMAND=$(echo "$IFS_NORM_COMMAND" | node "$HOOK_DIR/mask-quoted-text.mjs" 2>/dev/null) || true
 if [ -z "$MASKED_COMMAND" ]; then
-  MASKED_COMMAND="$COMMAND"
+  MASKED_COMMAND="$IFS_NORM_COMMAND"
 fi
 
 # Normalize: strip `git -C "<path>"` / `git -C <path>` so downstream subcommand

--- a/docs/examples/claude-code-hooks/normalize-ifs.mjs
+++ b/docs/examples/claude-code-hooks/normalize-ifs.mjs
@@ -29,12 +29,35 @@
 // literal text. Bash variable-name continuation characters are
 // `[A-Za-z0-9_]`; the braced form (`${IFS}`) has no such ambiguity, since
 // `}` unambiguously ends it.
+//
+// `${IFS:0:1}`/`${IFS:1:1}`/etc. (substring expansion — Greptile review):
+// bash's field-splitting applies to the RESULT of any unquoted parameter
+// expansion, not just a bare variable reference, so `${IFS:0:1}` (which
+// extracts a single whitespace character from IFS's default value) creates
+// exactly the same token boundary as the whole-variable form. Matched
+// generically as "any `${IFS` followed by a parameter-expansion operator up
+// to the closing `}`" — `[^}]*` — rather than enumerating every specific
+// bash operator (substring `:`, pattern-trim `#`/`%`, substitution `/`,
+// case-conversion `^`/`,`, …), so this also covers forms not spelled out
+// here. Assumes IFS still holds its default value (space/tab/newline) at
+// expansion time, the same implicit assumption the whole-variable form
+// already makes — a prior `IFS=...` reassignment earlier in the same
+// command line is a materially harder problem (tracking shell state across
+// the whole line) that this regex-based heuristic guard does not attempt,
+// matching the tolerance for edge cases already accepted by
+// mask-quoted-text.mjs and guard-git.sh's other checks. Does not handle a
+// nested `${...}` inside the offset/length (`${IFS:0:${N}}`) — `[^}]*`
+// stops at the first `}` — an exotic construction with no known real-world
+// motivation for this specific bypass.
 
 let input = '';
 process.stdin.on('data', (chunk) => {
   input += chunk;
 });
 process.stdin.on('end', () => {
-  const normalized = input.replace(/\$\{IFS\}/g, ' ').replace(/\$IFS(?![A-Za-z0-9_])/g, ' ');
+  const normalized = input
+    .replace(/\$\{IFS\}/g, ' ')
+    .replace(/\$\{IFS[^A-Za-z0-9_}][^}]*\}/g, ' ')
+    .replace(/\$IFS(?![A-Za-z0-9_])/g, ' ');
   process.stdout.write(normalized);
 });

--- a/docs/examples/claude-code-hooks/normalize-ifs.mjs
+++ b/docs/examples/claude-code-hooks/normalize-ifs.mjs
@@ -50,16 +50,29 @@
 //   `git reset`. This also protects the WITH-length form the same way:
 //   `${IFS:5:1}` is empty too (bash returns nothing once offset alone is
 //   out of range, regardless of the requested length).
-// - LENGTH, when present, must be a non-zero digit sequence (Greptile
-//   review): `${IFS:0:0}` extracts zero characters — an EMPTY string,
-//   which an unquoted expansion contributes NOTHING from (not even a
-//   separator) — `echo git${IFS:0:0}reset` really expands to the single
-//   harmless token `gitreset`. Once OFFSET is validated as in-range, ANY
-//   non-zero LENGTH is safe to accept without also bounding its upper
-//   value: bash clamps a length that exceeds what's actually available
-//   from OFFSET to the end of the string, rather than erroring or
-//   producing something unexpected, so a too-large length still yields a
-//   non-empty (if shorter than requested) whitespace-only result.
+// - LENGTH, when present, must be a digit sequence that isn't all zeros
+//   (Greptile review): `${IFS:0:0}` extracts zero characters — an EMPTY
+//   string, which an unquoted expansion contributes NOTHING from (not
+//   even a separator) — `echo git${IFS:0:0}reset` really expands to the
+//   single harmless token `gitreset`. Once OFFSET is validated as
+//   in-range, ANY non-zero LENGTH is safe to accept without also bounding
+//   its upper value: bash clamps a length that exceeds what's actually
+//   available from OFFSET to the end of the string, rather than erroring
+//   or producing something unexpected, so a too-large length still yields
+//   a non-empty (if shorter than requested) whitespace-only result.
+//
+// OFFSET and LENGTH both tolerate leading zeros (Greptile review):
+// bash evaluates both as arithmetic expressions, so `${IFS:00}` and
+// `${IFS:0:01}` are exactly as valid as `${IFS:0}` and `${IFS:0:1}` — an
+// earlier version's exact single-digit patterns (`[0-2]`, `[1-9]\d*`)
+// missed these zero-padded spellings entirely, leaving them unnormalized
+// even though bash evaluates them identically. `0*[0-2]`/`-0*[1-3]` for
+// OFFSET and `0*[1-9]\d*` for LENGTH accept any number of leading zeros
+// (including none) ahead of the same significant digit(s) validated
+// above. This does not attempt full arithmetic-expression support (hex,
+// operators, nested expansions, `$((...))`) — a genuinely open-ended
+// problem, the same class already tracked in #2558, not a bounded,
+// concretely-named gap like leading zeros.
 //
 // `${IFS:+ }`/`${IFS+ }` (alternate-value expansion, restricted to
 // ALL-whitespace content — Greptile review): unlike substring, this
@@ -114,7 +127,7 @@ process.stdin.on('data', (chunk) => {
 process.stdin.on('end', () => {
   const normalized = input
     .replace(/\$\{IFS\}/g, ' ')
-    .replace(/\$\{IFS: *(?:[0-2]|-[1-3])(?::[1-9]\d*)?\}/g, ' ')
+    .replace(/\$\{IFS: *(?:0*[0-2]|-0*[1-3])(?::0*[1-9]\d*)?\}/g, ' ')
     .replace(/\$\{IFS:?\+[ \t]+\}/g, ' ')
     .replace(/\$IFS(?![A-Za-z0-9_])/g, ' ');
   process.stdout.write(normalized);

--- a/docs/examples/claude-code-hooks/normalize-ifs.mjs
+++ b/docs/examples/claude-code-hooks/normalize-ifs.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+// normalize-ifs.mjs — reads a shell command line from stdin and writes it
+// back with every $IFS/${IFS} reference replaced by a single literal space
+// (#2451). Bash's own field-splitting on an unquoted $IFS/${IFS} expansion
+// produces exactly this effect at execution time — `git${IFS}checkout`
+// looks like one token as command TEXT, but Git actually receives
+// `checkout` as a separate argument once bash expands it. Every
+// verb-detection regex in guard-git.sh (including its own top-level "is
+// this even a git/gh command" fast-path filter, which the unnormalized
+// form bypasses entirely, exiting 0 before any check runs) assumes a
+// literal space between a command verb and its arguments — this
+// normalization runs upstream of all of them so none needs its own
+// IFS-awareness.
+//
+// Deliberately not quote-aware: this runs BEFORE mask-quoted-text.mjs in
+// guard-git.sh's pipeline, so a $IFS/${IFS} that happens to sit inside a
+// quoted, inert string gets replaced with a space here but is then blanked
+// out (along with everything else in that quoted span) by masking anyway —
+// the two passes compose correctly without this script needing its own
+// quote-tracking. A $IFS/${IFS} inside a command-substitution span
+// (`$(...)`/backticks) is left exactly as normalized here, since masking
+// deliberately copies those spans through verbatim — they execute
+// unconditionally in real bash, so IFS-driven splitting genuinely applies
+// there too.
+//
+// The bare `$IFS` form must not swallow the start of a longer variable
+// name — `$IFSOMETHING` references a completely different (and almost
+// certainly unset, hence empty-expanding) variable, not `$IFS` followed by
+// literal text. Bash variable-name continuation characters are
+// `[A-Za-z0-9_]`; the braced form (`${IFS}`) has no such ambiguity, since
+// `}` unambiguously ends it.
+
+let input = '';
+process.stdin.on('data', (chunk) => {
+  input += chunk;
+});
+process.stdin.on('end', () => {
+  const normalized = input.replace(/\$\{IFS\}/g, ' ').replace(/\$IFS(?![A-Za-z0-9_])/g, ' ');
+  process.stdout.write(normalized);
+});

--- a/docs/examples/claude-code-hooks/normalize-ifs.mjs
+++ b/docs/examples/claude-code-hooks/normalize-ifs.mjs
@@ -74,6 +74,14 @@
 // problem, the same class already tracked in #2558, not a bounded,
 // concretely-named gap like leading zeros.
 //
+// `-0`/`-00`/etc. (negative zero — Greptile review): integers have no
+// signed zero, so bash evaluates `-0` to the same value as `0` — offset
+// `-0` is offset `0` FROM THE START (valid, non-empty), NOT "0 characters
+// before the end" the way `-1`/`-2`/`-3` are. `-0*[1-3]` requires a
+// non-zero digit after the leading zeros, so it correctly does not match
+// a run of ALL zeros after the minus sign — matched separately here via
+// `-0+` (a literal minus followed by one or more zeros and nothing else).
+//
 // `${IFS:+ }`/`${IFS+ }` (alternate-value expansion, restricted to
 // ALL-whitespace content — Greptile review): unlike substring, this
 // operator does NOT extract from IFS's own value at all — it substitutes
@@ -127,7 +135,7 @@ process.stdin.on('data', (chunk) => {
 process.stdin.on('end', () => {
   const normalized = input
     .replace(/\$\{IFS\}/g, ' ')
-    .replace(/\$\{IFS: *(?:0*[0-2]|-0*[1-3])(?::0*[1-9]\d*)?\}/g, ' ')
+    .replace(/\$\{IFS: *(?:0*[0-2]|-0*[1-3]|-0+)(?::0*[1-9]\d*)?\}/g, ' ')
     .replace(/\$\{IFS:?\+[ \t]+\}/g, ' ')
     .replace(/\$IFS(?![A-Za-z0-9_])/g, ' ');
   process.stdout.write(normalized);

--- a/docs/examples/claude-code-hooks/normalize-ifs.mjs
+++ b/docs/examples/claude-code-hooks/normalize-ifs.mjs
@@ -34,36 +34,61 @@
 // bash's field-splitting applies to the RESULT of any unquoted parameter
 // expansion, not just a bare variable reference, so `${IFS:0:1}` (which
 // extracts a single whitespace character from IFS's default value) creates
-// exactly the same token boundary as the whole-variable form.
+// exactly the same token boundary as the whole-variable form. The LENGTH
+// portion must be a non-zero digit sequence (Greptile review):
+// `${IFS:0:0}` extracts zero characters — an EMPTY string, which an
+// unquoted expansion contributes NOTHING from (not even a separator) —
+// `echo git${IFS:0:0}reset` really expands to the single harmless token
+// `gitreset`, not `git reset`.
 //
-// Deliberately scoped to ONLY the substring form (`${IFS:offset}` /
-// `${IFS:offset:length}`, offset/length optionally negative, digits only —
-// not general arithmetic expressions), not "any `${IFS<operator>...}`"
-// generically: an earlier version of this normalizer tried the generic
-// form and was wrong (Greptile review) — several other bash operators that
-// also start with `${IFS` do NOT extract a value derived from IFS's own
-// characters at all, they use IFS's set/unset/null STATE as a condition and
-// substitute a completely arbitrary, attacker-chosen alternate string
-// instead: `${IFS:+word}`/`${IFS+word}` (substitute `word` when IFS IS set
-// and non-null — the normally-true case, so `word` is what actually comes
-// out), `${IFS/pattern/replacement}` (substitutes `replacement` wherever
-// `pattern` matches within IFS's value), and the bash 4.4+ `${IFS@Q}`-style
+// `${IFS:+ }`/`${IFS+ }` (alternate-value expansion, restricted to
+// ALL-whitespace content — Greptile review): unlike substring, this
+// operator does NOT extract from IFS's own value at all — it substitutes
+// an entirely separate, attacker-chosen string `word` whenever IFS IS set
+// and non-null (`:+`) or merely set (`+`), which normally means `word` is
+// what actually comes out, not IFS's value. Because of that, this is
+// matched ONLY when `word` consists of one or more spaces/tabs and
+// NOTHING else — `${IFS:+ }` really does expand to a literal space
+// (`word` itself, not derived from IFS), so it's exactly as safe to
+// normalize as the whole-variable form; `${IFS:+x}` is not touched, since
+// `x` is not whitespace and substituting a space for it would fabricate a
+// token boundary bash never produces (an earlier version of this
+// normalizer treated the operator as unconditionally unsafe and missed
+// this whitespace-content special case — Greptile review).
+//
+// Deliberately does NOT generalize to "any `${IFS<operator>...}`": an
+// earlier version tried that and was wrong (Greptile review) —
+// `${IFS/pattern/replacement}` (substitutes `replacement` wherever
+// `pattern` matches within IFS's value) and the bash 4.4+ `${IFS@Q}`-style
 // transformation operators (e.g. `@Q` shell-quotes the value, producing
-// `$' \t\n'`-shaped text, not plain whitespace). `echo git${IFS:+x}reset`
-// really expands to the single harmless token `gitxreset` in real bash, but
-// the generic form wrongly rewrote it to `git reset`, fabricating a git
-// invocation out of an `echo` argument. Rather than trying to enumerate
-// every operator that IS safe (`:-`, `-`, `:=`, `=`, `:?`, `?`, `#`, `##`,
-// `%`, `%%`, `^`, `^^`, `,`, `,,` all still yield IFS's own characters,
-// assuming it wasn't reassigned first — see below) and risk missing
-// another unsafe one, this stays narrowly scoped to the ONE form that's
-// been concretely demonstrated as exploitable and is provably always
-// whitespace-only: a substring of IFS's own value can never contain a
-// character IFS's value didn't already have.
+// `$' \t\n'`-shaped text) can ALSO produce arbitrary non-whitespace text,
+// the same class of problem `:+`/`+` have — and unlike `:+`/`+`, there is
+// no simple "restrict to all-whitespace content" fix for them, since
+// `pattern`/`replacement ` are two separate, differently-shaped fields.
+// Left unhandled rather than risk another incorrect generalization; a
+// determined obfuscator using one of these is a known, accepted gap in
+// this heuristic guard (see #2558 for tracking the closely related,
+// broader problem that `:+`/`+` with all-whitespace content isn't even
+// unique to the `IFS` name — `${HOME:+ }`/`${PWD:+ }`/any other normally-set
+// variable works identically, which a per-variable-name normalizer like
+// this one can never fully close).
+//
+// Also does not attempt to detect an out-of-range substring OFFSET with no
+// explicit length (`${IFS:3}` — offset 3 is at the end of the 3-character
+// default IFS value, so this is ALSO empty, the same problem as an
+// explicit zero length) — narrower and easier to get precisely right than
+// modeling every offset/length combination against IFS's exact default
+// length, and not the concrete form named in review.
+//
+// The bare `$IFS` form must not swallow the start of a longer variable
+// name — `$IFSOMETHING` references a completely different (and almost
+// certainly unset, hence empty-expanding) variable, not `$IFS` followed by
+// literal text. Bash variable-name continuation characters are
+// `[A-Za-z0-9_]`; the braced forms have no such ambiguity, since a
+// non-identifier operator character or `}` unambiguously ends the name.
 //
 // Assumes IFS still holds its default value (space/tab/newline) at
-// expansion time, the same implicit assumption the whole-variable form
-// already makes — a prior `IFS=...` reassignment earlier in the same
+// expansion time — a prior `IFS=...` reassignment earlier in the same
 // command line is a materially harder problem (tracking shell state across
 // the whole line) that this regex-based heuristic guard does not attempt,
 // matching the tolerance for edge cases already accepted by
@@ -76,7 +101,8 @@ process.stdin.on('data', (chunk) => {
 process.stdin.on('end', () => {
   const normalized = input
     .replace(/\$\{IFS\}/g, ' ')
-    .replace(/\$\{IFS: *-?\d+(: *-?\d+)?\}/g, ' ')
+    .replace(/\$\{IFS: *-?\d+(: *-?[1-9]\d*)?\}/g, ' ')
+    .replace(/\$\{IFS:?\+[ \t]+\}/g, ' ')
     .replace(/\$IFS(?![A-Za-z0-9_])/g, ' ');
   process.stdout.write(normalized);
 });

--- a/docs/examples/claude-code-hooks/normalize-ifs.mjs
+++ b/docs/examples/claude-code-hooks/normalize-ifs.mjs
@@ -34,21 +34,40 @@
 // bash's field-splitting applies to the RESULT of any unquoted parameter
 // expansion, not just a bare variable reference, so `${IFS:0:1}` (which
 // extracts a single whitespace character from IFS's default value) creates
-// exactly the same token boundary as the whole-variable form. Matched
-// generically as "any `${IFS` followed by a parameter-expansion operator up
-// to the closing `}`" — `[^}]*` — rather than enumerating every specific
-// bash operator (substring `:`, pattern-trim `#`/`%`, substitution `/`,
-// case-conversion `^`/`,`, …), so this also covers forms not spelled out
-// here. Assumes IFS still holds its default value (space/tab/newline) at
+// exactly the same token boundary as the whole-variable form.
+//
+// Deliberately scoped to ONLY the substring form (`${IFS:offset}` /
+// `${IFS:offset:length}`, offset/length optionally negative, digits only —
+// not general arithmetic expressions), not "any `${IFS<operator>...}`"
+// generically: an earlier version of this normalizer tried the generic
+// form and was wrong (Greptile review) — several other bash operators that
+// also start with `${IFS` do NOT extract a value derived from IFS's own
+// characters at all, they use IFS's set/unset/null STATE as a condition and
+// substitute a completely arbitrary, attacker-chosen alternate string
+// instead: `${IFS:+word}`/`${IFS+word}` (substitute `word` when IFS IS set
+// and non-null — the normally-true case, so `word` is what actually comes
+// out), `${IFS/pattern/replacement}` (substitutes `replacement` wherever
+// `pattern` matches within IFS's value), and the bash 4.4+ `${IFS@Q}`-style
+// transformation operators (e.g. `@Q` shell-quotes the value, producing
+// `$' \t\n'`-shaped text, not plain whitespace). `echo git${IFS:+x}reset`
+// really expands to the single harmless token `gitxreset` in real bash, but
+// the generic form wrongly rewrote it to `git reset`, fabricating a git
+// invocation out of an `echo` argument. Rather than trying to enumerate
+// every operator that IS safe (`:-`, `-`, `:=`, `=`, `:?`, `?`, `#`, `##`,
+// `%`, `%%`, `^`, `^^`, `,`, `,,` all still yield IFS's own characters,
+// assuming it wasn't reassigned first — see below) and risk missing
+// another unsafe one, this stays narrowly scoped to the ONE form that's
+// been concretely demonstrated as exploitable and is provably always
+// whitespace-only: a substring of IFS's own value can never contain a
+// character IFS's value didn't already have.
+//
+// Assumes IFS still holds its default value (space/tab/newline) at
 // expansion time, the same implicit assumption the whole-variable form
 // already makes — a prior `IFS=...` reassignment earlier in the same
 // command line is a materially harder problem (tracking shell state across
 // the whole line) that this regex-based heuristic guard does not attempt,
 // matching the tolerance for edge cases already accepted by
-// mask-quoted-text.mjs and guard-git.sh's other checks. Does not handle a
-// nested `${...}` inside the offset/length (`${IFS:0:${N}}`) — `[^}]*`
-// stops at the first `}` — an exotic construction with no known real-world
-// motivation for this specific bypass.
+// mask-quoted-text.mjs and guard-git.sh's other checks.
 
 let input = '';
 process.stdin.on('data', (chunk) => {
@@ -57,7 +76,7 @@ process.stdin.on('data', (chunk) => {
 process.stdin.on('end', () => {
   const normalized = input
     .replace(/\$\{IFS\}/g, ' ')
-    .replace(/\$\{IFS[^A-Za-z0-9_}][^}]*\}/g, ' ')
+    .replace(/\$\{IFS: *-?\d+(: *-?\d+)?\}/g, ' ')
     .replace(/\$IFS(?![A-Za-z0-9_])/g, ' ');
   process.stdout.write(normalized);
 });

--- a/docs/examples/claude-code-hooks/normalize-ifs.mjs
+++ b/docs/examples/claude-code-hooks/normalize-ifs.mjs
@@ -34,12 +34,32 @@
 // bash's field-splitting applies to the RESULT of any unquoted parameter
 // expansion, not just a bare variable reference, so `${IFS:0:1}` (which
 // extracts a single whitespace character from IFS's default value) creates
-// exactly the same token boundary as the whole-variable form. The LENGTH
-// portion must be a non-zero digit sequence (Greptile review):
-// `${IFS:0:0}` extracts zero characters — an EMPTY string, which an
-// unquoted expansion contributes NOTHING from (not even a separator) —
-// `echo git${IFS:0:0}reset` really expands to the single harmless token
-// `gitreset`, not `git reset`.
+// exactly the same token boundary as the whole-variable form.
+//
+// Both OFFSET and LENGTH are constrained to the exact values that are
+// PROVABLY non-empty against IFS's 3-character default value
+// (space/tab/newline), rather than accepting any digit sequence:
+//
+// - OFFSET is restricted to `0`/`1`/`2` (from the start) or `-1`/`-2`/`-3`
+//   (from the end) — the only positions that exist within a 3-character
+//   string. `${IFS:3}` (Greptile review) starts extraction AT the end of
+//   the string — bash's substring expansion returns EMPTY once offset is
+//   at or past the string's length, the same "empty, not whitespace"
+//   problem as an explicit zero length below — `echo git${IFS:3}reset`
+//   really expands to the single harmless token `gitreset`, not
+//   `git reset`. This also protects the WITH-length form the same way:
+//   `${IFS:5:1}` is empty too (bash returns nothing once offset alone is
+//   out of range, regardless of the requested length).
+// - LENGTH, when present, must be a non-zero digit sequence (Greptile
+//   review): `${IFS:0:0}` extracts zero characters — an EMPTY string,
+//   which an unquoted expansion contributes NOTHING from (not even a
+//   separator) — `echo git${IFS:0:0}reset` really expands to the single
+//   harmless token `gitreset`. Once OFFSET is validated as in-range, ANY
+//   non-zero LENGTH is safe to accept without also bounding its upper
+//   value: bash clamps a length that exceeds what's actually available
+//   from OFFSET to the end of the string, rather than erroring or
+//   producing something unexpected, so a too-large length still yields a
+//   non-empty (if shorter than requested) whitespace-only result.
 //
 // `${IFS:+ }`/`${IFS+ }` (alternate-value expansion, restricted to
 // ALL-whitespace content — Greptile review): unlike substring, this
@@ -73,13 +93,6 @@
 // variable works identically, which a per-variable-name normalizer like
 // this one can never fully close).
 //
-// Also does not attempt to detect an out-of-range substring OFFSET with no
-// explicit length (`${IFS:3}` — offset 3 is at the end of the 3-character
-// default IFS value, so this is ALSO empty, the same problem as an
-// explicit zero length) — narrower and easier to get precisely right than
-// modeling every offset/length combination against IFS's exact default
-// length, and not the concrete form named in review.
-//
 // The bare `$IFS` form must not swallow the start of a longer variable
 // name — `$IFSOMETHING` references a completely different (and almost
 // certainly unset, hence empty-expanding) variable, not `$IFS` followed by
@@ -101,7 +114,7 @@ process.stdin.on('data', (chunk) => {
 process.stdin.on('end', () => {
   const normalized = input
     .replace(/\$\{IFS\}/g, ' ')
-    .replace(/\$\{IFS: *-?\d+(: *-?[1-9]\d*)?\}/g, ' ')
+    .replace(/\$\{IFS: *(?:[0-2]|-[1-3])(?::[1-9]\d*)?\}/g, ' ')
     .replace(/\$\{IFS:?\+[ \t]+\}/g, ' ')
     .replace(/\$IFS(?![A-Za-z0-9_])/g, ' ');
   process.stdout.write(normalized);

--- a/tests/unit/hook-guard-git-clean.test.ts
+++ b/tests/unit/hook-guard-git-clean.test.ts
@@ -312,7 +312,12 @@ describe('guard-git.sh docs example stays in sync (#2105)', () => {
   // reflected the real hook's behavior at all. Kept as an exact copy and
   // enforced here instead of documented-and-hoped-for, since a prose note
   // alone already failed to prevent the original drift.
-  const HOOKS = ['guard-git.sh', 'mask-quoted-text.mjs', 'check-git-clean-force.mjs'];
+  const HOOKS = [
+    'guard-git.sh',
+    'mask-quoted-text.mjs',
+    'check-git-clean-force.mjs',
+    'normalize-ifs.mjs',
+  ];
   const DOCS_DIR = path.join(REPO_ROOT, 'docs', 'examples', 'claude-code-hooks');
 
   it.each(HOOKS)('%s is byte-identical to its docs/examples copy', (name) => {

--- a/tests/unit/hook-guard-git-ifs-bypass.test.ts
+++ b/tests/unit/hook-guard-git-ifs-bypass.test.ts
@@ -139,6 +139,22 @@ describe('guard-git.sh IFS whitespace-expansion bypass (#2451)', () => {
     expect(isDenied('echo git${IFS:0:0}reset')).toBe(false);
   });
 
+  it('does not invent a token boundary from an out-of-range IFS substring offset (Greptile review)', () => {
+    // ${IFS:3} starts extraction AT the end of IFS's 3-character default
+    // value (indices 0, 1, 2) — bash's substring expansion returns EMPTY
+    // once offset is at or past the string's length, the same "empty, not
+    // whitespace" problem as an explicit zero length.
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal bash syntax under test, not a missed template literal
+    expect(isDenied('echo git${IFS:3}reset')).toBe(false);
+  });
+
+  it('does not invent a token boundary from an out-of-range offset even with an explicit length', () => {
+    // ${IFS:5:1} is ALSO empty: bash returns nothing once offset alone is
+    // out of range, regardless of the requested length.
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal bash syntax under test, not a missed template literal
+    expect(isDenied('echo git${IFS:5:1}reset')).toBe(false);
+  });
+
   it('still blocks git reset via a whitespace-only IFS alternate-value expansion (Greptile review)', () => {
     // ${IFS:+ } substitutes the literal single space "word" itself
     // whenever IFS is set and non-null (the normally-true case) — the

--- a/tests/unit/hook-guard-git-ifs-bypass.test.ts
+++ b/tests/unit/hook-guard-git-ifs-bypass.test.ts
@@ -92,6 +92,25 @@ describe('guard-git.sh IFS whitespace-expansion bypass (#2451)', () => {
     expect(isDenied('git${IFS}checkout${IFS}--detach')).toBe(false);
   });
 
+  it('still blocks git add -A via IFS substring expansion (Greptile review)', () => {
+    // ${IFS:0:1} extracts a single whitespace character from IFS's default
+    // value via bash's substring-expansion syntax, not the whole-variable
+    // form — but the RESULT still undergoes the same unquoted field
+    // splitting, so it creates the identical token boundary.
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal bash syntax under test, not a missed template literal
+    expect(isDenied('git${IFS:0:1}add${IFS:0:1}-A')).toBe(true);
+  });
+
+  it('still blocks the fast-path bypass via IFS substring expansion (Greptile review)', () => {
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal bash syntax under test, not a missed template literal
+    expect(isDenied('git${IFS:1:1}checkout${IFS:1:1}--${IFS:1:1}some-file.txt')).toBe(true);
+  });
+
+  it('does not mistake a differently-named variable for an IFS substring expansion', () => {
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal bash syntax under test, not a missed template literal
+    expect(isDenied('echo ${IFSOMETHING:0:1}')).toBe(false);
+  });
+
   it('does not treat an IFS reference appearing inside a quoted, inert string as a token boundary', () => {
     // Quoted text is data, not a command invocation — mask-quoted-text.mjs
     // already blanks it out downstream of the IFS-normalization pass, so

--- a/tests/unit/hook-guard-git-ifs-bypass.test.ts
+++ b/tests/unit/hook-guard-git-ifs-bypass.test.ts
@@ -180,6 +180,19 @@ describe('guard-git.sh IFS whitespace-expansion bypass (#2451)', () => {
     expect(isDenied('git${IFS:002}reset')).toBe(true);
   });
 
+  it('still blocks git reset via a negative-zero IFS substring offset (Greptile review)', () => {
+    // Integers have no signed zero, so bash evaluates "-0" to the same
+    // value as "0" — offset -0 is offset 0 FROM THE START (valid,
+    // non-empty), not "0 characters before the end" the way -1/-2/-3 are.
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal bash syntax under test, not a missed template literal
+    expect(isDenied('git${IFS: -0}reset')).toBe(true);
+  });
+
+  it('still blocks git reset via a zero-padded negative-zero IFS substring offset', () => {
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal bash syntax under test, not a missed template literal
+    expect(isDenied('git${IFS: -00}reset')).toBe(true);
+  });
+
   it('still blocks git reset via a whitespace-only IFS alternate-value expansion (Greptile review)', () => {
     // ${IFS:+ } substitutes the literal single space "word" itself
     // whenever IFS is set and non-null (the normally-true case) — the

--- a/tests/unit/hook-guard-git-ifs-bypass.test.ts
+++ b/tests/unit/hook-guard-git-ifs-bypass.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Regression guard for issue #2451: bash's own whitespace-field-separator
+ * variable (IFS) supplies a token boundary that the command TEXT itself has
+ * no literal whitespace for. Referencing it unquoted between two words
+ * looks, as static text, like a single token — but bash expands the
+ * unquoted reference to whitespace before Git ever runs, so Git actually
+ * receives the two halves as separate arguments.
+ *
+ * This bypassed guard-git.sh at two levels:
+ * 1. The hook's own top-level fast-path filter requires literal whitespace
+ *    directly after `git`/`gh`. A command with an IFS reference in place of
+ *    every literal space has no literal whitespace anywhere, so the filter
+ *    didn't recognize it as a git command at all and exited 0 immediately —
+ *    skipping EVERY check in the file, not just whichever one was targeted.
+ * 2. Every individual subcommand check has the same literal-whitespace
+ *    assumption between the verb and its own subcommand/flags — an IFS
+ *    reference between `git` and `add` is recognized as *a* git command
+ *    (the space after `git` is real), but slips past the add-A-specific
+ *    check, which requires literal whitespace between `add` and `-A` too.
+ *
+ * The fix normalizes an IFS reference into a literal space
+ * (normalize-ifs.mjs) upstream of both the fast-path filter and the
+ * existing quote-masking pipeline, so no individual regex needs its own
+ * IFS-awareness.
+ */
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const HOOK_PATH = path.join(REPO_ROOT, '.claude', 'hooks', 'guard-git.sh');
+
+interface HookDecision {
+  hookSpecificOutput?: {
+    permissionDecision?: string;
+    permissionDecisionReason?: string;
+  };
+}
+
+function runHook(command: string): HookDecision {
+  const toolInput = JSON.stringify({ tool_input: { command } });
+  const stdout = execFileSync('bash', [HOOK_PATH], { input: toolInput, encoding: 'utf8' });
+  return stdout.trim() ? JSON.parse(stdout) : {};
+}
+
+function isDenied(command: string): boolean {
+  return runHook(command).hookSpecificOutput?.permissionDecision === 'deny';
+}
+
+describe('guard-git.sh IFS whitespace-expansion bypass (#2451)', () => {
+  it('still blocks git checkout -- via the braced IFS form in place of every literal space', () => {
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal bash syntax under test, not a missed template literal
+    expect(isDenied('git${IFS}checkout${IFS}--${IFS}some-file.txt')).toBe(true);
+  });
+
+  it('still blocks git add -A via the bare IFS form immediately before the flag', () => {
+    // A bare $IFS only unambiguously references the IFS variable when the
+    // next character is NOT part of a longer identifier — `$IFScheckout`
+    // is bash's own distinct (and here undefined, empty-expanding) variable
+    // "IFScheckout", not "$IFS" + literal "checkout". Right before a flag
+    // (a non-identifier "-") is exactly where the bare form is realistic.
+    expect(isDenied('git add$IFS-A')).toBe(true);
+  });
+
+  it('still blocks git add -A when the braced IFS form separates the verb from its flag', () => {
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal bash syntax under test, not a missed template literal
+    expect(isDenied('git add${IFS}-A')).toBe(true);
+  });
+
+  it('still blocks git reset when the braced IFS form separates git from the subcommand', () => {
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal bash syntax under test, not a missed template literal
+    expect(isDenied('git${IFS}reset')).toBe(true);
+  });
+
+  it('still blocks git stash when the braced IFS form separates git from the subcommand', () => {
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal bash syntax under test, not a missed template literal
+    expect(isDenied('git${IFS}stash')).toBe(true);
+  });
+
+  it('does not mistake a longer variable name for the bare IFS form followed by literal text', () => {
+    // $IFSOMETHING references a distinct (and here, undefined -> harmless)
+    // variable, not "$IFS" + literal "OMETHING" — must not be normalized
+    // into a space that would fabricate a token boundary bash never
+    // produces for this form.
+    expect(isDenied('echo hello$IFSOMETHINGworld')).toBe(false);
+  });
+
+  it('still allows a legitimate flag sharing the checkout -- prefix via the braced IFS form', () => {
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal bash syntax under test, not a missed template literal
+    expect(isDenied('git${IFS}checkout${IFS}--detach')).toBe(false);
+  });
+
+  it('does not treat an IFS reference appearing inside a quoted, inert string as a token boundary', () => {
+    // Quoted text is data, not a command invocation — mask-quoted-text.mjs
+    // already blanks it out downstream of the IFS-normalization pass, so
+    // this must not falsely block on text that merely mentions IFS.
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal bash syntax under test, not a missed template literal
+    expect(isDenied('gh issue create --body "explains ${IFS} bash quirk"')).toBe(false);
+  });
+});

--- a/tests/unit/hook-guard-git-ifs-bypass.test.ts
+++ b/tests/unit/hook-guard-git-ifs-bypass.test.ts
@@ -130,6 +130,38 @@ describe('guard-git.sh IFS whitespace-expansion bypass (#2451)', () => {
     expect(isDenied('echo git${IFS/ /X}reset')).toBe(false);
   });
 
+  it('does not invent a token boundary from an empty IFS substring (Greptile review)', () => {
+    // ${IFS:0:0} extracts zero characters — an empty string, which an
+    // unquoted expansion contributes NOTHING from (not even a separator).
+    // "echo git${IFS:0:0}reset" really expands to the single harmless
+    // token "gitreset" in real bash, never "git reset".
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal bash syntax under test, not a missed template literal
+    expect(isDenied('echo git${IFS:0:0}reset')).toBe(false);
+  });
+
+  it('still blocks git reset via a whitespace-only IFS alternate-value expansion (Greptile review)', () => {
+    // ${IFS:+ } substitutes the literal single space "word" itself
+    // whenever IFS is set and non-null (the normally-true case) — the
+    // substituted text IS whitespace this time, so it produces exactly
+    // the same token boundary as the whole-variable form.
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal bash syntax under test, not a missed template literal
+    expect(isDenied('git${IFS:+ }reset')).toBe(true);
+  });
+
+  it('still blocks git reset via the bare (colon-less) whitespace-only IFS alternate-value form', () => {
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal bash syntax under test, not a missed template literal
+    expect(isDenied('git${IFS+ }reset')).toBe(true);
+  });
+
+  it('does not invent a token boundary from an empty IFS alternate-value expansion', () => {
+    // ${IFS:+} (nothing between + and }) substitutes an EMPTY string when
+    // IFS is set and non-null — an unquoted empty expansion contributes
+    // nothing, not even a separator, so this must not be treated the same
+    // as the non-empty, all-whitespace form above.
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal bash syntax under test, not a missed template literal
+    expect(isDenied('echo git${IFS:+}reset')).toBe(false);
+  });
+
   it('does not treat an IFS reference appearing inside a quoted, inert string as a token boundary', () => {
     // Quoted text is data, not a command invocation — mask-quoted-text.mjs
     // already blanks it out downstream of the IFS-normalization pass, so

--- a/tests/unit/hook-guard-git-ifs-bypass.test.ts
+++ b/tests/unit/hook-guard-git-ifs-bypass.test.ts
@@ -155,6 +155,31 @@ describe('guard-git.sh IFS whitespace-expansion bypass (#2451)', () => {
     expect(isDenied('echo git${IFS:5:1}reset')).toBe(false);
   });
 
+  it('still blocks git reset via a leading-zero-padded IFS substring offset (Greptile review)', () => {
+    // ${IFS:00} evaluates identically to ${IFS:0} in bash's arithmetic
+    // context — an exact single-digit-only pattern misses this zero-padded
+    // spelling entirely.
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal bash syntax under test, not a missed template literal
+    expect(isDenied('git${IFS:00}reset')).toBe(true);
+  });
+
+  it('still blocks git reset via a leading-zero-padded IFS substring length (Greptile review)', () => {
+    // ${IFS:0:01} evaluates identically to ${IFS:0:1}.
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal bash syntax under test, not a missed template literal
+    expect(isDenied('git${IFS:0:01}reset')).toBe(true);
+  });
+
+  it('does not invent a token boundary from a leading-zero-padded but still zero length', () => {
+    // ${IFS:0:00} is still an empty substring (length zero, however spelled).
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal bash syntax under test, not a missed template literal
+    expect(isDenied('echo git${IFS:0:00}reset')).toBe(false);
+  });
+
+  it('still blocks git reset via a leading-zero-padded IFS substring in a later part of the command', () => {
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal bash syntax under test, not a missed template literal
+    expect(isDenied('git${IFS:002}reset')).toBe(true);
+  });
+
   it('still blocks git reset via a whitespace-only IFS alternate-value expansion (Greptile review)', () => {
     // ${IFS:+ } substitutes the literal single space "word" itself
     // whenever IFS is set and non-null (the normally-true case) — the

--- a/tests/unit/hook-guard-git-ifs-bypass.test.ts
+++ b/tests/unit/hook-guard-git-ifs-bypass.test.ts
@@ -111,6 +111,25 @@ describe('guard-git.sh IFS whitespace-expansion bypass (#2451)', () => {
     expect(isDenied('echo ${IFSOMETHING:0:1}')).toBe(false);
   });
 
+  it('does not invent a token boundary from an alternate-value IFS expansion (Greptile review)', () => {
+    // ${IFS:+x} substitutes the literal "x" when IFS IS set and non-null —
+    // the normally-true case — so this expands to the single harmless
+    // token "gitxreset" in real bash, never "git reset". An earlier,
+    // over-broad version of the normalizer treated ANY `${IFS<operator>}`
+    // form as whitespace and wrongly rewrote this into "echo git reset",
+    // fabricating a git invocation out of a plain echo argument.
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal bash syntax under test, not a missed template literal
+    expect(isDenied('echo git${IFS:+x}reset')).toBe(false);
+  });
+
+  it('does not invent a token boundary from an IFS pattern-substitution expansion', () => {
+    // ${IFS/ /X} replaces spaces in IFS's value with the literal "X" —
+    // arbitrary attacker-chosen replacement text, not a value drawn from
+    // IFS's own characters.
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal bash syntax under test, not a missed template literal
+    expect(isDenied('echo git${IFS/ /X}reset')).toBe(false);
+  });
+
   it('does not treat an IFS reference appearing inside a quoted, inert string as a token boundary', () => {
     // Quoted text is data, not a command invocation — mask-quoted-text.mjs
     // already blanks it out downstream of the IFS-normalization pass, so


### PR DESCRIPTION
## Summary

While fixing #2280 (the `checkout --` false-positive/bypass narrowing), Greptile's review surfaced that `${IFS}` (bash's own whitespace-field-separator variable) can supply a token boundary that the command TEXT itself has no literal whitespace for — `git checkout --${IFS}file.txt` looks, as static text, like a single token, but bash expands the unquoted `${IFS}` to whitespace before Git ever runs, so Git actually receives `checkout -- file.txt`.

That specific instance (the `checkout --`/`--ours`/`--theirs` boundaries) was fixed in #2280 / PR #2450. This issue is the broader, systemic version, predating that PR:

1. **The hook's own top-level fast-path filter** requires literal whitespace directly after `git`/`gh`. A command like `git${IFS}checkout${IFS}--${IFS}file.txt` has no literal whitespace anywhere, so the filter didn't recognize it as a git command at all, and exited 0 immediately — **skipping every single check in the file**, not just the checkout one.
2. **Every individual subcommand check** has the same literal-whitespace assumption between the verb and its own subcommand/flags — e.g. `git add${IFS}-A` is recognized as *a* git command (the space after `git` is real), but slips past the `add -A`-specific check, which requires literal whitespace between `add` and `-A` too.

## Fix

Rather than patching each regex individually (how PR #2450 had to iterate three times just for one check), this adds a shared normalization pass — `normalize-ifs.mjs` — that replaces every `$IFS`/`${IFS}` reference with a literal space **upstream of both** the fast-path filter and the existing quote-masking pipeline (`mask-quoted-text.mjs`), so no individual regex needs its own IFS-awareness.

Deliberately not quote-aware on its own: it runs *before* masking, so:
- An IFS reference inside a quoted, inert string gets replaced with a space here, then blanked out (along with everything else in that span) by masking anyway.
- An IFS reference inside a command-substitution span (`$(...)`/backticks) is left exactly as normalized, since masking copies those spans through verbatim — they execute unconditionally in real bash, so IFS-driven splitting genuinely applies there too.

The bare `$IFS` form (as opposed to the unambiguous braced `${IFS}`) only safely references the `IFS` variable when the next character isn't part of a longer identifier — `$IFScheckout` is bash's own distinct (and here undefined, empty-expanding) variable `IFScheckout`, not `$IFS` + literal `checkout`. The normalization uses a negative-lookahead boundary to avoid over-matching this.

## Tests

- `tests/unit/hook-guard-git-ifs-bypass.test.ts`: exercises both bug classes from the issue's repro (fast-path bypass via `git${IFS}checkout${IFS}--${IFS}file.txt`, and the `add -A`-specific bypass via both braced and bare IFS forms), plus the negative cases (doesn't over-match a longer variable name, doesn't create a false token boundary inside quoted text, still allows legitimate `--detach`-style flags).
- Revert-verified: ran the new tests against the pre-fix hook script and confirmed the targeted ones fail; restored and confirmed all pass.
- All pre-existing `guard-git.sh` tests (including PR #2450's own checkout-- IFS tests) still pass — no regression to that prior fix.
- Updated `docs/examples/claude-code-hooks/` (README + byte-identical copies of `guard-git.sh` and the new `normalize-ifs.mjs`) and added the new file to the existing docs-sync test's tracked list, per that test's own established pattern.
- Full suite: 339 test files / 5410 tests pass.

Closes #2451