### PR TITLE
feat(communities): native Leiden reads per-edge weights

### DIFF
--- a/crates/codegraph-core/src/graph/algorithms/leiden.rs
+++ b/crates/codegraph-core/src/graph/algorithms/leiden.rs
@@ -10,22 +10,35 @@
 //!
 //! ## Scope
 //!
-//! This port covers exactly the option surface reachable through
+//! This port covers the option surface reachable through
 //! `louvainCommunities`/`LouvainOptions`
 //! (`src/graph/algorithms/louvain.ts`): undirected graphs, modularity
 //! quality (not CPM), the default "neighbors" candidate strategy,
-//! `refine: true` (always), uniform node size (1.0) and edge weight (1.0
-//! per edge — `GraphEdge` carries no weight field), no
-//! `maxCommunitySize`/`fixedNodes`/`preserveLabels` overrides. These are the
-//! *only* knobs `louvainCommunities` ever threads through to either engine
-//! (see `LouvainOptions` and `louvainJS()`'s call into `detectClusters`).
+//! `refine: true` (always), per-edge weights, uniform node size (1.0), no
+//! `maxCommunitySize`/`fixedNodes`/`preserveLabels` overrides.
 //!
-//! The TS `leiden/` directory's directed-graph mode, CPM quality function,
-//! alternate candidate strategies (all/random/random-neighbor),
-//! `allowNewCommunity`, `fixedNodes`, and `preserveLabels` knobs are **not**
-//! ported — they are unreachable from this binding today. Issue #1936
-//! tracks porting that remaining surface if a caller ever needs to drive
-//! native Leiden with it.
+//! Per-edge weights arrive through `leiden_weighted_communities` and are
+//! resolved *on the TypeScript side* (`resolveEdgeWeight` in
+//! `src/graph/algorithms/leiden/adapter.ts`, shared with the JS reference's
+//! own adapter) so that the rule mapping an edge attribute to a number has
+//! exactly one implementation across both engines. This binding therefore
+//! takes already-resolved numbers and does not reimplement that rule — see
+//! `resolve_weight` below. The older `leiden_communities` entry point is
+//! retained for version skew (newer addon, older JS) and is exactly the
+//! all-weights-1.0 case.
+//!
+//! Node size is still uniform 1.0: nothing in-tree attaches a `size`
+//! attribute, so there is no caller to verify a port against. Sizes are not
+//! inert under modularity — `compact_community_ids` sorts communities by
+//! total size to assign final IDs — so `nativeParityBlocker` in `louvain.ts`
+//! routes any size-bearing graph to the JS reference rather than letting the
+//! two engines label communities differently.
+//!
+//! The TS `leiden/` directory's CPM quality function, alternate candidate
+//! strategies (all/random/random-neighbor), `allowNewCommunity`,
+//! `fixedNodes`, and `preserveLabels` knobs are **not** ported — they are
+//! unreachable from this binding today. Issue #1936 tracks porting that
+//! remaining surface if a caller ever needs to drive native Leiden with it.
 //!
 //! ## Determinism
 //!
@@ -61,6 +74,24 @@ use crate::types::GraphEdge;
 // napi-facing types + entry point
 // ════════════════════════════════════════════════════════════════════════
 
