### PR TITLE
test(hcl): mark resolution-benchmark fixture's module-reference edges as aspirational

### DIFF
--- a/tests/benchmarks/resolution/fixtures/hcl/expected-edges.json
+++ b/tests/benchmarks/resolution/fixtures/hcl/expected-edges.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../expected-edges.schema.json",
   "language": "hcl",
-  "description": "Hand-annotated call edges for HCL/Terraform resolution benchmark. HCL uses module references rather than function calls — edges represent module source references.",
+  "description": "ASPIRATIONAL, not currently enforced (see resolution-benchmark.test.ts's hcl threshold, pinned at 0.0/0.0, and issue #2524): hand-annotated module-reference edges for a HCL/Terraform resolution capability that does not exist yet. HCL has no functions/calls to resolve in the traditional sense — these edges describe a genuinely different, unimplemented notion of module-source-reference linkage ('module.user_service references module.repository'), not a gap in the same call-resolution machinery other 0.0/0.0 languages (cuda/groovy/verilog) are missing. Building this fixture today yields 0 of these 2 edges; every edge that does materialize is a structural 'contains' edge.",
   "edges": [
     {
       "source": { "name": "module.user_service", "file": "main.tf" },

--- a/tests/benchmarks/resolution/resolution-benchmark.test.ts
+++ b/tests/benchmarks/resolution/resolution-benchmark.test.ts
@@ -245,6 +245,12 @@ const THRESHOLDS: Record<string, { precision: number; recall: number }> = {
   cuda: { precision: 0.0, recall: 0.0 },
   groovy: { precision: 0.0, recall: 0.0 },
   verilog: { precision: 0.0, recall: 0.0 },
+  // hcl's fixture (unlike cuda/groovy/verilog above) isn't just "call
+  // resolution not implemented yet" for the same kind of edge every other
+  // language has — HCL has no functions/calls at all. Its expected-edges.json
+  // aspirationally describes a genuinely different, unimplemented capability
+  // (module-source-reference linkage) that 0 of its own edges currently
+  // materialize (see that file's own description and issue #2524).
   hcl: { precision: 0.0, recall: 0.0 },
 };
 


### PR DESCRIPTION
## Summary
- `tests/benchmarks/resolution/fixtures/hcl/expected-edges.json` declares 2 `calls` edges (`module.user_service` → `module.repository`, → `module.validators`), but building that fixture yields 31 nodes, 27 edges, all `contains` — verified empirically (built the fixture directly and inspected the DB's `edges` table), 0 of 2 expected edges materialize.
- The benchmark currently passes only because HCL's threshold in `resolution-benchmark.test.ts` is `{ precision: 0.0, recall: 0.0 }` — so the fixture and its manifest were encoding an aspiration ("HCL module references should resolve") that no test actually enforces or was ever expected to enforce.
- Per the issue's own suggested fix (option 2 — annotate rather than implement, since option 1 would mean designing and implementing an entirely new module-source-reference edge kind across both engines, a bigger feature deserving its own dedicated session, not a quick fixer-batch pass): documents this explicitly in the fixture's own `description` field and an inline comment next to the threshold in `resolution-benchmark.test.ts`, distinguishing it from cuda/groovy/verilog's own `0.0/0.0` entries (those are "call resolution not implemented yet" for the *same* kind of edge every other language has; HCL has no functions/calls at all — its expected edges describe a genuinely different, unimplemented capability).

## Test plan
- [x] Verified empirically: built the HCL fixture directly (`codegraph build ... --engine wasm`) and queried the resulting DB — confirmed exactly 27 `contains` edges, 0 `calls` edges, matching the issue's claim precisely.
- [x] `npx vitest run tests/benchmarks/resolution/resolution-benchmark.test.ts -t hcl` — still passes (pure documentation change, threshold and behavior unchanged).
- [x] Full `npx vitest run` (5514 tests) and `npm run lint` clean.
- [x] `expected-edges.json` still validates as well-formed JSON.

Closes #2524