### PR TITLE
fix(communities): defer to JS Leiden for graphs native cannot represent

### DIFF
--- a/src/graph/algorithms/louvain.ts
+++ b/src/graph/algorithms/louvain.ts
@@ -14,8 +14,16 @@
  * "neighbors" candidate strategy, refine always on) — see that file's module
  * doc for the precise (deliberately narrower) subset ported and the
  * follow-up issue tracking the rest.
+ *
+ * Because that subset is narrower than what the JS reference accepts,
+ * `nativeParityBlocker` below inspects the graph before choosing the native
+ * path and defers to the JS reference for any input native cannot represent
+ * faithfully -- see its doc comment. Without that check the two engines would
+ * silently disagree on weighted graphs rather than erroring, which is the
+ * failure mode this module exists to prevent.
  */
 
+import { debug } from '../../infrastructure/logger.js';
 import { loadNative } from '../../infrastructure/native.js';
 import type { CodeGraph } from '../model.js';
 import type { DetectClustersResult } from './leiden/index.js';
@@ -37,6 +45,52 @@ export interface LouvainResult {
   modularity: number;
 }
 
+/**
+ * Report the first graph attribute the JS reference honors but the native
+ * binding cannot see, or `null` when both engines would optimize the same
+ * weighted graph.
+ *
+ * `louvainCommunities` hands native `graph.toEdgeArray()`, which yields
+ * `{ source, target }` only -- every edge attribute is dropped at the FFI
+ * boundary -- and passes no node attributes at all, so `leiden.rs` assumes a
+ * uniform weight of 1.0 per edge and size of 1.0 per node. The JS reference
+ * instead resolves both from attributes (`adapter.ts`'s default
+ * `linkWeight`/`nodeSize`: `attrs.weight` / `attrs.size` when numeric, else
+ * 1). On a graph carrying either attribute the two engines therefore
+ * optimize *different* weighted graphs and can return different partitions
+ * -- exactly the engine-dependent output #1804 exists to eliminate, except
+ * silent, since nothing errors and both answers look plausible.
+ *
+ * No in-tree builder attaches `weight`/`size` today (`buildTemporalGraph`
+ * stores its Jaccard score under a `jaccard` key, which neither engine reads,
+ * and `buildDependencyGraph` sets only `kind`), so this is a trap for the
+ * *next* caller rather than a live divergence. Routing such a graph to the JS
+ * reference keeps the result correct-by-definition instead of engine-
+ * dependent; issue #1936 tracks teaching native to read these directly.
+ *
+ * A value of exactly 1 is not a blocker: it is what native already assumes,
+ * so both engines agree. Non-numeric values are not blockers either -- the JS
+ * defaults fall back to 1 for those, matching native.
+ *
+ * Exported so tests can assert the *negative* case directly: an over-eager
+ * blocker would quietly route every graph to the (slower) JS reference while
+ * every parity assertion still passed, since the two engines agree on
+ * everything this predicate lets through.
+ */
+export function nativeParityBlocker(graph: CodeGraph): string | null {
+  for (const [source, target, attrs] of graph.edges()) {
+    if (typeof attrs.weight === 'number' && attrs.weight !== 1) {
+      return `edge ${source}->${target} carries weight=${attrs.weight}`;
+    }
+  }
+  for (const [id, attrs] of graph.nodes()) {
+    if (typeof attrs.size === 'number' && attrs.size !== 1) {
+      return `node ${id} carries size=${attrs.size}`;
+    }
+  }
+  return null;
+}
+
 export function louvainCommunities(graph: CodeGraph, opts: LouvainOptions = {}): LouvainResult {
   if (graph.nodeCount === 0 || graph.edgeCount === 0) {
     return { assignments: new Map(), modularity: 0 };
@@ -45,7 +99,14 @@ export function louvainCommunities(graph: CodeGraph, opts: LouvainOptions = {}):
   const resolution: number = opts.resolution ?? 1.0;
 
   const native = loadNative();
-  if (native?.leidenCommunities) {
+  const blocker = native?.leidenCommunities ? nativeParityBlocker(graph) : null;
+  if (blocker) {
+    debug(
+      `louvainCommunities: using the JS Leiden reference instead of the native ` +
+        `binding -- native cannot represent this graph faithfully (${blocker})`,
+    );
+  }
+  if (native?.leidenCommunities && !blocker) {
     const edges = graph.toEdgeArray();
     const nodeIds = graph.nodeIds();
     const result = native.leidenCommunities(

--- a/tests/graph/algorithms/leiden-native-parity.test.ts
+++ b/tests/graph/algorithms/leiden-native-parity.test.ts
@@ -16,7 +16,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { detectClusters } from '../../../src/graph/algorithms/leiden/index.js';
-import { louvainCommunities } from '../../../src/graph/algorithms/louvain.js';
+import { louvainCommunities, nativeParityBlocker } from '../../../src/graph/algorithms/louvain.js';
 import { CodeGraph } from '../../../src/graph/model.js';
 import { getNative, isNativeAvailable } from '../../../src/infrastructure/native.js';
 
@@ -235,5 +235,96 @@ describe.skipIf(!hasNative)('native/JS Leiden parity (issue #1804)', () => {
     }
     expect(snapshot(native.assignments)).toEqual(snapshot(jsAssignments));
     expect(native.modularity).toBe(jsResult.quality());
+  });
+});
+
+/**
+ * Graphs the native binding cannot represent (issue #1936).
+ *
+ * `toEdgeArray()` drops every edge attribute at the FFI boundary and no node
+ * attributes are passed at all, so native always optimizes a uniformly
+ * weighted graph while the JS reference honors `attrs.weight`/`attrs.size`.
+ * `nativeParityBlocker` detects that mismatch up front and defers to the JS
+ * reference. These tests pin both halves: that the mismatch is real (native
+ * genuinely cannot see the weights) and that the public API therefore returns
+ * the JS reference's answer rather than an engine-dependent one.
+ */
+describe('Leiden native/JS parity — inputs native cannot represent (#1936)', () => {
+  /**
+   * Two triangles joined by a single bridge edge whose weight dominates every
+   * intra-triangle edge. Unweighted, the triangles are the obvious partition;
+   * weighted, the bridge is by far the strongest tie in the graph, so weights
+   * are load-bearing for both the partition and the modularity score.
+   */
+  function buildWeightedBridgeGraph(bridgeWeight: number | undefined): CodeGraph {
+    const g = new CodeGraph();
+    for (const [a, b] of [
+      ['a1', 'a2'],
+      ['a2', 'a3'],
+      ['a3', 'a1'],
+      ['b1', 'b2'],
+      ['b2', 'b3'],
+      ['b3', 'b1'],
+    ] as const) {
+      g.addEdge(a, b, { weight: 1 });
+    }
+    g.addEdge('a1', 'b1', bridgeWeight == null ? {} : { weight: bridgeWeight });
+    return g;
+  }
+
+  it('flags weighted edges and unit-sized nodes correctly', () => {
+    expect(nativeParityBlocker(buildWeightedBridgeGraph(25))).toMatch(/weight=25/);
+    // weight === 1 is exactly what native assumes, so it is not a blocker --
+    // pins that the predicate stays narrow instead of rejecting every graph
+    // that merely carries a `weight` key.
+    expect(nativeParityBlocker(buildWeightedBridgeGraph(1))).toBeNull();
+    expect(nativeParityBlocker(buildWeightedBridgeGraph(undefined))).toBeNull();
+  });
+
+  it('does not flag non-numeric weight/size attrs (JS falls back to 1 for those too)', () => {
+    const g = new CodeGraph();
+    g.addEdge('a', 'b', { weight: 'heavy' });
+    g.addNode('a', { size: null });
+    expect(nativeParityBlocker(g)).toBeNull();
+  });
+
+  it('flags node size attrs', () => {
+    const g = new CodeGraph();
+    g.addEdge('a', 'b');
+    g.addNode('a', { size: 4 });
+    expect(nativeParityBlocker(g)).toMatch(/size=4/);
+  });
+
+  it.runIf(hasNative)('confirms native genuinely cannot see edge weights', () => {
+    // Justifies the guard: native returns the *same* answer whether or not
+    // the weights are present (it never sees them), while JS returns a
+    // different modularity for the two graphs (it does). Without the guard,
+    // `louvainCommunities` would hand back the weight-blind answer for a
+    // weighted graph.
+    const weighted = buildWeightedBridgeGraph(25);
+    const unweighted = buildWeightedBridgeGraph(undefined);
+
+    expect(snapshot(runNativeDirect(weighted).assignments)).toEqual(
+      snapshot(runNativeDirect(unweighted).assignments),
+    );
+    expect(runNativeDirect(weighted).modularity).toBe(runNativeDirect(unweighted).modularity);
+    expect(runJS(weighted).modularity).not.toBe(runJS(unweighted).modularity);
+  });
+
+  it('returns the JS reference result for a weighted graph', () => {
+    const g = buildWeightedBridgeGraph(25);
+    const viaPublicApi = louvainCommunities(g);
+    const js = runJS(g);
+    expect(snapshot(viaPublicApi.assignments)).toEqual(snapshot(js.assignments));
+    expect(viaPublicApi.modularity).toBe(js.modularity);
+  });
+
+  it('returns the JS reference result for a graph with node sizes', () => {
+    const g = buildWeightedBridgeGraph(undefined);
+    g.addNode('a1', { size: 8 });
+    const viaPublicApi = louvainCommunities(g);
+    const js = runJS(g);
+    expect(snapshot(viaPublicApi.assignments)).toEqual(snapshot(js.assignments));
+    expect(viaPublicApi.modularity).toBe(js.modularity);
   });
 });


### PR DESCRIPTION
## Problem

`louvainCommunities` hands the native binding `graph.toEdgeArray()`, which yields `{ source, target }` only — every edge attribute is dropped at the FFI boundary — and passes no node attributes at all. `leiden.rs` therefore always assumes a uniform weight of 1.0 per edge and size of 1.0 per node.

The JS reference resolves both from attributes instead (`adapter.ts`'s default `linkWeight`/`nodeSize`: `attrs.weight` / `attrs.size` when numeric, else 1).

So on a graph carrying either attribute, the two engines optimize **different weighted graphs** and can return different partitions — engine-dependent output of exactly the kind #1804 exists to eliminate, except silent: nothing errors, and both answers look plausible.

The new test `confirms native genuinely cannot see edge weights` pins the mechanism: native returns an identical partition *and* modularity whether or not the weights are present, while JS returns a different modularity for the two graphs.

## Is it live?

No — this was a trap for the next caller, not a current divergence. No in-tree builder attaches `weight`/`size` today: `buildTemporalGraph` stores its Jaccard score under a `jaccard` key that neither engine reads, and `buildDependencyGraph` sets only `kind`. But it fails *silently*, so it is worth closing before something lands on top of it.

## Fix

`nativeParityBlocker` inspects the graph up front — one O(V+E) pass, negligible beside Leiden itself — and defers to the JS reference when native cannot represent the input faithfully. That keeps the result correct-by-definition rather than engine-dependent.

It stays deliberately narrow:

- a weight/size of exactly **1** is what native already assumes, so both engines agree — not a blocker
- **non-numeric** values hit the same fallback-to-1 in the JS defaults — also not a blocker

It is exported so tests can assert those negative cases directly. An over-eager blocker would quietly route every graph to the slower JS path while every parity assertion still passed, since the two engines agree on everything the predicate lets through.

## Context

Found while working through #1936, whose original gate ("only take this on if/when a real caller needs one of these knobs") could never be satisfied: the knobs are unreachable because `LouvainOptions` does not expose them, and exposing them *is* the work being gated. This PR is the part that is a plain correctness fix regardless of that decision.

## Verification

- 5518 vitest tests pass (0 failures); `tsc --noEmit` and `biome check` clean
- 6 new tests, including the native-gated one above that proves the divergence is real
- Local runs are on Node 24 while CI pins 22

Refs #1936