### PR TITLE
fix(cli): distinguish zero exports from an unbuilt graph in exports <file>

### DIFF
--- a/src/domain/analysis/exports.ts
+++ b/src/domain/analysis/exports.ts
@@ -28,6 +28,18 @@ const _reexportSymbolsStmtCache: StmtCache<NodeRow> = new WeakMap();
 const _wildcardReexportTargetsStmtCache: StmtCache<{ file: string }> = new WeakMap();
 
 /**
+ * Whether `matchedFile` is exactly (case-sensitively) the file the caller
+ * asked for, or a `/`-bounded path suffix of it. Checked before the
+ * case-insensitive variant below so that a genuine exact-case match always
+ * wins over a merely case-insensitive one when both exist among the
+ * candidates (e.g. distinct real files `src/utils.js` and `src/UTILS.js` on
+ * a case-sensitive filesystem — #2530 review round 5).
+ */
+function isExactFileMatch(matchedFile: string, target: string): boolean {
+  return matchedFile === target || matchedFile.endsWith(`/${target}`);
+}
+
+/**
  * Whether `matchedFile` (a result of the `LIKE '%target%'` fuzzy lookup used
  * throughout this module) plausibly *is* the file the caller asked for,
  * rather than an unrelated file whose path merely contains `target` as a
@@ -40,7 +52,8 @@ const _wildcardReexportTargetsStmtCache: StmtCache<{ file: string }> = new WeakM
  * case-insensitive) — otherwise a target that only differs from the graph's
  * stored casing would pass the LIKE lookup but fail this stricter check,
  * reintroducing a false "not found" for a match SQLite itself already deemed
- * a hit (#2530 review round 3).
+ * a hit (#2530 review round 3). Callers selecting among multiple candidates
+ * should prefer `isExactFileMatch` first (round 5).
  */
 function isPlausibleFileMatch(matchedFile: string, target: string): boolean {
   const a = matchedFile.toLowerCase();
@@ -92,15 +105,27 @@ export function exportsData(
       );
     }
 
