### PR TITLE
fix(extractors): recover exports dropped by tree-sitter's bare export+newline misparse

### DIFF
--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -3289,8 +3289,46 @@ fn handle_reexport(node: &Node, source_node: &Node, source: &[u8], symbols: &mut
     symbols.imports.push(imp);
 }
 
+/// Recover the export relationship tree-sitter-javascript/typescript drops
+/// for a bare `export` keyword followed by a newline before certain
+/// declarations (#2459). Mirrors `recoverBareExportMisparse` in
+/// `src/extractors/javascript.ts` — see that function's doc comment for the
+/// full ECMAScript-grammar rationale and the reserved-word argument for why
+/// this can't misfire on a legitimate identifier reference. Reuses
+/// `handle_export_declaration`, the same function a correctly-parsed
+/// `export_statement`'s declaration goes through, so the recovered symbol is
+/// classified identically to a real export (and inherits that function's own
+/// gaps, e.g. `enum_declaration` isn't tracked either way — see #2560 —
+/// rather than this fix silently papering over a different bug).
+///
+/// Restricted to direct children of `program`: `export` is not valid syntax
+/// anywhere else a bare single-identifier expression statement could appear.
+/// Comment nodes between the bare `export` and the declaration are skipped
+/// when walking forward, since comments are ordinary siblings in this
+/// grammar, not children of either statement.
+fn recover_bare_export_misparse(bare_export_stmt: &Node, source: &[u8], symbols: &mut FileSymbols) {
+    let Some(parent) = bare_export_stmt.parent() else {
+        return;
+    };
+    if parent.kind() != "program" {
+        return;
+    }
+    let mut sib = bare_export_stmt.next_sibling();
+    while let Some(s) = sib {
+        if s.kind() != "comment" {
+            handle_export_declaration(&s, source, symbols);
+            return;
+        }
+        sib = s.next_sibling();
+    }
+}
+
 fn handle_expr_stmt(node: &Node, source: &[u8], symbols: &mut FileSymbols) {
     let Some(expr) = node.child(0) else { return };
+    if expr.kind() == "identifier" && node_text(&expr, source) == "export" {
+        recover_bare_export_misparse(node, source, symbols);
+        return;
+    }
     if expr.kind() != "assignment_expression" {
         return;
     }
@@ -10627,6 +10665,113 @@ mod tests {
             "expected 'greet' exported as function at line 2; got: {:?}",
             s.exports
         );
+    }
+
+    // #2459: tree-sitter-javascript/typescript misparses `export` followed by
+    // a newline before const/let/var/class/function/interface/type as a
+    // standalone `(expression_statement (identifier))` rather than a single
+    // `export_statement` — `export default`/`{`/`*` ARE handled correctly
+    // across a newline (see the two tests directly above, which use
+    // `export default` for exactly that reason), which is why this needed
+    // recover_bare_export_misparse rather than a line-computation fix.
+    #[test]
+    fn recovers_an_exported_const_split_across_a_newline_from_the_export_keyword() {
+        let s = parse_js("export\nconst onOwnLine = 5;");
+        assert!(
+            s.definitions
+                .iter()
+                .any(|d| d.name == "onOwnLine" && d.kind == "constant" && d.line == 2),
+            "expected 'onOwnLine' defined as constant at line 2; got: {:?}",
+            s.definitions
+        );
+        assert!(
+            s.exports
+                .iter()
+                .any(|e| e.name == "onOwnLine" && e.kind == "constant" && e.line == 2),
+            "expected 'onOwnLine' exported as constant at line 2; got: {:?}",
+            s.exports
+        );
+    }
+
+    #[test]
+    fn recovers_an_exported_class_split_across_a_newline_from_the_export_keyword() {
+        let s = parse_js("export\nclass Widget {}");
+        assert!(
+            s.exports
+                .iter()
+                .any(|e| e.name == "Widget" && e.kind == "class" && e.line == 2),
+            "expected 'Widget' exported as class at line 2; got: {:?}",
+            s.exports
+        );
+    }
+
+    #[test]
+    fn recovers_an_exported_function_split_across_a_newline_from_the_export_keyword() {
+        let s = parse_js("export\nfunction greet() {}");
+        assert!(
+            s.exports
+                .iter()
+                .any(|e| e.name == "greet" && e.kind == "function" && e.line == 2),
+            "expected 'greet' exported as function at line 2; got: {:?}",
+            s.exports
+        );
+    }
+
+    #[test]
+    fn recovers_an_exported_ts_interface_split_across_a_newline_from_the_export_keyword() {
+        let s = parse_ts("export\ninterface Shape {}");
+        assert!(
+            s.exports
+                .iter()
+                .any(|e| e.name == "Shape" && e.kind == "interface" && e.line == 2),
+            "expected 'Shape' exported as interface at line 2; got: {:?}",
+            s.exports
+        );
+    }
+
+    #[test]
+    fn recovers_an_exported_ts_type_alias_split_across_a_newline_from_the_export_keyword() {
+        let s = parse_ts("export\ntype Id = string;");
+        assert!(
+            s.exports
+                .iter()
+                .any(|e| e.name == "Id" && e.kind == "type" && e.line == 2),
+            "expected 'Id' exported as type at line 2; got: {:?}",
+            s.exports
+        );
+    }
+
+    #[test]
+    fn skips_a_comment_between_the_export_keyword_and_the_declaration() {
+        let s = parse_js("export\n// why is this exported\nconst withComment = 1;");
+        assert!(
+            s.exports
+                .iter()
+                .any(|e| e.name == "withComment" && e.kind == "constant" && e.line == 3),
+            "expected 'withComment' exported as constant at line 3; got: {:?}",
+            s.exports
+        );
+    }
+
+    #[test]
+    fn still_exports_a_same_line_declaration_normally_no_regression_from_the_recovery_path() {
+        let s = parse_js("export const sameLine = 6;");
+        assert!(
+            s.exports
+                .iter()
+                .any(|e| e.name == "sameLine" && e.kind == "constant" && e.line == 1),
+            "expected 'sameLine' exported as constant at line 1; got: {:?}",
+            s.exports
+        );
+    }
+
+    #[test]
+    fn does_not_export_a_plain_top_level_statement_referencing_an_unrelated_identifier() {
+        // Sanity check that recovery is keyed on the literal text "export" (a
+        // reserved word — this can only ever be the misparse), not on "any
+        // bare identifier expression statement followed by a declaration".
+        let s = parse_js("notExport;\nconst untouched = 1;");
+        assert!(!s.exports.iter().any(|e| e.name == "untouched"));
     }
 
     #[test]

