### PR TITLE
fix(bench): make the diffImpact metric measure diff-impact analysis

### DIFF
--- a/scripts/lib/hub-selection.ts
+++ b/scripts/lib/hub-selection.ts
@@ -52,11 +52,26 @@ export interface HubTargets {
 	 */
 	mid: string;
 	leaf: string;
+	/**
+	 * 1-based line range of the resolved hub definition, when the graph
+	 * recorded one.
+	 *
+	 * `benchDiffImpact` needs it to place its probe edit *inside* the hub
+	 * function's body. Appending the probe after the last line instead (what it
+	 * did before #2598) puts the changed range outside every function, so
+	 * `diffImpactData` finds zero affected functions and short-circuits before
+	 * the BFS/co-change/ownership work the metric exists to guard — measuring
+	 * the short-circuit rather than the analysis.
+	 */
+	hubLine: number | null;
+	hubEndLine: number | null;
 }
 
 interface NodeRow {
 	name: string;
 	file: string;
+	line: number | null;
+	end_line: number | null;
 }
 
 interface RankedNodeRow extends NodeRow {
@@ -84,10 +99,12 @@ export function selectHubTargets(dbPath: string, pinnedCandidates: readonly stri
 
 		let hub: string | null = null;
 		let hubFile: string | null = null;
+		let hubLine: number | null = null;
+		let hubEndLine: number | null = null;
 		for (const candidate of pinnedCandidates) {
 			const row = db
 				.prepare(
-					`SELECT n.name, n.file FROM nodes n
+					`SELECT n.name, n.file, n.line, n.end_line FROM nodes n
            JOIN edges e ON e.source_id = n.id OR e.target_id = n.id
            WHERE n.name = ? AND n.kind IN (${kindPlaceholders})
              AND n.file NOT LIKE '%test%' AND n.file NOT LIKE '%spec%'
@@ -98,13 +115,15 @@ export function selectHubTargets(dbPath: string, pinnedCandidates: readonly stri
 			if (row) {
 				hub = row.name;
 				hubFile = row.file;
+				hubLine = row.line;
+				hubEndLine = row.end_line;
 				break;
 			}
 		}
 
 		const rows = db
 			.prepare(
-				`SELECT n.id, n.name, n.file, COUNT(e.id) AS cnt
+				`SELECT n.id, n.name, n.file, n.line, n.end_line, COUNT(e.id) AS cnt
          FROM nodes n
          JOIN edges e ON e.source_id = n.id OR e.target_id = n.id
          WHERE n.kind IN (${kindPlaceholders})
@@ -121,12 +140,14 @@ export function selectHubTargets(dbPath: string, pinnedCandidates: readonly stri
 		if (!hub) {
 			hub = rows[0].name;
 			hubFile = rows[0].file;
+			hubLine = rows[0].line;
+			hubEndLine = rows[0].end_line;
 		}
 
 		const mid = rows[Math.floor(rows.length / 2)].name;
 		const leaf = rows[rows.length - 1].name;
 
-		return { hub, hubFile: hubFile as string, mid, leaf };
+		return { hub, hubFile: hubFile as string, mid, leaf, hubLine, hubEndLine };
 	} finally {
 		db.close();
 	}

--- a/scripts/query-benchmark.ts
+++ b/scripts/query-benchmark.ts
@@ -92,9 +92,16 @@ const { srcDir, cleanup } = await resolveBenchmarkSource();
 const dbPath = path.join(root, '.codegraph', 'graph.db');
 
 const { buildGraph } = await import(srcImport(srcDir, 'domain/graph/builder.js'));
-const { fnDepsData, fnImpactData, diffImpactData } = await import(
-	srcImport(srcDir, 'domain/queries.js')
-);
+const queries = await import(srcImport(srcDir, 'domain/queries.js'));
+const { fnDepsData, fnImpactData, diffImpactData } = queries;
+// #2598: `runGitDiff` + `diffImpactData`'s `diffText` option let this
+// benchmark hoist the `git` subprocess out of the timed region, so the metric
+// measures graph work instead of process spawn (spawn was ~8ms of a ~9ms
+// call). Older releases -- which this script also benchmarks, via
+// resolveBenchmarkSource -- lack both, so fall back to timing the whole call
+// there rather than failing. Numbers from the two modes are not comparable;
+// see benchDiffImpact.
+const runGitDiff = typeof queries.runGitDiff === 'function' ? queries.runGitDiff : null;
 // v3.9.5+ parses WASM in a worker_thread that keeps the event loop alive until
 // disposed. Older releases don't export disposeParsers — fall back to a no-op.
 let disposeParsers = async () => {};
@@ -154,6 +161,45 @@ function resolveDbFile(rootDir: string, dbFile: string): string | null {
 	return null;
 }
 
+/**
+ * Apply the probe edit whose impact this benchmark measures.
+ *
+ * The edit is placed *inside* the resolved hub function's body, so the changed
+ * line range intersects a real definition and `diffImpactData` runs its actual
+ * analysis — BFS to `depth: 3`, co-change lookup, ownership, boundary checks.
+ *
+ * Before #2598 the probe was appended after the file's last line, which lands
+ * outside every function: `findAffectedFunctions` returned empty and the call
+ * short-circuited, so the metric timed the short-circuit (plus a `git`
+ * subprocess) rather than the traversal. Measured on this repo, that made the
+ * whole call ~0.5ms of analysis inside a ~9ms measurement.
+ *
+ * Falls back to appending at end-of-file when the graph recorded no usable
+ * line range for the hub, so the benchmark still runs (with the old, weaker
+ * semantics) rather than failing.
+ */
+function probeEdit(original: string, targets: HubTargets): string {
+	const { hubLine, hubEndLine } = targets;
+	const lines = original.split('\n');
+	if (
+		hubLine == null ||
+		hubEndLine == null ||
+		hubEndLine <= hubLine + 1 ||
+		hubEndLine > lines.length
+	) {
+		console.error(
+			`[benchDiffImpact] no usable hub line range (${hubLine}..${hubEndLine}); appending probe at EOF`,
+		);
+		return original + '\n// benchmark-probe\n';
+	}
+	// Midpoint of the body, converted from the 1-based line range to a 0-based
+	// splice index. Strictly inside (hubLine, hubEndLine), so it cannot land on
+	// the signature or the closing brace.
+	const insertAt = Math.floor((hubLine + hubEndLine) / 2);
+	lines.splice(insertAt, 0, '\t// benchmark-probe');
+	return lines.join('\n');
+}
+
 async function benchDiffImpact(targets: HubTargets) {
 	// Reuse the exact physical node selectHubTargets already resolved for
 	// `targets.hub` instead of re-querying `nodes` by name — a second,
@@ -171,13 +217,27 @@ async function benchDiffImpact(targets: HubTargets) {
 	const original = fs.readFileSync(hubFile, 'utf8');
 
 	try {
-		fs.writeFileSync(hubFile, original + '\n// benchmark-probe\n');
+		fs.writeFileSync(hubFile, probeEdit(original, targets));
 		execFileSync('git', ['add', hubFile], { cwd: root, stdio: 'pipe' });
 
+		// Capture the diff once, outside the timed region, using the very
+		// function diffImpactData would have called — so the measurement covers
+		// parse + graph analysis over exactly the same input, minus the spawn.
+		const captured = runGitDiff
+			? runGitDiff(root, { staged: true }, 1 << 26)
+			: null;
+		if (captured && 'error' in captured && captured.error) {
+			console.error(`[benchDiffImpact] runGitDiff failed: ${captured.error}`);
+		}
+		const opts =
+			captured && captured.output != null
+				? { depth: 3, noTests: true, diffText: captured.output }
+				: { staged: true, depth: 3, noTests: true };
+
 		// Warm the diffImpact path before timing, exactly as benchDepths does for
-		// fnDeps/fnImpact. diffImpactData is a distinct query path from those -- its
-		// own DB pages, and a `git` subprocess to read the staged diff -- so the
-		// warmup those calls already paid does not carry over.
+		// fnDeps/fnImpact (#2591). diffImpactData is a distinct query path from
+		// those -- its own DB handle and its own pages -- so the warmup those
+		// calls already paid does not carry over.
 		//
 		// What these calls warm is narrower than on the native fnDeps path, and it
 		// is deliberately not the statement cache: diffImpactData opens its own
@@ -185,28 +245,33 @@ async function benchDiffImpact(targets: HubTargets) {
 		// prepared statements are discarded per call and no timed run ever reuses
 		// one. What does carry into the timed runs is process- and OS-wide state:
 		// loadConfig's per-root cache (resolveDbConfig re-reads .codegraphrc.json
-		// only on the first call), the OS page cache for the DB file and for the
-		// `.git` data the staged-diff subprocess reads, and V8 tiering up the diff
-		// parsing and BFS code that only this path exercises.
+		// only on the first call), the OS page cache for the DB file, and V8
+		// tiering up the diff parsing and BFS code that only this path exercises.
+		//
+		// #2591's rationale also counted warming the `.git` data read by the
+		// staged-diff subprocess. That no longer applies here: the subprocess now
+		// runs once above, outside the timed region, so no timed run reads `.git`
+		// at all (#2598).
 		//
 		// Without this, diffImpact was the only query metric measured cold: the
 		// same defect #2584 fixed for benchmark.ts's Full build, and that #2436
 		// traced part of the gate's non-determinism to (#2590).
-		for (let i = 0; i < WARMUP_RUNS; i++) {
-			diffImpactData(dbPath, { staged: true, depth: 3, noTests: true });
-		}
 
 		let lastResult = null;
-		const latencyMs = round1(
-			await timeMedian(() => {
-				lastResult = diffImpactData(dbPath, { staged: true, depth: 3, noTests: true });
-			}, RUNS),
-		);
+		const call = () => {
+			lastResult = diffImpactData(dbPath, opts);
+		};
+		for (let i = 0; i < WARMUP_RUNS; i++) call();
+		const latencyMs = round1(await timeMedian(call, RUNS));
 
 		return {
 			latencyMs,
 			affectedFunctions: lastResult?.affectedFunctions?.length || 0,
 			affectedFiles: lastResult?.affectedFiles?.length || 0,
+			// Records which mode produced `latencyMs`, so a baseline comparison
+			// can tell "analysis only" numbers from legacy spawn-inclusive ones
+			// instead of reading the drop as a huge improvement.
+			excludesGitSpawn: Boolean(captured && captured.output != null),
 		};
 	} finally {
 		execFileSync('git', ['restore', '--staged', hubFile], { cwd: root, stdio: 'pipe' });

--- a/src/domain/analysis/diff-impact.ts
+++ b/src/domain/analysis/diff-impact.ts
@@ -37,8 +37,13 @@ function findGitRoot(repoRoot: string): boolean {
 /**
  * Execute git diff and return the raw output string.
  * Returns `{ output: string }` on success or `{ error: string }` on failure.
+ *
+ * Exported so a caller that wants to time the *analysis* can hoist the
+ * subprocess out of its measured region and feed the result back through
+ * `diffImpactData`'s `diffText` option, while still measuring the exact diff
+ * this function would have produced -- see that option's doc comment.
  */
-function runGitDiff(
+export function runGitDiff(
   repoRoot: string,
   opts: { staged?: boolean; ref?: string },
   maxBuffer: number,
@@ -267,6 +272,22 @@ export function diffImpactData(
     limit?: number;
     offset?: number;
     config?: any;
+    /**
+     * Pre-captured `git diff` output to analyze instead of shelling out.
+     *
+     * Exists because this function's cost is dominated by the `git`
+     * subprocess, not by the graph work: measured on this repo, `git diff
+     * --cached --unified=0` alone is ~8ms of a ~9ms total call. A caller that
+     * wants to measure the analysis -- the `diffImpact` benchmark in
+     * `scripts/query-benchmark.ts` -- cannot do so while the spawn sits inside
+     * the timed region, because spawn cost swamps the signal and varies with
+     * machine load (see #2598).
+     *
+     * Pass the output of the exported `runGitDiff` to measure (or re-analyze)
+     * exactly what this function would otherwise have produced itself. When
+     * set, `staged`/`ref` are unused.
+     */
+    diffText?: string;
   } = {},
 ) {
   // Resolve config before opening the DB so config.db.busyTimeoutMs can be
@@ -291,7 +312,10 @@ export function diffImpactData(
       return { error: `Not a git repository: ${repoRoot}` };
     }
 
-    const gitResult = runGitDiff(repoRoot, opts, config.check.execMaxBufferBytes);
+    const gitResult =
+      opts.diffText != null
+        ? { output: opts.diffText }
+        : runGitDiff(repoRoot, opts, config.check.execMaxBufferBytes);
     if ('error' in gitResult) return { error: gitResult.error };
 
     if (!gitResult.output.trim()) {

--- a/src/domain/analysis/impact.ts
+++ b/src/domain/analysis/impact.ts
@@ -7,5 +7,5 @@
  * - presentation/diff-impact-mermaid.ts: diffImpactMermaid (Mermaid diagram generation)
  */
 
-export { diffImpactData } from './diff-impact.js';
+export { diffImpactData, runGitDiff } from './diff-impact.js';
 export { bfsTransitiveCallers, fnImpactData, impactAnalysisData } from './fn-impact.js';

--- a/src/domain/queries.ts
+++ b/src/domain/queries.ts
@@ -31,6 +31,7 @@ export {
   diffImpactData,
   fnImpactData,
   impactAnalysisData,
+  runGitDiff,
 } from './analysis/impact.js';
 export { implementationsData, interfacesData } from './analysis/implementations.js';
 export {


### PR DESCRIPTION
Closes #2598

## Why

`Pre-publish benchmark gate` failed on #2593 with `diffImpact latency: 10.1 → 24.4 (+142%)`. Investigating it turned up two defects in the *measurement*, not in the product — and together they meant the gate could not fail on the regression it exists to catch, while failing on unrelated PRs instead.

**It was not a product regression.** Ruled out point by point:

- No commit in the 32 since `v3.17.0` touches `diff-impact.ts`, `queries.ts`, or `impact.ts`.
- Reproduced locally at baseline: replicating the benchmark exactly gave **native 9.1ms / wasm 9.2ms** against the 10.1ms baseline.
- The engines are not building different graphs: nodes 20812 vs 20812, edges 45499 vs 45789 (native slightly *fewer*), same 67 indexes, no `sqlite_stat1`, no leftover `-wal`.
- Every other native query is *faster* than wasm in the same run (fnDeps 11.4 vs 13.8). Only `diffImpact` inverted.
- The native/wasm split is systemic across unrelated branches — `fix/issue-2512` 9.9/19.8, `fix/issue-2521` 9.5/15.1, `fix/issue-2524` 15.2/18.7 — so it is attributable to no commit.

## The two defects

**1. The `git` subprocess sat inside the timed region.** `benchDiffImpact` timed `diffImpactData(…, { staged: true })`, which shells out via `runGitDiff` → `execFileSync('git', …)`. Measured here, `git diff --cached --unified=0` alone is **~8ms of a ~9ms call** — the metric was ~90% process spawn.

**2. The probe edit landed outside every function.** It appended `// benchmark-probe` after the last line, so the changed range intersected no definition: `findAffectedFunctions` returned empty and the call short-circuited before the BFS/co-change/ownership work. Every recorded run shows `affectedFunctions: 0`.

Net effect: the analysis was **~0.5ms inside a ~9ms measurement**, so a real 2× regression in diff-impact's graph work would move the metric by well under a millisecond — far below the gate's 10ms `MIN_ABSOLUTE_DELTA`.

## What this changes

- `diffImpactData` gains a `diffText` option accepting pre-captured diff output, and `runGitDiff` is exported so a caller can capture exactly the diff the function would have produced itself. `benchDiffImpact` captures once, outside the timed region.
- The probe is inserted at the midpoint of the resolved hub function's **body**, using a line range now returned by `selectHubTargets` — the single source of truth for target selection, whose doc comment already directed probe-writing callers there.
- Both degrade gracefully: an older benchmark source without `runGitDiff`/`diffText` falls back to timing the whole call (this script benchmarks published versions too, via `resolveBenchmarkSource`), and a missing hub line range falls back to appending at EOF. `excludesGitSpawn` is recorded so the two modes are distinguishable rather than reading as a huge improvement.

Stacked on #2591, which landed the `WARMUP_RUNS` fix while this was in progress. I kept that commit's warmup rationale and corrected the one clause it left stale — it credited warming the `.git` data read by the staged-diff subprocess, which no longer runs inside the timed region.

## Verification

```
diffImpact  before: ~9ms measured, affectedFunctions 0   (≈0.5ms of analysis)
            after:  0.6ms wasm / 0.7ms native, affectedFunctions 1, affectedFiles 2
```

The two engines now agree, confirming the 2.4× CI gap was spawn cost rather than a query regression.

- `npx tsc --noEmit` clean; `npx biome check src/ tests/` clean; `npm run build` clean
- `RUN_REGRESSION_GUARD=1 npm run test:regression-guard` — **36/36 pass** against a regenerated report (17 of those are skipped without a `dev` entry, so they had not been exercised locally before)
- `npx vitest run tests/graph tests/integration` — 171 files, 1838 pass / 2 skipped / 2 todo
- Benchmark run emits no fallback warnings, so the probe lands inside the hub body as intended

## Deliberately not in this PR

- **Re-recording the baseline.** The metric now measures a different, much smaller quantity, so 0.7ms vs the recorded 10.1ms reads as an improvement and cannot fail the gate. It should be re-recorded on the next release rather than hand-edited here.
- **Scaling `MIN_ABSOLUTE_DELTA` for sub-10ms metrics.** A ~0.7ms metric can never exceed a 10ms absolute floor, so `diffImpact` remains effectively unguarded even after this fix. That is a policy call on a constant shared with other metrics, and it needs its own decision — see #2598's remaining item.

One caveat worth stating: `scripts/` is excluded from `tsconfig.json`, so these script changes are not covered by `npm run typecheck`. They are validated by running them, which is what the verification above does.