### PR TITLE
fix(skills): lint-skill.sh no longer masks cross-fence leaks fed via read here-strings

### DIFF
--- a/.claude/skills/create-skill/scripts/lint-skill.sh
+++ b/.claude/skills/create-skill/scripts/lint-skill.sh
@@ -78,24 +78,36 @@ collect_assignments() {
 }
 # Strips a trailing, unquoted `# comment` from a read command's argument
 # text. A `#` is only a genuine shell comment when it isn't inside an open
-# double-quoted string, so this walks the string quote-span by quote-span
-# (checking for `#` only in the text BETWEEN quotes) rather than scanning
-# for the first `#` outright (#2491 Greptile round 3: `read -r NUM < f
-# # MAX_LIMIT` left `# MAX_LIMIT` for the destination grep to pick up
-# `MAX_LIMIT` as a spurious destination).
+# quoted string (double OR single — a literal `#` inside a single-quoted
+# redirect target, e.g. `<<< '#tag value'`, is data, not a comment marker,
+# and must not truncate away a genuine destination that follows it (#2491
+# Greptile round 4)), so this walks the string quote-span by quote-span —
+# whichever quote character opens first — checking for `#` only in the
+# text BETWEEN quotes, rather than scanning for the first `#` outright
+# (#2491 Greptile round 3: `read -r NUM < f # MAX_LIMIT` left
+# `# MAX_LIMIT` for the destination grep to pick up `MAX_LIMIT` as a
+# spurious destination).
 strip_trailing_comment() {
-  local s="$1" out="" seg
-  while [[ "$s" == *'"'* ]]; do
-    seg="${s%%\"*}"
+  local s="$1" out="" seg q before_dq before_sq
+  while [[ "$s" == *'"'* ]] || [[ "$s" == *"'"* ]]; do
+    before_dq="${s%%\"*}"
+    before_sq="${s%%\'*}"
+    if [[ "$s" == *'"'* ]] && { [[ "$s" != *"'"* ]] || [ "${#before_dq}" -le "${#before_sq}" ]; }; then
+      q='"'
+      seg="$before_dq"
+    else
+      q="'"
+      seg="$before_sq"
+    fi
     if [[ "$seg" == *'#'* ]]; then
       printf '%s' "${out}${seg%%#*}"
       return
     fi
-    out+="${seg}\""
-    s="${s#*\"}"
-    seg="${s%%\"*}"
-    out+="${seg}\""
-    s="${s#*\"}"
+    out+="${seg}${q}"
+    s="${s#*"$q"}"
+    seg="${s%%"$q"*}"
+    out+="${seg}${q}"
+    s="${s#*"$q"}"
   done
   if [[ "$s" == *'#'* ]]; then
     printf '%s' "${out}${s%%#*}"

--- a/.claude/skills/create-skill/scripts/lint-skill.sh
+++ b/.claude/skills/create-skill/scripts/lint-skill.sh
@@ -114,6 +114,46 @@ is_read_dest_of_line() {
   done < <(extract_read_dest_vars "$line")
   return 1
 }
+# Extracts the INPUT-supplying portion of a `read` line — the mirror image
+# of extract_read_dest_vars's "%%<*" truncation, keeping everything from the
+# first standalone `<` onward (`< file`, `<<< "value"`) instead of discarding
+# it. Empty output if the line has no `<` at all (e.g. `read -p "..." VAR`).
+extract_read_input() {
+  local line="$1"
+  [[ "$line" =~ (^|[^A-Za-z0-9_])read([[:space:]].*)?$ ]] || return 0
+  local read_args="${BASH_REMATCH[2]}"
+  read_args="${read_args%%;*}"
+  [[ "$read_args" == *'<'* ]] || return 0
+  printf '%s' "${read_args#*<}"
+}
+# Whether $var (as $var, not the bare destination name) appears in this
+# line's own `read` input clause — the here-string/redirect operand, not
+# the destination it binds.
+is_read_input_of_line() {
+  local var="$1" line="$2" input
+  input=$(extract_read_input "$line")
+  [ -n "$input" ] && [[ "$input" =~ \$\{?${var}\}?([^A-Za-z0-9_]|$) ]]
+}
+# Whether this line both binds $var as a `read` destination AND feeds $var
+# into that same read's own input — a same-line self-reference like
+# `read -r FOO <<< "$FOO"` genuinely leaks the stale $FOO into itself even
+# though FOO is also this line's destination, because the here-string's
+# input is evaluated before the destination is rebound. Every OTHER line in
+# the block that references $var after this one is still legitimately safe
+# (this line does bind a fresh, in-process value) — only this exact line's
+# own reference is a leak (Greptile round 1 on PR #2574 for #2491:
+# is_read_dest_of_line alone only checks whether $var is *a* destination
+# somewhere on the line, not whether the specific $var occurrence that
+# triggered the outer reference check is safe, and the block-wide
+# REASSIGNED exemption doesn't distinguish this line from later ones).
+is_self_referential_read() {
+  is_read_dest_of_line "$1" "$2" && is_read_input_of_line "$1" "$2"
+}
+# Whether $var is a destination this line's `read` binds, WITHOUT also
+# being a same-line self-reference (see is_self_referential_read above).
+is_read_rebind_exempt() {
+  is_read_dest_of_line "$1" "$2" && ! is_self_referential_read "$1" "$2"
+}
 # Whether $line has a genuine single-`<` file-redirection ("< file",
 # "<\"file\"") — as opposed to a `<<<` here-string, which feeds an
 # IN-MEMORY value as input (the opposite of reading from a file) but
@@ -156,19 +196,24 @@ while IFS=$'\t' read -r bnum line; do
         # Narrow check: ensure the $VAR reference isn't followed by [A-Za-z0-9_]
         # (which would mean it's a different, longer variable name)
         if [[ "$line" =~ \$${var}([^A-Za-z0-9_]|$) ]] || [[ "$line" == *'${'"${var}"'}'* ]]; then
-          # Check if the same block also assigns it (re-assignment is fine) — O(1) lookup
-          if [ -z "${REASSIGNED[${var}:${bnum}]+x}" ]; then
+          # Check if the same block also assigns it (re-assignment is fine) — O(1) lookup.
+          # A same-line self-referential read (`read -r FOO <<< "$FOO"`) still forces
+          # the deeper check below even though REASSIGNED is set for this block: that
+          # flag correctly protects LATER lines referencing the freshly-bound $var, but
+          # this exact line's own reference predates the rebind and is still a leak.
+          if [ -z "${REASSIGNED[${var}:${bnum}]+x}" ] || is_self_referential_read "$var" "$line"; then
             # Check it's not read from a file (cat, $(...) with cat/read).
             # The `read` case checks that $var is actually THIS line's read
-            # destination, not merely that a `read` command appears
-            # somewhere on the line, and the redirection case excludes
-            # here-strings (`<<<`) — both were blanket substring matches
-            # that wrongly exempted a genuine cross-fence leak used as that
-            # same line's `read` INPUT (e.g. `read -r BAR <<< "$FOO"`: $FOO
-            # is a stale in-memory reference, not a file re-derivation, even
-            # though the line contains `read ` and the `<<<` operator's own
-            # text contains a trailing `< `) (#2491).
-            if [[ "$line" != *'cat '* ]] && ! is_read_dest_of_line "$var" "$line" && \
+            # destination AND isn't also that same read's own input (a
+            # same-line self-reference like `read -r FOO <<< "$FOO"` still
+            # leaks the stale value into itself), and the redirection case
+            # excludes here-strings (`<<<`) — all were blanket substring
+            # matches that wrongly exempted a genuine cross-fence leak used
+            # as that same line's `read` INPUT (e.g. `read -r BAR <<< "$FOO"`:
+            # $FOO is a stale in-memory reference, not a file re-derivation,
+            # even though the line contains `read ` and the `<<<` operator's
+            # own text contains a trailing `< `) (#2491).
+            if [[ "$line" != *'cat '* ]] && ! is_read_rebind_exempt "$var" "$line" && \
                ! has_file_redirect_in "$line" && [[ "$line" != *'$(<'* ]]; then
               error "Cross-fence variable: \$$var assigned in bash block $assigned_in, referenced in block $bnum without file persistence (Pattern 1)"
             fi

--- a/.claude/skills/create-skill/scripts/lint-skill.sh
+++ b/.claude/skills/create-skill/scripts/lint-skill.sh
@@ -76,27 +76,102 @@ collect_assignments() {
     s="${s#*"${BASH_REMATCH[0]}"}"
   done
 }
-# ERE for ONE `read` input-redirection clause: 1-3 `<` characters (covers
-# `<`, `<<`, `<<<`), optional whitespace, then its target — a double-quoted
-# string (matched whole, so a space inside it can't split off a trailing
-# word) or a bare unquoted word. A single-quoted target is deliberately not
-# matched here: bash never expands `$var` inside single quotes, so it can
-# never hold a reference this file's cross-fence check cares about, and
-# excluding it avoids the quoting gymnastics of embedding a literal `'`
-# in an ERE built from bash string fragments.
-# Shared by extract_read_dest_vars (removes the clause so a destination
-# AFTER it survives extraction) and extract_read_input (captures just the
-# clause's target) so both agree on what "the redirection" is, regardless
-# of where it falls among read's other arguments (#2491 Greptile round 2:
-# `read -r <<< "$FOO" BAR` is valid bash — BAR is still a real destination
-# even though it comes after the redirection).
-READ_REDIRECT_RE='<{1,3}[[:space:]]*("[^"]*"|[^[:space:]]+)'
+# Strips a trailing, unquoted `# comment` from a read command's argument
+# text. A `#` is only a genuine shell comment when it isn't inside an open
+# double-quoted string, so this walks the string quote-span by quote-span
+# (checking for `#` only in the text BETWEEN quotes) rather than scanning
+# for the first `#` outright (#2491 Greptile round 3: `read -r NUM < f
+# # MAX_LIMIT` left `# MAX_LIMIT` for the destination grep to pick up
+# `MAX_LIMIT` as a spurious destination).
+strip_trailing_comment() {
+  local s="$1" out="" seg
+  while [[ "$s" == *'"'* ]]; do
+    seg="${s%%\"*}"
+    if [[ "$seg" == *'#'* ]]; then
+      printf '%s' "${out}${seg%%#*}"
+      return
+    fi
+    out+="${seg}\""
+    s="${s#*\"}"
+    seg="${s%%\"*}"
+    out+="${seg}\""
+    s="${s#*\"}"
+  done
+  if [[ "$s" == *'#'* ]]; then
+    printf '%s' "${out}${s%%#*}"
+  else
+    printf '%s' "${out}${s}"
+  fi
+}
+# Consumes EVERY redirection clause (operator + target) from read_args,
+# regardless of how many there are or where they fall among read's other
+# arguments, populating two caller-local outputs via dynamic scoping (the
+# caller must `local` these two names before calling):
+#   READ_DEST_ARGS    — read_args with every redirection clause removed,
+#                        leaving only flags and genuine destinations
+#   READ_INPUT_TARGETS — every redirection's target, space-joined
+# A quoted target (double OR single) is consumed in full regardless of
+# embedded whitespace, so a multiword single-quoted operand like
+# `<<< 'FOO BAZ'` doesn't leave `BAZ'` dangling for the destination grep
+# (#2491 Greptile round 3), and EVERY redirect on the line participates —
+# not just the first — since `read` permits more than one input
+# redirection syntactically and each target could independently reference
+# a stale variable (#2491 Greptile round 3: `read -r FOO < "$CONFIG" <<<
+# "$FOO"` — the later here-string must still be checked for self-reference).
+split_read_redirects() {
+  local args="$1" op op_core after target inner remaining
+  READ_DEST_ARGS="$args"
+  READ_INPUT_TARGETS=""
+  READ_HERE_TARGETS=""
+  while [[ "$READ_DEST_ARGS" =~ (\<{1,3}[[:space:]]*) ]]; do
+    op="${BASH_REMATCH[1]}"
+    op_core="${op%%[[:space:]]*}"
+    after="${READ_DEST_ARGS#*"$op"}"
+    case "$after" in
+      \"*)
+        inner="${after#\"}"
+        inner="${inner%%\"*}"
+        target="\"${inner}\""
+        remaining="${after#*\"}"
+        remaining="${remaining#*\"}"
+        ;;
+      \'*)
+        inner="${after#\'}"
+        inner="${inner%%\'*}"
+        target="'${inner}'"
+        remaining="${after#*\'}"
+        remaining="${remaining#*\'}"
+        ;;
+      *)
+        target="${after%%[[:space:]]*}"
+        if [[ "$after" == *[[:space:]]* ]]; then
+          remaining="${after#*[[:space:]]}"
+        else
+          remaining=""
+        fi
+        ;;
+    esac
+    READ_INPUT_TARGETS+="${target} "
+    # `<<`/`<<<` (heredoc/here-string) feed an IN-MEMORY value, never a
+    # file — tracked separately so has_file_redirect_in's file-persistence
+    # exemption can require $var's reference to come from a genuine
+    # single-`<` target, not from a same-line `<<<` sitting alongside an
+    # unrelated file redirect (#2491 Greptile round 3: `read -r FOO <
+    # "$CONFIG" <<< "$FOO"` — the file redirect on $CONFIG must not exempt
+    # the separate, genuine here-string leak of $FOO).
+    if [ "${#op_core}" -ge 2 ]; then
+      READ_HERE_TARGETS+="${target} "
+    fi
+    READ_DEST_ARGS="${READ_DEST_ARGS%%"$op"*}${remaining}"
+  done
+}
 # Extracts the destination variable name(s) actually bound by a `read ...`
 # command on a line (e.g. `read -r VAR1 VAR2`) — one per output line via
 # stdout — stripping everything that ISN'T a real destination first:
 #   - a trailing command on the same line (`; do`)
