### PR TITLE
fix: export enum declarations now produce an Export record

### DIFF
--- a/crates/codegraph-core/src/extractors/javascript.rs
+++ b/crates/codegraph-core/src/extractors/javascript.rs
@@ -3161,6 +3161,7 @@ fn handle_export_declaration(decl: &Node, source: &[u8], symbols: &mut FileSymbo
         "class_declaration" | "abstract_class_declaration" => ("class", "name"),
         "interface_declaration" => ("interface", "name"),
         "type_alias_declaration" => ("type", "name"),
+        "enum_declaration" => ("enum", "name"),
         "lexical_declaration" | "variable_declaration" => {
             collect_exported_var_declarations(decl, source, symbols);
             return;
@@ -10737,6 +10738,46 @@ mod tests {
                 .iter()
                 .any(|e| e.name == "Id" && e.kind == "type" && e.line == 2),
             "expected 'Id' exported as type at line 2; got: {:?}",
+            s.exports
+        );
+    }
+
+    #[test]
+    fn exports_an_enum_declaration_with_kind_enum() {
+        // Regression guard for #2560: enum_declaration had no arm in
+        // handle_export_declaration's match, so `export enum Foo {}` was
+        // extracted as a Definition (via handle_enum_decl) but never marked
+        // exported.
+        let s = parse_ts("export enum Color { Red, Green, Blue }");
+        assert!(
+            s.definitions
+                .iter()
+                .any(|d| d.name == "Color" && d.kind == "enum" && d.line == 1),
+            "expected 'Color' defined as enum at line 1; got: {:?}",
+            s.definitions
+        );
+        assert!(
+            s.exports
+                .iter()
+                .any(|e| e.name == "Color" && e.kind == "enum" && e.line == 1),
+            "expected 'Color' exported as enum at line 1; got: {:?}",
+            s.exports
+        );
+    }
+
+    #[test]
+    fn does_not_export_a_non_exported_enum() {
+        let s = parse_ts("enum Internal { A, B }");
+        assert!(
+            s.definitions
+                .iter()
+                .any(|d| d.name == "Internal" && d.kind == "enum"),
+            "expected 'Internal' defined as enum; got: {:?}",
+            s.definitions
+        );
+        assert!(
+            !s.exports.iter().any(|e| e.name == "Internal"),
+            "did not expect 'Internal' to be exported; got: {:?}",
             s.exports
         );
     }

--- a/src/extractors/javascript.ts
+++ b/src/extractors/javascript.ts
@@ -210,6 +210,7 @@ const EXPORT_DECL_KIND: Record<string, string> = {
   abstract_class_declaration: 'class',
   interface_declaration: 'interface',
   type_alias_declaration: 'type',
+  enum_declaration: 'enum',
 };
 
 /**
@@ -218,8 +219,8 @@ const EXPORT_DECL_KIND: Record<string, string> = {
  * walk-based `handleExportStmt`) so they can't drift apart on what counts as
  * an export — see the "two code paths" gotcha for this extractor.
  *
- * Named function/class/interface/type declarations carry their own `name`
- * field. `export const/let/var …` has no such field — each declarator's value
+ * Named function/class/interface/type/enum declarations carry their own
+ * `name` field. `export const/let/var …` has no such field — each declarator's value
  * is classified the same way `handleVariableDeclarator` classifies it when
  * building the matching Definition (function-valued → kind 'function'; any
  * other `const` initializer shape → kind 'constant', regardless of complexity —

--- a/tests/parsers/javascript.test.ts
+++ b/tests/parsers/javascript.test.ts
@@ -3973,6 +3973,37 @@ function runDemo(reporter: Reporter, users: string[]): void {
     });
   });
 
+  describe('export enum declarations produce an Export record (#2560)', () => {
+    // Regression guard for #2560: `enum_declaration` was extracted as a
+    // Definition (via handleEnumDecl) but had no entry in EXPORT_DECL_KIND,
+    // so collectExportedDeclarations silently no-op'd for it — the enum
+    // itself was never marked exported, even though real TS/JS semantics say
+    // `export enum Foo {}` genuinely exports `Foo`.
+    function parseTS(code) {
+      const parser = parsers.get('typescript');
+      const tree = parser.parse(code);
+      return extractSymbols(tree, 'test.ts');
+    }
+
+    it('lists an exported enum with kind "enum"', () => {
+      const symbols = parseTS(`export enum Color { Red, Green, Blue }`);
+      expect(symbols.definitions).toContainEqual(
+        expect.objectContaining({ name: 'Color', kind: 'enum', line: 1 }),
+      );
+      expect(symbols.exports).toContainEqual(
+        expect.objectContaining({ name: 'Color', kind: 'enum', line: 1 }),
+      );
+    });
+
+    it('does not list a non-exported enum', () => {
+      const symbols = parseTS(`enum Internal { A, B }`);
+      expect(symbols.definitions).toContainEqual(
+        expect.objectContaining({ name: 'Internal', kind: 'enum' }),
+      );
+      expect(symbols.exports.some((e) => e.name === 'Internal')).toBe(false);
+    });
+  });
+
   describe('export line matches the declaration, not the `export` keyword (#2293)', () => {
     // Regression guard for #2293: collectExportedDeclarations computed a single
     // `exportLine` from the wrapping `export_statement` node and applied it to


### PR DESCRIPTION
## Summary
- Discovered while investigating #2459. `export enum Foo {}` is correctly parsed as an `export_statement` wrapping an `enum_declaration` in both engines, but the export-collection logic that turns a wrapped declaration into an `Export` record had no case for `enum_declaration` — it silently fell through to a no-op. The enum's `Definition` was still created (via `handleEnumDecl`/`handle_enum_decl`), just never marked `exported=1`.
- Both engines agreed with each other (not a cross-engine parity gap) but were both wrong relative to real JS/TS semantics: `export enum Foo {}` genuinely exports `Foo`.
- Fix: added `enum_declaration: 'enum'` to `EXPORT_DECL_KIND` in `src/extractors/javascript.ts`, and `"enum_declaration" => ("enum", "name"),` to `handle_export_declaration`'s match in `crates/codegraph-core/src/extractors/javascript.rs` — the exact existing pattern already used for function/class/interface/type declarations, since both engines already build the enum's own `Definition` with `kind: 'enum'` from the same node's `name`/line.
- Both TS's `collectExportedDeclarations` and Rust's `handle_export_declaration` are each single, shared functions across all their respective call sites, so this is a genuinely one-point fix per engine (no risk of the "two code paths" extractor gotcha).

Closes #2560

## Test plan
- [x] New tests in `tests/parsers/javascript.test.ts` (TS/WASM path) and `crates/codegraph-core/src/extractors/javascript.rs` (native path): an exported enum produces both a `Definition` (kind `enum`) and an `Export` (kind `enum`) at the correct line; a non-exported enum still gets a `Definition` but no `Export`.
- [x] Revert-verify (both engines independently): temporarily removed each fix and confirmed the corresponding new test fails with exactly the pre-fix symptom (empty exports array); restored both and all pass again.
- [x] End-to-end verification beyond the extractor-unit level: built a real fixture with `codegraph build --engine wasm` and `--engine native` (rebuilding the native addon from this branch's Rust source) — `codegraph exports` correctly lists the exported enum and correctly omits the non-exported one, for both engines.
- [x] `cargo fmt -- --check` and `cargo test --lib extractors::javascript` (328/328) clean.
- [x] `npm run lint` clean.
- [x] Full `npx vitest run`: 5534/5534 tests pass (344 test files, +2 new).