--- a/src/domain/parser.ts
+++ b/src/domain/parser.ts
@@ -176,6 +176,14 @@ const COMMON_QUERY_PATTERNS: string[] = [
   '(method_definition name: (string) @meth_name) @meth_node',
   '(import_statement source: (string) @imp_source) @imp_node',
   '(export_statement) @exp_node',
+  // #2459: recovers the export relationship tree-sitter drops for a bare
+  // `export` keyword misparsed as a standalone identifier expression
+  // statement (see recoverBareExportMisparse in extractors/javascript.ts for
+  // the full rationale and the reserved-word argument for why this can't
+  // misfire on a legitimate identifier reference). Filtered/dispatched in
+  // JS, not via a query predicate — this codebase has no existing predicate
+  // usage, so filtering in dispatchQueryMatch matches the established idiom.
+  '(expression_statement (identifier) @bare_export_kw) @bare_export_stmt',
   '(call_expression function: (identifier) @callfn_name) @callfn_node',
   '(call_expression function: (member_expression) @callmem_fn) @callmem_node',
   '(call_expression function: (subscript_expression) @callsub_fn) @callsub_node',

--- a/src/domain/wasm-worker-entry.ts
+++ b/src/domain/wasm-worker-entry.ts
@@ -121,6 +121,14 @@ const COMMON_QUERY_PATTERNS: string[] = [
   '(method_definition name: (string) @meth_name) @meth_node',
   '(import_statement source: (string) @imp_source) @imp_node',
   '(export_statement) @exp_node',
+  // #2459: recovers the export relationship tree-sitter drops for a bare
+  // `export` keyword misparsed as a standalone identifier expression
+  // statement (see recoverBareExportMisparse in extractors/javascript.ts for
+  // the full rationale and the reserved-word argument for why this can't
+  // misfire on a legitimate identifier reference). Filtered/dispatched in
+  // JS, not via a query predicate — this codebase has no existing predicate
+  // usage, so filtering in dispatchQueryMatch matches the established idiom.
+  '(expression_statement (identifier) @bare_export_kw) @bare_export_stmt',
   '(call_expression function: (identifier) @callfn_name) @callfn_node',
   '(call_expression function: (member_expression) @callmem_fn) @callmem_node',
   '(call_expression function: (subscript_expression) @callsub_fn) @callsub_node',

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -394,6 +394,16 @@ function dispatchQueryMatch(
     handleImportCapture(c, imports);
   } else if (c.exp_node) {
     handleExportCapture(c, exps, imports);
+  } else if (c.bare_export_stmt) {
+    // #2459 — see recoverBareExportMisparse's doc comment. The query pattern
+    // matches every bare single-identifier expression statement (there's no
+    // existing predicate usage in this codebase's queries to filter by text
+    // at the query level — see the pattern's own comment in parser.ts /
+    // wasm-worker-entry.ts), so the "is this actually the reserved word"
+    // check happens here, matching the walk path's equivalent check.
+    if (c.bare_export_kw!.text === 'export') {
+      recoverBareExportMisparse(c.bare_export_stmt, exps);
+    }
   } else if (c.callfn_node) {
     // Route through extractCallInfo so special identifier calls (eval) get classified.
     const callfnInfo = extractCallInfo(c.callfn_name!, c.callfn_node);
@@ -2499,6 +2509,50 @@ function handleImportStmt(node: TreeSitterNode, ctx: ExtractorOutput): void {
   }
 }
 
+/**
+ * Recover the export relationship tree-sitter-javascript/typescript drops for
+ * a bare `export` keyword followed by a newline before certain declarations
+ * (#2459). Per the ECMAScript grammar `export Declaration` has no
+ * `[no LineTerminator here]` restriction — unlike `return`/`throw`, ASI does
+ * not apply — so `export\nconst x = 5;` is valid, correctly-exported JS in
+ * every real engine. The grammar's ASI-like heuristic special-cases
+ * `default`/`{`/`*` as valid same-line continuations after `export` but not
+ * `const`/`let`/`var`/`class`/`function`/`interface`/`type` directly, so it
+ * misparses `export` alone as a standalone `(expression_statement
+ * (identifier))`, and the declaration that follows becomes an ordinary,
+ * non-exported top-level statement — never wrapped in an `export_statement`,
+ * so neither extraction path's normal export detection (which requires a
+ * real `export_statement` node) can ever see it.
+ *
+ * `export` is a reserved word, so a genuine `identifier` node whose text is
+ * exactly "export" can only occur via this misparse — never a legitimate
+ * variable reference — making recovery here unambiguous. Reuses
+ * `collectExportedDeclarations`, the same function a correctly-parsed
+ * `export_statement`'s declaration goes through, so the recovered symbol is
+ * classified identically to a real export (and inherits any of that
+ * function's own gaps, e.g. `enum_declaration` isn't tracked either way —
+ * see #2560 — rather than this fix silently papering over a different bug).
+ *
+ * Restricted to direct children of `program`: `export` is not valid syntax
+ * anywhere else a bare single-identifier expression statement could appear
+ * (nested blocks, function bodies, etc.), so this can't misfire on unrelated
+ * code — it is simply never reached there because `bareExportStmt.parent`
+ * won't be `program`.
+ *
+ * Comment nodes between the bare `export` and the declaration (e.g.
+ * `export\n// why\nconst x = 5;`) are skipped when walking forward, since
+ * comments are ordinary siblings in this grammar, not children of either
+ * statement — without this, a comment would be handed to
+ * `collectExportedDeclarations`, which recognizes neither its own node type
+ * nor any of `EXPORT_DECL_KIND`'s, and silently no-ops.
+ */
+function recoverBareExportMisparse(bareExportStmt: TreeSitterNode, exps: Export[]): void {
+  if (bareExportStmt.parent?.type !== 'program') return;
+  let sib = bareExportStmt.nextSibling;
+  while (sib?.type === 'comment') sib = sib.nextSibling;
+  if (sib) collectExportedDeclarations(sib, exps);
+}
+
 function handleExportStmt(node: TreeSitterNode, ctx: ExtractorOutput): void {
   const decl = node.childForFieldName('declaration');
   if (decl) collectExportedDeclarations(decl, ctx.exports);
@@ -2525,6 +2579,10 @@ function handleExportStmt(node: TreeSitterNode, ctx: ExtractorOutput): void {
 
 function handleExpressionStmt(node: TreeSitterNode, ctx: ExtractorOutput): void {
   const expr = node.child(0);
+  if (expr && expr.type === 'identifier' && expr.text === 'export') {
+    recoverBareExportMisparse(node, ctx.exports);
+    return;
+  }
   if (expr && expr.type === 'assignment_expression') {
     const left = expr.childForFieldName('left');
     const right = expr.childForFieldName('right');

--- a/tests/engines/query-walk-parity.test.ts
+++ b/tests/engines/query-walk-parity.test.ts
@@ -128,6 +128,25 @@ a.b.c();
 `,
   },
   {
+    // #2459: bare `export` + newline before a declaration misparses as a
+    // standalone identifier expression statement in tree-sitter-javascript;
+    // both paths must recover the export relationship identically.
+    name: 'bare export keyword split across a newline from its declaration (#2459)',
+    file: 'test.js',
+    code: `
+export
+const onOwnLine = 5;
+
+export const sameLine = 6;
+
+export
+class Widget {}
+
+notExport;
+const untouched = 1;
+`,
+  },
+  {
     name: 'CommonJS require patterns',
     file: 'test.js',
     code: `
@@ -425,4 +444,24 @@ describe('Query vs Walk parity', () => {
       expect(queryResult).toEqual(walkResult);
     });
   }
+});
+
+describe('bare export keyword recovery — query path correctness (#2459)', () => {
+  // The parity loop above only proves the query path AGREES with the walk
+  // path; it doesn't independently confirm either is actually correct. The
+  // walk path's expected content is asserted directly in
+  // tests/parsers/javascript.test.ts — this asserts the query path's own
+  // `bare_export_stmt`/`bare_export_kw` capture (parser.ts /
+  // wasm-worker-entry.ts) fires and recovers the right export on its own.
+  it('recovers an exported const split across a newline via the query-based extractor', async () => {
+    const result = await queryExtract(`export\nconst onOwnLine = 5;`, 'test.js');
+    expect(result.exports).toContainEqual(
+      expect.objectContaining({ name: 'onOwnLine', kind: 'constant', line: 2 }),
+    );
+  });
+
+  it('does not export via the query path when the identifier is not literally "export"', async () => {
+    const result = await queryExtract(`notExport;\nconst untouched = 1;`, 'test.js');
+    expect(result.exports.some((e) => e.name === 'untouched')).toBe(false);
+  });
 });

--- a/tests/parsers/javascript.test.ts
+++ b/tests/parsers/javascript.test.ts
@@ -4017,6 +4017,81 @@ function runDemo(reporter: Reporter, users: string[]): void {
     });
   });
 