-#   - the input source (`< file`, `<<< "$X"` here-strings), from anywhere
-#     in the argument list, not just a trailing truncation
+#   - a trailing unquoted comment (`# ...`)
+#   - every input source (`< file`, `<<< "$X"` here-strings), from
+#     anywhere in the argument list, not just a trailing truncation
 #   - quoted option arguments (`-p "prompt text"`, which may contain
 #     arbitrary uppercase words that aren't destinations at all)
 #   - a value-taking flag's own argument (`-t 5`, `-u FD`, `-d ':'`,
@@ -114,7 +189,10 @@ extract_read_dest_vars() {
   [[ "$line" =~ (^|[^A-Za-z0-9_])read([[:space:]].*)?$ ]] || return 0
   local read_args="${BASH_REMATCH[2]}"
   read_args="${read_args%%;*}"
-  read_args=$(printf '%s' "$read_args" | sed -E "s/${READ_REDIRECT_RE}//")
+  read_args=$(strip_trailing_comment "$read_args")
+  local READ_DEST_ARGS READ_INPUT_TARGETS
+  split_read_redirects "$read_args"
+  read_args="$READ_DEST_ARGS"
   read_args=$(printf '%s' "$read_args" | sed -E 's/"[^"]*"//g' | sed -E "s/'[^']*'//g")
   read_args=$(printf '%s' "$read_args" | sed -E 's/-[a-zA-Z]*[ptnNdui][[:space:]]+[^[:space:]]+//g')
   printf '%s' "$read_args" | grep -oE '(^|[^A-Za-z0-9_$])[A-Z][A-Z0-9_]+' | sed -E 's/^[^A-Za-z0-9_]//'
@@ -130,17 +208,33 @@ is_read_dest_of_line() {
   done < <(extract_read_dest_vars "$line")
   return 1
 }
-# Extracts just the TARGET of a `read` line's input redirection (e.g. the
-# `"$FOO"` in `read -r BAR <<< "$FOO"`), using the same READ_REDIRECT_RE as
-# extract_read_dest_vars so the two agree on where the redirection is.
-# Empty output if the line has no redirection at all (e.g. `read -p "..." VAR`).
+# Extracts every TARGET of a `read` line's input redirections, space-joined
+# (e.g. `"$FOO"` for `read -r BAR <<< "$FOO"`), via the same
+# split_read_redirects used by extract_read_dest_vars so both agree on
+# where the redirections are. Empty output if the line has none at all
+# (e.g. `read -p "..." VAR`).
 extract_read_input() {
   local line="$1"
   [[ "$line" =~ (^|[^A-Za-z0-9_])read([[:space:]].*)?$ ]] || return 0
   local read_args="${BASH_REMATCH[2]}"
   read_args="${read_args%%;*}"
-  [[ "$read_args" =~ $READ_REDIRECT_RE ]] || return 0
-  printf '%s' "${BASH_REMATCH[1]}"
+  local READ_DEST_ARGS READ_INPUT_TARGETS READ_HERE_TARGETS
+  split_read_redirects "$read_args"
+  printf '%s' "$READ_INPUT_TARGETS"
+}
+# Extracts only the HERE-string/heredoc (`<<`, `<<<`) targets of a `read`
+# line, excluding genuine single-`<` file targets — the in-memory subset of
+# extract_read_input, used where a mix of a real file redirect and an
+# in-memory here-string on the SAME line must be told apart (#2491 Greptile
+# round 3).
+extract_read_here_input() {
+  local line="$1"
+  [[ "$line" =~ (^|[^A-Za-z0-9_])read([[:space:]].*)?$ ]] || return 0
+  local read_args="${BASH_REMATCH[2]}"
+  read_args="${read_args%%;*}"
+  local READ_DEST_ARGS READ_INPUT_TARGETS READ_HERE_TARGETS
+  split_read_redirects "$read_args"
+  printf '%s' "$READ_HERE_TARGETS"
 }
 # Whether $var (as $var, not the bare destination name) appears in this
 # line's own `read` input clause — the here-string/redirect operand, not
@@ -148,6 +242,17 @@ extract_read_input() {
 is_read_input_of_line() {
   local var="$1" line="$2" input
   input=$(extract_read_input "$line")
+  [ -n "$input" ] && [[ "$input" =~ \$\{?${var}\}?([^A-Za-z0-9_]|$) ]]
+}
+# Whether $var appears specifically within a here-string/heredoc target on
+# this `read` line, as opposed to a genuine single-`<` file target — used
+# to tell apart `read -r FOO < "$CONFIG" <<< "$FOO"`'s two redirects: the
+# first is a real (if itself possibly stale) file path, the second is an
+# in-memory leak of $FOO that a blanket "this line has a file redirect"
+# check must not paper over.
+is_read_here_input_of_line() {
+  local var="$1" line="$2" input
+  input=$(extract_read_here_input "$line")
   [ -n "$input" ] && [[ "$input" =~ \$\{?${var}\}?([^A-Za-z0-9_]|$) ]]
 }
 # Whether this line both binds $var as a `read` destination AND feeds $var
@@ -223,14 +328,20 @@ while IFS=$'\t' read -r bnum line; do
             # destination AND isn't also that same read's own input (a
             # same-line self-reference like `read -r FOO <<< "$FOO"` still
             # leaks the stale value into itself), and the redirection case
-            # excludes here-strings (`<<<`) — all were blanket substring
-            # matches that wrongly exempted a genuine cross-fence leak used
-            # as that same line's `read` INPUT (e.g. `read -r BAR <<< "$FOO"`:
-            # $FOO is a stale in-memory reference, not a file re-derivation,
-            # even though the line contains `read ` and the `<<<` operator's
-            # own text contains a trailing `< `) (#2491).
+            # excludes here-strings (`<<<`) UNLESS $var's own reference is
+            # itself the here-string's target — a line can have a genuine
+            # single-`<` file redirect ALONGSIDE an unrelated `<<<` leak
+            # (`read -r FOO < "$CONFIG" <<< "$FOO"`: the file redirect must
+            # not paper over the separate, genuine leak of $FOO) — all were
+            # blanket substring/whole-line matches that wrongly exempted a
+            # genuine cross-fence leak used as that same line's `read`
+            # INPUT (e.g. `read -r BAR <<< "$FOO"`: $FOO is a stale
+            # in-memory reference, not a file re-derivation, even though
+            # the line contains `read ` and the `<<<` operator's own text
+            # contains a trailing `< `) (#2491).
             if [[ "$line" != *'cat '* ]] && ! is_read_rebind_exempt "$var" "$line" && \
-               ! has_file_redirect_in "$line" && [[ "$line" != *'$(<'* ]]; then
+               { ! has_file_redirect_in "$line" || is_read_here_input_of_line "$var" "$line"; } && \
+               [[ "$line" != *'$(<'* ]]; then
               error "Cross-fence variable: \$$var assigned in bash block $assigned_in, referenced in block $bnum without file persistence (Pattern 1)"
             fi
           fi

--- a/.claude/skills/create-skill/scripts/lint-skill.sh
+++ b/.claude/skills/create-skill/scripts/lint-skill.sh
@@ -76,6 +76,55 @@ collect_assignments() {
     s="${s#*"${BASH_REMATCH[0]}"}"
   done
 }
+# Extracts the destination variable name(s) actually bound by a `read ...`
+# command on a line (e.g. `read -r VAR1 VAR2`) — one per output line via
+# stdout — stripping everything that ISN'T a real destination first:
+#   - a trailing command on the same line (`; do`)
+#   - the input source (`< file`, `<<< "$X"` here-strings)
+#   - quoted option arguments (`-p "prompt text"`, which may contain
+#     arbitrary uppercase words that aren't destinations at all)
+#   - a value-taking flag's own argument (`-t 5`, `-u FD`, `-d ':'`,
+#     `-i "initial text"`, and combined short forms like `-ei FOO`, where
+#     `-e` takes no argument but the trailing `-i` does — every read flag
+#     EXCEPT `-a` (whose argument is itself a genuine destination: the
+#     array read into), so the strip only fires when the cluster's LAST
+#     letter is one of the other value-taking flags
+#   - a `$`-prefixed token, which REFERENCES a var rather than binding it
+# Shared by collect_assignments's registration pass and the cross-fence
+# reference check's read-exemption (#2491) so both agree on what a `read`
+# line actually binds.
+extract_read_dest_vars() {
+  local line="$1"
+  [[ "$line" =~ (^|[^A-Za-z0-9_])read([[:space:]].*)?$ ]] || return 0
+  local read_args="${BASH_REMATCH[2]}"
+  read_args="${read_args%%;*}"
+  read_args="${read_args%%<*}"
+  read_args=$(printf '%s' "$read_args" | sed -E 's/"[^"]*"//g' | sed -E "s/'[^']*'//g")
+  read_args=$(printf '%s' "$read_args" | sed -E 's/-[a-zA-Z]*[ptnNdui][[:space:]]+[^[:space:]]+//g')
+  printf '%s' "$read_args" | grep -oE '(^|[^A-Za-z0-9_$])[A-Z][A-Z0-9_]+' | sed -E 's/^[^A-Za-z0-9_]//'
+}
+# Whether $var is one of the destination variables a `read` on this line
+# actually binds — as opposed to merely appearing somewhere else on the
+# line (e.g. as a here-string/redirection INPUT to that same read, which is
+# a genuine cross-fence reference, not a rebinding).
+is_read_dest_of_line() {
+  local var="$1" line="$2" dest
+  while IFS= read -r dest; do
+    [ "$dest" = "$var" ] && return 0
+  done < <(extract_read_dest_vars "$line")
+  return 1
+}
+# Whether $line has a genuine single-`<` file-redirection ("< file",
+# "<\"file\"") — as opposed to a `<<<` here-string, which feeds an
+# IN-MEMORY value as input (the opposite of reading from a file) but
+# contains the same `< `/`<"` substrings a blanket check would wrongly
+# treat as file persistence (#2491: `read -r BAR <<< "$FOO"` — $FOO is a
+# genuine cross-fence leak, not a file re-derivation, even though the `<<<`
+# operator's own text contains a trailing `< `).
+has_file_redirect_in() {
+  local line="$1"
+  [[ "$line" =~ (^|[^\<])\<[[:space:]] ]] || [[ "$line" =~ (^|[^\<])\<\" ]]
+}
 while IFS=$'\t' read -r bnum line; do
   # Skip comment lines — they document context but don't register variable assignments
   [[ "$line" =~ ^[[:space:]]*# ]] && continue
@@ -89,31 +138,10 @@ while IFS=$'\t' read -r bnum line; do
   # (issue #2344 — fixer/SKILL.md's own I4 integrity check does exactly this
   # with a loop-local $COUNT that collides in name only with the unrelated
   # batch-size $COUNT set up in Phase 0).
-  if [[ "$line" =~ (^|[^A-Za-z0-9_])read([[:space:]].*)?$ ]]; then
-    read_args="${BASH_REMATCH[2]}"
-    # Only the destination variable *names* on a `read` line are real
-    # bindings — strip everything else first so none of it is misread as
-    # one (Greptile review on PR #2490/#2344):
-    #   - a trailing command on the same line (`; do`)
-    #   - the input source (`< file`, `<<< "$X"` here-strings)
-    #   - quoted option arguments (`-p "prompt text"`, which may contain
-    #     arbitrary uppercase words that aren't destinations at all)
-    #   - a value-taking flag's own argument (`-t 5`, `-u FD`, `-d ':'`,
-    #     `-i "initial text"`, and combined short forms like `-ei FOO`,
-    #     where `-e` takes no argument but the trailing `-i` does — every
-    #     read flag EXCEPT `-a` (whose argument is itself a genuine
-    #     destination: the array read into), so the strip only fires when
-    #     the cluster's LAST letter is one of the other value-taking flags
-    #   - a `$`-prefixed token, which REFERENCES a var rather than binding it
-    read_args="${read_args%%;*}"
-    read_args="${read_args%%<*}"
-    read_args=$(printf '%s' "$read_args" | sed -E 's/"[^"]*"//g' | sed -E "s/'[^']*'//g")
-    read_args=$(printf '%s' "$read_args" | sed -E 's/-[a-zA-Z]*[ptnNdui][[:space:]]+[^[:space:]]+//g')
-    while IFS= read -r var; do
-      [ -z "$var" ] && continue
-      register_var "$var" "$bnum"
-    done < <(printf '%s' "$read_args" | grep -oE '(^|[^A-Za-z0-9_$])[A-Z][A-Z0-9_]+' | sed -E 's/^[^A-Za-z0-9_]//')
-  fi
+  while IFS= read -r var; do
+    [ -z "$var" ] && continue
+    register_var "$var" "$bnum"
+  done < <(extract_read_dest_vars "$line")
 done < "$BLOCKS_FILE"
 
 # Check for references in later blocks without file persistence
@@ -130,9 +158,18 @@ while IFS=$'\t' read -r bnum line; do
         if [[ "$line" =~ \$${var}([^A-Za-z0-9_]|$) ]] || [[ "$line" == *'${'"${var}"'}'* ]]; then
           # Check if the same block also assigns it (re-assignment is fine) — O(1) lookup
           if [ -z "${REASSIGNED[${var}:${bnum}]+x}" ]; then
-            # Check it's not read from a file (cat, $(...) with cat/read)
-            if [[ "$line" != *'cat '* ]] && [[ "$line" != *'read '* ]] && \
-               [[ "$line" != *'< '* ]] && [[ "$line" != *'<"'* ]] && [[ "$line" != *'$(<'* ]]; then
+            # Check it's not read from a file (cat, $(...) with cat/read).
+            # The `read` case checks that $var is actually THIS line's read
+            # destination, not merely that a `read` command appears
+            # somewhere on the line, and the redirection case excludes
+            # here-strings (`<<<`) — both were blanket substring matches
+            # that wrongly exempted a genuine cross-fence leak used as that
+            # same line's `read` INPUT (e.g. `read -r BAR <<< "$FOO"`: $FOO
+            # is a stale in-memory reference, not a file re-derivation, even
+            # though the line contains `read ` and the `<<<` operator's own
+            # text contains a trailing `< `) (#2491).
+            if [[ "$line" != *'cat '* ]] && ! is_read_dest_of_line "$var" "$line" && \
+               ! has_file_redirect_in "$line" && [[ "$line" != *'$(<'* ]]; then
               error "Cross-fence variable: \$$var assigned in bash block $assigned_in, referenced in block $bnum without file persistence (Pattern 1)"
             fi
           fi

--- a/.claude/skills/create-skill/scripts/lint-skill.sh
+++ b/.claude/skills/create-skill/scripts/lint-skill.sh
@@ -76,11 +76,27 @@ collect_assignments() {
     s="${s#*"${BASH_REMATCH[0]}"}"
   done
 }
+# ERE for ONE `read` input-redirection clause: 1-3 `<` characters (covers
+# `<`, `<<`, `<<<`), optional whitespace, then its target — a double-quoted
+# string (matched whole, so a space inside it can't split off a trailing
+# word) or a bare unquoted word. A single-quoted target is deliberately not
+# matched here: bash never expands `$var` inside single quotes, so it can
+# never hold a reference this file's cross-fence check cares about, and
+# excluding it avoids the quoting gymnastics of embedding a literal `'`
+# in an ERE built from bash string fragments.
+# Shared by extract_read_dest_vars (removes the clause so a destination
+# AFTER it survives extraction) and extract_read_input (captures just the
+# clause's target) so both agree on what "the redirection" is, regardless
+# of where it falls among read's other arguments (#2491 Greptile round 2:
+# `read -r <<< "$FOO" BAR` is valid bash — BAR is still a real destination
+# even though it comes after the redirection).
+READ_REDIRECT_RE='<{1,3}[[:space:]]*("[^"]*"|[^[:space:]]+)'
 # Extracts the destination variable name(s) actually bound by a `read ...`
 # command on a line (e.g. `read -r VAR1 VAR2`) — one per output line via
 # stdout — stripping everything that ISN'T a real destination first:
 #   - a trailing command on the same line (`; do`)
-#   - the input source (`< file`, `<<< "$X"` here-strings)
+#   - the input source (`< file`, `<<< "$X"` here-strings), from anywhere
+#     in the argument list, not just a trailing truncation
 #   - quoted option arguments (`-p "prompt text"`, which may contain
 #     arbitrary uppercase words that aren't destinations at all)
 #   - a value-taking flag's own argument (`-t 5`, `-u FD`, `-d ':'`,
@@ -98,7 +114,7 @@ extract_read_dest_vars() {
   [[ "$line" =~ (^|[^A-Za-z0-9_])read([[:space:]].*)?$ ]] || return 0
   local read_args="${BASH_REMATCH[2]}"
   read_args="${read_args%%;*}"
-  read_args="${read_args%%<*}"
+  read_args=$(printf '%s' "$read_args" | sed -E "s/${READ_REDIRECT_RE}//")
   read_args=$(printf '%s' "$read_args" | sed -E 's/"[^"]*"//g' | sed -E "s/'[^']*'//g")
   read_args=$(printf '%s' "$read_args" | sed -E 's/-[a-zA-Z]*[ptnNdui][[:space:]]+[^[:space:]]+//g')
   printf '%s' "$read_args" | grep -oE '(^|[^A-Za-z0-9_$])[A-Z][A-Z0-9_]+' | sed -E 's/^[^A-Za-z0-9_]//'
@@ -114,17 +130,17 @@ is_read_dest_of_line() {
   done < <(extract_read_dest_vars "$line")
   return 1
 }
-# Extracts the INPUT-supplying portion of a `read` line — the mirror image
-# of extract_read_dest_vars's "%%<*" truncation, keeping everything from the
-# first standalone `<` onward (`< file`, `<<< "value"`) instead of discarding
-# it. Empty output if the line has no `<` at all (e.g. `read -p "..." VAR`).
+# Extracts just the TARGET of a `read` line's input redirection (e.g. the
+# `"$FOO"` in `read -r BAR <<< "$FOO"`), using the same READ_REDIRECT_RE as
+# extract_read_dest_vars so the two agree on where the redirection is.
+# Empty output if the line has no redirection at all (e.g. `read -p "..." VAR`).
 extract_read_input() {
   local line="$1"
   [[ "$line" =~ (^|[^A-Za-z0-9_])read([[:space:]].*)?$ ]] || return 0
   local read_args="${BASH_REMATCH[2]}"
   read_args="${read_args%%;*}"
-  [[ "$read_args" == *'<'* ]] || return 0
-  printf '%s' "${read_args#*<}"
+  [[ "$read_args" =~ $READ_REDIRECT_RE ]] || return 0
+  printf '%s' "${BASH_REMATCH[1]}"
 }
 # Whether $var (as $var, not the bare destination name) appears in this
 # line's own `read` input clause — the here-string/redirect operand, not

--- a/tests/unit/lint-skill-here-string-2491.test.ts
+++ b/tests/unit/lint-skill-here-string-2491.test.ts
@@ -184,5 +184,51 @@ describe.skipIf(BASH4 === null)(
         'Cross-fence variable: $FOO assigned in bash block 1, referenced in block 2',
       );
     });
+
+    // Greptile round 3 on PR #2574: three further gaps in the generalized
+    // redirect handling, each verified to be a genuine bash construct
+    // before fixing (`bash -c` reproductions, not just reasoning about it).
+    it('does not register a trailing comment word as a destination', () => {
+      const { stdout, ranSuccessfully } = runLint([
+        'MAX_LIMIT=5',
+        'read -r NUM < .codegraph/nums # MAX_LIMIT\necho "leak: $MAX_LIMIT"',
+      ]);
+      expect(ranSuccessfully).toBe(true);
+      expect(stdout).toContain(
+        'Cross-fence variable: $MAX_LIMIT assigned in bash block 1, referenced in block 2',
+      );
+    });
+
+    it('does not register a trailing word from inside a multiword single-quoted target', () => {
+      const { stdout, ranSuccessfully } = runLint([
+        'BAZ=hello',
+        'read -r BAR <<< \'FOO BAZ\'\necho "leak: $BAZ"',
+      ]);
+      expect(ranSuccessfully).toBe(true);
+      expect(stdout).toContain(
+        'Cross-fence variable: $BAZ assigned in bash block 1, referenced in block 2',
+      );
+    });
+
+    it('checks every redirect on a line with more than one, not just the first', () => {
+      const { stdout, ranSuccessfully } = runLint([
+        'FOO=hello',
+        'CONFIG=cfg.txt',
+        'read -r FOO < "$CONFIG" <<< "$FOO"',
+      ]);
+      expect(ranSuccessfully).toBe(true);
+      expect(stdout).toContain(
+        'Cross-fence variable: $FOO assigned in bash block 1, referenced in block 3',
+      );
+    });
+
+    it('still exempts a genuine single-redirect file read alongside an unrelated var', () => {
+      const { stdout, ranSuccessfully } = runLint([
+        'FOO=hello\nprintf \'%s\' "$FOO" > .codegraph/foo',
+        'read -r FOO < .codegraph/foo\necho "reloaded: $FOO"',
+      ]);
+      expect(ranSuccessfully).toBe(true);
+      expect(stdout).not.toContain('Cross-fence variable: $FOO');
+    });
   },
 );

--- a/tests/unit/lint-skill-here-string-2491.test.ts
+++ b/tests/unit/lint-skill-here-string-2491.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Regression test for issue #2491: `lint-skill.sh`'s cross-fence variable
+ * check (Pattern 1) exempted ANY line containing the substring `read ` from
+ * being flagged, on the theory that `read` re-derives a variable's value
+ * fresh (e.g. from a file), so a same-named reference on that line can't be
+ * a stale cross-fence leak.
+ *
+ * That blanket substring match didn't check that the variable in question
+ * was actually the destination `read` bound on that line. A here-string
+ * (`read -r BAR <<< "$FOO"`) puts the leaked variable on the INPUT side of
+ * `read`, not its destination — `$FOO` here is a genuine stale reference to
+ * an earlier block's variable, not a fresh binding, yet the line still
+ * contains the literal substring `read `.
+ *
+ * A second, independent exemption (a blanket `< ` substring check meant to
+ * detect genuine file redirection) made this worse: `<<<`'s own text
+ * contains a trailing `< ` (its third `<` immediately followed by a space),
+ * so even after narrowing the `read` exemption to genuine destinations, the
+ * here-string line still slipped through via this second, unrelated
+ * exemption clause.
+ *
+ * Fixed by `is_read_dest_of_line` (checks whether `$var` is actually a
+ * destination `extract_read_dest_vars` finds for that line) and
+ * `has_file_redirect_in` (a regex distinguishing a genuine single-`<` file
+ * redirect from `<<`/`<<<`).
+ */
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const LINT_SCRIPT = path.join(
+  REPO_ROOT,
+  '.claude',
+  'skills',
+  'create-skill',
+  'scripts',
+  'lint-skill.sh',
+);
+
+// lint-skill.sh requires bash 4+ (associative arrays). macOS ships bash 3.2
+// as the `bash` on PATH, including on GitHub Actions' macos-latest runner —
+// resolve a real bash 4+ explicitly rather than assuming plain "bash" works.
+function resolveBash4(): string | null {
+  const candidates = ['/opt/homebrew/bin/bash', '/usr/local/bin/bash', 'bash'];
+  for (const candidate of candidates) {
+    try {
+      const version = execFileSync(candidate, ['--version'], { encoding: 'utf8' });
+      const match = version.match(/version (\d+)\./);
+      if (match && Number(match[1]) >= 4) return candidate;
+    } catch {
+      // candidate not on PATH — try the next one
+    }
+  }
+  return null;
+}
+
+const BASH4 = resolveBash4();
+
+const FRONTMATTER = `---
+name: lint-test-skill
+description: test
+argument-hint: none
+allowed-tools: Bash
+---
+
+## Phase 0
+
+pre-flight
+`;
+
+function runLint(bashBlocks: string[]): { stdout: string; ranSuccessfully: boolean } {
+  const blocksMarkdown = bashBlocks.map((b) => `\`\`\`bash\n${b}\n\`\`\`\n`).join('\n');
+  const content = `${FRONTMATTER}\n${blocksMarkdown}\n## Rules\n\nrules here\n\n## Examples\n\nexample here\n\n**Exit condition:** done\n`;
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lint-skill-herestring-'));
+  const skillPath = path.join(dir, 'SKILL.md');
+  fs.writeFileSync(skillPath, content);
+  try {
+    const result = execFileSync(BASH4!, [LINT_SCRIPT, skillPath], { encoding: 'utf8' });
+    return { stdout: result, ranSuccessfully: true };
+  } catch (err) {
+    const e = err as { stdout?: string };
+    const stdout = e.stdout ?? '';
+    return { stdout, ranSuccessfully: /lint-skill: \d+ error/.test(stdout) };
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe.skipIf(BASH4 === null)(
+  'lint-skill.sh catches a leak fed into a `read` here-string, not just a plain reference (#2491)',
+  () => {
+    it('flags the exact issue repro: a here-string feeding a stale variable into `read`', () => {
+      const { stdout, ranSuccessfully } = runLint(['FOO=hello', 'read -r BAR <<< "$FOO"']);
+      expect(ranSuccessfully).toBe(true);
+      expect(stdout).toContain(
+        'Cross-fence variable: $FOO assigned in bash block 1, referenced in block 2',
+      );
+    });
+
+    it('still exempts a genuine read-destination rebinding on the same line (#2344 coverage)', () => {
+      const { stdout, ranSuccessfully } = runLint([
+        'COUNT=5',
+        'read -r COUNT < .codegraph/count\necho "fresh: $COUNT"',
+      ]);
+      expect(ranSuccessfully).toBe(true);
+      expect(stdout).not.toContain('Cross-fence variable: $COUNT');
+    });
+
+    it('still exempts a genuine file redirection (single `<`) as file persistence', () => {
+      const { stdout, ranSuccessfully } = runLint([
+        'FOO=hello\nprintf \'%s\' "$FOO" > .codegraph/foo',
+        'read -r FOO < .codegraph/foo\necho "reloaded: $FOO"',
+      ]);
+      expect(ranSuccessfully).toBe(true);
+      expect(stdout).not.toContain('Cross-fence variable: $FOO');
+    });
+
+    it('still flags a plain reference fed via a here-string with no `read` at all', () => {
+      const { stdout, ranSuccessfully } = runLint(['FOO=hello', 'wc -l <<< "$FOO"']);
+      expect(ranSuccessfully).toBe(true);
+      expect(stdout).toContain(
+        'Cross-fence variable: $FOO assigned in bash block 1, referenced in block 2',
+      );
+    });
+
+    it('still flags a leak past an unrelated `read` whose destination is a different var', () => {
+      const { stdout, ranSuccessfully } = runLint([
+        'FOO=hello',
+        'read -r OTHER < .codegraph/other\necho "leak: $FOO"',
+      ]);
+      expect(ranSuccessfully).toBe(true);
+      expect(stdout).toContain(
+        'Cross-fence variable: $FOO assigned in bash block 1, referenced in block 2',
+      );
+    });
+  },
+);

--- a/tests/unit/lint-skill-here-string-2491.test.ts
+++ b/tests/unit/lint-skill-here-string-2491.test.ts
@@ -162,5 +162,27 @@ describe.skipIf(BASH4 === null)(
         .filter((l) => l.includes('Cross-fence variable: $FOO'));
       expect(crossFenceErrors).toHaveLength(1);
     });
+
+    // Greptile round 2 on PR #2574: destination extraction truncated at the
+    // FIRST `<`, so a destination placed AFTER the redirection (valid bash —
+    // `read -r <<< "hello" FOO` really does bind FOO) was silently dropped,
+    // and a later, legitimate reference to the freshly-bound value was
+    // falsely reported as a stale cross-fence leak.
+    it('does not false-flag a later reference when the destination follows the redirection', () => {
+      const { stdout, ranSuccessfully } = runLint([
+        'FOO=stale',
+        'read -r <<< "hello" FOO\necho "now fresh: $FOO"',
+      ]);
+      expect(ranSuccessfully).toBe(true);
+      expect(stdout).not.toContain('Cross-fence variable: $FOO');
+    });
+
+    it('still flags a same-line self-reference when input precedes the destination', () => {
+      const { stdout, ranSuccessfully } = runLint(['FOO=hello', 'read -r <<< "$FOO" FOO']);
+      expect(ranSuccessfully).toBe(true);
+      expect(stdout).toContain(
+        'Cross-fence variable: $FOO assigned in bash block 1, referenced in block 2',
+      );
+    });
   },
 );

--- a/tests/unit/lint-skill-here-string-2491.test.ts
+++ b/tests/unit/lint-skill-here-string-2491.test.ts
@@ -138,5 +138,29 @@ describe.skipIf(BASH4 === null)(
         'Cross-fence variable: $FOO assigned in bash block 1, referenced in block 2',
       );
     });
