### PR TITLE
fix(resolve): probe .mts/.cts extensions for extension-less imports

### DIFF
--- a/crates/codegraph-core/src/domain/graph/resolve.rs
+++ b/crates/codegraph-core/src/domain/graph/resolve.rs
@@ -1512,6 +1512,8 @@ fn probe_known_extensions(
         ".pyi",
         "/index.ts",
         "/index.tsx",
+        "/index.mts",
+        "/index.cts",
         "/index.js",
         "/__init__.py",
     ];
@@ -1996,6 +1998,51 @@ mod tests {
             None,
         );
         assert_eq!(result, "src/legacy.cts");
+    }
+
+    #[test]
+    fn probe_known_extensions_resolves_a_directory_specifier_to_its_index_mts() {
+        // Greptile follow-up on #2464: the direct .mts/.cts candidates alone
+        // don't cover the directory-index convention (`./dir` -> `dir/index.mts`),
+        // which every other extension in this list already supports.
+        let mut known = HashSet::new();
+        known.insert("src/esm-dir/index.mts".to_string());
+
+        let aliases = PathAliases {
+            base_url: None,
+            paths: vec![],
+        };
+
+        let result = resolve_import_path_inner(
+            "/project/src/index.mts",
+            "./esm-dir",
+            "/project",
+            &aliases,
+            Some(&known),
+            None,
+        );
+        assert_eq!(result, "src/esm-dir/index.mts");
+    }
+
+    #[test]
+    fn probe_known_extensions_resolves_a_directory_specifier_to_its_index_cts() {
+        let mut known = HashSet::new();
+        known.insert("src/cjs-dir/index.cts".to_string());
+
+        let aliases = PathAliases {
+            base_url: None,
+            paths: vec![],
+        };
+
+        let result = resolve_import_path_inner(
+            "/project/src/index.cts",
+            "./cjs-dir",
+            "/project",
+            &aliases,
+            Some(&known),
+            None,
+        );
+        assert_eq!(result, "src/cjs-dir/index.cts");
     }
 
     #[test]

