### PR TITLE
fix(benchmarks): normalize Full build regression-gate metric per file count

### DIFF
--- a/scripts/update-incremental-report.ts
+++ b/scripts/update-incremental-report.ts
@@ -76,6 +76,33 @@ function findPrevMetric(hist, fromIdx, getter) {
 	return null;
 }
 
+// Like findPrevMetric, but returns the whole matching entry rather than a
+// single extracted value. Used for the "Full build" ms/file trend (#2455):
+// the ms/file figure needs `fullBuildMs` and `files` from the *same*
+// historical entry, and finding each independently via findPrevMetric could
+// pair a metric from one release with a file count from another if either
+// value happened to be null on a different intervening release.
+function findPrevEntry(hist, fromIdx, predicate) {
+	for (let i = fromIdx + 1; i < hist.length; i++) {
+		if (hist[i].version === 'dev') continue;
+		if (predicate(hist[i])) return hist[i];
+	}
+	return null;
+}
+
+// `ms / files` when both are present and `files` is a positive count, else
+// null. Mirrors perFileMs in tests/benchmarks/regression-guard.test.ts —
+// the report's "Full build (ms/file)" column is display-only and does not
+// gate anything, but it should show the same figure the gate compares.
+function perFileMs(ms, files) {
+	if (ms == null || files == null || files <= 0) return null;
+	return ms / files;
+}
+
+function formatPerFile(v) {
+	return v != null ? v.toFixed(4) : 'n/a';
+}
+
 // ── Helpers ──────────────────────────────────────────────────────────────
 function trend(current, previous, lowerIsBetter = true) {
 	// Guard against null/undefined and a zero baseline — dividing by zero would
@@ -100,6 +127,14 @@ function engineRow(hist, i, engineKey, prevResolveNative, prevResolveJs) {
 	if (!e) return null;
 
 	const fullT = trend(e.fullBuildMs, findPrevMetric(hist, i, (r) => r[engineKey]?.fullBuildMs));
+
+	// ms/file trend (#2455) — the previous value must come from the same
+	// historical entry as the previous fullBuildMs (see findPrevEntry).
+	const curPerFile = perFileMs(e.fullBuildMs, h.files);
+	const prevEntry = findPrevEntry(hist, i, (r) => r[engineKey]?.fullBuildMs != null);
+	const prevPerFile = prevEntry ? perFileMs(prevEntry[engineKey].fullBuildMs, prevEntry.files) : null;
+	const fullPerFileT = trend(curPerFile, prevPerFile);
+
 	const noopT = trend(e.noopRebuildMs, findPrevMetric(hist, i, (r) => r[engineKey]?.noopRebuildMs));
 	const oneT = trend(
 		e.oneFileRebuildMs,
@@ -116,6 +151,7 @@ function engineRow(hist, i, engineKey, prevResolveNative, prevResolveJs) {
 	return (
 		`| ${h.version} | ${engineKey} | ${h.files} ` +
 		`| ${formatMs(e.fullBuildMs)}${fullT} ` +
+		`| ${formatPerFile(curPerFile)}${fullPerFileT} ` +
 		`| ${noopCell} ` +
 		`| ${oneFileCell} ` +
 		`| ${r.nativeBatchMs != null ? formatMs(r.nativeBatchMs) + natT : 'n/a'} ` +
@@ -130,9 +166,9 @@ md += 'Build tiers: full (cold), no-op (nothing changed), 1-file (single file mo
 md += 'Import resolution: native batch vs JS fallback throughput.\n\n';
 
 md +=
-	'| Version | Engine | Files | Full Build | No-op | 1-File | Resolve (native) | Resolve (JS) |\n';
+	'| Version | Engine | Files | Full Build | Full Build (ms/file) | No-op | 1-File | Resolve (native) | Resolve (JS) |\n';
 md +=
-	'|---------|--------|------:|-----------:|------:|-------:|------------------:|-------------:|\n';
+	'|---------|--------|------:|-----------:|----------------------:|------:|-------:|------------------:|-------------:|\n';
 
 for (let i = 0; i < history.length; i++) {
 	// Resolve metrics are release-level (not engine-specific), so pre-compute
@@ -159,6 +195,7 @@ for (const engineKey of ['native', 'wasm']) {
 	md += '| Metric | Value |\n';
 	md += '|--------|------:|\n';
 	md += `| Full build | ${formatMs(e.fullBuildMs)} |\n`;
+	md += `| Full build (ms/file) | ${formatPerFile(perFileMs(e.fullBuildMs, latest.files))} |\n`;
 	md += `| No-op rebuild | ${e.noopRebuildMs != null ? formatMs(e.noopRebuildMs) : 'n/a'} |\n`;
 	md += `| 1-file rebuild | ${e.oneFileRebuildMs != null ? formatMs(e.oneFileRebuildMs) : 'n/a'} |\n\n`;
 
@@ -254,10 +291,15 @@ for (const engineKey of ['native', 'wasm']) {
 	const e = latest[engineKey];
 	if (!e) continue;
 	const tag = `[${engineKey}]`;
+	// Compared as ms/file (#2455), matching the hard-fail gate in
+	// tests/benchmarks/regression-guard.test.ts — otherwise this warning
+	// fires on every commit that merely grows the corpus or adds legitimate
+	// per-file work, even though the gate itself no longer flags it.
+	const fullPrevEntry = findPrevEntry(history, 0, (r) => r[engineKey]?.fullBuildMs != null);
 	checkRegression(
-		`${tag} Full build`,
-		e.fullBuildMs,
-		findPrevMetric(history, 0, (r) => r[engineKey]?.fullBuildMs),
+		`${tag} Full build (ms/file)`,
+		perFileMs(e.fullBuildMs, latest.files),
+		fullPrevEntry ? perFileMs(fullPrevEntry[engineKey].fullBuildMs, fullPrevEntry.files) : null,
 	);
 	if (e.noopRebuildMs != null) {
 		checkRegression(

--- a/tests/benchmarks/regression-guard.test.ts
+++ b/tests/benchmarks/regression-guard.test.ts
@@ -193,6 +193,36 @@ const SIZE_METRICS = new Set<string>(['DB bytes/file']);
 const MIN_ABSOLUTE_DELTA = 10;
 
 /**
+ * Minimum absolute delta, in ms/file, required before a normalized "Full
+ * build" regression is flagged (#2455).
+ *
+ * "Full build" is compared as `fullBuildMs / files` instead of raw
+ * `fullBuildMs` (see `perFileMs` below) so that corpus growth and legitimate
+ * per-file work growth — neither of which is a regression — don't keep
+ * tripping the gate release over release (#2081, #2412, #2436). Recorded
+ * ms/file values run ~5-25 (generated/benchmarks/INCREMENTAL-BENCHMARKS.md),
+ * two orders of magnitude below MIN_ABSOLUTE_DELTA's 10ms floor, which was
+ * calibrated for raw millisecond metrics — reusing it here would mean
+ * `absDelta < minAbsoluteDelta` is true for nearly every real delta at this
+ * scale, silently disabling the floor rather than filtering noise. 0.1
+ * ms/file is well below the delta the 25%/75% percentage thresholds already
+ * require at these baselines (e.g. 25% of a 6.5ms/file native baseline is
+ * ~1.6ms/file), so it only filters float-level measurement noise while
+ * leaving the percentage threshold as the actual regression signal.
+ */
+const MIN_ABSOLUTE_DELTA_PER_FILE = 0.1;
+
+/**
+ * `ms / files` when both are present and `files` is a positive count, else
+ * null — propagates through `checkRegression`'s existing null-skip. Used to
+ * normalize "Full build" (see MIN_ABSOLUTE_DELTA_PER_FILE above).
+ */
+function perFileMs(ms: number | null | undefined, files: number | null | undefined): number | null {
+  if (ms == null || files == null || files <= 0) return null;
+  return ms / files;
+}
+
+/**
  * Versions to skip entirely from regression comparisons.
  *
  * - v3.8.0: benchmarks produced with broken native build orchestrator (#804)
@@ -244,11 +274,10 @@ const SKIP_VERSIONS = new Set(['3.8.0']);
  * handled structurally by WASM_TIMING_THRESHOLD (see above); native keeps the
  * strict thresholds and is the canary for real algorithmic regressions.
  *
- * v3.16.0 was released 2026-07-20 and no stable release has landed since.
- * The same growth/runner-variance drift documented for 3.15.0 above (#2081)
- * has recurred against this baseline on both metrics — tracked in #2412
- * (Full build) and #2436 (both metrics). Evidence this is drift/noise, not a
- * PR-introduced regression:
+ * v3.16.0 was released 2026-07-20. The same growth/runner-variance drift
+ * documented for 3.15.0 above (#2081) recurred against this baseline —
+ * tracked in #2412 (Full build) and #2436 (both metrics). Evidence this was
+ * drift/noise, not a PR-introduced regression:
  * - #2412: a docs-only PR touching only two Markdown files hit
  *   `Full build: 4844 → 6063 (+25%)`; a second docs-only PR (#2382) hit the
  *   identical failure and was merged anyway.
@@ -261,12 +290,21 @@ const SKIP_VERSIONS = new Set(['3.8.0']);
  *   commits existed. The environment, not the code, accounts for the
  *   swing: local `dev` measured faster than the recorded 3.16.0 baseline,
  *   while CI measured 26-103% slower.
- * Exemption clears itself: prune both entries once the next stable release
- * folds current repo size and runner conditions into a fresh baseline (same
- * pattern as the 3.12.0/3.13.0 prune at 3.15.0, and the 3.15.0 prune at
- * 3.16.0, documented above).
+ * `3.16.0:Full build` is pruned here (#2455): "Full build" is now compared
+ * as ms/file (see MIN_ABSOLUTE_DELTA_PER_FILE / perFileMs above), which
+ * absorbs exactly the corpus-growth drift this entry was working around —
+ * `3.17.0 vs 3.16.0` clears the normalized threshold on both engines without
+ * the exemption (native +16.1% ms/file vs the 25% threshold, wasm +8.9%
+ * ms/file vs the 75% WASM threshold; the raw-ms deltas were +31.0%/+22.9%).
+ * `3.16.0:1-file rebuild` stays — #2455 only normalizes Full build; per its
+ * own "Suggested direction," 1-file rebuild's flakiness looks dominated by
+ * near-zero-baseline absolute jitter rather than corpus size, so per-file
+ * normalization may not be the right fix for it. Prune once a future stable
+ * release folds current repo size and runner conditions into a fresh
+ * baseline (same pattern as the 3.12.0/3.13.0 prune at 3.15.0, and the
+ * 3.15.0 prune at 3.16.0, documented above).
  */
-const KNOWN_REGRESSIONS = new Set<string>(['3.16.0:Full build', '3.16.0:1-file rebuild']);
+const KNOWN_REGRESSIONS = new Set<string>(['3.16.0:1-file rebuild']);
 
 /**
  * Maximum minor-version gap allowed for comparison. When the nearest
@@ -493,10 +531,11 @@ function checkRegression(
   label: string,
   current: number | null | undefined,
   previous: number | null | undefined,
+  minAbsoluteDelta: number = MIN_ABSOLUTE_DELTA,
 ): RegressionCheck | null {
   if (current == null || previous == null || previous === 0) return null;
   const absDelta = current - previous;
-  if (absDelta < MIN_ABSOLUTE_DELTA) return null; // below noise floor
+  if (absDelta < minAbsoluteDelta) return null; // below noise floor
   const pctChange = absDelta / previous;
   return { label, current, previous, pctChange };
 }
@@ -619,6 +658,123 @@ describe('assertNoRegressions — KNOWN_REGRESSIONS baseline fallback', () => {
         testKnownRegressions,
       ),
     ).toThrow(/Full build/);
+  });
+});
+
+// Pure-logic tests for the "Full build" ms/file normalization (#2455).
+// These exercise perFileMs and checkRegression's minAbsoluteDelta override
+// directly with synthetic data, so — like the KNOWN_REGRESSIONS baseline
+// fallback tests above — they always run and don't depend on committed
+// benchmark history.
+describe('perFileMs normalization for Full build (#2455)', () => {
+  test('perFileMs divides ms by files', () => {
+    expect(perFileMs(4844, 741)).toBeCloseTo(6.5371, 4);
+  });
+
+  test('perFileMs returns null when ms is missing', () => {
+    expect(perFileMs(null, 741)).toBeNull();
+    expect(perFileMs(undefined, 741)).toBeNull();
+  });
+
+  test('perFileMs returns null when files is missing, zero, or negative', () => {
+    expect(perFileMs(4844, null)).toBeNull();
+    expect(perFileMs(4844, 0)).toBeNull();
+    expect(perFileMs(4844, -5)).toBeNull();
+  });
+
+  test('pure corpus growth at constant per-file cost does not register as a regression', () => {
+    // #2081's own numbers: 629 -> 1013 files (+61%), timing tracking the
+    // same ratio. Raw ms clears the 25% threshold; ms/file does not, because
+    // the per-file cost genuinely did not change.
+    const prevFullBuildMs = 3500;
+    const prevFiles = 629;
+    const perFileCost = prevFullBuildMs / prevFiles;
+    const curFiles = 1013;
+    const curFullBuildMs = perFileCost * curFiles; // same per-file cost, more files
+
+    const rawCheck = checkRegression('Full build', curFullBuildMs, prevFullBuildMs);
+    expect(rawCheck).not.toBeNull();
+    expect(rawCheck.pctChange).toBeGreaterThan(0.25); // raw would have flagged this
+
+    const normalizedCheck = checkRegression(
+      'Full build',
+      perFileMs(curFullBuildMs, curFiles),
+      perFileMs(prevFullBuildMs, prevFiles),
+      MIN_ABSOLUTE_DELTA_PER_FILE,
+    );
+    expect(normalizedCheck).toBeNull(); // per-file cost is unchanged
+  });
+
+  test('a genuine per-file regression at constant file count is still caught', () => {
+    const files = 800;
+    const prevFullBuildMs = 5200; // 6.5 ms/file
+    const curFullBuildMs = 8000; // 10.0 ms/file, +53.8%
+
+    const normalizedCheck = checkRegression(
+      'Full build',
+      perFileMs(curFullBuildMs, files),
+      perFileMs(prevFullBuildMs, files),
+      MIN_ABSOLUTE_DELTA_PER_FILE,
+    );
+    expect(normalizedCheck).not.toBeNull();
+    expect(normalizedCheck.pctChange).toBeGreaterThan(0.25);
+
+    expect(() =>
+      assertNoRegressions(
+        [normalizedCheck],
+        'dev',
+        '9.9.9',
+        'native',
+        new Set<string>(), // no exemption for this synthetic version
+      ),
+    ).toThrow(/Full build/);
+  });
+
+  test('a real-release-vs-baseline regression at constant file count is still caught (not just dev)', () => {
+    // Mirrors the KNOWN_REGRESSIONS baseline-fallback tests above — confirms
+    // the ms/file check participates in the same fallback machinery rather
+    // than bypassing it.
+    const files = 800;
+    const normalizedCheck = checkRegression(
+      'Full build',
+      perFileMs(8000, files),
+      perFileMs(4000, files), // +100%, well over threshold
+      MIN_ABSOLUTE_DELTA_PER_FILE,
+    );
+    expect(() =>
+      assertNoRegressions([normalizedCheck], '10.0.0', '9.8.0', 'native', new Set<string>()),
+    ).toThrow(/Full build/);
+  });
+
+  test('MIN_ABSOLUTE_DELTA_PER_FILE filters trivial ms/file jitter even at a large percentage', () => {
+    // A near-zero baseline (e.g. a corpus so small ms/file rounds to almost
+    // nothing) can produce a huge percentage from a sub-noise-floor absolute
+    // delta — exactly the false-positive pattern MIN_ABSOLUTE_DELTA guards
+    // against for raw-ms metrics elsewhere in this file.
+    const check = checkRegression('Full build', 0.15, 0.1, MIN_ABSOLUTE_DELTA_PER_FILE);
+    expect(check).toBeNull(); // delta is 0.05 ms/file, below the 0.1 floor
+  });
+
+  test('the real 3.17.0 vs 3.16.0 data clears the normalized threshold without a KNOWN_REGRESSIONS entry', () => {
+    // Recorded in generated/benchmarks/INCREMENTAL-BENCHMARKS.md. Raw ms grew
+    // +31.0% (native) / +22.9% (wasm) — over the 25%/75% thresholds, which is
+    // exactly why '3.16.0:Full build' existed in KNOWN_REGRESSIONS before
+    // this fix. Normalized, both clear their threshold on their own.
+    const nativeCheck = checkRegression(
+      'Full build',
+      perFileMs(6345, 836),
+      perFileMs(4844, 741),
+      MIN_ABSOLUTE_DELTA_PER_FILE,
+    );
+    expect(nativeCheck.pctChange).toBeLessThan(0.25);
+
+    const wasmCheck = checkRegression(
+      'Full build',
+      perFileMs(19082, 836),
+      perFileMs(15537, 741),
+      MIN_ABSOLUTE_DELTA_PER_FILE,
+    );
+    expect(wasmCheck.pctChange).toBeLessThan(0.75);
   });
 });
 
@@ -838,7 +994,12 @@ describe.runIf(RUN_REGRESSION_GUARD)('Benchmark regression guard', () => {
       test(`${engineKey} engine — ${latest.version} vs ${previous.version}`, () => {
         assertNoRegressions(
           [
-            checkRegression(`Full build`, cur.fullBuildMs, prev.fullBuildMs),
+            checkRegression(
+              `Full build`,
+              perFileMs(cur.fullBuildMs, latest.files),
+              perFileMs(prev.fullBuildMs, previous.files),
+              MIN_ABSOLUTE_DELTA_PER_FILE,
+            ),
             checkRegression(`No-op rebuild`, cur.noopRebuildMs, prev.noopRebuildMs),
             checkRegression(`1-file rebuild`, cur.oneFileRebuildMs, prev.oneFileRebuildMs),
           ],

--- a/tests/unit/update-incremental-report.test.ts
+++ b/tests/unit/update-incremental-report.test.ts
@@ -118,6 +118,61 @@ ${NOTES_B}
     expect(out.match(/<!--\s*NOTES_END\s*-->/g)?.length).toBe(2);
   });
 
+  it('renders a Full Build (ms/file) column normalized against files, with its own trend (#2455)', () => {
+    const initial = `# Codegraph Incremental Build Benchmarks
+
+<!-- INCREMENTAL_BENCHMARK_DATA
+[
+  {
+    "version": "9.9.8",
+    "date": "2026-05-01",
+    "files": 800,
+    "wasm": { "fullBuildMs": 16000, "noopRebuildMs": 20, "oneFileRebuildMs": 100 },
+    "native": { "fullBuildMs": 5200, "noopRebuildMs": 10, "oneFileRebuildMs": 50 },
+    "resolve": { "imports": 100, "nativeBatchMs": 5, "jsFallbackMs": 10, "perImportNativeMs": 0, "perImportJsMs": 0 }
+  }
+]
+-->
+`;
+    fs.writeFileSync(reportPath, initial);
+    // 9.9.9 doubles files (800 -> 1600) and roughly doubles native fullBuildMs
+    // (5200 -> 10400) — same per-file cost, so raw ms doubles (+100%) but
+    // ms/file should read as unchanged (~0%).
+    fs.writeFileSync(
+      entryPath,
+      JSON.stringify({
+        version: '9.9.9',
+        date: '2026-05-14',
+        files: 1600,
+        wasm: { fullBuildMs: 32000, noopRebuildMs: 20, oneFileRebuildMs: 100 },
+        native: { fullBuildMs: 10400, noopRebuildMs: 10, oneFileRebuildMs: 50 },
+        resolve: {
+          imports: 200,
+          nativeBatchMs: 5,
+          jsFallbackMs: 10,
+          perImportNativeMs: 0,
+          perImportJsMs: 0,
+        },
+      }),
+    );
+
+    runScript();
+    const out = fs.readFileSync(reportPath, 'utf8');
+
+    expect(out).toContain('Full Build (ms/file)');
+    const nativeRow = out.match(/^\| 9\.9\.9 \| native \|.*$/m)?.[0];
+    expect(nativeRow).toBeDefined();
+    // Raw full build doubled (+100%)...
+    expect(nativeRow).toContain('↑100%');
+    // ...but ms/file (6.5) is unchanged from the prior release, so its own
+    // trend cell reads "~" rather than another "↑100%".
+    expect(nativeRow).toContain('6.5000 ~');
+
+    const latestSection = out.slice(out.indexOf('### Latest results'));
+    expect(latestSection).toContain('Full build (ms/file)');
+    expect(latestSection).toContain('6.5000');
+  });
+
   it('does not invent a NOTES block when none was present', () => {
     const initial = `# Codegraph Incremental Build Benchmarks
 


### PR DESCRIPTION
## Summary

`Full build` in `tests/benchmarks/regression-guard.test.ts` compared raw `fullBuildMs` against a fixed release baseline. Corpus growth and legitimate per-file work growth (new persisted-evidence tables, new resolution passes) are not regressions, but the gate had no way to tell them apart from a real algorithmic slowdown — requiring a hand-added `KNOWN_REGRESSIONS` entry roughly every release cycle (#2081/#2107, #2412, #2436).

Per #2412's own "Suggested directions" (normalize by file count, previously unscoped), this normalizes "Full build" to `fullBuildMs / files`:

- **Gate** (`tests/benchmarks/regression-guard.test.ts`): the `Full build` check now compares `perFileMs(fullBuildMs, files)` instead of raw `fullBuildMs`. `checkRegression` gained an optional `minAbsoluteDelta` override — the existing 10ms floor was calibrated for raw-ms metrics and would never fire on ms/file values (~5-25), silently disabling noise filtering; a new `MIN_ABSOLUTE_DELTA_PER_FILE = 0.1` restores it at the right scale. `No-op rebuild` / `1-file rebuild` are untouched — per the issue, `1-file rebuild`'s flakiness looks dominated by near-zero-baseline jitter rather than corpus size, so it's a separate problem.
- **Report** (`scripts/update-incremental-report.ts`): added a `Full Build (ms/file)` column to the historical table and "Latest results" summary (computed from the existing `files`/`fullBuildMs` fields already recorded on every entry — no benchmark JSON schema change needed, and it works retroactively across all history). The bottom `::warning` regression annotation was switched to the same normalized figure so it doesn't keep firing on growth-driven commits the hard gate no longer flags.
- **`KNOWN_REGRESSIONS`**: pruned `3.16.0:Full build`. Verified via the real committed history: `3.17.0 vs 3.16.0` clears the normalized threshold on both engines without the exemption (native +16.1% ms/file vs the raw +31.0%; wasm +8.9% vs the raw +22.9%). `3.16.0:1-file rebuild` is left in place (out of scope here).

Denominator choice: uses the existing `files` count already recorded per entry (which already excludes `tests/benchmarks/resolution/fixtures/**` via `BENCHMARK_EXCLUDES`), matching what the issue's own evidence table validated, rather than introducing a new `src/`+`crates/`-only counting mechanism.

## Test plan

- [x] `npx vitest run tests/benchmarks/regression-guard.test.ts tests/unit/update-incremental-report.test.ts tests/unit/incremental-report-trend-fallback.test.ts` (with `RUN_REGRESSION_GUARD=1`) — all pass
- [x] Revert-verified: temporarily restored the raw-ms gate + the pruned `KNOWN_REGRESSIONS` entry and confirmed `native engine — 3.17.0 vs 3.16.0` fails exactly as it did before this fix (`Full build: 4844 → 6345 (+31%, threshold 25%)`); restored the fix and confirmed green again
- [x] Revert-verified the report-generator test the same way
- [x] `npm test` (full suite) — 339 files, 5453 passed
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean

Closes #2455