### PR TITLE
fix(bench): give benchmark.ts's Full build metric a warmup-then-median too

### DIFF
--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -12,7 +12,6 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { performance } from 'node:perf_hooks';
 import { fileURLToPath } from 'node:url';
 import { resolveBenchmarkExcludes, resolveBenchmarkSource, srcImport } from './lib/bench-config.js';
 import { isWorker, workerEngine, workerTargets, forkEngines } from './lib/fork-engine.js';
@@ -92,6 +91,7 @@ try {
 } catch { /* older release — no worker pool to dispose */ }
 
 const WARMUP_RUNS = 2;
+const BUILD_RUNS = 5;
 const INCREMENTAL_RUNS = 5;
 const QUERY_RUNS = 5;
 const QUERY_WARMUP_RUNS = 3;
@@ -102,12 +102,21 @@ const BENCH_EXCLUDE = [...resolveBenchmarkExcludes()];
 const origLog = console.log;
 console.log = (...args) => console.error(...args);
 
-// Clean DB for a full build
-if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
-
-const buildStart = performance.now();
-const buildResult = await buildGraph(root, { engine, incremental: false, exclude: BENCH_EXCLUDE });
-const buildTimeMs = performance.now() - buildStart;
+// Full build (delete DB first each run). Warmup-then-median, mirroring
+// incremental-benchmark.ts's own fullBuildMs methodology (#2436) — a single
+// cold call conflates steady-state build cost with the one-time NAPI/rusqlite
+// static-init cost that can only ever land on a build's very first call in
+// this worker's process lifetime (#2549).
+for (let i = 0; i < WARMUP_RUNS; i++) {
+	if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
+	await buildGraph(root, { engine, incremental: false, exclude: BENCH_EXCLUDE });
+}
+const fullBuildMedian = await timeMedianWithValue(async () => {
+	if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
+	return await buildGraph(root, { engine, incremental: false, exclude: BENCH_EXCLUDE });
+}, BUILD_RUNS);
+const buildTimeMs = fullBuildMedian.ms;
+const buildResult = fullBuildMedian.value;
 
 // Warmed median of QUERY_RUNS samples with `noTests: true` to match the
 // methodology used by query-benchmark.ts and the per-target `queries.*Ms`


### PR DESCRIPTION
## Summary
- `scripts/benchmark.ts`'s `buildTimeMs` (feeding `BUILD-BENCHMARKS.md`) measured a single cold `buildGraph` call with no warmup and no median at all — a worse instance of the exact class of bug PR #2551 already fixed for the sibling `incremental-benchmark.ts`'s own `fullBuildMs` (feeding `INCREMENTAL-BENCHMARKS.md`).
- Full build is the first `buildGraph` call in this worker process's lifetime, so it's the metric most exposed to one-time NAPI/rusqlite/OS-page-cache cold-start cost — without warmup, that cost lands inside the single measured sample instead of being absorbed beforehand.
- Mirrors `incremental-benchmark.ts`'s already-established methodology exactly: 2 warmup runs (deleting the DB before each, matching a real full build), then a median of 5 timed runs via `timeMedianWithValue`, which also preserves `buildResult` for the `phases` breakdown used further down in the script.
- Filed as a courtesy follow-up from #2436's investigation (alongside #2550, still open), and this issue's own text gave the exact fix shape to apply.

Closes #2549

## Test plan
- `scripts/` is excluded from both `tsconfig.json` and the `biome` lint scope (`src/`+`tests/` only), and no existing unit test imports or executes `scripts/benchmark.ts` directly (confirmed: `tests/unit/hub-selection.test.ts`'s reference to `scripts/benchmark.ts` is a synthetic fixture filename string, unrelated to the real file's content) — matching PR #2551's own precedent for this exact class of fix (no test file changes there either, since verifying requires an actual full build's timing behavior, impractical for the fast suite).
- [x] Ran `node --experimental-strip-types --import ./scripts/ts-resolve-loader.js scripts/benchmark.ts` directly against this repo — completed successfully for both engines (wasm and native), producing valid `buildTimeMs`, `perFile.buildTimeMs`, and `phases` output for each.
- [x] `npx vitest run tests/unit/hub-selection.test.ts` — 6/6 pass, confirming the unrelated fixture reference is unaffected.
- [x] `npm run lint` clean.