--- a/crates/codegraph-core/src/domain/graph/resolve.rs
+++ b/crates/codegraph-core/src/domain/graph/resolve.rs
@@ -1503,6 +1503,8 @@ fn probe_known_extensions(
     const EXTENSIONS: &[&str] = &[
         ".ts",
         ".tsx",
+        ".mts",
+        ".cts",
         ".js",
         ".jsx",
         ".mjs",
@@ -1942,6 +1944,52 @@ mod tests {
         let result = resolve_import_path_inner(
             "/project/src/index.cts",
             "./legacy.cjs",
+            "/project",
+            &aliases,
+            Some(&known),
+            None,
+        );
+        assert_eq!(result, "src/legacy.cts");
+    }
+
+    #[test]
+    fn probe_known_extensions_resolves_an_extension_less_specifier_to_mts() {
+        // #2464: distinct from resolve_mjs_to_mts_remap_with_known_files above
+        // — `./utils` here carries no extension at all, unlike `./utils.mjs`,
+        // so it exercises probe_known_extensions's EXTENSIONS list directly
+        // instead of EMIT_EXTENSION_REMAPS.
+        let mut known = HashSet::new();
+        known.insert("src/utils.mts".to_string());
+
+        let aliases = PathAliases {
+            base_url: None,
+            paths: vec![],
+        };
+
+        let result = resolve_import_path_inner(
+            "/project/src/index.mts",
+            "./utils",
+            "/project",
+            &aliases,
+            Some(&known),
+            None,
+        );
+        assert_eq!(result, "src/utils.mts");
+    }
+
+    #[test]
+    fn probe_known_extensions_resolves_an_extension_less_specifier_to_cts() {
+        let mut known = HashSet::new();
+        known.insert("src/legacy.cts".to_string());
+
+        let aliases = PathAliases {
+            base_url: None,
+            paths: vec![],
+        };
+
+        let result = resolve_import_path_inner(
+            "/project/src/index.cts",
+            "./legacy",
             "/project",
             &aliases,
             Some(&known),

--- a/src/domain/graph/resolve.ts
+++ b/src/domain/graph/resolve.ts
@@ -1268,6 +1268,8 @@ function resolveImportPathJS(
     '.pyi',
     '/index.ts',
     '/index.tsx',
+    '/index.mts',
+    '/index.cts',
     '/index.js',
     '/__init__.py',
   ]) {

--- a/src/domain/graph/resolve.ts
+++ b/src/domain/graph/resolve.ts
@@ -1259,6 +1259,8 @@ function resolveImportPathJS(
   for (const ext of [
     '.ts',
     '.tsx',
+    '.mts',
+    '.cts',
     '.js',
     '.jsx',
     '.mjs',

--- a/tests/unit/resolve.test.ts
+++ b/tests/unit/resolve.test.ts
@@ -46,9 +46,13 @@ beforeAll(() => {
   //   shared/core.ts   (for alias resolution)
   //   src/esm/util.mts (for .mjs -> .mts remap, #2299)
   //   src/cjs/legacy.cts (for .cjs -> .cts remap, #2299)
+  //   src/esm-dir/index.mts (for /index.mts directory resolution, #2464)
+  //   src/cjs-dir/index.cts (for /index.cts directory resolution, #2464)
   fs.mkdirSync(path.join(tmpDir, 'src', 'lib'), { recursive: true });
   fs.mkdirSync(path.join(tmpDir, 'src', 'esm'), { recursive: true });
   fs.mkdirSync(path.join(tmpDir, 'src', 'cjs'), { recursive: true });
+  fs.mkdirSync(path.join(tmpDir, 'src', 'esm-dir'), { recursive: true });
+  fs.mkdirSync(path.join(tmpDir, 'src', 'cjs-dir'), { recursive: true });
   fs.mkdirSync(path.join(tmpDir, 'shared'), { recursive: true });
 
   fs.writeFileSync(path.join(tmpDir, 'src', 'math.js'), 'export const add = (a, b) => a + b;');
@@ -65,6 +69,11 @@ beforeAll(() => {
   fs.writeFileSync(path.join(tmpDir, 'shared', 'core.ts'), 'export const x = 1;');
   fs.writeFileSync(path.join(tmpDir, 'src', 'esm', 'util.mts'), 'export const greet = () => "hi";');
   fs.writeFileSync(path.join(tmpDir, 'src', 'cjs', 'legacy.cts'), 'export const x = 1;');
+  fs.writeFileSync(
+    path.join(tmpDir, 'src', 'esm-dir', 'index.mts'),
+    'export const greet = () => "hi";',
+  );
+  fs.writeFileSync(path.join(tmpDir, 'src', 'cjs-dir', 'index.cts'), 'export const x = 1;');
 });
 
 afterAll(() => {
@@ -125,6 +134,21 @@ describe('resolveImportPathJS', () => {
     const fromFile = path.join(tmpDir, 'src', 'cjs', 'index.cts');
     const result = resolveImportPathJS(fromFile, './legacy', tmpDir, null);
     expect(result).toMatch(/legacy\.cts$/);
+  });
+
+  it('resolves a directory specifier to its index.mts file (#2464, Greptile follow-up)', () => {
+    // Caught by review: the direct .mts/.cts candidates alone don't cover
+    // the directory-index convention (`import './dir'` -> `dir/index.mts`),
+    // which every other extension in this list already supports.
+    const fromFile = path.join(tmpDir, 'src', 'index.mts');
+    const result = resolveImportPathJS(fromFile, './esm-dir', tmpDir, null);
+    expect(result).toMatch(/esm-dir\/index\.mts$/);
+  });
+
+  it('resolves a directory specifier to its index.cts file (#2464, Greptile follow-up)', () => {
+    const fromFile = path.join(tmpDir, 'src', 'index.cts');
+    const result = resolveImportPathJS(fromFile, './cjs-dir', tmpDir, null);
+    expect(result).toMatch(/cjs-dir\/index\.cts$/);
   });
 
   it('resolves directory to index.js', () => {

--- a/tests/unit/resolve.test.ts
+++ b/tests/unit/resolve.test.ts
@@ -112,6 +112,21 @@ describe('resolveImportPathJS', () => {
     expect(result).toMatch(/legacy\.cts$/);
   });
 
+  it('resolves an extension-less specifier to a .mts file (#2464)', () => {
+    // Distinct from the #2299 remap tests above: `./util` here carries no
+    // extension at all, unlike `./util.mjs`, so it exercises the
+    // extension-probing loop directly instead of EMIT_EXTENSION_REMAPS.
+    const fromFile = path.join(tmpDir, 'src', 'esm', 'index.mts');
+    const result = resolveImportPathJS(fromFile, './util', tmpDir, null);
+    expect(result).toMatch(/util\.mts$/);
+  });
+
+  it('resolves an extension-less specifier to a .cts file (#2464)', () => {
+    const fromFile = path.join(tmpDir, 'src', 'cjs', 'index.cts');
+    const result = resolveImportPathJS(fromFile, './legacy', tmpDir, null);
+    expect(result).toMatch(/legacy\.cts$/);
+  });
+
   it('resolves directory to index.js', () => {
     const fromFile = path.join(tmpDir, 'src', 'index.js');
     const result = resolveImportPathJS(fromFile, './lib', tmpDir, null);


### PR DESCRIPTION
## Summary

Discovered while fixing #2299 (the `.mjs`→`.mts`/`.cjs`→`.cts` emitted-extension remap). A separate, distinct code path — resolving an extension-less relative specifier like `import './foo'` by probing a fixed list of candidate extensions — never tries `.mts`/`.cts` in either engine, even though both engines otherwise recognize and parse `.mts`/`.cts` files (#2073).

- TS: the extension-probing loop in `resolveImportPathJS` (`src/domain/graph/resolve.ts`) tried `['.ts', '.tsx', '.js', '.jsx', '.mjs', '.py', '.pyi', ...index variants]` — no `.mts`/`.cts`.
- Rust: `probe_known_extensions`'s `EXTENSIONS` constant (`crates/codegraph-core/src/domain/graph/resolve.rs`) had the identical list, same gap.

So `import './foo'` resolving to a source file `foo.mts`/`foo.cts` (as opposed to the emitted-specifier form `import './foo.mjs'`, which #2299 covers) fell through to proximity-based confidence instead of an import-aware match.

## Fix

Added `.mts`/`.cts` to both extension lists, in both engines, placed alongside `.ts`/`.tsx` to keep TypeScript-family extensions grouped (matching the existing ordering convention where TS extensions precede JS extensions in the list).

## Test plan

- [x] New tests in `tests/unit/resolve.test.ts`: extension-less specifier resolves to `.mts`, extension-less specifier resolves to `.cts` — reusing the exact fixture files (`src/esm/util.mts`, `src/cjs/legacy.cts`) #2299's own remap tests already set up, but exercising the extension-probing loop directly (no extension on the specifier at all) rather than `EMIT_EXTENSION_REMAPS`
- [x] New tests in `crates/codegraph-core/src/domain/graph/resolve.rs` mirroring both cases
- [x] Revert-verified on both engines: temporarily removed `.mts`/`.cts` from each list and confirmed the corresponding new tests fail with the exact pre-fix output (resolves to the bare specifier, no extension); restored and confirmed green
- [x] `cargo test --lib` (full suite) — 1096 passed (up from 1094, +2 new)
- [x] `cargo clippy --lib -- -D warnings` — clean
- [x] `npm test` (full suite) — 339 files, 5449 passed
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean

Closes #2464