+
+    // Greptile round 1 on PR #2574: is_read_dest_of_line alone only checked
+    // whether $var was *a* destination somewhere on the line, so a same-line
+    // self-reference (destination and stale here-string input sharing the
+    // same name) still slipped through undetected.
+    it('flags a same-line self-referential read (destination and input share a name)', () => {
+      const { stdout, ranSuccessfully } = runLint(['FOO=hello', 'read -r FOO <<< "$FOO"']);
+      expect(ranSuccessfully).toBe(true);
+      expect(stdout).toContain(
+        'Cross-fence variable: $FOO assigned in bash block 1, referenced in block 2',
+      );
+    });
+
+    it('does not flag a later line in the same block referencing the freshly self-bound value', () => {
+      const { stdout, ranSuccessfully } = runLint([
+        'FOO=hello',
+        'read -r FOO <<< "$FOO"\necho "now local: $FOO"',
+      ]);
+      expect(ranSuccessfully).toBe(true);
+      const crossFenceErrors = stdout
+        .split('\n')
+        .filter((l) => l.includes('Cross-fence variable: $FOO'));
+      expect(crossFenceErrors).toHaveLength(1);
+    });
   },
 );

--- a/tests/unit/lint-skill-here-string-2491.test.ts
+++ b/tests/unit/lint-skill-here-string-2491.test.ts
@@ -230,5 +230,18 @@ describe.skipIf(BASH4 === null)(
       expect(ranSuccessfully).toBe(true);
       expect(stdout).not.toContain('Cross-fence variable: $FOO');
     });