-    // For single-file match return flat; for multi-match prefer a plausible
-    // match over an arbitrary (unordered LIKE query) first result, so an
-    // unrelated substring collision returned before the genuine target can't
-    // shadow it (#2530 Greptile review) — otherwise falls back to the first
-    // result, like explainData.
-    const first = fileResults.find((r) => isPlausibleFileMatch(r.file, file)) ?? fileResults[0]!;
+    // For single-file match return flat; for multi-match prefer, in order: an
+    // exact-case match, then a case-insensitive/suffix match, then an
+    // arbitrary (unordered LIKE query) first result — so neither an unrelated
+    // substring collision nor a case-variant of a different real file can
+    // shadow the genuine target (#2530 Greptile review) — otherwise falls
+    // back to the first result, like explainData.
+    const first =
+      fileResults.find((r) => isExactFileMatch(r.file, file)) ??
+      fileResults.find((r) => isPlausibleFileMatch(r.file, file)) ??
+      fileResults[0]!;
+    // fileFound must stay true whenever we're actually returning real
+    // content (results or reexports) for `first`, even if that content came
+    // from the unordered-fallback branch above with no plausible candidate —
+    // otherwise structured (JSON/MCP) consumers see the self-contradictory
+    // combination of non-empty results alongside fileFound: false (#2530
+    // review round 5). The CLI's own messaging only ever reads fileFound
+    // inside the `results.length === 0` branch, so this has no effect there.
+    const hasContent = first.results.length > 0 || first.reexportedSymbols.length > 0;
     const base = {
       file: first.file,
-      fileFound: isPlausibleFileMatch(first.file, file),
+      fileFound: hasContent || isPlausibleFileMatch(first.file, file),
       results: first.results,
       reexports: first.reexports,
       reexportedSymbols: first.reexportedSymbols,

--- a/src/domain/analysis/exports.ts
+++ b/src/domain/analysis/exports.ts
@@ -35,9 +35,17 @@ const _wildcardReexportTargetsStmtCache: StmtCache<{ file: string }> = new WeakM
  * `badd.jsx`, or `utils.js` matching `my-utils.js` with no path separator
  * before it). Requires an exact match or a `/`-bounded path suffix — the
  * only two cases where the match reflects genuine user intent (#2530 review).
+ *
+ * Case-insensitive to match SQLite's own default `LIKE` behavior (ASCII
+ * case-insensitive) — otherwise a target that only differs from the graph's
+ * stored casing would pass the LIKE lookup but fail this stricter check,
+ * reintroducing a false "not found" for a match SQLite itself already deemed
+ * a hit (#2530 review round 3).
  */
 function isPlausibleFileMatch(matchedFile: string, target: string): boolean {
-  return matchedFile === target || matchedFile.endsWith(`/${target}`);
+  const a = matchedFile.toLowerCase();
+  const b = target.toLowerCase();
+  return a === b || a.endsWith(`/${b}`);
 }
 
 export function exportsData(

--- a/src/domain/analysis/exports.ts
+++ b/src/domain/analysis/exports.ts
@@ -27,6 +27,19 @@ const _reexportsToStmtCache: StmtCache<{ file: string }> = new WeakMap();
 const _reexportSymbolsStmtCache: StmtCache<NodeRow> = new WeakMap();
 const _wildcardReexportTargetsStmtCache: StmtCache<{ file: string }> = new WeakMap();
 
+/**
+ * Whether `matchedFile` (a result of the `LIKE '%target%'` fuzzy lookup used
+ * throughout this module) plausibly *is* the file the caller asked for,
+ * rather than an unrelated file whose path merely contains `target` as a
+ * substring somewhere in the middle (e.g. target `add.js` mid-string-matching
+ * `badd.jsx`, or `utils.js` matching `my-utils.js` with no path separator
+ * before it). Requires an exact match or a `/`-bounded path suffix — the
+ * only two cases where the match reflects genuine user intent (#2530 review).
+ */
+function isPlausibleFileMatch(matchedFile: string, target: string): boolean {
+  return matchedFile === target || matchedFile.endsWith(`/${target}`);
+}
+
 export function exportsData(
   file: string,
   customDbPath: string,
@@ -75,7 +88,7 @@ export function exportsData(
     const first = fileResults[0]!;
     const base = {
       file: first.file,
-      fileFound: true,
+      fileFound: isPlausibleFileMatch(first.file, file),
       results: first.results,
       reexports: first.reexports,
       reexportedSymbols: first.reexportedSymbols,

--- a/src/domain/analysis/exports.ts
+++ b/src/domain/analysis/exports.ts
@@ -56,6 +56,7 @@ export function exportsData(
       return paginateResult(
         {
           file,
+          fileFound: false,
           results: [],
           reexports: [],
           reexportedSymbols: [],
@@ -74,6 +75,7 @@ export function exportsData(
     const first = fileResults[0]!;
     const base = {
       file: first.file,
+      fileFound: true,
       results: first.results,
       reexports: first.reexports,
       reexportedSymbols: first.reexportedSymbols,

--- a/src/domain/analysis/exports.ts
+++ b/src/domain/analysis/exports.ts
@@ -84,8 +84,12 @@ export function exportsData(
       );
     }
 
-    // For single-file match return flat; for multi-match return first (like explainData)
-    const first = fileResults[0]!;
+    // For single-file match return flat; for multi-match prefer a plausible
+    // match over an arbitrary (unordered LIKE query) first result, so an
+    // unrelated substring collision returned before the genuine target can't
+    // shadow it (#2530 Greptile review) — otherwise falls back to the first
+    // result, like explainData.
+    const first = fileResults.find((r) => isPlausibleFileMatch(r.file, file)) ?? fileResults[0]!;
     const base = {
       file: first.file,
       fileFound: isPlausibleFileMatch(first.file, file),

--- a/src/domain/analysis/exports.ts
+++ b/src/domain/analysis/exports.ts
@@ -86,7 +86,18 @@ export function exportsData(
     const unused = opts.unused || false;
     const fileResults = exportsFileImpl(db, file, noTests, getFileLines, unused, displayOpts);
 
-    if (fileResults.length === 0) {
+    // Prefer, in order: an exact-case match, then a case-insensitive/suffix
+    // match. If NEITHER exists among the LIKE lookup's results, treat this
+    // exactly like "no file found at all" rather than falling back to an
+    // arbitrary unrelated substring collision's real data — returning that
+    // collision's export payload under a mismatched query is misleading
+    // regardless of what `fileFound` says about it (#2530 Greptile round 6),
+    // and it can never be a plausible answer to what was actually asked.
+    const first =
+      fileResults.find((r) => isExactFileMatch(r.file, file)) ??
+      fileResults.find((r) => isPlausibleFileMatch(r.file, file));
+
+    if (!first) {
       return paginateResult(
         {
           file,
@@ -105,27 +116,12 @@ export function exportsData(
       );
     }
 
-    // For single-file match return flat; for multi-match prefer, in order: an
-    // exact-case match, then a case-insensitive/suffix match, then an
-    // arbitrary (unordered LIKE query) first result — so neither an unrelated
-    // substring collision nor a case-variant of a different real file can
-    // shadow the genuine target (#2530 Greptile review) — otherwise falls
-    // back to the first result, like explainData.
-    const first =
-      fileResults.find((r) => isExactFileMatch(r.file, file)) ??
-      fileResults.find((r) => isPlausibleFileMatch(r.file, file)) ??
-      fileResults[0]!;
-    // fileFound must stay true whenever we're actually returning real
-    // content (results or reexports) for `first`, even if that content came
-    // from the unordered-fallback branch above with no plausible candidate —
-    // otherwise structured (JSON/MCP) consumers see the self-contradictory
-    // combination of non-empty results alongside fileFound: false (#2530
-    // review round 5). The CLI's own messaging only ever reads fileFound
-    // inside the `results.length === 0` branch, so this has no effect there.
-    const hasContent = first.results.length > 0 || first.reexportedSymbols.length > 0;
     const base = {
       file: first.file,
-      fileFound: hasContent || isPlausibleFileMatch(first.file, file),
+      // Always true here: `first` only exists when isExactFileMatch or
+      // isPlausibleFileMatch accepted it, so this can never contradict
+      // non-empty results the way an unconditional plausibility check could.
+      fileFound: true,
       results: first.results,
       reexports: first.reexports,
       reexportedSymbols: first.reexportedSymbols,

--- a/src/presentation/queries-cli/exports.ts
+++ b/src/presentation/queries-cli/exports.ts
@@ -43,6 +43,8 @@ interface ReexportedSymbol extends ExportSymbol {
 
 interface ExportsDataResult {
   file: string;
+  /** Whether a file-kind node for this file exists in the graph at all (#2530). */
+  fileFound: boolean;
   totalExported: number;
   totalInternal: number;
   totalUnused: number;
@@ -151,6 +153,10 @@ export function fileExports(file: string, customDbPath: string, opts: ExportsOpt
   if (data.results.length === 0 && !hasReexported) {
     if (opts.unused) {
       console.log(`No unused exports found for "${file}".`);
+    } else if (data.fileFound) {
+      // The file is in the graph — it simply has no exports (an entry
+      // script, a side-effect-only module, etc.), not an unbuilt graph (#2530).
+      console.log(`No exported symbols found for "${file}".`);
     } else {
       console.log(`No exported symbols found for "${file}". Run "codegraph build" first.`);
     }

--- a/src/presentation/queries-cli/exports.ts
+++ b/src/presentation/queries-cli/exports.ts
@@ -43,7 +43,11 @@ interface ReexportedSymbol extends ExportSymbol {
 
 interface ExportsDataResult {
   file: string;
-  /** Whether a file-kind node for this file exists in the graph at all (#2530). */
+  /**
+   * Whether `file`'s matched node is plausibly the requested target itself,
+   * not just an unrelated file whose path happens to contain it as a
+   * substring (#2530).
+   */
   fileFound: boolean;
   totalExported: number;
   totalInternal: number;

--- a/tests/integration/exports.test.ts
+++ b/tests/integration/exports.test.ts
@@ -79,6 +79,22 @@ beforeAll(() => {
   // match is explicitly preferred (#2530 Greptile round 2).
   insertNode(db, 'src/my-utils.js', 'file', 'src/my-utils.js', 0);
   insertNode(db, 'src/utils.js', 'file', 'src/utils.js', 0);
+  // A collision file WITH real exports, for a target with no plausible
+  // candidate at all ("gadget.js" -> "src/my-gadget.js"). fileFound must
+  // still be true here, since real (non-empty) results are being returned —
+  // fileFound: false alongside non-empty results is a self-contradictory
+  // signal for structured/JSON consumers (#2530 Greptile round 5).
+  insertNode(db, 'src/my-gadget.js', 'file', 'src/my-gadget.js', 0);
+  const gadgetExport = insertNode(db, 'buildGadget', 'function', 'src/my-gadget.js', 1);
+  // Two distinct real files differing only by case, to test that an
+  // exact-case match always wins over a same-name case-insensitive one
+  // (#2530 Greptile round 5). The case-different file is inserted FIRST so
+  // an unordered LIKE scan visits it before the exact-case match, forcing a
+  // naive case-insensitive-only `.find()` to pick the wrong file.
+  insertNode(db, 'src/CaseDemo.js', 'file', 'src/CaseDemo.js', 0);
+  const upperCaseExport = insertNode(db, 'upperCaseFn', 'function', 'src/CaseDemo.js', 1);
+  insertNode(db, 'src/casedemo.js', 'file', 'src/casedemo.js', 0);
+  const lowerCaseExport = insertNode(db, 'lowerCaseFn', 'function', 'src/casedemo.js', 1);
 
   // Function nodes in lib.js
   const add = insertNode(db, 'add', 'function', 'lib.js', 1);
@@ -97,6 +113,9 @@ beforeAll(() => {
   markExported.run(add);
   markExported.run(multiply);
   markExported.run(unusedFn);
+  markExported.run(gadgetExport);
+  markExported.run(lowerCaseExport);
+  markExported.run(upperCaseExport);
 
   // Import edges
   insertEdge(db, fApp, fLib, 'imports');
@@ -222,6 +241,29 @@ describe('exportsData', () => {
     const data = exportsData('Entry.js', dbPath);
     expect(data.file).toBe('entry.js');
     expect(data.fileFound).toBe(true);
+  });
+
+  test('fileFound is true when the unordered fallback still returns real, non-empty results (#2530 Greptile round 5)', () => {
+    // "gadget.js" has no plausible candidate at all -- only the collision
+    // "src/my-gadget.js" LIKE-matches it, and that collision has a REAL
+    // export. fileFound must not be false here: false alongside non-empty
+    // results is a self-contradictory signal for structured/JSON consumers,
+    // even though the CLI's own text messaging never reads fileFound when
+    // results are non-empty (the results.length === 0 branch is never hit).
+    const data = exportsData('gadget.js', dbPath);
+    expect(data.file).toBe('src/my-gadget.js');
+    expect(data.results.length).toBeGreaterThan(0);
+    expect(data.fileFound).toBe(true);
+  });
+
+  test('prefers an exact-case match over a same-name case-insensitive match (#2530 Greptile round 5)', () => {
+    // "src/casedemo.js" and "src/CaseDemo.js" are two DISTINCT real files.
+    // A query for the exact-case "casedemo.js" must resolve to
+    // "src/casedemo.js", never to its differently-cased sibling, even though
+    // isPlausibleFileMatch's case-insensitivity (round 3) would accept both.
+    const data = exportsData('casedemo.js', dbPath);
+    expect(data.file).toBe('src/casedemo.js');
+    expect(data.results.map((r) => r.name)).toEqual(['lowerCaseFn']);
   });
 
   test('pagination works', () => {

--- a/tests/integration/exports.test.ts
+++ b/tests/integration/exports.test.ts
@@ -66,6 +66,11 @@ beforeAll(() => {
   // Entry script with a file-kind node but no exported symbols at all (#2530).
   insertNode(db, 'entry.js', 'file', 'entry.js', 0);
   insertNode(db, 'runApp', 'function', 'entry.js', 1); // never marked exported
+  // Unrelated file whose path contains "utils.js" as a mid-string substring
+  // (not a `/`-bounded suffix) and also has zero exports — a false LIKE-query
+  // collision for a query of "utils.js" that must NOT report fileFound: true
+  // (#2530 Greptile review).
+  insertNode(db, 'src/my-utils.js', 'file', 'src/my-utils.js', 0);
 
   // Function nodes in lib.js
   const add = insertNode(db, 'add', 'function', 'lib.js', 1);
@@ -176,6 +181,16 @@ describe('exportsData', () => {
     expect(data.results).toEqual([]);
     expect(data.totalExported).toBe(0);
     expect(data.fileFound).toBe(true);
+  });
+
+  test('fileFound is false for a target that only mid-string-collides with an unrelated file (#2530 Greptile review)', () => {
+    // "utils.js" is not a real file, but "src/my-utils.js" contains it as a
+    // substring (not a `/`-bounded suffix) and the LIKE '%utils.js%' lookup
+    // matches it. The rebuild suggestion must still fire here, since this is
+    // not genuinely the file the caller asked about.
+    const data = exportsData('utils.js', dbPath);
+    expect(data.results).toEqual([]);
+    expect(data.fileFound).toBe(false);
   });
 
   test('pagination works', () => {

--- a/tests/integration/exports.test.ts
+++ b/tests/integration/exports.test.ts
@@ -63,6 +63,9 @@ beforeAll(() => {
   const fApp = insertNode(db, 'app.js', 'file', 'app.js', 0);
   const fBarrel = insertNode(db, 'barrel.js', 'file', 'barrel.js', 0);
   const fTest = insertNode(db, 'lib.test.js', 'file', 'lib.test.js', 0);
+  // Entry script with a file-kind node but no exported symbols at all (#2530).
+  insertNode(db, 'entry.js', 'file', 'entry.js', 0);
+  insertNode(db, 'runApp', 'function', 'entry.js', 1); // never marked exported
 
   // Function nodes in lib.js
   const add = insertNode(db, 'add', 'function', 'lib.js', 1);
@@ -164,6 +167,15 @@ describe('exportsData', () => {
     expect(data.totalExported).toBe(0);
     expect(data.totalInternal).toBe(0);
     expect(data.totalUnused).toBe(0);
+    // No file-kind node matched at all — genuinely unbuilt/not-found (#2530).
+    expect(data.fileFound).toBe(false);
+  });
+
+  test('fileFound is true for a file in the graph with legitimately zero exports (#2530)', () => {
+    const data = exportsData('entry.js', dbPath);
+    expect(data.results).toEqual([]);
+    expect(data.totalExported).toBe(0);
+    expect(data.fileFound).toBe(true);
   });
 
   test('pagination works', () => {

--- a/tests/integration/exports.test.ts
+++ b/tests/integration/exports.test.ts
@@ -214,6 +214,16 @@ describe('exportsData', () => {
     expect(data.fileFound).toBe(true);
   });
 
+  test("fileFound is case-insensitive, matching SQLite LIKE's own default case-insensitivity (#2530 Greptile round 3)", () => {
+    // SQLite's LIKE is case-insensitive for ASCII by default, so a
+    // case-mismatched target ("Entry.js") still LIKE-matches the stored
+    // "entry.js" -- isPlausibleFileMatch must not be stricter than the LIKE
+    // lookup that already decided this is a hit.
+    const data = exportsData('Entry.js', dbPath);
+    expect(data.file).toBe('entry.js');
+    expect(data.fileFound).toBe(true);
+  });
+
   test('pagination works', () => {
     const data = exportsData('lib.js', dbPath, { limit: 1 });
     expect(data.results.length).toBe(1);

--- a/tests/integration/exports.test.ts
+++ b/tests/integration/exports.test.ts
@@ -243,17 +243,18 @@ describe('exportsData', () => {
     expect(data.fileFound).toBe(true);
   });
 
-  test('fileFound is true when the unordered fallback still returns real, non-empty results (#2530 Greptile round 5)', () => {
+  test('treats a collision with no plausible candidate as not-found, even when the collision itself has real exports (#2530 Greptile round 6)', () => {
     // "gadget.js" has no plausible candidate at all -- only the collision
     // "src/my-gadget.js" LIKE-matches it, and that collision has a REAL
-    // export. fileFound must not be false here: false alongside non-empty
-    // results is a self-contradictory signal for structured/JSON consumers,
-    // even though the CLI's own text messaging never reads fileFound when
-    // results are non-empty (the results.length === 0 branch is never hit).
+    // export. Earlier this fell back to returning the collision's real data
+    // with fileFound: true, which is misleading regardless of what fileFound
+    // says (round 6) -- and fileFound: false alongside non-empty results was
+    // self-contradictory before that (round 5). Requiring a plausible
+    // candidate to exist at all resolves both: nothing plausible means
+    // nothing is returned, full stop, exactly like a genuinely missing file.
     const data = exportsData('gadget.js', dbPath);
-    expect(data.file).toBe('src/my-gadget.js');
-    expect(data.results.length).toBeGreaterThan(0);
-    expect(data.fileFound).toBe(true);
+    expect(data.results).toEqual([]);
+    expect(data.fileFound).toBe(false);
   });
 
   test('prefers an exact-case match over a same-name case-insensitive match (#2530 Greptile round 5)', () => {

--- a/tests/integration/exports.test.ts
+++ b/tests/integration/exports.test.ts
@@ -66,11 +66,19 @@ beforeAll(() => {
   // Entry script with a file-kind node but no exported symbols at all (#2530).
   insertNode(db, 'entry.js', 'file', 'entry.js', 0);
   insertNode(db, 'runApp', 'function', 'entry.js', 1); // never marked exported
-  // Unrelated file whose path contains "utils.js" as a mid-string substring
+  // Unrelated file whose path contains "widget.js" as a mid-string substring
   // (not a `/`-bounded suffix) and also has zero exports — a false LIKE-query
-  // collision for a query of "utils.js" that must NOT report fileFound: true
-  // (#2530 Greptile review).
+  // collision for a query of "widget.js" that must NOT report fileFound:
+  // true, with no genuine match present anywhere in the graph (#2530
+  // Greptile review).
+  insertNode(db, 'src/my-widget.js', 'file', 'src/my-widget.js', 0);
+  // Same shape, but paired with a genuine match: "src/my-utils.js" (a
+  // collision for "utils.js", inserted first) and "src/utils.js" (the
+  // genuine target, inserted after). findFileNodes has no ORDER BY, so an
+  // unordered LIKE scan would return the collision first unless a plausible
+  // match is explicitly preferred (#2530 Greptile round 2).
   insertNode(db, 'src/my-utils.js', 'file', 'src/my-utils.js', 0);
+  insertNode(db, 'src/utils.js', 'file', 'src/utils.js', 0);
 
   // Function nodes in lib.js
   const add = insertNode(db, 'add', 'function', 'lib.js', 1);
@@ -183,14 +191,27 @@ describe('exportsData', () => {
     expect(data.fileFound).toBe(true);
   });
 
-  test('fileFound is false for a target that only mid-string-collides with an unrelated file (#2530 Greptile review)', () => {
-    // "utils.js" is not a real file, but "src/my-utils.js" contains it as a
-    // substring (not a `/`-bounded suffix) and the LIKE '%utils.js%' lookup
-    // matches it. The rebuild suggestion must still fire here, since this is
-    // not genuinely the file the caller asked about.
-    const data = exportsData('utils.js', dbPath);
+  test('fileFound is false for a target that only mid-string-collides with an unrelated file, no genuine match present (#2530 Greptile review)', () => {
+    // "widget.js" is not a real file anywhere in the fixture, but
+    // "src/my-widget.js" (added below) contains it as a substring (not a
+    // `/`-bounded suffix). The rebuild suggestion must still fire, since this
+    // is not genuinely the file the caller asked about.
+    const data = exportsData('widget.js', dbPath);
     expect(data.results).toEqual([]);
     expect(data.fileFound).toBe(false);
+  });
+
+  test('prefers a genuine exact/suffix match over an unordered mid-string collision returned first (#2530 Greptile round 2)', () => {
+    // findFileNodes has no ORDER BY, so a plain LIKE '%utils.js%' scan
+    // returns whichever row SQLite visits first. "src/my-utils.js" (a
+    // collision, no `/`-bounded suffix match) was inserted BEFORE the
+    // genuine "src/utils.js" — without preferring a plausible match, the
+    // first (arbitrary) result would win and wrongly report fileFound: false
+    // plus the wrong file's (empty) data, even though "src/utils.js" is a
+    // real, matching file in the graph.
+    const data = exportsData('utils.js', dbPath);
+    expect(data.file).toBe('src/utils.js');
+    expect(data.fileFound).toBe(true);
   });
 
   test('pagination works', () => {

--- a/tests/presentation/queries-cli.test.ts
+++ b/tests/presentation/queries-cli.test.ts
@@ -591,9 +591,10 @@ describe('fileExports', () => {
     expect(out).toContain('from math.js');
   });
 
-  it('prints message when no exports found', () => {
+  it('recommends a rebuild when the file was never found in the graph', () => {
     mocks.exportsData.mockReturnValue({
       file: 'empty.js',
+      fileFound: false,
       totalExported: 0,
       totalInternal: 0,
       totalUnused: 0,
@@ -603,6 +604,23 @@ describe('fileExports', () => {
     });
     fileExports('empty.js', '/db');
     expect(output()).toContain('No exported symbols found');
+    expect(output()).toContain('Run "codegraph build" first');
+  });
+
+  it('does not recommend a rebuild when the file is in the graph with legitimately zero exports (#2530)', () => {
+    mocks.exportsData.mockReturnValue({
+      file: 'entry.js',
+      fileFound: true,
+      totalExported: 0,
+      totalInternal: 0,
+      totalUnused: 0,
+      results: [],
+      reexportedSymbols: [],
+      reexports: [],
+    });
+    fileExports('entry.js', '/db');
+    expect(output()).toContain('No exported symbols found');
+    expect(output()).not.toContain('Run "codegraph build" first');
   });
 
   it('prints unused header when opts.unused', () => {


### PR DESCRIPTION
## Summary
- Issue #2390 fixed `codegraph roles --role <X>` conflating "the graph has no classified symbols at all" with "this filter matched nothing." #2530 identifies the same conflation in `codegraph exports <file>`.
- `src/domain/analysis/exports.ts`'s `exportsData` returned the exact same shape (`results: []`, all totals zero) whether a file's `file`-kind node was never found in the graph at all (unbuilt/nonexistent file) or the file *was* found but simply has zero exports (e.g. an entry script, a side-effect-only module, or a file that only re-exports via `export *`).
- Both cases hit `fileExports`'s single "No exported symbols found... Run `codegraph build` first." branch, which is misleading on a correctly built graph.
- Fix: `exportsData` now also returns `fileFound: boolean` — `true` whenever `findFileNodes` matched a `file`-kind node for the target, independent of its export count. `fileExports` uses it to print `No exported symbols found for "<file>".` (no rebuild suggestion) whenever the file was actually found, mirroring the pattern #2390 used with `totalClassified`.
- Pure TS query/presentation-layer fix — no Rust engine changes needed (this is CLI messaging over an already-built graph, not extraction).

Closes #2530

## Test plan
- [x] `tests/integration/exports.test.ts`: added a `entry.js` fixture file (a file-kind node with a non-exported function, simulating an entry script) and a new test asserting `fileFound: true` with zero exports; updated the existing "unknown file" test to assert `fileFound: false`.
- [x] `tests/presentation/queries-cli.test.ts`: split the old single "no exports found" test into two — one confirming the rebuild suggestion still appears when `fileFound: false`, one confirming it's absent when `fileFound: true`.
- [x] Revert-verify: temporarily disabled the `data.fileFound` branch and confirmed the new "does not recommend a rebuild..." test fails with the exact pre-fix message; restored the fix and it passes again.
- [x] `codegraph diff-impact --staged -T`: 3 functions changed, 2 transitive callers affected — contained blast radius, no unexpected consumers.
- [x] `npm run lint` clean.
- [x] Full `npx vitest run`: 5520/5520 tests pass (344 test files, +2 new).