### PR TITLE
fix(bench): give query-benchmark.ts's diffImpact metric a warmup too

### DIFF
--- a/scripts/query-benchmark.ts
+++ b/scripts/query-benchmark.ts
@@ -109,13 +109,18 @@ console.log = (...args) => console.error(...args);
 
 const RUNS = 5;
 
-// First 2-3 native fnDeps calls per process pay a cold-start cost (rusqlite
-// statement-cache warmup, OS page cache for the DB file, NAPI-side static
-// init from tree-sitter's transitive crates linked into the .node binary).
-// On Linux x86_64 CI, that pulled median(5) into cold-start territory once
-// tree-sitter 0.25 grew the binary's init footprint (#1076), even though
-// steady-state per-call latency is unchanged. Discard the first WARMUP_RUNS
-// before timing so the metric reflects warm-call latency, not cold-start.
+// The first 2-3 native calls into a given query path per process pay a
+// cold-start cost (rusqlite statement-cache warmup, OS page cache for the DB
+// file, NAPI-side static init from tree-sitter's transitive crates linked
+// into the .node binary). On Linux x86_64 CI, that pulled median(5) into
+// cold-start territory once tree-sitter 0.25 grew the binary's init footprint
+// (#1076), even though steady-state per-call latency is unchanged. Discard
+// the first WARMUP_RUNS before timing so the metric reflects warm-call
+// latency, not cold-start.
+//
+// This applies per query path, not just once per process: each of fnDeps,
+// fnImpact and diffImpact prepares its own statements and touches its own DB
+// pages, so warming one does not warm the next (#2590).
 const WARMUP_RUNS = 3;
 
 async function benchDepths(fn, name, depths) {
@@ -165,6 +170,17 @@ async function benchDiffImpact(targets: HubTargets) {
 	try {
 		fs.writeFileSync(hubFile, original + '\n// benchmark-probe\n');
 		execFileSync('git', ['add', hubFile], { cwd: root, stdio: 'pipe' });
+
+		// Warm the diffImpact path before timing, exactly as benchDepths does for
+		// fnDeps/fnImpact. diffImpactData is a distinct query path from those --
+		// its own prepared statements, its own DB pages, and a `git` subprocess to
+		// read the staged diff -- so the warmup those calls already paid does not
+		// carry over. Without this, diffImpact was the only query metric measured
+		// cold: the same defect #2584 fixed for benchmark.ts's Full build, and
+		// that #2436 traced part of the gate's non-determinism to (#2590).
+		for (let i = 0; i < WARMUP_RUNS; i++) {
+			diffImpactData(dbPath, { staged: true, depth: 3, noTests: true });
+		}
 
 		let lastResult = null;
 		const latencyMs = round1(

--- a/scripts/query-benchmark.ts
+++ b/scripts/query-benchmark.ts
@@ -118,9 +118,12 @@ const RUNS = 5;
 // the first WARMUP_RUNS before timing so the metric reflects warm-call
 // latency, not cold-start.
 //
-// This applies per query path, not just once per process: each of fnDeps,
-// fnImpact and diffImpact prepares its own statements and touches its own DB
-// pages, so warming one does not warm the next (#2590).
+// This applies per query path, not just once per process: fnDeps, fnImpact and
+// diffImpact each run different code over different DB pages, so warming one
+// does not warm the next (#2590). Which specific cold-start costs a warmup
+// removes differs by path, though -- the list above describes the native
+// fnDeps/fnImpact path; see benchDiffImpact for the JS/better-sqlite3 case,
+// where the statement cache does not outlive a single call.
 const WARMUP_RUNS = 3;
 
 async function benchDepths(fn, name, depths) {
@@ -172,12 +175,23 @@ async function benchDiffImpact(targets: HubTargets) {
 		execFileSync('git', ['add', hubFile], { cwd: root, stdio: 'pipe' });
 
 		// Warm the diffImpact path before timing, exactly as benchDepths does for
-		// fnDeps/fnImpact. diffImpactData is a distinct query path from those --
-		// its own prepared statements, its own DB pages, and a `git` subprocess to
-		// read the staged diff -- so the warmup those calls already paid does not
-		// carry over. Without this, diffImpact was the only query metric measured
-		// cold: the same defect #2584 fixed for benchmark.ts's Full build, and
-		// that #2436 traced part of the gate's non-determinism to (#2590).
+		// fnDeps/fnImpact. diffImpactData is a distinct query path from those -- its
+		// own DB pages, and a `git` subprocess to read the staged diff -- so the
+		// warmup those calls already paid does not carry over.
+		//
+		// What these calls warm is narrower than on the native fnDeps path, and it
+		// is deliberately not the statement cache: diffImpactData opens its own
+		// readonly better-sqlite3 handle and closes it in a `finally`, so its
+		// prepared statements are discarded per call and no timed run ever reuses
+		// one. What does carry into the timed runs is process- and OS-wide state:
+		// loadConfig's per-root cache (resolveDbConfig re-reads .codegraphrc.json
+		// only on the first call), the OS page cache for the DB file and for the
+		// `.git` data the staged-diff subprocess reads, and V8 tiering up the diff
+		// parsing and BFS code that only this path exercises.
+		//
+		// Without this, diffImpact was the only query metric measured cold: the
+		// same defect #2584 fixed for benchmark.ts's Full build, and that #2436
+		// traced part of the gate's non-determinism to (#2590).
 		for (let i = 0; i < WARMUP_RUNS; i++) {
 			diffImpactData(dbPath, { staged: true, depth: 3, noTests: true });
 		}


### PR DESCRIPTION
## Summary

`WARMUP_RUNS` in `scripts/query-benchmark.ts` was applied only inside `benchDepths`, which serves `fnDeps` and `fnImpact`. `benchDiffImpact` called `timeMedian` directly with no warmup loop, making **`diffImpact latency` the only query metric measured cold**.

This is the same defect class #2584 just fixed for `benchmark.ts`'s Full build metric, and that #2436 traced part of the pre-publish gate's non-determinism to — *the one metric that measured without this warmup*. `diffImpact` was the remaining instance.

The warmup the earlier `benchDepths` calls already paid does not carry over: `diffImpactData` is a distinct query path with its own prepared statements and its own DB pages, and it shells out to `git` to read the staged diff.

## Why this surfaced now

Discovered while diagnosing why the pre-publish benchmark gate kept failing #2586, whose diff (one `enum_declaration` map arm per engine) provably cannot affect any benchmark — the benchmarked corpus contains zero `export enum` declarations. Three consecutive runs of that unchanged head each failed on a *different* metric, with each previously-failing metric returning to baseline:

| attempt | native noop | native diffImpact | wasm 1-file (setupMs) | result |
|---|---|---|---|---|
| 1 | **103** (baseline 32) | **26.5** | 173 (7.8) | FAIL x3 |
| 2 | 24 | 12.3 | **349** (**221.8**) | FAIL x1 |
| 3 | 23 | **21.8** | 158 (16.1) | FAIL x1 |

Native `diffImpact latency` across the four most recent PR runs — 12.4, 16.5, 16.9, then 12.3 / 21.8 / 26.5 — against a recorded 3.17.0 baseline of 10.1. Recent *passing* runs at 16.5–16.9 were already +63–67% over the 25% threshold and survived only because the ~10ms `MIN_ABSOLUTE_DELTA` floor filtered their 6.8ms delta. Full analysis in #2590.

## Test plan

- [x] Ran `scripts/query-benchmark.ts` against this repo, 3 runs per variant, alternating baseline/fixed to control for machine drift:

  | variant | native diffImpact (ms) | wasm diffImpact (ms) |
  |---|---|---|
  | before | 10.9 / 10.8 / 11.2 | 9.4 / 9.2 / 9.6 |
  | after | 9.9 / 9.8 / 9.9 | 9.4 / 9.4 / 9.7 |

  Both a ~10% drop and a visibly tighter spread on native. WASM is unchanged, which is the expected signature — the cold-start cost this removes is the native NAPI/rusqlite one, exactly as the `WARMUP_RUNS` docstring describes.
- [x] Output JSON stays well-formed and `affectedFunctions` / `affectedFiles` still populate (the warmup loop deliberately does not assign `lastResult`, so the reported result still comes from a timed run).
- [x] `npm run lint` clean.

## Honest scope note

This fixes a real methodological defect and measurably tightens the metric, but to be straight about what it does **not** prove: a ~1ms improvement measured on a quiet local machine is not evidence that CI will stop spiking to 21–26ms. The gate's remaining exposure — a stale 10.1 baseline that the metric no longer sits near, and the fact that `affectedFunctions: 0` on every historical entry means this benchmark measures near-pure fixed overhead — is tracked in #2590 and deliberately left out of this PR to keep it to one concern.

Note that adding `diffImpact latency` to `NOISY_METRICS` would *not* have helped: a failure needs both the percentage and the ~10ms absolute-delta floor to trip, and 21.8ms clears a 50% threshold on a 10.1 baseline just as it clears 25%.

Refs #2590