+/// A graph edge carrying an already-resolved weight.
+///
+/// Distinct from the shared `GraphEdge` on purpose: `GraphEdge` is also the
+/// input to `detect_cycles`, `shortest_path`, `fan_in_out` and `bfs`, none of
+/// which read a weight. Adding an inert field there would let a caller set a
+/// weight on, say, a `shortest_path` edge and have it silently ignored —
+/// which is the same class of quiet-wrong-answer bug that per-edge weight
+/// support exists to close.
+#[napi(object)]
+#[derive(Debug, Clone)]
+pub struct LeidenWeightedEdge {
+    pub source: String,
+    pub target: String,
+    /// Resolved edge weight; `None` means 1.0 (see the module doc — the
+    /// attribute-to-number rule lives on the TypeScript side).
+    pub weight: Option<f64>,
+}
+
 #[napi(object)]
 #[derive(Debug, Clone)]
 pub struct LeidenCommunityAssignment {
@@ -75,7 +106,23 @@ pub struct LeidenCommunitiesResult {
     pub modularity: f64,
 }
 
-/// Leiden community detection (undirected modularity optimization).
+/// Resolve one edge's weight for the adapter.
+///
+/// Weights arrive already resolved from TypeScript (see the module doc), so
+/// this is deliberately not a reimplementation of the attribute-to-number
+/// rule — only the two mappings that cannot be expressed across the FFI
+/// boundary by the caller: an absent weight means 1.0, and NaN means 0.0
+/// (matching the JS adapter's `+w || 0` coercion, which turns NaN into a
+/// dropped edge rather than poisoning every modularity sum downstream).
+fn resolve_weight(weight: Option<f64>) -> f64 {
+    match weight {
+        None => 1.0,
+        Some(w) if w.is_nan() => 0.0,
+        Some(w) => w,
+    }
+}
+
+/// Leiden community detection over per-edge weights (undirected modularity).
 ///
 /// Mirrors `detectClusters(graph, { resolution, randomSeed, directed: false,
 /// maxLevels, maxLocalPasses, refinementTheta, capacityGrowthFactor })` in
@@ -83,9 +130,68 @@ pub struct LeidenCommunitiesResult {
 /// the precise (and deliberately narrower) option surface covered.
 #[napi]
 #[allow(clippy::too_many_arguments)]
+pub fn leiden_weighted_communities(
+    edges: Vec<LeidenWeightedEdge>,
+    node_ids: Vec<String>,
+    resolution: Option<f64>,
+    random_seed: Option<u32>,
+    max_levels: Option<u32>,
+    max_local_passes: Option<u32>,
+    refinement_theta: Option<f64>,
+    capacity_growth_factor: Option<f64>,
+) -> LeidenCommunitiesResult {
+    leiden_impl(
+        &edges,
+        &node_ids,
+        resolution,
+        random_seed,
+        max_levels,
+        max_local_passes,
+        refinement_theta,
+        capacity_growth_factor,
+    )
+}
+
+/// Unweighted entry point — every edge weighs 1.0.
+///
+/// Retained for version skew (a newer addon loaded by older JS that only
+/// knows this name); current JS always calls `leiden_weighted_communities`.
+#[napi]
+#[allow(clippy::too_many_arguments)]
 pub fn leiden_communities(
     edges: Vec<GraphEdge>,
     node_ids: Vec<String>,
+    resolution: Option<f64>,
+    random_seed: Option<u32>,
+    max_levels: Option<u32>,
+    max_local_passes: Option<u32>,
+    refinement_theta: Option<f64>,
+    capacity_growth_factor: Option<f64>,
+) -> LeidenCommunitiesResult {
+    let weighted: Vec<LeidenWeightedEdge> = edges
+        .into_iter()
+        .map(|e| LeidenWeightedEdge {
+            source: e.source,
+            target: e.target,
+            weight: None,
+        })
+        .collect();
+    leiden_impl(
+        &weighted,
+        &node_ids,
+        resolution,
+        random_seed,
+        max_levels,
+        max_local_passes,
+        refinement_theta,
+        capacity_growth_factor,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn leiden_impl(
+    edges: &[LeidenWeightedEdge],
+    node_ids: &[String],
     resolution: Option<f64>,
     random_seed: Option<u32>,
     max_levels: Option<u32>,
@@ -125,16 +231,14 @@ pub fn leiden_communities(
     for (i, id) in node_ids.iter().enumerate() {
         id_to_idx.insert(id.as_str(), i);
     }
-    // Edge weight is always 1.0: `GraphEdge` carries no weight field, and
-    // `graph.toEdgeArray()` (the sole caller, in louvain.ts) never attaches
-    // one either -- matching the TS reference's default `linkWeight`
-    // fallback, which is the only value ever exercised by this binding.
+    // Edges whose endpoints are not in `node_ids` are skipped, matching the
+    // JS adapter's `if (a == null || b == null) continue`.
     let raw_edges: Vec<(usize, usize, f64)> = edges
         .iter()
         .filter_map(|e| {
             let a = *id_to_idx.get(e.source.as_str())?;
             let b = *id_to_idx.get(e.target.as_str())?;
-            Some((a, b, 1.0))
+            Some((a, b, resolve_weight(e.weight)))
         })
         .collect();
 
@@ -1159,6 +1263,102 @@ fn compute_final_modularity(base: &GraphAdapter, original_to_current: &[usize]) 
 mod tests {
     use super::*;
     use std::collections::HashMap as StdHashMap;
+
+    fn wedge(src: &str, tgt: &str, weight: Option<f64>) -> LeidenWeightedEdge {
+        LeidenWeightedEdge {
+            source: src.to_string(),
+            target: tgt.to_string(),
+            weight,
+        }
+    }
+
+    /// The two mappings `resolve_weight` owns (everything else is resolved on
+    /// the TS side): absent means 1.0, NaN means 0.0 so it drops the edge
+    /// instead of poisoning every modularity sum downstream.
+    #[test]
+    fn resolve_weight_maps_absent_to_one_and_nan_to_zero() {
+        assert_eq!(resolve_weight(None), 1.0);
+        assert_eq!(resolve_weight(Some(f64::NAN)), 0.0);
+        assert_eq!(resolve_weight(Some(0.0)), 0.0);
+        assert_eq!(resolve_weight(Some(2.5)), 2.5);
+        assert_eq!(resolve_weight(Some(-3.0)), -3.0);
+    }
+
+    /// An all-absent-weight weighted call must equal the unweighted binding:
+    /// the retained `leiden_communities` entry point is defined as exactly
+    /// that case, so any drift between the two is a bug.
+    #[test]
+    fn weighted_with_no_weights_equals_unweighted_binding() {
+        let nodes: Vec<String> = ["a", "b", "c", "x", "y", "z"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let pairs = [
+            ("a", "b"),
+            ("b", "c"),
+            ("c", "a"),
+            ("x", "y"),
+            ("y", "z"),
+            ("z", "x"),
+            ("c", "x"),
+        ];
+
+        let unweighted = leiden_communities(
+            pairs.iter().map(|(a, b)| edge(a, b)).collect(),
+            nodes.clone(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+        let weighted = leiden_weighted_communities(
+            pairs.iter().map(|(a, b)| wedge(a, b, None)).collect(),
+            nodes.clone(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+
+        assert_eq!(unweighted.modularity, weighted.modularity);
+        let as_pairs = |r: &LeidenCommunitiesResult| {
+            let mut v: Vec<(String, i32)> = r
+                .assignments
+                .iter()
+                .map(|a| (a.node.clone(), a.community))
+                .collect();
+            v.sort();
+            v
+        };
+        assert_eq!(as_pairs(&unweighted), as_pairs(&weighted));
+    }
+
+    /// Explicit weight 1.0 must also be identical to an absent weight --
+    /// `louvainCommunities` omits the field for weight-1 edges to keep the
+    /// wire format compact, so the two spellings have to agree.
+    #[test]
+    fn explicit_unit_weight_equals_absent_weight() {
+        let nodes: Vec<String> = ["a", "b", "c"].iter().map(|s| s.to_string()).collect();
+        let pairs = [("a", "b"), ("b", "c"), ("c", "a")];
+        let run = |w: Option<f64>| {
+            leiden_weighted_communities(
+                pairs.iter().map(|(a, b)| wedge(a, b, w)).collect(),
+                nodes.clone(),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .modularity
+        };
+        assert_eq!(run(None), run(Some(1.0)));
+    }
 
     fn edge(src: &str, tgt: &str) -> GraphEdge {
         GraphEdge {

--- a/src/graph/algorithms/leiden/adapter.ts
+++ b/src/graph/algorithms/leiden/adapter.ts
@@ -41,6 +41,39 @@ export interface GraphAdapter {
 }
 
 /**
+ * The default edge-weight rule: `attrs.weight` when numeric, else 1.
+ *
+ * Kept as a named function (rather than inlined into `resolveAdapterOptions`)
+ * because the native Leiden binding has to apply the *same* rule when it
+ * resolves weights for the FFI boundary. Two independent copies of this rule
+ * would let the engines disagree about what a graph weighs, which is the whole
+ * bug class `resolveEdgeWeight` exists to prevent.
+ */
+function defaultLinkWeight(attrs: EdgeAttrs): number {
+  return attrs && typeof attrs.weight === 'number' ? attrs.weight : 1;
+}
+
+/**
+ * Numeric coercion applied to every resolved link weight. Non-finite and
+ * zero results collapse to 0, which drops the edge from the adapter rather
+ * than propagating NaN through every modularity sum downstream.
+ */
+function coerceLinkWeight(w: number): number {
+  return +w || 0;
+}
+
+/**
+ * Resolve an edge attribute bag to the weight both engines must agree on.
+ *
+ * Exported for `louvainCommunities`, which builds the native binding's edge
+ * array: doing the resolution here means the attribute-to-number rule has one
+ * implementation shared by the native and JS paths instead of one per engine.
+ */
+export function resolveEdgeWeight(attrs: EdgeAttrs): number {
+  return coerceLinkWeight(defaultLinkWeight(attrs));
+}
+
+/**
  * Populate edge arrays for a directed graph. Each edge is stored once in
  * outEdges[from] and inEdges[to]. Self-loops are tracked in both the selfLoop
  * array and the adjacency lists (partition.ts accounts for this).
@@ -59,7 +92,7 @@ function populateDirectedEdges(
     const from = idToIndex.get(src);
     const to = idToIndex.get(tgt);
     if (from == null || to == null) continue;
-    const w: number = +linkWeight(attrs) || 0;
+    const w: number = coerceLinkWeight(linkWeight(attrs));
     if (from === to) {
       taAdd(selfLoop, from, w);
       // Self-loop is intentionally kept in outEdges/inEdges as well.
@@ -107,7 +140,7 @@ function aggregateUndirectedPairs(
     const a = idToIndex.get(src);
     const b = idToIndex.get(tgt);
     if (a == null || b == null) continue;
-    const w: number = +linkWeight(attrs) || 0;
+    const w: number = coerceLinkWeight(linkWeight(attrs));
     if (a === b) {
       taAdd(selfLoop, a, w);
       continue;
@@ -199,9 +232,7 @@ interface ResolvedAdapterOptions {
 /** Apply GraphAdapterOptions defaults (weight=1, size=1, directed=false). */
 function resolveAdapterOptions(opts: GraphAdapterOptions): ResolvedAdapterOptions {
   return {
-    linkWeight:
-      opts.linkWeight ||
-      ((attrs) => (attrs && typeof attrs.weight === 'number' ? attrs.weight : 1)),
+    linkWeight: opts.linkWeight || defaultLinkWeight,
     nodeSize:
       opts.nodeSize || ((attrs) => (attrs && typeof attrs.size === 'number' ? attrs.size : 1)),
     directed: !!opts.directed,

--- a/src/graph/algorithms/leiden/adapter.ts
+++ b/src/graph/algorithms/leiden/adapter.ts
@@ -54,9 +54,18 @@ function defaultLinkWeight(attrs: EdgeAttrs): number {
 }
 
 /**
- * Numeric coercion applied to every resolved link weight. Non-finite and
- * zero results collapse to 0, which drops the edge from the adapter rather
- * than propagating NaN through every modularity sum downstream.
+ * Numeric coercion applied to every resolved link weight: `NaN`, zero, and
+ * anything non-numeric collapse to 0, which drops the edge from the adapter
+ * rather than propagating NaN through every modularity sum downstream.
+ *
+ * `Infinity`/`-Infinity` are *not* collapsed -- they are truthy, so `+w || 0`
+ * keeps them, and they then poison the modularity sums via
+ * `Infinity - Infinity`. That is a real gap rather than intended design, but
+ * both engines share it (the native binding's `resolve_weight` mirrors this
+ * rule exactly, NaN included) and nothing in-tree can produce an infinite
+ * weight today, so it is tracked in #2597 rather than changed here: clamping
+ * would alter the vendored reference's numeric semantics and needs its own
+ * decision plus a matching native change.
  */
 function coerceLinkWeight(w: number): number {
   return +w || 0;

--- a/src/graph/algorithms/louvain.ts
+++ b/src/graph/algorithms/louvain.ts
@@ -26,6 +26,7 @@
 import { debug } from '../../infrastructure/logger.js';
 import { loadNative } from '../../infrastructure/native.js';
 import type { CodeGraph } from '../model.js';
+import { resolveEdgeWeight } from './leiden/adapter.js';
 import type { DetectClustersResult } from './leiden/index.js';
 import { detectClusters } from './leiden/index.js';
 
@@ -50,37 +51,43 @@ export interface LouvainResult {
  * binding cannot see, or `null` when both engines would optimize the same
  * weighted graph.
  *
- * `louvainCommunities` hands native `graph.toEdgeArray()`, which yields
- * `{ source, target }` only -- every edge attribute is dropped at the FFI
- * boundary -- and passes no node attributes at all, so `leiden.rs` assumes a
- * uniform weight of 1.0 per edge and size of 1.0 per node. The JS reference
- * instead resolves both from attributes (`adapter.ts`'s default
- * `linkWeight`/`nodeSize`: `attrs.weight` / `attrs.size` when numeric, else
- * 1). On a graph carrying either attribute the two engines therefore
- * optimize *different* weighted graphs and can return different partitions
- * -- exactly the engine-dependent output #1804 exists to eliminate, except
- * silent, since nothing errors and both answers look plausible.
+ * The native binding receives a flat edge array across the FFI boundary and
+ * no node attributes at all, so anything the JS reference derives from an
+ * attribute native cannot see makes the two engines optimize *different*
+ * graphs and return different partitions -- exactly the engine-dependent
+ * output #1804 exists to eliminate, except silent, since nothing errors and
+ * both answers look plausible.
  *
- * No in-tree builder attaches `weight`/`size` today (`buildTemporalGraph`
- * stores its Jaccard score under a `jaccard` key, which neither engine reads,
- * and `buildDependencyGraph` sets only `kind`), so this is a trap for the
- * *next* caller rather than a live divergence. Routing such a graph to the JS
- * reference keeps the result correct-by-definition instead of engine-
- * dependent; issue #1936 tracks teaching native to read these directly.
+ * Two attributes are at stake. Per-edge `weight` is now understood natively
+ * (`leidenWeightedCommunities`), so it is only a blocker when that newer
+ * binding is missing -- an older published addon loaded by newer JS -- hence
+ * the `weightsSupported` parameter. Per-node `size` is never understood
+ * natively: nothing in-tree attaches it, so there is no caller to verify a
+ * port against, and it is not inert (the JS reference sorts communities by
+ * total size when assigning final IDs, so sizes change the labels even when
+ * the grouping matches).
  *
- * A value of exactly 1 is not a blocker: it is what native already assumes,
- * so both engines agree. Non-numeric values are not blockers either -- the JS
- * defaults fall back to 1 for those, matching native.
+ * Routing a graph native cannot represent to the JS reference keeps the
+ * result correct-by-definition instead of engine-dependent.
+ *
+ * The predicate stays deliberately narrow. A value of exactly 1 is what
+ * native already assumes, so both engines agree; non-numeric values hit the
+ * JS defaults' own fallback to 1, which also matches. Neither is a blocker.
  *
  * Exported so tests can assert the *negative* case directly: an over-eager
  * blocker would quietly route every graph to the (slower) JS reference while
  * every parity assertion still passed, since the two engines agree on
  * everything this predicate lets through.
  */
-export function nativeParityBlocker(graph: CodeGraph): string | null {
-  for (const [source, target, attrs] of graph.edges()) {
-    if (typeof attrs.weight === 'number' && attrs.weight !== 1) {
-      return `edge ${source}->${target} carries weight=${attrs.weight}`;
+export function nativeParityBlocker(
+  graph: CodeGraph,
+  { weightsSupported }: { weightsSupported: boolean },
+): string | null {
+  if (!weightsSupported) {
+    for (const [source, target, attrs] of graph.edges()) {
+      if (typeof attrs.weight === 'number' && attrs.weight !== 1) {
+        return `edge ${source}->${target} carries weight=${attrs.weight}`;
+      }
     }
   }
   for (const [id, attrs] of graph.nodes()) {
@@ -99,34 +106,73 @@ export function louvainCommunities(graph: CodeGraph, opts: LouvainOptions = {}):
   const resolution: number = opts.resolution ?? 1.0;
 
   const native = loadNative();
-  const blocker = native?.leidenCommunities ? nativeParityBlocker(graph) : null;
-  if (blocker) {
-    debug(
-      `louvainCommunities: using the JS Leiden reference instead of the native ` +
-        `binding -- native cannot represent this graph faithfully (${blocker})`,
-    );
-  }
-  if (native?.leidenCommunities && !blocker) {
-    const edges = graph.toEdgeArray();
-    const nodeIds = graph.nodeIds();
-    const result = native.leidenCommunities(
-      edges,
-      nodeIds,
-      resolution,
-      DEFAULT_RANDOM_SEED,
-      opts.maxLevels,
-      opts.maxLocalPasses,
-      opts.refinementTheta,
-      opts.capacityGrowthFactor,
-    );
-    const assignments = new Map<string, number>();
-    for (const entry of result.assignments) {
-      assignments.set(entry.node, entry.community);
+  // Prefer the weighted binding; `leidenCommunities` is the pre-#1936 export
+  // kept for the case where an older published addon is loaded by newer JS.
+  const weighted = native?.leidenWeightedCommunities;
+  const unweighted = native?.leidenCommunities;
+  const binding = weighted ?? unweighted;
+
+  if (binding) {
+    const blocker = nativeParityBlocker(graph, { weightsSupported: weighted != null });
+    if (blocker) {
+      debug(
+        `louvainCommunities: using the JS Leiden reference instead of the native ` +
+          `binding -- native cannot represent this graph faithfully (${blocker})`,
+      );
+    } else {
+      const nodeIds = graph.nodeIds();
+      const result = weighted
+        ? weighted(
+            toWeightedEdgeArray(graph),
+            nodeIds,
+            resolution,
+            DEFAULT_RANDOM_SEED,
+            opts.maxLevels,
+            opts.maxLocalPasses,
+            opts.refinementTheta,
+            opts.capacityGrowthFactor,
+          )
+        : // biome-ignore lint/style/noNonNullAssertion: `binding` is non-null
+          // and `weighted` is null here, so `unweighted` is the binding.
+          unweighted!(
+            graph.toEdgeArray(),
+            nodeIds,
+            resolution,
+            DEFAULT_RANDOM_SEED,
+            opts.maxLevels,
+            opts.maxLocalPasses,
+            opts.refinementTheta,
+            opts.capacityGrowthFactor,
+          );
+      const assignments = new Map<string, number>();
+      for (const entry of result.assignments) {
+        assignments.set(entry.node, entry.community);
+      }
+      return { assignments, modularity: result.modularity };
     }
-    return { assignments, modularity: result.modularity };
   }
 
   return louvainJS(graph, opts, resolution);
+}
+
+/**
+ * Build the native weighted binding's edge array.
+ *
+ * Weight resolution happens here, via the same `resolveEdgeWeight` the JS
+ * adapter uses, so both engines agree on what each edge weighs by
+ * construction rather than by two matching implementations. `undefined` is
+ * sent for the default so the wire format stays compact on the overwhelmingly
+ * common unweighted graph -- native reads an absent weight as 1.0.
+ */
+function toWeightedEdgeArray(
+  graph: CodeGraph,
+): { source: string; target: string; weight?: number }[] {
+  const edges: { source: string; target: string; weight?: number }[] = [];
+  for (const [source, target, attrs] of graph.edges()) {
+    const weight = resolveEdgeWeight(attrs);
+    edges.push(weight === 1 ? { source, target } : { source, target, weight });
+  }
+  return edges;
 }
 
 /** JS fallback using the vendored Leiden algorithm. */

--- a/src/graph/algorithms/louvain.ts
+++ b/src/graph/algorithms/louvain.ts
@@ -14,8 +14,16 @@
  * "neighbors" candidate strategy, refine always on) — see that file's module
  * doc for the precise (deliberately narrower) subset ported and the
  * follow-up issue tracking the rest.
+ *
+ * Because that subset is narrower than what the JS reference accepts,
+ * `nativeParityBlocker` below inspects the graph before choosing the native
+ * path and defers to the JS reference for any input native cannot represent
+ * faithfully -- see its doc comment. Without that check the two engines would
+ * silently disagree on weighted graphs rather than erroring, which is the
+ * failure mode this module exists to prevent.
  */
 
+import { debug } from '../../infrastructure/logger.js';
 import { loadNative } from '../../infrastructure/native.js';
 import type { CodeGraph } from '../model.js';
 import type { DetectClustersResult } from './leiden/index.js';
@@ -37,6 +45,52 @@ export interface LouvainResult {
   modularity: number;
 }
 
+/**
+ * Report the first graph attribute the JS reference honors but the native
+ * binding cannot see, or `null` when both engines would optimize the same
+ * weighted graph.
+ *
+ * `louvainCommunities` hands native `graph.toEdgeArray()`, which yields
+ * `{ source, target }` only -- every edge attribute is dropped at the FFI
+ * boundary -- and passes no node attributes at all, so `leiden.rs` assumes a
+ * uniform weight of 1.0 per edge and size of 1.0 per node. The JS reference
+ * instead resolves both from attributes (`adapter.ts`'s default
+ * `linkWeight`/`nodeSize`: `attrs.weight` / `attrs.size` when numeric, else
+ * 1). On a graph carrying either attribute the two engines therefore
+ * optimize *different* weighted graphs and can return different partitions
+ * -- exactly the engine-dependent output #1804 exists to eliminate, except
+ * silent, since nothing errors and both answers look plausible.
+ *
+ * No in-tree builder attaches `weight`/`size` today (`buildTemporalGraph`
+ * stores its Jaccard score under a `jaccard` key, which neither engine reads,
+ * and `buildDependencyGraph` sets only `kind`), so this is a trap for the
+ * *next* caller rather than a live divergence. Routing such a graph to the JS
+ * reference keeps the result correct-by-definition instead of engine-
+ * dependent; issue #1936 tracks teaching native to read these directly.
+ *
+ * A value of exactly 1 is not a blocker: it is what native already assumes,
+ * so both engines agree. Non-numeric values are not blockers either -- the JS
+ * defaults fall back to 1 for those, matching native.
+ *
+ * Exported so tests can assert the *negative* case directly: an over-eager
+ * blocker would quietly route every graph to the (slower) JS reference while
+ * every parity assertion still passed, since the two engines agree on
+ * everything this predicate lets through.
+ */
+export function nativeParityBlocker(graph: CodeGraph): string | null {
+  for (const [source, target, attrs] of graph.edges()) {
+    if (typeof attrs.weight === 'number' && attrs.weight !== 1) {
+      return `edge ${source}->${target} carries weight=${attrs.weight}`;
+    }
+  }
+  for (const [id, attrs] of graph.nodes()) {
+    if (typeof attrs.size === 'number' && attrs.size !== 1) {
+      return `node ${id} carries size=${attrs.size}`;
+    }
+  }
+  return null;
+}
+
 export function louvainCommunities(graph: CodeGraph, opts: LouvainOptions = {}): LouvainResult {
   if (graph.nodeCount === 0 || graph.edgeCount === 0) {
     return { assignments: new Map(), modularity: 0 };
@@ -45,7 +99,14 @@ export function louvainCommunities(graph: CodeGraph, opts: LouvainOptions = {}):
   const resolution: number = opts.resolution ?? 1.0;
 
   const native = loadNative();
-  if (native?.leidenCommunities) {
+  const blocker = native?.leidenCommunities ? nativeParityBlocker(graph) : null;
+  if (blocker) {
+    debug(
+      `louvainCommunities: using the JS Leiden reference instead of the native ` +
+        `binding -- native cannot represent this graph faithfully (${blocker})`,
+    );
+  }
+  if (native?.leidenCommunities && !blocker) {
     const edges = graph.toEdgeArray();
     const nodeIds = graph.nodeIds();
     const result = native.leidenCommunities(

--- a/src/graph/builders/temporal.ts
+++ b/src/graph/builders/temporal.ts
@@ -44,7 +44,15 @@ export function buildTemporalGraph(
   for (const r of rows) {
     if (!graph.hasNode(r.file_a)) graph.addNode(r.file_a, { label: r.file_a });
     if (!graph.hasNode(r.file_b)) graph.addNode(r.file_b, { label: r.file_b });
-    graph.addEdge(r.file_a, r.file_b, { jaccard: r.jaccard });
+    // `weight` is the key every weight-aware consumer reads (`resolveEdgeWeight`
+    // in the Leiden adapter, and the native binding through it). Storing the
+    // Jaccard score only under a `jaccard` key -- as this builder used to --
+    // meant the graph this function advertises as "weighted by Jaccard
+    // similarity" was in fact uniformly weighted for every such consumer, which
+    // silently discards the entire co-change signal (measured on this repo:
+    // 628 pairs spanning Jaccard 0.02-1.0). `jaccard` is kept alongside it so
+    // existing readers of that key keep working.
+    graph.addEdge(r.file_a, r.file_b, { jaccard: r.jaccard, weight: r.jaccard });
   }
 
   return graph;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2809,6 +2809,30 @@ export interface NativeAddon {
     assignments: Array<{ node: string; community: number }>;
     modularity: number;
   };
+  /**
+   * Leiden community detection over per-edge weights (issue #1936) — an
+   * absent `weight` means 1.0, so this subsumes `leidenCommunities` above and
+   * is what `louvainCommunities` calls whenever it is present.
+   *
+   * Optional for the same reason as `leidenCommunities`: an addon published
+   * before #1936 lacks this export, and `louvainCommunities` must then fall
+   * back to the unweighted binding (for graphs with no weights) or to
+   * `detectClusters` (for graphs that have them) rather than silently
+   * dropping the weights.
+   */
+  leidenWeightedCommunities?(
+    edges: Array<{ source: string; target: string; weight?: number }>,
+    nodeIds: string[],
+    resolution?: number | null,
+    randomSeed?: number | null,
+    maxLevels?: number | null,
+    maxLocalPasses?: number | null,
+    refinementTheta?: number | null,
+    capacityGrowthFactor?: number | null,
+  ): {
+    assignments: Array<{ node: string; community: number }>;
+    modularity: number;
+  };
   buildCallEdges(
     files: unknown[],
     nodes: unknown[],

--- a/tests/graph/algorithms/leiden-native-parity.test.ts
+++ b/tests/graph/algorithms/leiden-native-parity.test.ts
@@ -16,7 +16,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { detectClusters } from '../../../src/graph/algorithms/leiden/index.js';
-import { louvainCommunities } from '../../../src/graph/algorithms/louvain.js';
+import { louvainCommunities, nativeParityBlocker } from '../../../src/graph/algorithms/louvain.js';
 import { CodeGraph } from '../../../src/graph/model.js';
 import { getNative, isNativeAvailable } from '../../../src/infrastructure/native.js';
 
@@ -235,5 +235,96 @@ describe.skipIf(!hasNative)('native/JS Leiden parity (issue #1804)', () => {
     }
     expect(snapshot(native.assignments)).toEqual(snapshot(jsAssignments));
     expect(native.modularity).toBe(jsResult.quality());
+  });
+});
+
+/**
+ * Graphs the native binding cannot represent (issue #1936).
+ *
+ * `toEdgeArray()` drops every edge attribute at the FFI boundary and no node
+ * attributes are passed at all, so native always optimizes a uniformly
+ * weighted graph while the JS reference honors `attrs.weight`/`attrs.size`.
+ * `nativeParityBlocker` detects that mismatch up front and defers to the JS
+ * reference. These tests pin both halves: that the mismatch is real (native
+ * genuinely cannot see the weights) and that the public API therefore returns
+ * the JS reference's answer rather than an engine-dependent one.
+ */
+describe('Leiden native/JS parity — inputs native cannot represent (#1936)', () => {
+  /**
+   * Two triangles joined by a single bridge edge whose weight dominates every
+   * intra-triangle edge. Unweighted, the triangles are the obvious partition;
+   * weighted, the bridge is by far the strongest tie in the graph, so weights
+   * are load-bearing for both the partition and the modularity score.
+   */
+  function buildWeightedBridgeGraph(bridgeWeight: number | undefined): CodeGraph {
+    const g = new CodeGraph();
+    for (const [a, b] of [
+      ['a1', 'a2'],
+      ['a2', 'a3'],
+      ['a3', 'a1'],
+      ['b1', 'b2'],
+      ['b2', 'b3'],
+      ['b3', 'b1'],
+    ] as const) {
+      g.addEdge(a, b, { weight: 1 });
+    }
+    g.addEdge('a1', 'b1', bridgeWeight == null ? {} : { weight: bridgeWeight });
+    return g;
+  }
+
+  it('flags weighted edges and unit-sized nodes correctly', () => {
+    expect(nativeParityBlocker(buildWeightedBridgeGraph(25))).toMatch(/weight=25/);
+    // weight === 1 is exactly what native assumes, so it is not a blocker --
+    // pins that the predicate stays narrow instead of rejecting every graph
+    // that merely carries a `weight` key.
+    expect(nativeParityBlocker(buildWeightedBridgeGraph(1))).toBeNull();
+    expect(nativeParityBlocker(buildWeightedBridgeGraph(undefined))).toBeNull();
+  });
+
+  it('does not flag non-numeric weight/size attrs (JS falls back to 1 for those too)', () => {
+    const g = new CodeGraph();
+    g.addEdge('a', 'b', { weight: 'heavy' });
+    g.addNode('a', { size: null });
+    expect(nativeParityBlocker(g)).toBeNull();
+  });
+
+  it('flags node size attrs', () => {
+    const g = new CodeGraph();
+    g.addEdge('a', 'b');
+    g.addNode('a', { size: 4 });
+    expect(nativeParityBlocker(g)).toMatch(/size=4/);
+  });
+
+  it.runIf(hasNative)('confirms native genuinely cannot see edge weights', () => {
+    // Justifies the guard: native returns the *same* answer whether or not
+    // the weights are present (it never sees them), while JS returns a
+    // different modularity for the two graphs (it does). Without the guard,
+    // `louvainCommunities` would hand back the weight-blind answer for a
+    // weighted graph.
+    const weighted = buildWeightedBridgeGraph(25);
+    const unweighted = buildWeightedBridgeGraph(undefined);
+
+    expect(snapshot(runNativeDirect(weighted).assignments)).toEqual(
+      snapshot(runNativeDirect(unweighted).assignments),
+    );
+    expect(runNativeDirect(weighted).modularity).toBe(runNativeDirect(unweighted).modularity);
+    expect(runJS(weighted).modularity).not.toBe(runJS(unweighted).modularity);
+  });
+
+  it('returns the JS reference result for a weighted graph', () => {
+    const g = buildWeightedBridgeGraph(25);
+    const viaPublicApi = louvainCommunities(g);
+    const js = runJS(g);
+    expect(snapshot(viaPublicApi.assignments)).toEqual(snapshot(js.assignments));
+    expect(viaPublicApi.modularity).toBe(js.modularity);
+  });
+
+  it('returns the JS reference result for a graph with node sizes', () => {
+    const g = buildWeightedBridgeGraph(undefined);
+    g.addNode('a1', { size: 8 });
+    const viaPublicApi = louvainCommunities(g);
+    const js = runJS(g);
+    expect(snapshot(viaPublicApi.assignments)).toEqual(snapshot(js.assignments));
+    expect(viaPublicApi.modularity).toBe(js.modularity);
   });
 });

--- a/tests/graph/algorithms/leiden-native-parity.test.ts
+++ b/tests/graph/algorithms/leiden-native-parity.test.ts
@@ -15,6 +15,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import { resolveEdgeWeight } from '../../../src/graph/algorithms/leiden/adapter.js';
 import { detectClusters } from '../../../src/graph/algorithms/leiden/index.js';
 import { louvainCommunities, nativeParityBlocker } from '../../../src/graph/algorithms/louvain.js';
 import { CodeGraph } from '../../../src/graph/model.js';
@@ -24,7 +25,10 @@ import { getNative, isNativeAvailable } from '../../../src/infrastructure/native
 // `leidenCommunities` binding (#1804 review): without the export check,
 // assertParity would silently degrade to a JS-vs-JS comparison and
 // runNativeDirect's non-null assertion would throw a confusing TypeError.
-const hasNative = isNativeAvailable() && typeof getNative()?.leidenCommunities === 'function';
+const hasNative =
+  isNativeAvailable() &&
+  typeof getNative()?.leidenCommunities === 'function' &&
+  typeof getNative()?.leidenWeightedCommunities === 'function';
 
 /** Sorted "node:community" pairs — stable snapshot for deep-equal comparison. */
 function snapshot(assignments: Map<string, number>): string[] {
@@ -49,17 +53,46 @@ function runJS(
   return { assignments, modularity: result.quality() };
 }
 
-/** Run the native Leiden binding directly, bypassing louvainCommunities' hardcoded seed. */
+/**
+ * Run the native weighted Leiden binding directly, bypassing
+ * louvainCommunities' hardcoded seed. Resolves weights exactly as the public
+ * API does, so weighted fixtures reach the binding as real weights rather than
+ * being flattened to 1.0.
+ */
 function runNativeDirect(
   graph: CodeGraph,
   opts: { resolution?: number; randomSeed?: number } = {},
 ): { assignments: Map<string, number>; modularity: number } {
   const native = getNative();
-  const edges = graph.toEdgeArray();
-  const nodeIds = graph.nodeIds();
-  const result = native.leidenCommunities!(
+  const edges = [...graph.edges()].map(([source, target, attrs]) => ({
+    source,
+    target,
+    weight: resolveEdgeWeight(attrs),
+  }));
+  const result = native.leidenWeightedCommunities!(
     edges,
-    nodeIds,
+    graph.nodeIds(),
+    opts.resolution ?? 1.0,
+    opts.randomSeed ?? 42,
+  );
+  const assignments = new Map<string, number>();
+  for (const entry of result.assignments) assignments.set(entry.node, entry.community);
+  return { assignments, modularity: result.modularity };
+}
+
+/**
+ * Run the pre-#1936 unweighted binding, still exported for version skew (a
+ * newer addon loaded by JS that only knows the old name). Kept under test so
+ * that path cannot rot silently.
+ */
+function runNativeUnweightedDirect(
+  graph: CodeGraph,
+  opts: { resolution?: number; randomSeed?: number } = {},
+): { assignments: Map<string, number>; modularity: number } {
+  const native = getNative();
+  const result = native.leidenCommunities!(
+    graph.toEdgeArray(),
+    graph.nodeIds(),
     opts.resolution ?? 1.0,
     opts.randomSeed ?? 42,
   );
@@ -173,18 +206,27 @@ describe.skipIf(!hasNative)('native/JS Leiden parity (issue #1804)', () => {
   });
 
   it('matches on a graph with self-loops', () => {
-    // Unweighted self-loop only: custom edge weights are out of scope for
-    // the native binding (GraphEdge carries no weight field, and none of
-    // louvainCommunities' real call sites ever set one — see leiden.rs's
-    // module doc). This still guards the actual regression: the classic
-    // Louvain implementation this file replaces dropped self-loops
-    // entirely instead of counting them once toward degree/modularity.
+    // Guards the original regression: the classic Louvain implementation this
+    // file replaces dropped self-loops entirely instead of counting them once
+    // toward degree/modularity. (Weighted self-loops are covered in the
+    // per-edge-weight block below.)
     const g = new CodeGraph();
     g.addEdge('a', 'b');
     g.addEdge('b', 'c');
     g.addEdge('c', 'a');
     g.addEdge('a', 'a');
     assertParity(g);
+  });
+
+  it.runIf(hasNative)('the retained unweighted binding still agrees with JS', () => {
+    // `leidenCommunities` is no longer what `louvainCommunities` calls, but it
+    // stays exported for version skew, so it needs its own coverage — the
+    // weighted path above would not catch it rotting.
+    const g = buildClusteredGraph(8, 5, 0.03, 'unweighted-binding-seed');
+    const native = runNativeUnweightedDirect(g, { randomSeed: 42 });
+    const js = runJS(g, { randomSeed: 42 });
+    expect(snapshot(native.assignments)).toEqual(snapshot(js.assignments));
+    expect(native.modularity).toBe(js.modularity);
   });
 
   it('matches on a graph forcing multi-level coarsening', () => {
@@ -239,17 +281,14 @@ describe.skipIf(!hasNative)('native/JS Leiden parity (issue #1804)', () => {
 });
 
 /**
- * Graphs the native binding cannot represent (issue #1936).
+ * Per-edge weights and the inputs native still cannot represent (issue #1936).
  *
- * `toEdgeArray()` drops every edge attribute at the FFI boundary and no node
- * attributes are passed at all, so native always optimizes a uniformly
- * weighted graph while the JS reference honors `attrs.weight`/`attrs.size`.
- * `nativeParityBlocker` detects that mismatch up front and defers to the JS
- * reference. These tests pin both halves: that the mismatch is real (native
- * genuinely cannot see the weights) and that the public API therefore returns
- * the JS reference's answer rather than an engine-dependent one.
+ * Native reads per-edge weights through `leidenWeightedCommunities`, with the
+ * attribute-to-number rule resolved once on the TS side (`resolveEdgeWeight`)
+ * and shared with the JS adapter. Node `size` is still native-blind, so
+ * `nativeParityBlocker` keeps routing size-bearing graphs to the JS reference.
  */
-describe('Leiden native/JS parity — inputs native cannot represent (#1936)', () => {
+describe('Leiden native/JS parity — per-edge weights (#1936)', () => {
   /**
    * Two triangles joined by a single bridge edge whose weight dominates every
    * intra-triangle edge. Unweighted, the triangles are the obvious partition;
@@ -272,59 +311,131 @@ describe('Leiden native/JS parity — inputs native cannot represent (#1936)', (
     return g;
   }
 
-  it('flags weighted edges and unit-sized nodes correctly', () => {
-    expect(nativeParityBlocker(buildWeightedBridgeGraph(25))).toMatch(/weight=25/);
-    // weight === 1 is exactly what native assumes, so it is not a blocker --
-    // pins that the predicate stays narrow instead of rejecting every graph
-    // that merely carries a `weight` key.
-    expect(nativeParityBlocker(buildWeightedBridgeGraph(1))).toBeNull();
-    expect(nativeParityBlocker(buildWeightedBridgeGraph(undefined))).toBeNull();
+  describe('nativeParityBlocker', () => {
+    it('does not flag weighted edges once the weighted binding is available', () => {
+      expect(
+        nativeParityBlocker(buildWeightedBridgeGraph(25), { weightsSupported: true }),
+      ).toBeNull();
+    });
+
+    it('flags weighted edges when only the pre-#1936 unweighted binding exists', () => {
+      // Version skew: an addon published before the weighted export, loaded by
+      // this (newer) JS. Silently sending the weights to a binding that cannot
+      // read them is the exact failure this predicate exists to prevent.
+      expect(
+        nativeParityBlocker(buildWeightedBridgeGraph(25), { weightsSupported: false }),
+      ).toMatch(/weight=25/);
+    });
+
+    it('stays narrow: weight === 1 and absent weights are never blockers', () => {
+      for (const weightsSupported of [true, false]) {
+        expect(nativeParityBlocker(buildWeightedBridgeGraph(1), { weightsSupported })).toBeNull();
+        expect(
+          nativeParityBlocker(buildWeightedBridgeGraph(undefined), { weightsSupported }),
+        ).toBeNull();
+      }
+    });
+
+    it('does not flag non-numeric weight/size attrs (JS falls back to 1 for those too)', () => {
+      const g = new CodeGraph();
+      g.addEdge('a', 'b', { weight: 'heavy' });
+      g.addNode('a', { size: null });
+      expect(nativeParityBlocker(g, { weightsSupported: false })).toBeNull();
+    });
+
+    it('flags node size attrs regardless of weight support', () => {
+      // Sizes are not inert under modularity: the JS reference sorts
+      // communities by total size when assigning final IDs, so a size-bearing
+      // graph can get different community *labels* even when the grouping
+      // matches. Nothing in-tree sets `size`, so there is no caller to verify
+      // a native port against — the JS reference stays authoritative.
+      const g = new CodeGraph();
+      g.addEdge('a', 'b');
+      g.addNode('a', { size: 4 });
+      for (const weightsSupported of [true, false]) {
+        expect(nativeParityBlocker(g, { weightsSupported })).toMatch(/size=4/);
+      }
+    });
   });
 
-  it('does not flag non-numeric weight/size attrs (JS falls back to 1 for those too)', () => {
+  it.runIf(hasNative)('exposes the weighted binding', () => {
+    // If this fails the suite below silently degrades to JS-vs-JS: the public
+    // API would fall back rather than error, and every assertion would still
+    // pass. Rebuild the addon (`napi build --release`) if it does.
+    expect(typeof getNative()?.leidenWeightedCommunities).toBe('function');
+  });
+
+  it.runIf(hasNative)('weights change the answer, so parity below is meaningful', () => {
+    // Pins that the weighted fixture is actually weight-sensitive. Without
+    // this, a binding that ignored weights entirely would still pass every
+    // parity assertion in this block.
+    const weighted = runJS(buildWeightedBridgeGraph(25));
+    const unweighted = runJS(buildWeightedBridgeGraph(undefined));
+    expect(weighted.modularity).not.toBe(unweighted.modularity);
+  });
+
+  it('matches the JS reference on a weighted graph via the public API', () => {
+    for (const bridgeWeight of [0.25, 1, 2, 7, 25, 1000]) {
+      const g = buildWeightedBridgeGraph(bridgeWeight);
+      const viaPublicApi = louvainCommunities(g);
+      const js = runJS(g);
+      expect(snapshot(viaPublicApi.assignments)).toEqual(snapshot(js.assignments));
+      expect(viaPublicApi.modularity).toBe(js.modularity);
+    }
+  });
+
+  it('matches on weighted reciprocal edges (undirected averaging path)', () => {
+    // adapter.ts sums both directions then divides by how many were seen, so
+    // asymmetric reciprocal weights exercise that averaging with a non-unit
+    // numerator on both sides of the FFI boundary.
     const g = new CodeGraph();
-    g.addEdge('a', 'b', { weight: 'heavy' });
-    g.addNode('a', { size: null });
-    expect(nativeParityBlocker(g)).toBeNull();
+    g.addEdge('a', 'b', { weight: 5 });
+    g.addEdge('b', 'a', { weight: 1 });
+    g.addEdge('b', 'c', { weight: 3 });
+    g.addEdge('c', 'b', { weight: 3 });
+    g.addEdge('c', 'd', { weight: 0.5 });
+    assertParity(g);
   });
 
-  it('flags node size attrs', () => {
+  it('matches on a weighted self-loop', () => {
     const g = new CodeGraph();
-    g.addEdge('a', 'b');
-    g.addNode('a', { size: 4 });
-    expect(nativeParityBlocker(g)).toMatch(/size=4/);
+    g.addEdge('a', 'b', { weight: 2 });
+    g.addEdge('b', 'c', { weight: 2 });
+    g.addEdge('c', 'a', { weight: 2 });
+    g.addEdge('a', 'a', { weight: 9 });
+    assertParity(g);
   });
 
-  it.runIf(hasNative)('confirms native genuinely cannot see edge weights', () => {
-    // Justifies the guard: native returns the *same* answer whether or not
-    // the weights are present (it never sees them), while JS returns a
-    // different modularity for the two graphs (it does). Without the guard,
-    // `louvainCommunities` would hand back the weight-blind answer for a
-    // weighted graph.
-    const weighted = buildWeightedBridgeGraph(25);
-    const unweighted = buildWeightedBridgeGraph(undefined);
-
-    expect(snapshot(runNativeDirect(weighted).assignments)).toEqual(
-      snapshot(runNativeDirect(unweighted).assignments),
-    );
-    expect(runNativeDirect(weighted).modularity).toBe(runNativeDirect(unweighted).modularity);
-    expect(runJS(weighted).modularity).not.toBe(runJS(unweighted).modularity);
+  it('matches on zero and NaN weights (both drop the edge)', () => {
+    // `resolveEdgeWeight`'s `+w || 0` coercion maps both to 0, which the
+    // adapter drops. Native must agree rather than treating the edge as 1.0 or
+    // propagating NaN through every modularity sum.
+    for (const weight of [0, Number.NaN]) {
+      const g = new CodeGraph();
+      g.addEdge('a', 'b', { weight: 4 });
+      g.addEdge('b', 'c', { weight: 4 });
+      g.addEdge('c', 'a', { weight: 4 });
+      g.addEdge('a', 'd', { weight });
+      g.addEdge('d', 'e', { weight: 4 });
+      g.addEdge('e', 'a', { weight: 4 });
+      assertParity(g);
+    }
   });
 
-  it('returns the JS reference result for a weighted graph', () => {
-    const g = buildWeightedBridgeGraph(25);
-    const viaPublicApi = louvainCommunities(g);
-    const js = runJS(g);
-    expect(snapshot(viaPublicApi.assignments)).toEqual(snapshot(js.assignments));
-    expect(viaPublicApi.modularity).toBe(js.modularity);
-  });
-
-  it('returns the JS reference result for a graph with node sizes', () => {
-    const g = buildWeightedBridgeGraph(undefined);
-    g.addNode('a1', { size: 8 });
-    const viaPublicApi = louvainCommunities(g);
-    const js = runJS(g);
-    expect(snapshot(viaPublicApi.assignments)).toEqual(snapshot(js.assignments));
-    expect(viaPublicApi.modularity).toBe(js.modularity);
+  it('matches on a weighted multi-level graph across seeds and resolutions', () => {
+    const g = buildClusteredGraph(10, 6, 0.03, 'weighted-seed-1');
+    // Deterministic pseudo-weights derived from the endpoint ids, so the
+    // fixture is weighted without needing a second RNG in the test.
+    let i = 0;
+    for (const [src, tgt] of [...g.edges()].map(([a, b]) => [a, b] as const)) {
+      i += 1;
+      g.addEdge(src, tgt, { weight: 1 + (i % 7) * 0.5 });
+    }
+    for (const resolution of [0.5, 1.0, 2.0]) {
+      assertParity(g, { resolution });
+    }
+    for (const randomSeed of [1, 42, 2026]) {
+      assertParityDirect(g, { randomSeed });
+    }
   });
 });

--- a/tests/graph/builders/temporal.test.ts
+++ b/tests/graph/builders/temporal.test.ts
@@ -1,6 +1,7 @@
 import Database from 'better-sqlite3';
 import { describe, expect, it } from 'vitest';
 import { initSchema } from '../../../src/db/index.js';
+import { resolveEdgeWeight } from '../../../src/graph/algorithms/leiden/adapter.js';
 import { buildTemporalGraph } from '../../../src/graph/builders/temporal.js';
 
 function createTestDb() {
@@ -31,6 +32,26 @@ describe('buildTemporalGraph', () => {
     expect(graph.nodeCount).toBe(3);
     expect(graph.hasEdge('a.js', 'b.js')).toBe(true);
     expect(graph.hasEdge('b.js', 'a.js')).toBe(true); // undirected
+    db.close();
+  });
+
+  it('exposes the Jaccard score as `weight`, the key weight-aware consumers read', () => {
+    // Regression (#1936): this builder advertises a graph "weighted by Jaccard
+    // similarity", but stored the score only under `jaccard` -- a key neither
+    // Leiden engine reads. Every weight-aware consumer therefore saw a
+    // uniformly weighted graph, silently discarding the whole co-change
+    // signal. `resolveEdgeWeight` reads `weight`, so that is what has to carry
+    // it; `jaccard` stays for existing readers of that key.
+    const db = createTestDb();
+    db.exec(`
+      INSERT INTO co_changes (file_a, file_b, commit_count, jaccard) VALUES ('a.js', 'b.js', 5, 0.8);
+      INSERT INTO co_changes (file_a, file_b, commit_count, jaccard) VALUES ('b.js', 'c.js', 2, 0.3);
+    `);
+
+    const graph = buildTemporalGraph(db);
+    expect(graph.getEdgeAttrs('a.js', 'b.js')).toMatchObject({ jaccard: 0.8, weight: 0.8 });
+    expect(graph.getEdgeAttrs('b.js', 'c.js')).toMatchObject({ jaccard: 0.3, weight: 0.3 });
+    expect(resolveEdgeWeight(graph.getEdgeAttrs('a.js', 'b.js')!)).toBe(0.8);
     db.close();
   });
 


### PR DESCRIPTION
> **Stacked on #2592** — review that first; the base will retarget to `main` automatically once it merges.

## What this does

Adds `leidenWeightedCommunities` to the native binding, so per-edge weights reach native Leiden instead of being flattened to 1.0 at the FFI boundary. This is item 3 of #1936's plan, and it removes edge weights from `nativeParityBlocker`'s reasons to fall back — weighted graphs now run on whichever engine is available and produce byte-identical results.

## Design notes

**A new napi struct, not a field on `GraphEdge`.** `GraphEdge` is also the input to `detectCycles`, `shortestPath`, `fanInOut` and `bfs`, none of which read a weight. An inert field there would let a caller set a weight on a `shortestPath` edge and have it silently ignored — the same class of quiet-wrong-answer bug this change exists to close.

**One implementation of the attribute-to-number rule.** `resolveEdgeWeight` (exported from the Leiden adapter, and used by the adapter's own call sites) resolves weights for both engines, so native and JS cannot drift apart on what a graph weighs. Rust owns only the two mappings that cannot cross the FFI boundary: absent means 1.0, NaN means 0.0.

**Version skew is handled in both directions.** `leidenCommunities` stays exported, defined as exactly the all-weights-1.0 case, for a newer addon loaded by older JS; a Rust test pins the two entry points to identical output and the TS suite keeps it covered so it cannot rot. In the reverse case — older addon, newer JS — the weighted export is missing and `nativeParityBlocker` falls back to JS for weighted graphs rather than sending weights to a binding that cannot read them.

## Also fixed: `buildTemporalGraph` was not actually weighted

It advertises a graph "weighted by Jaccard similarity" but stored the score only under a `jaccard` key that **neither engine reads** — so every weight-aware consumer saw a uniformly weighted graph and the entire co-change signal was silently discarded. It now sets `weight` too (`jaccard` kept for existing readers). Measured on this repo: 628 co-change pairs spanning Jaccard 0.02–1.0.

## What is deliberately NOT wired up, having measured it

**Call-site multiplicity — the premise was false.** Repeated call sites are not recoverable from the DB: `idx_edges_content_unique` (#2072) makes duplicate `(source, target, kind, confidence, …)` rows impossible in both engines. This repo's graph has **10712 `calls` rows for 10711 distinct pairs** (max multiplicity 2, from two resolution techniques on one pair — not multiplicity). Recording it needs a schema column, not a weight attribute.

**Weighting by resolution `confidence` — measured, no value.** Already available on `CallEdgeRow` for 22% of call edges, so it was the cheapest candidate. It does not improve community quality on this repo:

| graph | modularity | directory purity |
|---|---|---|
| file-level, unweighted | 0.5071 | 0.7771 |
| file-level, confidence-weighted | 0.5077 | **0.7725** |
| function-level, unweighted | 0.5879 | 0.9647 |
| function-level, confidence-weighted | 0.5912 | **0.9641** |

Confidence clusters at 0.9–1.0, so it perturbs the graph without restructuring it. Not enabling a behavior change by default on a measurement that says "no better, slightly worse alignment". (Modularity is not comparable across weightings — it is a different objective function — which is why directory purity is the readout.)

Node `size` remains native-blind and still routes to the JS reference: nothing in-tree sets it, so there is no caller to verify a port against, and it is not inert — the JS reference sorts communities by total size when assigning final IDs.

## Verification

- **5518** vitest tests pass (0 failures); **1132 + 3 new** Rust tests pass
- `cargo fmt --check` and `cargo clippy --workspace --all-targets -D warnings` clean; `tsc --noEmit` and `biome check` clean
- Native/JS **byte-for-byte** parity asserted across weighted bridges, weighted reciprocal edges (the undirected averaging path), weighted self-loops, zero/NaN weights, and a weighted multi-level graph across 3 resolutions and 3 seeds
- Verified against a locally built addon, not the published one — note that `napi build --release` writes `codegraph-core.node` while the loader looks for `codegraph-core.darwin-arm64.node`, so a local build is silently ignored unless renamed (filed separately)
- Local runs are on Node 24 while CI pins 22

Refs #1936