### PR TITLE
test(hooks): lock in check-git-clean-force.mjs's handling of prose-in-echo false positives

### DIFF
--- a/tests/unit/hook-guard-git-clean.test.ts
+++ b/tests/unit/hook-guard-git-clean.test.ts
@@ -194,6 +194,30 @@ describe('guard-git.sh does not false-positive on quoted text (#2099)', () => {
     ].join('\n');
     expect(isDenied(command)).toBe(false);
   });
+
+  it('does not block a descriptive echo label mentioning git clean before an unrelated, properly-guarded real invocation (#2468)', () => {
+    // Investigated as #2468: an echo LABEL narrating what a later command
+    // does (a natural thing to write in a multi-line script, e.g.
+    // /housekeep's own dirt-discovery phase) must not be misread as its own
+    // unprotected git-clean invocation just because it happens to mention
+    // force-like flag characters and the word "dry-run" (without a leading
+    // dash, since it's prose, not a real flag) in quoted text. The mask
+    // already reduces this to inert `#` characters before verb-detection
+    // runs (mask-quoted-text.mjs) — confirmed not reproducible against the
+    // current hook end-to-end; this locks that in against regression.
+    const command = [
+      `echo "=== gitignored dirt (git clean -fdX dry-run) ==="`,
+      `git clean -fdX --dry-run`,
+    ].join('\n');
+    expect(isDenied(command)).toBe(false);
+  });
+
+  it('does not block a single-line echo whose quoted prose mentions an unprotected-looking git clean (#2468)', () => {
+    // Isolates the same false-positive shape without the second, real
+    // invocation — the prose alone, once naively unmasked, reads as
+    // "git clean -fdX" with no dash-prefixed dry-run token nearby.
+    expect(isDenied('echo "we ran git clean -fdX dry-run here"')).toBe(false);
+  });
 });
 
 describe('guard-git.sh mask-quoted-text.mjs', () => {


### PR DESCRIPTION
## Summary

Investigated #2468: a descriptive `echo` label mentioning "git clean" plus force-like flag characters and a dash-less "dry-run" word in prose gets misread as its own unprotected `git clean` invocation, potentially suppressing an unrelated real invocation later in the same multi-line command block.

## Investigation

The issue describes guard-git.sh's quote-masking as a single crude step (`s/["'()]/ /g`, replacing quote characters with spaces) and manually constructs what it believes the "masked" text looks like based on that model, then confirms that hand-constructed text blocks when piped directly into `check-git-clean-force.mjs`.

Reproducing the exact repro against the **actual, current, end-to-end** hook pipeline (not a manual simulation) shows it does **not** reproduce: `mask-quoted-text.mjs` (introduced by #2329, five days before this issue was filed) already reduces the *contents* of an ordinary quoted string to inert `#` characters before any verb-detection check — including `check-git-clean-force.mjs`'s — ever runs. The crude `s/["'()]/ /g` step the issue describes is a separate, later cleanup pass that only strips residual delimiter punctuation around already-masked or intentionally-unmasked (exec-triggered/command-substitution) spans — by the time it runs, the prose has already been reduced to `#` runs, so no readable "git clean"/force-flag/dry-run text survives to strip.

Confirmed via direct testing against the live hook pipeline:
- The issue's exact multi-line repro (`echo "=== gitignored dirt (git clean -fdX dry-run) ==="` followed by a real, properly-guarded `git clean -fdX --dry-run`) does not block.
- The `gh issue create --body "..."` scenario the issue describes hitting while filing itself also does not block, including with nested escaped quotes.
- Feeding the issue's own hand-constructed "masked" text directly into `check-git-clean-force.mjs` (bypassing the real pipeline) *does* block — confirming the detector's own logic matches the issue's description, and the discrepancy is specifically that the real masking pipeline never produces that intermediate text.

No production code change — the underlying fix already exists via #2329's `mask-quoted-text.mjs`. This PR only adds regression coverage so a future refactor of `mask-quoted-text.mjs` or `check-git-clean-force.mjs` can't silently reintroduce this false-positive class un-noticed.

## Test plan

- [x] Two new tests in `tests/unit/hook-guard-git-clean.test.ts`'s existing "does not false-positive on quoted text" describe block, using the established `runHook`/`isDenied` end-to-end harness: the exact multi-line issue repro, and an isolated single-line variant
- [x] Verified the new tests are meaningful (not vacuously passing): temporarily disabled `mask-quoted-text.mjs`'s masking (pass-through stub) and confirmed both new tests fail with the exact false-positive `BLOCK` the issue describes; restored and confirmed green
- [x] `npm test` (full suite) — 339 files, 5453 passed
- [x] `npx tsc --noEmit` / `npm run lint` — clean
- [x] No hook script was modified, so `docs/examples/claude-code-hooks/`'s byte-identical mirror requirement doesn't apply here

Closes #2468