+  describe('bare `export` + newline before a declaration (#2459)', () => {
+    // tree-sitter-javascript/typescript misparses `export` followed by a
+    // newline before const/let/var/class/function/interface/type as a
+    // standalone `(expression_statement (identifier))` rather than a single
+    // `export_statement` — `export default`/`{`/`*` ARE handled correctly
+    // across a newline (the grammar's ASI-like heuristic special-cases
+    // them), which is why the #2293 suite above uses `export default` to
+    // exercise its line-computation fix instead of this exact shape.
+    function parseTS(code) {
+      const parser = parsers.get('typescript');
+      const tree = parser.parse(code);
+      return extractSymbols(tree, 'test.ts');
+    }
+
+    it('recovers an exported const split across a newline from the export keyword', () => {
+      const symbols = parseJS(`export\nconst onOwnLine = 5;`);
+      expect(symbols.definitions).toContainEqual(
+        expect.objectContaining({ name: 'onOwnLine', kind: 'constant', line: 2 }),
+      );
+      expect(symbols.exports).toContainEqual(
+        expect.objectContaining({ name: 'onOwnLine', kind: 'constant', line: 2 }),
+      );
+    });
+
+    it('recovers an exported class split across a newline from the export keyword', () => {
+      const symbols = parseJS(`export\nclass Widget {}`);
+      expect(symbols.exports).toContainEqual(
+        expect.objectContaining({ name: 'Widget', kind: 'class', line: 2 }),
+      );
+    });
+
+    it('recovers an exported function split across a newline from the export keyword', () => {
+      const symbols = parseJS(`export\nfunction greet() {}`);
+      expect(symbols.exports).toContainEqual(
+        expect.objectContaining({ name: 'greet', kind: 'function', line: 2 }),
+      );
+    });
+
+    it('recovers an exported TS interface split across a newline from the export keyword', () => {
+      const symbols = parseTS(`export\ninterface Shape {}`);
+      expect(symbols.exports).toContainEqual(
+        expect.objectContaining({ name: 'Shape', kind: 'interface', line: 2 }),
+      );
+    });
+
+    it('recovers an exported TS type alias split across a newline from the export keyword', () => {
+      const symbols = parseTS(`export\ntype Id = string;`);
+      expect(symbols.exports).toContainEqual(
+        expect.objectContaining({ name: 'Id', kind: 'type', line: 2 }),
+      );
+    });
+
+    it('skips a comment between the export keyword and the declaration', () => {
+      const symbols = parseJS(`export\n// why is this exported\nconst withComment = 1;`);
+      expect(symbols.exports).toContainEqual(
+        expect.objectContaining({ name: 'withComment', kind: 'constant', line: 3 }),
+      );
+    });
+
+    it('still exports a same-line declaration normally (no regression from the recovery path)', () => {
+      const symbols = parseJS(`export const sameLine = 6;`);
+      expect(symbols.exports).toContainEqual(
+        expect.objectContaining({ name: 'sameLine', kind: 'constant', line: 1 }),
+      );
+    });
+
+    it('does not export a plain top-level statement that merely references an unrelated identifier', () => {
+      // Sanity check that the recovery is keyed on the literal text "export"
+      // (a reserved word — this can only ever be the misparse), not on "any
+      // bare identifier expression statement followed by a declaration".
+      const symbols = parseJS(`notExport;\nconst untouched = 1;`);
+      expect(symbols.exports.some((e) => e.name === 'untouched')).toBe(false);
+    });
+  });
+
   describe('top-level const with a non-"literal-shaped" initializer (#1819)', () => {
     it('extracts a const with a parenthesized member-expression initializer as a definition (repro)', () => {
       // Repro from #1819: `(...).version` isn't one of the recognized "literal"


### PR DESCRIPTION
## Summary

tree-sitter-javascript/typescript misparses `export` followed by a newline before `const`/`let`/`var`/`class`/`function`/`interface`/`type` as a standalone `(expression_statement (identifier))` node instead of a single `export_statement` (`export default`/`{`/`*` ARE handled correctly across a newline — the grammar's ASI-like heuristic special-cases only those). The declaration that follows is then extracted as an ordinary, internal (non-exported) top-level statement — the export relationship never exists in the parse tree, so no `Export` entry is ever created, in either engine.

Per the ECMAScript grammar, `export Declaration` has no `[no LineTerminator here]` restriction — unlike `return`/`throw`, ASI does not apply — so this is valid, correctly-exported JS/TS in every real engine.

## Fix

`export` is a reserved word, so a real `identifier` node whose text is exactly `"export"` can only ever occur via this misparse — never a legitimate variable reference — making recovery unambiguous:

- **TS walk path** (`src/extractors/javascript.ts`): `handleExpressionStmt` detects the bare-`export` shape and calls the new `recoverBareExportMisparse`, which walks forward past any comment siblings to the next declaration and feeds it through `collectExportedDeclarations` — the same function a correctly-parsed `export_statement`'s declaration already goes through.
- **TS query path**: new capture `(expression_statement (identifier) @bare_export_kw) @bare_export_stmt` added to `COMMON_QUERY_PATTERNS` in both `src/domain/parser.ts` and `src/domain/wasm-worker-entry.ts` (this codebase duplicates that list across the two build contexts). Filtered by text (`=== 'export'`) in `dispatchQueryMatch` rather than a query predicate, since this codebase has no existing predicate usage.
- **Rust native engine** (`crates/codegraph-core/src/extractors/javascript.rs`): `handle_expr_stmt` gained the same check, calling the new `recover_bare_export_misparse`, mirroring the TS walk path and reusing `handle_export_declaration`.

Restricted to direct children of `program` in both engines — `export` is not valid syntax anywhere else a bare single-identifier expression statement could appear.

## Out-of-scope finding filed separately

While investigating, found that `enum_declaration` is entirely absent from `collectExportedDeclarations`/`handle_export_declaration` in both engines — `export enum Foo {}` never produces an `Export` record even when correctly parsed (a real, pre-existing, unrelated bug). Filed as #2560 rather than folding into this PR.

## Test plan

- [x] New tests in `tests/parsers/javascript.test.ts` (walk path): recovers const/class/function/TS interface/TS type-alias, skips an intervening comment, still exports same-line declarations normally, and doesn't misfire on an unrelated identifier (`notExport;`)
- [x] New tests in `tests/engines/query-walk-parity.test.ts`: a parity case proving query and walk paths agree, plus two dedicated query-path-only tests proving the query capture itself fires correctly (not just "agrees with walk")
- [x] New tests in `crates/codegraph-core/src/extractors/javascript.rs` mirroring all of the above
- [x] Revert-verified on both engines: temporarily disabled the fix (TS walk path, TS query dispatch, Rust) and confirmed all corresponding new tests fail with the exact expected pre-fix output (`[]` / empty exports); restored and confirmed green
- [x] End-to-end verified against the real build pipeline (not just unit tests) — rebuilt the native `.node` addon, ran `codegraph build --engine native` and `--engine wasm` against a temp fixture with the exact repro from the issue, confirmed `codegraph exports` lists the recovered symbol as exported on both engines
- [x] `npm test` (full suite) — 339 files, 5447+ passed
- [x] `cargo test --lib` (full suite) — 1088 passed
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean

Closes #2459