+
+    // Greptile round 4 on PR #2574: strip_trailing_comment only alternated
+    // on double quotes, so a literal `#` inside a single-quoted redirect
+    // target was mistaken for a real comment, truncating away a genuine
+    // destination that followed it (verified against real bash first).
+    it('does not mistake a literal # inside a single-quoted target for a comment', () => {
+      const { stdout, ranSuccessfully } = runLint([
+        'EXTRA=stale',
+        'read -r <<< \'#tag value\' FOO EXTRA\necho "now fresh: $EXTRA"',
+      ]);
+      expect(ranSuccessfully).toBe(true);
+      expect(stdout).not.toContain('Cross-fence variable: $EXTRA');
+    });
   },
 );


### PR DESCRIPTION
## Summary
- `lint-skill.sh`'s Pattern-1 cross-fence variable check exempted any line containing the substring `read ` from being flagged, without checking whether the variable in question was actually the destination `read` bound — so a stale variable fed as the *input* to a `read` here-string (`read -r BAR <<< "$FOO"`) slipped through undetected.
- A second, independent blanket exemption (`< ` substring match, meant to detect genuine file redirection) made this worse: `<<<`'s own text contains a trailing `< `, so even narrowing the `read` exemption alone wouldn't have caught the exact repro.
- Adds `extract_read_dest_vars`/`is_read_dest_of_line` (checks whether `$var` is genuinely the destination a `read` line binds) and `has_file_redirect_in` (a regex distinguishing a real single-`<` file redirect from `<<`/`<<<`), replacing both blanket substring checks.

## Test plan
- [x] New regression test `tests/unit/lint-skill-here-string-2491.test.ts`: exact issue repro + here-string-no-read case fail before the fix and pass after (revert-verified against the pre-fix script).
- [x] Existing `read`-binding exemption (#2344) and genuine file-redirection exemption still pass — no regressions.
- [x] Ran the updated linter against all 21 real `SKILL.md` files in the repo — output identical to before the fix (zero new false positives).
- [x] `npm test` (full suite, 92 files / 1929 tests) and `npm run lint` both pass.

Closes #2491